### PR TITLE
Add Python tests to CI presubmit

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -1,0 +1,33 @@
+name: python-tests
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'tools/**'
+      - '.github/workflows/python-tests.yml'
+  pull_request:
+    paths:
+      - 'tools/**'
+      - '.github/workflows/python-tests.yml'
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Git Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install pytest
+
+      - name: Run tests
+        run: |
+          python -m pytest tools/tests/ -v --tb=short

--- a/tools/tests/conftest.py
+++ b/tools/tests/conftest.py
@@ -1,0 +1,12 @@
+"""
+Pytest configuration for tools tests.
+
+Adds the tools/lib directory to the Python path so that imports work correctly.
+"""
+
+import sys
+from pathlib import Path
+
+# Add tools/lib to Python path for imports
+tools_lib = Path(__file__).parent.parent / "lib"
+sys.path.insert(0, str(tools_lib))

--- a/tools/tests/test_code_extractor.py
+++ b/tools/tests/test_code_extractor.py
@@ -14,7 +14,7 @@ import unittest
 from pathlib import Path
 
 # Path setup handled by conftest.py (auto-loaded by pytest)
-from lib.code_extractor import extract_function, extract_global
+from code_extractor import extract_function, extract_global
 
 
 class TestExtractFunction(unittest.TestCase):

--- a/tools/tests/test_symbol_locator.py
+++ b/tools/tests/test_symbol_locator.py
@@ -14,7 +14,7 @@ import unittest
 from pathlib import Path
 
 # Path setup handled by conftest.py (auto-loaded by pytest)
-from lib.symbol_locator import SymbolLocator
+from symbol_locator import SymbolLocator
 
 
 class TestSymbolLocator(unittest.TestCase):


### PR DESCRIPTION
## Summary
- Add `.github/workflows/python-tests.yml` to run pytest on `tools/` directory
- Add `tools/tests/conftest.py` for Python path setup
- Fix imports in test files to use direct module imports

## Context
Python tests exist for the merge analysis tools (normalizer, code_extractor, symbol_locator) but weren't being run in CI. This PR adds them to presubmit.

## Test plan
- [x] All 99 tests pass locally
- [ ] CI workflow runs on this PR

🤖 Generated with [Claude Code](https://claude.ai/code)

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-windows.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/5215272972.zip)
  - [soh-linux.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/5215291643.zip)
<!--- section:artifacts:end -->