### PR TITLE
Add Python wrapper for PMD CPD clone detection

### DIFF
--- a/tools/lib/cpd_runner.py
+++ b/tools/lib/cpd_runner.py
@@ -1,0 +1,205 @@
+"""
+Python wrapper for PMD CPD (Copy/Paste Detector) clone detection.
+
+PMD CPD is an industry-standard tool that detects duplicate code across files.
+This wrapper runs CPD on given directories and parses the CSV output to return
+structured clone detection results.
+"""
+
+import csv
+import subprocess
+import shutil
+from dataclasses import dataclass
+from io import StringIO
+from typing import List, Optional
+
+
+@dataclass
+class ClonePair:
+    """Represents a detected clone pair between two files."""
+    file1: str
+    line1: int
+    file2: str
+    line2: int
+    lines: int
+    tokens: int
+
+
+class CPDError(Exception):
+    """Exception raised when CPD execution fails."""
+    pass
+
+
+class CPDNotFoundError(CPDError):
+    """Exception raised when PMD CPD is not installed."""
+    pass
+
+
+def _find_pmd_executable() -> str:
+    """Find the PMD executable on the system.
+
+    Returns:
+        Path to the PMD executable.
+
+    Raises:
+        CPDNotFoundError: If PMD is not found on the system.
+    """
+    # Check if 'pmd' is in PATH
+    pmd_path = shutil.which("pmd")
+    if pmd_path:
+        return pmd_path
+
+    # Common installation locations
+    common_paths = [
+        "/usr/local/bin/pmd",
+        "/opt/pmd/bin/pmd",
+        "/opt/pmd-bin/bin/pmd",
+    ]
+
+    for path in common_paths:
+        if shutil.which(path):
+            return path
+
+    raise CPDNotFoundError(
+        "PMD CPD not found. Please install PMD from https://pmd.github.io/ "
+        "and ensure 'pmd' is in your PATH."
+    )
+
+
+def _parse_cpd_csv(csv_output: str) -> List[ClonePair]:
+    """Parse CPD CSV output into ClonePair objects.
+
+    CPD CSV format (each line after header):
+    lines,tokens,occurrences,file1,startline1,file2,startline2[,file3,startline3,...]
+
+    For pairs (occurrences=2):
+    15,89,2,games/oot/src/file.c,10,games/mm/src/file.c,10
+
+    Args:
+        csv_output: Raw CSV output from CPD.
+
+    Returns:
+        List of ClonePair objects representing detected clones.
+    """
+    clones = []
+
+    # Skip empty output
+    if not csv_output.strip():
+        return clones
+
+    reader = csv.reader(StringIO(csv_output))
+
+    for row in reader:
+        # Skip header row
+        if not row or row[0] == "lines":
+            continue
+
+        # Skip malformed rows
+        if len(row) < 7:
+            continue
+
+        try:
+            lines = int(row[0])
+            tokens = int(row[1])
+            occurrences = int(row[2])
+
+            # For each pair of occurrences, create a ClonePair
+            # CSV format: lines,tokens,occurrences,file1,line1,file2,line2,...
+            # Starting at index 3, each occurrence is (file, line) pair
+            occurrence_data = []
+            idx = 3
+            while idx + 1 < len(row):
+                file_path = row[idx]
+                line_num = int(row[idx + 1])
+                occurrence_data.append((file_path, line_num))
+                idx += 2
+
+            # Create ClonePair for each unique pair of occurrences
+            for i in range(len(occurrence_data)):
+                for j in range(i + 1, len(occurrence_data)):
+                    file1, line1 = occurrence_data[i]
+                    file2, line2 = occurrence_data[j]
+
+                    clones.append(ClonePair(
+                        file1=file1,
+                        line1=line1,
+                        file2=file2,
+                        line2=line2,
+                        lines=lines,
+                        tokens=tokens,
+                    ))
+
+        except (ValueError, IndexError):
+            # Skip rows that can't be parsed
+            continue
+
+    return clones
+
+
+def run_cpd(
+    directories: List[str],
+    language: str = "cpp",
+    min_tokens: int = 50,
+    ignore_identifiers: bool = True,
+    ignore_literals: bool = True,
+) -> List[ClonePair]:
+    """Run PMD CPD on given directories and return detected clones.
+
+    Args:
+        directories: List of directory paths to scan for duplicates.
+        language: Programming language (default: "cpp" for C/C++).
+        min_tokens: Minimum token count for a duplicate (default: 50).
+        ignore_identifiers: Ignore identifier names when comparing (default: True).
+        ignore_literals: Ignore literal values when comparing (default: True).
+
+    Returns:
+        List of ClonePair objects representing detected duplicate code.
+
+    Raises:
+        CPDNotFoundError: If PMD CPD is not installed.
+        CPDError: If CPD execution fails.
+    """
+    pmd_path = _find_pmd_executable()
+
+    # Build command
+    cmd = [
+        pmd_path, "cpd",
+        "--language", language,
+        "--minimum-tokens", str(min_tokens),
+        "--format", "csv",
+    ]
+
+    if ignore_identifiers:
+        cmd.append("--ignore-identifiers")
+
+    if ignore_literals:
+        cmd.append("--ignore-literals")
+
+    # Add directories
+    for directory in directories:
+        cmd.extend(["--dir", directory])
+
+    try:
+        result = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            timeout=300,  # 5 minute timeout
+        )
+
+        # CPD returns exit code 4 when duplicates are found (which is expected)
+        # Exit code 0 means no duplicates found
+        # Other exit codes indicate errors
+        if result.returncode not in (0, 4):
+            error_msg = result.stderr.strip() if result.stderr else "Unknown error"
+            raise CPDError(f"CPD failed with exit code {result.returncode}: {error_msg}")
+
+        return _parse_cpd_csv(result.stdout)
+
+    except subprocess.TimeoutExpired:
+        raise CPDError("CPD execution timed out after 5 minutes")
+    except FileNotFoundError:
+        raise CPDNotFoundError(
+            "PMD CPD not found. Please install PMD from https://pmd.github.io/ "
+            "and ensure 'pmd' is in your PATH."
+        )

--- a/tools/tests/test_cpd_runner.py
+++ b/tools/tests/test_cpd_runner.py
@@ -1,0 +1,176 @@
+"""Tests for the cpd_runner module."""
+
+import pytest
+
+from cpd_runner import (
+    ClonePair,
+    CPDError,
+    CPDNotFoundError,
+    _parse_cpd_csv,
+    run_cpd,
+)
+
+
+class TestClonePair:
+    """Tests for ClonePair dataclass."""
+
+    def test_clone_pair_creation(self):
+        clone = ClonePair(
+            file1="file1.c",
+            line1=10,
+            file2="file2.c",
+            line2=20,
+            lines=15,
+            tokens=89,
+        )
+        assert clone.file1 == "file1.c"
+        assert clone.line1 == 10
+        assert clone.file2 == "file2.c"
+        assert clone.line2 == 20
+        assert clone.lines == 15
+        assert clone.tokens == 89
+
+
+class TestParseCpdCsv:
+    """Tests for _parse_cpd_csv function."""
+
+    def test_parses_simple_clone_pair(self):
+        csv_output = """lines,tokens,occurrences
+15,89,2,games/oot/src/file.c,10,games/mm/src/file.c,20"""
+        clones = _parse_cpd_csv(csv_output)
+        assert len(clones) == 1
+        clone = clones[0]
+        assert clone.lines == 15
+        assert clone.tokens == 89
+        assert clone.file1 == "games/oot/src/file.c"
+        assert clone.line1 == 10
+        assert clone.file2 == "games/mm/src/file.c"
+        assert clone.line2 == 20
+
+    def test_parses_multiple_clone_pairs(self):
+        csv_output = """lines,tokens,occurrences
+15,89,2,games/oot/src/a.c,10,games/mm/src/a.c,20
+20,100,2,games/oot/src/b.c,30,games/mm/src/b.c,40"""
+        clones = _parse_cpd_csv(csv_output)
+        assert len(clones) == 2
+
+        assert clones[0].lines == 15
+        assert clones[0].file1 == "games/oot/src/a.c"
+        assert clones[0].file2 == "games/mm/src/a.c"
+
+        assert clones[1].lines == 20
+        assert clones[1].file1 == "games/oot/src/b.c"
+        assert clones[1].file2 == "games/mm/src/b.c"
+
+    def test_parses_triple_occurrence(self):
+        # When a clone appears in 3 files, we get 3 pairs: (1,2), (1,3), (2,3)
+        csv_output = """lines,tokens,occurrences
+15,89,3,file1.c,10,file2.c,20,file3.c,30"""
+        clones = _parse_cpd_csv(csv_output)
+        assert len(clones) == 3
+
+        # Pair (file1, file2)
+        assert clones[0].file1 == "file1.c"
+        assert clones[0].line1 == 10
+        assert clones[0].file2 == "file2.c"
+        assert clones[0].line2 == 20
+
+        # Pair (file1, file3)
+        assert clones[1].file1 == "file1.c"
+        assert clones[1].line1 == 10
+        assert clones[1].file2 == "file3.c"
+        assert clones[1].line2 == 30
+
+        # Pair (file2, file3)
+        assert clones[2].file1 == "file2.c"
+        assert clones[2].line1 == 20
+        assert clones[2].file2 == "file3.c"
+        assert clones[2].line2 == 30
+
+    def test_handles_empty_output(self):
+        clones = _parse_cpd_csv("")
+        assert clones == []
+
+    def test_handles_whitespace_only_output(self):
+        clones = _parse_cpd_csv("   \n\t  ")
+        assert clones == []
+
+    def test_handles_header_only(self):
+        csv_output = "lines,tokens,occurrences\n"
+        clones = _parse_cpd_csv(csv_output)
+        assert clones == []
+
+    def test_skips_malformed_rows(self):
+        csv_output = """lines,tokens,occurrences
+15,89,2,games/oot/src/a.c,10,games/mm/src/a.c,20
+invalid,row,data
+20,100,2,games/oot/src/b.c,30,games/mm/src/b.c,40"""
+        clones = _parse_cpd_csv(csv_output)
+        # Should still parse the valid rows
+        assert len(clones) == 2
+
+    def test_skips_rows_with_missing_fields(self):
+        csv_output = """lines,tokens,occurrences
+15,89,2,file.c,10
+20,100,2,games/oot/src/b.c,30,games/mm/src/b.c,40"""
+        clones = _parse_cpd_csv(csv_output)
+        # First row doesn't have enough fields for a pair
+        assert len(clones) == 1
+        assert clones[0].file1 == "games/oot/src/b.c"
+
+    def test_handles_paths_with_spaces(self):
+        csv_output = """lines,tokens,occurrences
+15,89,2,path/to/my file.c,10,another path/file.c,20"""
+        clones = _parse_cpd_csv(csv_output)
+        assert len(clones) == 1
+        assert clones[0].file1 == "path/to/my file.c"
+        assert clones[0].file2 == "another path/file.c"
+
+
+class TestRunCpd:
+    """Tests for run_cpd function."""
+
+    def test_raises_cpd_not_found_when_pmd_missing(self):
+        # When PMD is not installed, should raise CPDNotFoundError
+        # This test will pass on systems without PMD installed
+        try:
+            run_cpd(["nonexistent_dir"])
+        except CPDNotFoundError as e:
+            assert "PMD" in str(e) or "pmd" in str(e)
+        except CPDError:
+            # CPD may also raise a general error if the directory doesn't exist
+            pass
+
+    def test_accepts_language_parameter(self):
+        # Test that the function accepts the language parameter
+        # (actual execution depends on PMD being installed)
+        try:
+            run_cpd(["nonexistent_dir"], language="java")
+        except (CPDNotFoundError, CPDError):
+            pass  # Expected when PMD not installed or dir doesn't exist
+
+    def test_accepts_min_tokens_parameter(self):
+        try:
+            run_cpd(["nonexistent_dir"], min_tokens=100)
+        except (CPDNotFoundError, CPDError):
+            pass
+
+    def test_accepts_ignore_flags(self):
+        try:
+            run_cpd(
+                ["nonexistent_dir"],
+                ignore_identifiers=False,
+                ignore_literals=False,
+            )
+        except (CPDNotFoundError, CPDError):
+            pass
+
+
+class TestCPDExceptions:
+    """Tests for CPD exception hierarchy."""
+
+    def test_cpd_not_found_error_is_cpd_error(self):
+        assert issubclass(CPDNotFoundError, CPDError)
+
+    def test_cpd_error_is_exception(self):
+        assert issubclass(CPDError, Exception)


### PR DESCRIPTION
## Summary
- Add `tools/lib/cpd_runner.py` - Python wrapper for PMD CPD (Copy/Paste Detector)
- Implements `ClonePair` dataclass for structured clone results
- `run_cpd()` function with configurable options (language, min_tokens, ignore settings)
- CSV output parsing with support for multi-occurrence clones
- Error handling with `CPDError` and `CPDNotFoundError` exceptions
- Comprehensive unit tests in `tools/tests/test_cpd_runner.py`

## Context
Part of merge analysis tooling (WP-005). Used to detect duplicate code between OoT and MM that can be merged into `rsbs/`.

## Usage
```python
from tools.lib.cpd_runner import run_cpd

clones = run_cpd(
    ["games/oot/src/libultra", "games/mm/src/libultra"],
    min_tokens=30,
    ignore_identifiers=True
)
```

## Test plan
- [ ] Unit tests pass: `python -m pytest tools/tests/test_cpd_runner.py -v`
- [ ] Integration test with real PMD CPD on libultra directories

🤖 Generated with [Claude Code](https://claude.ai/code)

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-windows.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/5215094136.zip)
  - [soh-linux.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/5215110780.zip)
<!--- section:artifacts:end -->