### PR TITLE
Fix duplicate Game enum definitions

### DIFF
--- a/combo/include/combo/CrossGameEntrance.h
+++ b/combo/include/combo/CrossGameEntrance.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "combo/Export.h"
+#include "combo/Game.h"
 
 /**
  * Cross-Game Entrance Infrastructure
@@ -20,15 +21,6 @@
 #include <vector>
 
 namespace Combo {
-
-/**
- * Game identifier enum
- */
-enum class Game : uint8_t {
-    None = 0,
-    OoT = 1,
-    MM = 2
-};
 
 /**
  * Represents a link between entrances in different games

--- a/combo/include/combo/Game.h
+++ b/combo/include/combo/Game.h
@@ -1,0 +1,24 @@
+#pragma once
+
+/**
+ * Game.h - Canonical definition of the Game enum
+ *
+ * This is the single source of truth for the Game enum used throughout
+ * the combo codebase. All headers that need the Game enum should include
+ * this file instead of defining their own.
+ */
+
+#include <cstdint>
+
+namespace Combo {
+
+/**
+ * Game identifier enum
+ */
+enum class Game : uint8_t {
+    None = 0,
+    OoT = 1,
+    MM = 2
+};
+
+} // namespace Combo

--- a/combo/include/combo/GameAPI.h
+++ b/combo/include/combo/GameAPI.h
@@ -20,6 +20,8 @@
 
 #pragma once
 
+#include "combo/Game.h"
+
 #include <cstdint>
 
 // Forward declarations for game types
@@ -27,19 +29,6 @@
 struct Actor;
 struct PlayState;
 struct SaveContext;
-
-namespace Combo {
-
-/**
- * Game identifier for runtime dispatch
- */
-enum class Game : uint8_t {
-    None = 0,
-    OoT = 1,
-    MM = 2
-};
-
-} // namespace Combo
 
 /**
  * OoT namespace - wrapper for OoT_* prefixed functions

--- a/combo/include/combo/GameArchives.h
+++ b/combo/include/combo/GameArchives.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "combo/Export.h"
+#include "combo/Game.h"
 #include <memory>
 #include <string>
 #include <unordered_map>
@@ -14,11 +15,6 @@ struct File;
 } // namespace Ship
 
 namespace Combo {
-
-enum class Game {
-    OOT,
-    MM
-};
 
 /**
  * Manages game-specific archive access for the combo randomizer.
@@ -81,7 +77,7 @@ private:
 
 // Convenience functions
 inline std::shared_ptr<Ship::File> LoadOoTFile(const std::string& path) {
-    return GameArchiveManager::Instance().LoadFile(Game::OOT, path);
+    return GameArchiveManager::Instance().LoadFile(Game::OoT, path);
 }
 
 inline std::shared_ptr<Ship::File> LoadMMFile(const std::string& path) {

--- a/combo/src/GameArchives.cpp
+++ b/combo/src/GameArchives.cpp
@@ -45,14 +45,14 @@ bool GameArchiveManager::HasFile(Game game, const std::string& path) const {
 }
 
 Game GameArchiveManager::GetFileOwner(const std::string& path) const {
-    bool inOoT = HasFile(Game::OOT, path);
+    bool inOoT = HasFile(Game::OoT, path);
     bool inMM = HasFile(Game::MM, path);
 
     if (inOoT && inMM) {
         throw std::runtime_error("File exists in both games: " + path);
     }
     if (inOoT) {
-        return Game::OOT;
+        return Game::OoT;
     }
     if (inMM) {
         return Game::MM;

--- a/combo/tests/game_archives_test.cpp
+++ b/combo/tests/game_archives_test.cpp
@@ -22,22 +22,22 @@ TEST_F(GameArchivesTest, InstanceIsSingleton) {
 }
 
 TEST_F(GameArchivesTest, InitiallyNoGamesLoaded) {
-    EXPECT_FALSE(GameArchiveManager::Instance().IsGameLoaded(Game::OOT));
+    EXPECT_FALSE(GameArchiveManager::Instance().IsGameLoaded(Game::OoT));
     EXPECT_FALSE(GameArchiveManager::Instance().IsGameLoaded(Game::MM));
 }
 
 TEST_F(GameArchivesTest, GetArchivesReturnsEmptyWhenNoneRegistered) {
-    auto archives = GameArchiveManager::Instance().GetArchives(Game::OOT);
+    auto archives = GameArchiveManager::Instance().GetArchives(Game::OoT);
     EXPECT_TRUE(archives.empty());
 }
 
 TEST_F(GameArchivesTest, HasFileReturnsFalseWhenNoArchives) {
-    EXPECT_FALSE(GameArchiveManager::Instance().HasFile(Game::OOT, "objects/object_link_boy/some_asset"));
+    EXPECT_FALSE(GameArchiveManager::Instance().HasFile(Game::OoT, "objects/object_link_boy/some_asset"));
     EXPECT_FALSE(GameArchiveManager::Instance().HasFile(Game::MM, "objects/object_link/some_asset"));
 }
 
 TEST_F(GameArchivesTest, LoadFileReturnsNullWhenNoArchives) {
-    auto file = GameArchiveManager::Instance().LoadFile(Game::OOT, "objects/object_link_boy/some_asset");
+    auto file = GameArchiveManager::Instance().LoadFile(Game::OoT, "objects/object_link_boy/some_asset");
     EXPECT_EQ(file, nullptr);
 }
 
@@ -49,14 +49,14 @@ TEST_F(GameArchivesTest, GetFileOwnerThrowsWhenNotFound) {
 }
 
 TEST_F(GameArchivesTest, RegisterNullArchiveIsNoOp) {
-    GameArchiveManager::Instance().RegisterArchive(Game::OOT, nullptr);
-    EXPECT_FALSE(GameArchiveManager::Instance().IsGameLoaded(Game::OOT));
+    GameArchiveManager::Instance().RegisterArchive(Game::OoT, nullptr);
+    EXPECT_FALSE(GameArchiveManager::Instance().IsGameLoaded(Game::OoT));
 }
 
 TEST_F(GameArchivesTest, ClearRemovesAllArchives) {
     // Even without registering real archives, Clear should work
     GameArchiveManager::Instance().Clear();
-    EXPECT_FALSE(GameArchiveManager::Instance().IsGameLoaded(Game::OOT));
+    EXPECT_FALSE(GameArchiveManager::Instance().IsGameLoaded(Game::OoT));
     EXPECT_FALSE(GameArchiveManager::Instance().IsGameLoaded(Game::MM));
 }
 


### PR DESCRIPTION
## Summary
- Consolidates duplicate `Game` enum definitions into a single location
- Fixes critical bug where two incompatible enum definitions existed
- Addresses Issue #94

## Test plan
- [ ] Verify only one Game enum definition exists
- [ ] Build passes on all platforms

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!--- section:artifacts:start -->
### Build Artifacts
  - [rsbs-windows.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/5216434968.zip)
  - [rsbs-linux.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/5216454507.zip)
<!--- section:artifacts:end -->