### PR TITLE
Migrate libultra/os functions to rsbs (WP-009 Batch 2)

### DIFF
--- a/games/mm/src/libultra/os/afterprenmi.c
+++ b/games/mm/src/libultra/os/afterprenmi.c
@@ -1,5 +1,0 @@
-#include "ultra64.h"
-
-s32 osAfterPreNMI(void) {
-    return __osSpSetPc(0);
-}

--- a/games/mm/src/libultra/os/getactivequeue.c
+++ b/games/mm/src/libultra/os/getactivequeue.c
@@ -1,5 +1,0 @@
-#include "ultra64.h"
-
-OSThread* __osGetActiveQueue(void) {
-    return __osActiveQueue;
-}

--- a/games/oot/src/libultra/os/afterprenmi.c
+++ b/games/oot/src/libultra/os/afterprenmi.c
@@ -1,6 +1,0 @@
-#include <libultraship/libultra.h>
-#include "global.h"
-
-s32 osAfterPreNMI(void) {
-    return __osSpSetPc(0);
-}

--- a/games/oot/src/libultra/os/getactivequeue.c
+++ b/games/oot/src/libultra/os/getactivequeue.c
@@ -1,5 +1,0 @@
-#include "global.h"
-
-OSThread* __osGetActiveQueue(void) {
-    return __osActiveQueue;
-}

--- a/rsbs/CMakeLists.txt
+++ b/rsbs/CMakeLists.txt
@@ -10,6 +10,10 @@ add_library(rsbs STATIC
     # Files will be added as code is migrated
     src/placeholder.c
     src/combo_context.c
+
+    # libultra/os - Unified OS functions (WP-009)
+    src/libultra/os/afterprenmi.c
+    src/libultra/os/getactivequeue.c
 )
 
 target_include_directories(rsbs PUBLIC

--- a/rsbs/src/libultra/os/afterprenmi.c
+++ b/rsbs/src/libultra/os/afterprenmi.c
@@ -1,0 +1,14 @@
+/**
+ * @file afterprenmi.c
+ * @brief Unified osAfterPreNMI implementation for OoT and MM
+ *
+ * Migrated from games/oot/src/libultra/os/afterprenmi.c
+ *           and games/mm/src/libultra/os/afterprenmi.c
+ */
+#include <libultraship/libultra.h>
+
+extern s32 __osSpSetPc(u32 pc);
+
+s32 osAfterPreNMI(void) {
+    return __osSpSetPc(0);
+}

--- a/rsbs/src/libultra/os/getactivequeue.c
+++ b/rsbs/src/libultra/os/getactivequeue.c
@@ -1,0 +1,14 @@
+/**
+ * @file getactivequeue.c
+ * @brief Unified __osGetActiveQueue implementation for OoT and MM
+ *
+ * Migrated from games/oot/src/libultra/os/getactivequeue.c
+ *           and games/mm/src/libultra/os/getactivequeue.c
+ */
+#include <libultraship/libultra.h>
+
+extern OSThread* __osActiveQueue;
+
+OSThread* __osGetActiveQueue(void) {
+    return __osActiveQueue;
+}


### PR DESCRIPTION
## Summary
- Migrates identical libultra/os functions from both games to shared rsbs/ library
- Part of WP-009: Migrate first batch of identical functions

## Test plan
- [ ] CI builds pass for Linux and Windows
- [ ] Both games link against shared rsbs library

🤖 Generated with [Claude Code](https://claude.ai/code)

<!--- section:artifacts:start -->
### Build Artifacts
  - [rsbs-windows.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/5216960165.zip)
  - [rsbs-linux.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/5216991789.zip)
<!--- section:artifacts:end -->