### PR TITLE
Implement ComboContext for cross-game state (WP-010)

### DIFF
--- a/rsbs/CMakeLists.txt
+++ b/rsbs/CMakeLists.txt
@@ -9,6 +9,7 @@ cmake_minimum_required(VERSION 3.14)
 add_library(rsbs STATIC
     # Files will be added as code is migrated
     src/placeholder.c
+    src/combo_context.c
 )
 
 target_include_directories(rsbs PUBLIC

--- a/rsbs/include/rsbs/combo_context.h
+++ b/rsbs/include/rsbs/combo_context.h
@@ -1,0 +1,33 @@
+#ifndef RSBS_COMBO_CONTEXT_H
+#define RSBS_COMBO_CONTEXT_H
+
+#include <stdint.h>
+#include <stdbool.h>
+
+typedef enum {
+    COMBO_GAME_NONE = 0,
+    COMBO_GAME_OOT = 1,
+    COMBO_GAME_MM = 2
+} ComboGame;
+
+typedef struct {
+    char magic[8];        // "OoT+MM<3"
+    uint32_t version;
+    bool switchRequested;
+    ComboGame targetGame;
+    uint16_t targetEntrance;
+    ComboGame sourceGame;
+    uint16_t sourceEntrance;
+    uint32_t sharedFlags[64];
+    uint16_t sharedItems[32];
+    int32_t saveSlot;
+} ComboContext;
+
+extern ComboContext gComboCtx;
+
+void ComboContext_Init(void);
+void ComboContext_RequestSwitch(ComboGame target, uint16_t entrance);
+bool ComboContext_IsSwitchPending(void);
+void ComboContext_ClearSwitch(void);
+
+#endif

--- a/rsbs/src/combo_context.c
+++ b/rsbs/src/combo_context.c
@@ -1,0 +1,43 @@
+/**
+ * @file combo_context.c
+ * @brief Cross-game context for OoT+MM unified engine
+ *
+ * Manages shared state between Ocarina of Time and Majora's Mask,
+ * including game switching, shared flags, and shared items.
+ */
+
+#include "rsbs/combo_context.h"
+#include <string.h>
+
+#define COMBO_CONTEXT_VERSION 1
+#define COMBO_CONTEXT_MAGIC "OoT+MM<3"
+
+ComboContext gComboCtx;
+
+void ComboContext_Init(void) {
+    memset(&gComboCtx, 0, sizeof(ComboContext));
+    memcpy(gComboCtx.magic, COMBO_CONTEXT_MAGIC, 8);
+    gComboCtx.version = COMBO_CONTEXT_VERSION;
+    gComboCtx.switchRequested = false;
+    gComboCtx.targetGame = COMBO_GAME_NONE;
+    gComboCtx.targetEntrance = 0;
+    gComboCtx.sourceGame = COMBO_GAME_NONE;
+    gComboCtx.sourceEntrance = 0;
+    gComboCtx.saveSlot = -1;
+}
+
+void ComboContext_RequestSwitch(ComboGame target, uint16_t entrance) {
+    gComboCtx.switchRequested = true;
+    gComboCtx.targetGame = target;
+    gComboCtx.targetEntrance = entrance;
+}
+
+bool ComboContext_IsSwitchPending(void) {
+    return gComboCtx.switchRequested;
+}
+
+void ComboContext_ClearSwitch(void) {
+    gComboCtx.switchRequested = false;
+    gComboCtx.targetGame = COMBO_GAME_NONE;
+    gComboCtx.targetEntrance = 0;
+}


### PR DESCRIPTION
## Summary
- Adds `ComboContext` structure for cross-game state sharing
- Implements game switching request/clear API
- Adds shared flags and items storage
- Part of WP-010 for RedShipBlueShip unified engine

## Test plan
- [ ] Build passes with new rsbs files
- [ ] ComboContext API is properly exported

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!--- section:artifacts:start -->
### Build Artifacts
  - [rsbs-windows.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/5216420051.zip)
  - [rsbs-linux.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/5216441705.zip)
<!--- section:artifacts:end -->