### PR TITLE
Improve test infrastructure based on review feedback

### DIFF
--- a/combo/CMakeLists.txt
+++ b/combo/CMakeLists.txt
@@ -125,6 +125,9 @@ endif()
 if(BUILD_TESTING AND REDSHIP_BUILD_SHARED)
     enable_testing()
 
+    # Configurable timeout for CI environments with varying performance
+    set(REDSHIP_TEST_TIMEOUT 60 CACHE STRING "Test timeout in seconds")
+
     # Boot tests - verify each game can initialize
     add_test(NAME BootOoT COMMAND redship --test boot-oot)
     add_test(NAME BootMM COMMAND redship --test boot-mm)
@@ -136,11 +139,17 @@ if(BUILD_TESTING AND REDSHIP_BUILD_SHARED)
     # Full round-trip test
     add_test(NAME RoundTrip COMMAND redship --test roundtrip)
 
-    # Mark all tests as expected to fail until infrastructure is complete
+    # TODO(#29): Remove WILL_FAIL when unified build provides game integration
+    # Exit criteria for removing WILL_FAIL:
+    #   1. BootOoT: OoT boots to main menu within timeout in headless mode
+    #   2. BootMM: MM boots to main menu within timeout in headless mode
+    #   3. SwitchOoTMM: Cross-game transition completes without crash
+    #   4. SwitchMMOoT: Reverse transition completes without crash
+    #   5. RoundTrip: Full OoT->MM->OoT cycle with state verification
     set_tests_properties(
         BootOoT BootMM SwitchOoTMM SwitchMMOoT RoundTrip
         PROPERTIES
         WILL_FAIL TRUE
-        TIMEOUT 60
+        TIMEOUT ${REDSHIP_TEST_TIMEOUT}
     )
 endif()


### PR DESCRIPTION
## Summary

Addresses review feedback from PR #37 (SWE Principles Review):

| Feedback | Resolution |
|----------|------------|
| **WILL_FAIL exit strategy** | Added TODO(#29) with explicit exit criteria |
| **Test registration pattern** | Implemented `TestCase` struct + `GetRegisteredTests()` |
| **Exit code documentation** | Added semantics to header comments |
| **Configurable timeout** | Added `REDSHIP_TEST_TIMEOUT` cache variable |

## Changes

### 1. WILL_FAIL Exit Criteria (Backsliding Prevention)

```cmake
# TODO(#29): Remove WILL_FAIL when unified build provides game integration
# Exit criteria for removing WILL_FAIL:
#   1. BootOoT: OoT boots to main menu within timeout in headless mode
#   2. BootMM: MM boots to main menu within timeout in headless mode
#   ...
```

### 2. Test Registration Pattern (Code Liability)

Before: Hardcoded list + separate `RunTest()` switch
After: Single source of truth

```cpp
const std::vector<TestCase>& TestRunner::GetRegisteredTests() {
    static const std::vector<TestCase> s_tests = {
        {"boot-oot", [](TestRunner& r) { return r.TestBootGame(Game::OoT); }},
        // Adding new test = ONE change here
    };
    return s_tests;
}
```

### 3. Exit Code Documentation (Hyrum's Law)

```cpp
/**
 * Exit Codes (for CI integration):
 *   0     = All tests passed, OR 'list' command was executed
 *   N > 0 = N tests failed (when running 'all')
 *   1     = Single test failed (when running specific test)
 */
```

### 4. Configurable Timeout (Compatibility)

```cmake
set(REDSHIP_TEST_TIMEOUT 60 CACHE STRING "Test timeout in seconds")
# Override: cmake -DREDSHIP_TEST_TIMEOUT=120
```

### 5. Extracted Headless Setup (Code Liability)

```cpp
void SetupHeadlessEnvironment();  // Reusable by other tests
```

## Test Plan

- [x] Build passes
- [x] `redship --test list` works
- [x] `redship --test boot-oot` fails gracefully with expected message
- [x] Registration pattern produces same test list as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)