### PR TITLE
Fix silent fallback in FrozenStateManager::GetState

### DIFF
--- a/combo/src/FrozenState.cpp
+++ b/combo/src/FrozenState.cpp
@@ -1,4 +1,5 @@
 #include "combo/FrozenState.h"
+#include <cassert>
 #include <cstring>
 #include <stdexcept>
 
@@ -156,22 +157,31 @@ void FrozenStateManager::UpdateShadowCopy(Game game, const void* saveContextData
 }
 
 FrozenGameState& FrozenStateManager::GetState(Game game) {
-    if (game == Game::OoT) {
-        return mOoTState;
-    } else if (game == Game::MM) {
-        return mMMState;
+    switch (game) {
+        case Game::OoT:
+            return mOoTState;
+        case Game::MM:
+            return mMMState;
+        case Game::None:
+            break;
     }
-    // Fallback - shouldn't happen
-    return mOoTState;
+    // Unreachable if Game enum is used correctly
+    assert(false && "Invalid Game value passed to GetState");
+    return mOoTState;  // Satisfy compiler, never reached
 }
 
 const FrozenGameState& FrozenStateManager::GetState(Game game) const {
-    if (game == Game::OoT) {
-        return mOoTState;
-    } else if (game == Game::MM) {
-        return mMMState;
+    switch (game) {
+        case Game::OoT:
+            return mOoTState;
+        case Game::MM:
+            return mMMState;
+        case Game::None:
+            break;
     }
-    return mOoTState;
+    // Unreachable if Game enum is used correctly
+    assert(false && "Invalid Game value passed to GetState");
+    return mOoTState;  // Satisfy compiler, never reached
 }
 
 } // namespace Combo


### PR DESCRIPTION
## Summary
- Fixes silent fallback that masked potential bugs
- Uses exhaustive switch with assert for invalid cases
- Addresses Issue #95

## Test plan
- [ ] GetState properly handles all Game enum values
- [ ] Build passes

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!--- section:artifacts:start -->
### Build Artifacts
  - [rsbs-windows.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/5216412589.zip)
  - [rsbs-linux.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/5216463336.zip)
<!--- section:artifacts:end -->