### PR TITLE
Add GetVersion() declaration to combo/Game.h header

### DIFF
--- a/combo/include/combo/Game.h
+++ b/combo/include/combo/Game.h
@@ -21,4 +21,10 @@ enum class Game : uint8_t {
     MM = 2
 };
 
+/**
+ * Get the combo library version string
+ * @return Version string (e.g., "0.1.0-dev")
+ */
+const char* GetVersion();
+
 } // namespace Combo

--- a/combo/tests/sanity_test.cpp
+++ b/combo/tests/sanity_test.cpp
@@ -1,4 +1,5 @@
 #include <gtest/gtest.h>
+#include "combo/Game.h"
 
 // Sanity tests to verify GoogleTest framework is working
 
@@ -17,10 +18,6 @@ TEST(SanityTest, StringComparison) {
 }
 
 // Placeholder test for combo library
-namespace Combo {
-    extern const char* GetVersion();
-}
-
 TEST(ComboTest, VersionExists) {
     const char* version = Combo::GetVersion();
     EXPECT_NE(version, nullptr);


### PR DESCRIPTION
## Summary
- Adds missing GetVersion() function declaration to combo/Game.h
- Fixes implicit function declaration warning

Closes #97

## Test plan
- [ ] Build succeeds without implicit function declaration warnings
- [ ] GetVersion() is callable from code that includes the header

🤖 Generated with [Claude Code](https://claude.ai/code)

<!--- section:artifacts:start -->
### Build Artifacts
  - [rsbs-linux.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/5223052231.zip)
  - [rsbs-windows.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/5223068463.zip)
<!--- section:artifacts:end -->