### PR TITLE
Fix macOS build - use force_load for libultraship linking

### DIFF
--- a/.github/workflows/generate-builds.yml
+++ b/.github/workflows/generate-builds.yml
@@ -96,10 +96,6 @@ jobs:
         path: deps
 
   build-macos:
-    # DISABLED: macOS build is currently broken - see GitHub issue for tracking
-    # Error: OoT shared library not linking against libultraship properly
-    # Re-enable once issue is resolved
-    if: false
     needs: generate-soh-otr
     runs-on: macos-14
     steps:

--- a/games/mm/CMakeLists.txt
+++ b/games/mm/CMakeLists.txt
@@ -412,8 +412,13 @@ if (CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang|AppleClang")
             -pthread
         )
 
+        # On macOS, we need to force-load libultraship to ensure all N64 OS
+        # function stubs (osCreateMesgQueue, osRecvMesg, etc.) are included
+        # in the shared library. Unlike Linux which uses -Wl,-export-dynamic,
+        # macOS requires -force_load to include all symbols from static archives.
         target_link_options(${PROJECT_NAME} PRIVATE
             -pthread
+            "LINKER:-force_load,$<TARGET_FILE:libultraship>"
         )
     elseif (CMAKE_SYSTEM_NAME STREQUAL "NintendoSwitch")
         target_compile_options(${PROJECT_NAME} PRIVATE

--- a/games/oot/CMakeLists.txt
+++ b/games/oot/CMakeLists.txt
@@ -547,8 +547,13 @@ if (CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang|AppleClang")
             -pthread
         )
 
+        # On macOS, we need to force-load libultraship to ensure all N64 OS
+        # function stubs (osCreateMesgQueue, osRecvMesg, etc.) are included
+        # in the shared library. Unlike Linux which uses -Wl,-export-dynamic,
+        # macOS requires -force_load to include all symbols from static archives.
         target_link_options(${PROJECT_NAME} PRIVATE
             -pthread
+            "LINKER:-force_load,$<TARGET_FILE:libultraship>"
         )
     elseif (CMAKE_SYSTEM_NAME STREQUAL "NintendoSwitch")
         target_compile_options(${PROJECT_NAME} PRIVATE


### PR DESCRIPTION
## Summary
- Fixes macOS build which was failing with undefined symbols for N64 OS functions
- Uses -force_load linker flag on macOS to ensure all libultraship symbols are included

Closes #75

## Test plan
- [ ] Re-enable macOS build job in CI (remove `if: false`)
- [ ] Verify macOS build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-windows.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/5215824495.zip)
  - [soh-linux.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/5215852986.zip)
<!--- section:artifacts:end -->