### PR TITLE
Fix CI workflow and add conftest.py

### DIFF
--- a/.github/workflows/symbol-tools.yml
+++ b/.github/workflows/symbol-tools.yml
@@ -33,11 +33,7 @@ jobs:
   check-collisions:
     name: Check Symbol Collisions
     runs-on: ubuntu-latest
-    # Only run collision check if games/*/src changed
-    # This prevents false positives when only tools change
-    if: |
-      github.event_name == 'push' ||
-      contains(github.event.pull_request.changed_files, 'games/')
+    # Always run when workflow triggers - path filters already handle when to run
     steps:
       - uses: actions/checkout@v4
 
@@ -57,13 +53,23 @@ jobs:
 
           echo "Found $COLLISION_COUNT symbol collisions"
 
-          # Store the count for comparison
-          # In a real LSC scenario, you'd compare against a known baseline
-          # For now, we just report the count
+          # =================================================================
+          # Baseline Strategy (for after LSC completes):
+          # =================================================================
+          # 1. After namespacing LSC, commit baseline_collisions.txt with
+          #    expected collision count (ideally 0)
+          # 2. Enable the check below to fail if new collisions are introduced
+          # 3. This prevents backsliding - new un-namespaced symbols fail CI
+          #
+          # To enable after LSC:
+          #   - Set EXPECTED_COLLISIONS=0 (or whatever baseline is)
+          #   - Uncomment the comparison check
+          # =================================================================
 
-          # After namespacing is complete, uncomment this to fail on ANY collision:
-          # if [ "$COLLISION_COUNT" -gt 0 ]; then
-          #   echo "ERROR: Symbol collisions detected!"
+          # EXPECTED_COLLISIONS=0  # Set after LSC completes
+          # if [ "$COLLISION_COUNT" -gt "$EXPECTED_COLLISIONS" ]; then
+          #   echo "ERROR: New symbol collisions detected!"
+          #   echo "Expected: $EXPECTED_COLLISIONS, Found: $COLLISION_COUNT"
           #   echo "New symbols need OoT_/MM_ prefixes before merge."
           #   cat collision_report.txt
           #   exit 1

--- a/tools/tests/conftest.py
+++ b/tools/tests/conftest.py
@@ -1,0 +1,11 @@
+"""
+Pytest configuration for symbol tools tests.
+
+Automatically loaded by pytest to set up the Python path.
+"""
+
+import sys
+from pathlib import Path
+
+# Add tools directory to path so tests can import detect_collisions and namespace_symbols
+sys.path.insert(0, str(Path(__file__).parent.parent))

--- a/tools/tests/test_detect_collisions.py
+++ b/tools/tests/test_detect_collisions.py
@@ -12,10 +12,8 @@ Tests cover:
 import tempfile
 import unittest
 from pathlib import Path
-import sys
 
-# Add parent directory to path for imports
-sys.path.insert(0, str(Path(__file__).parent.parent))
+# Path setup handled by conftest.py (auto-loaded by pytest)
 from detect_collisions import extract_symbols
 
 

--- a/tools/tests/test_namespace_symbols.py
+++ b/tools/tests/test_namespace_symbols.py
@@ -12,10 +12,8 @@ Tests cover:
 import tempfile
 import unittest
 from pathlib import Path
-import sys
 
-# Add parent directory to path for imports
-sys.path.insert(0, str(Path(__file__).parent.parent))
+# Path setup handled by conftest.py (auto-loaded by pytest)
 from namespace_symbols import namespace_file, load_symbols
 
 


### PR DESCRIPTION
## Summary

Final improvements for the symbol collision tools CI:

- Fixed CI condition (removed non-working `contains()`)
- Added `conftest.py` for test path setup
- Documented baseline strategy for backsliding prevention

## Changes

### 1. CI Condition Fix

Removed broken condition - path filters on the workflow trigger already handle filtering.

### 2. conftest.py for Path Setup

```python
# tools/tests/conftest.py
import sys
from pathlib import Path
sys.path.insert(0, str(Path(__file__).parent.parent))
```

### 3. Documented Baseline Strategy

Added clear comments explaining how to enable backsliding check after LSC completes.

## Test Plan

- [x] All 37 tests pass
- [x] CI workflow syntax valid

🤖 Generated with [Claude Code](https://claude.com/claude-code)