### PR TITLE
Remove debug std::cerr output from production code

### DIFF
--- a/combo/src/ComboContextBridge.cpp
+++ b/combo/src/ComboContextBridge.cpp
@@ -132,22 +132,14 @@ bool ComboContextBridge::SwitchGame(Game game) {
 }
 
 int ComboContextBridge::Init(int argc, char** argv) {
-    std::cerr << "[BRIDGE DEBUG] Init called, mActiveGame="
-              << static_cast<int>(mActiveGame) << std::endl;
-    std::cerr.flush();
-
     if (mActiveGame == Game::None) {
         std::cerr << "ComboContextBridge: No active game to initialize" << std::endl;
         return -1;
     }
 
     auto& state = mGames[mActiveGame];
-    std::cerr << "[BRIDGE DEBUG] Got state, initialized=" << state.initialized
-              << ", Init ptr=" << (void*)state.exports.Init << std::endl;
-    std::cerr.flush();
 
     if (state.initialized) {
-        std::cerr << "ComboContextBridge: Game already initialized" << std::endl;
         return 0;
     }
 
@@ -156,11 +148,7 @@ int ComboContextBridge::Init(int argc, char** argv) {
         return -1;
     }
 
-    std::cerr << "[BRIDGE DEBUG] Calling game's Init function..." << std::endl;
-    std::cerr.flush();
     int result = state.exports.Init(argc, argv);
-    std::cerr << "[BRIDGE DEBUG] Game Init returned " << result << std::endl;
-    std::cerr.flush();
 
     if (result == 0) {
         state.initialized = true;
@@ -193,36 +181,22 @@ void ComboContextBridge::Run() {
 }
 
 void ComboContextBridge::Shutdown() {
-    std::cerr << "[BRIDGE DEBUG] Shutdown called, mActiveGame="
-              << static_cast<int>(mActiveGame) << std::endl;
-    std::cerr.flush();
-
     if (mActiveGame == Game::None) {
-        std::cerr << "[BRIDGE DEBUG] No active game, returning" << std::endl;
         return;
     }
 
     auto& state = mGames[mActiveGame];
-    std::cerr << "[BRIDGE DEBUG] Got state, initialized=" << state.initialized << std::endl;
-    std::cerr.flush();
 
     if (!state.initialized) {
-        std::cerr << "[BRIDGE DEBUG] Game not initialized, returning" << std::endl;
         return;
     }
 
     if (state.exports.Shutdown) {
-        std::cerr << "[BRIDGE DEBUG] Calling game's Shutdown function..." << std::endl;
-        std::cerr.flush();
         state.exports.Shutdown();
-        std::cerr << "[BRIDGE DEBUG] Game Shutdown complete" << std::endl;
-        std::cerr.flush();
     }
 
     state.initialized = false;
     state.running = false;
-    std::cerr << "[BRIDGE DEBUG] Shutdown finished" << std::endl;
-    std::cerr.flush();
 }
 
 std::optional<std::string> ComboContextBridge::GetGameName(Game game) const {

--- a/combo/src/main.cpp
+++ b/combo/src/main.cpp
@@ -130,14 +130,8 @@ LONG WINAPI CrashHandler(EXCEPTION_POINTERS* exceptionInfo) {
     return EXCEPTION_CONTINUE_SEARCH;
 }
 
-void AtExitHandler() {
-    std::cerr << "\n[ATEXIT] Process is exiting via exit() or return from main" << std::endl;
-    std::cerr.flush();
-}
-
 void InstallCrashHandler() {
     SetUnhandledExceptionFilter(CrashHandler);
-    std::atexit(AtExitHandler);
 }
 #else
 // Unix signal handler
@@ -478,39 +472,25 @@ int main(int argc, char** argv) {
             if (targetPreInitialized) {
                 // INSTANT HOT-SWITCH: Target game is pre-initialized
                 // Skip Shutdown/Init - just switch the active game pointer
-                std::cerr << "[HOT-SWITCH] Target game is pre-initialized, performing instant switch" << std::endl;
-                std::cerr << "[HOT-SWITCH] Target game: " << Combo::GameToId(nextGame) << std::endl;
 
                 // Try to restore frozen state for the target game
                 const GameExports* exports = bridge.GetGameExports(nextGame);
                 if (exports && exports->LoadState) {
-                    std::cerr << "[HOT-SWITCH] Attempting to restore frozen state..." << std::endl;
-                    int loadResult = exports->LoadState(nullptr, 0);
-                    std::cerr << "[HOT-SWITCH] LoadState returned: " << loadResult
-                              << " (0=success, -1=no state)" << std::endl;
-                } else {
-                    std::cerr << "[HOT-SWITCH] No LoadState function available" << std::endl;
+                    exports->LoadState(nullptr, 0);
                 }
 
                 // For entrance-based switches, set up the target entrance
                 if (isEntranceSwitch && targetEntrance != 0) {
-                    std::cerr << "[HOT-SWITCH] Setting startup entrance to 0x"
-                              << std::hex << targetEntrance << std::dec << std::endl;
                     Combo_SetStartupEntrance(targetEntrance);
-                    std::cerr << "[HOT-SWITCH] Startup entrance set, verifying: 0x"
-                              << std::hex << Combo_GetStartupEntrance() << std::dec << std::endl;
                 }
 
                 // Just switch - no shutdown, no init needed
                 selected = nextGame;
                 bridge.SwitchGame(selected);
-                std::cerr << "[HOT-SWITCH] Switch complete, about to run "
-                          << bridge.GetGameName(selected).value_or("game") << std::endl;
                 // Loop continues, will run the new game
             } else {
                 // FALLBACK: Target game not pre-initialized (shouldn't happen normally)
                 // Use the old shutdown/init path
-                std::cerr << "[SWITCH DEBUG] Target not pre-initialized, using shutdown/init path" << std::endl;
 
                 // Shutdown current game
                 bridge.Shutdown();


### PR DESCRIPTION
## Summary
- Removes debug `std::cerr` output left in production code
- Addresses Issue #96

## Test plan
- [ ] No std::cerr output in combo/ directory
- [ ] Build passes

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!--- section:artifacts:start -->
### Build Artifacts
  - [rsbs-windows.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/5216433772.zip)
  - [rsbs-linux.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/5216464072.zip)
<!--- section:artifacts:end -->