### PR TITLE
Implement pre-initialization and instant hot-switching

### DIFF
--- a/combo/include/combo/ComboContextBridge.h
+++ b/combo/include/combo/ComboContextBridge.h
@@ -82,6 +82,11 @@ public:
     bool IsGameLoaded(Game game) const;
 
     /**
+     * Check if a game is initialized (ready to Run without Init)
+     */
+    bool IsGameInitialized(Game game) const;
+
+    /**
      * Get the currently active game
      */
     Game GetActiveGame() const { return mActiveGame; }

--- a/combo/src/ComboContextBridge.cpp
+++ b/combo/src/ComboContextBridge.cpp
@@ -102,6 +102,11 @@ bool ComboContextBridge::IsGameLoaded(Game game) const {
     return it != mGames.end() && it->second.library.IsValid();
 }
 
+bool ComboContextBridge::IsGameInitialized(Game game) const {
+    auto it = mGames.find(game);
+    return it != mGames.end() && it->second.initialized;
+}
+
 bool ComboContextBridge::SwitchGame(Game game) {
     if (!IsGameLoaded(game)) {
         std::cerr << "ComboContextBridge: Cannot switch to unloaded game: "


### PR DESCRIPTION
## Summary
- **Issue #22**: Pre-initialize both games at startup so they share the SDL window
- **Issue #23**: Skip shutdown/init during game switch for instant hot-switching

## Changes

### Pre-initialization (Issue #22)
- Moved `gameArgv` construction before the pre-init block
- Added pre-init block after `LoadGame()` that:
  - Initializes OoT first (creates SDL window, stores via SharedGraphics)
  - Initializes MM second (reuses window via SharedGraphics)
- Removed redundant `Init()` call after game selection

### Instant Hot-Switch (Issue #23)
- Added `IsGameInitialized(Game game)` method to `ComboContextBridge`
- Modified switch logic to check if target game is pre-initialized:
  - If yes: Skip Shutdown/Init, just call `SwitchGame()` (instant!)
  - If no: Use fallback Shutdown/Init path (legacy behavior)

## Flow comparison

**OLD flow:**
```
LoadGame → Select → SwitchGame → Init → Run
[On switch: Shutdown → Init → Run]
```

**NEW flow:**
```
LoadGame → Pre-init ALL games → Select → SwitchGame → Run
[On switch: SwitchGame → Run]  ← No shutdown/init!
```

## Test plan
- [ ] Build: `cmake --build build --parallel 8`
- [ ] Run: `./build/redship --game oot`
- [ ] Verify output shows "Pre-initializing OoT..." then "Pre-initializing MM..."
- [ ] Verify only ONE SDL window is created
- [ ] Press F10 to switch games
- [ ] Verify switch shows "[HOT-SWITCH] Target game is pre-initialized"
- [ ] Verify switch is instant (no window flash/recreation)
- [ ] Test entrance-based switches work correctly

Closes #22
Closes #23

🤖 Generated with [Claude Code](https://claude.com/claude-code)