### PR TITLE
Skip configure step for cached dependencies

### DIFF
--- a/.github/workflows/generate-builds.yml
+++ b/.github/workflows/generate-builds.yml
@@ -264,8 +264,9 @@ jobs:
         cd deps/libzip-1.10.1
         mkdir -p build
         cd build
-        # Skip cmake configure if already done
-        if [ ! -f "Makefile" ]; then
+        # Skip cmake configure if already done AND configured with crypto disabled
+        # (stale cache with different options could cause build issues)
+        if [ ! -f "CMakeCache.txt" ] || ! grep -q "ENABLE_OPENSSL:BOOL=OFF" CMakeCache.txt; then
           cmake .. -DENABLE_COMMONCRYPTO=OFF -DENABLE_GNUTLS=OFF -DENABLE_MBEDTLS=OFF -DENABLE_OPENSSL=OFF
         fi
         make


### PR DESCRIPTION
## Summary
When the `deps/` folder is restored from cache, the configure step still ran every time even though it's slow (~30-60s per dep) and unnecessary.

Now we check if `Makefile` exists (configure already ran) and skip:
- **SDL**: skip `./configure` if Makefile exists  
- **SDL_net**: skip `./configure` if Makefile exists
- **tinyxml2**: skip `cmake` if Makefile exists
- **libzip**: skip `cmake` if Makefile exists

## Why this works
The cache saves the entire `deps/` folder including:
- Source code
- Generated Makefiles from configure/cmake
- Built object files

So on cache hit, we only need to run `make` (which is fast - nothing to rebuild) and `make install` (to copy to system paths).

## Impact
Should save 2-4 minutes per build by not re-running configure for each dependency.

## Test plan
- [ ] First build after cache miss: configure runs, deps build
- [ ] Subsequent builds with cache hit: configure skipped, make is no-op

🤖 Generated with [Claude Code](https://claude.ai/code)

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-windows.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/5215924592.zip)
  - [soh-linux.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/5215941727.zip)
<!--- section:artifacts:end -->