### PR TITLE
Skip submodule checkout when soh.o2r cache hits

### DIFF
--- a/.github/workflows/generate-builds.yml
+++ b/.github/workflows/generate-builds.yml
@@ -14,14 +14,15 @@ jobs:
     steps:
     - name: Git Checkout
       uses: actions/checkout@v4
-      with:
-        submodules: true
     - name: Restore soh.o2r Cache
       id: rsbs-otr-cache
       uses: actions/cache@v4
       with:
         key: rsbs-otr-v1-${{ hashFiles('games/**/*.c', 'games/**/*.h', 'games/**/*.xml', 'OTRExporter/**/*.cpp', 'OTRExporter/**/*.h', 'ZAPDTR/**/*.cpp', 'ZAPDTR/**/*.h') }}
         path: soh.o2r
+    - name: Checkout submodules
+      if: steps.rsbs-otr-cache.outputs.cache-hit != 'true'
+      run: git submodule update --init --recursive
     - name: Configure ccache
       if: steps.rsbs-otr-cache.outputs.cache-hit != 'true'
       uses: hendrikmuhs/ccache-action@v1.2


### PR DESCRIPTION
## Summary
- Skips submodule checkout in generate-rsbs-otr job when cache hits
- Reduces CI time when OTR is already cached
- Submodules are only needed when regenerating OTR

Closes #80

## Test plan
- [ ] When cache hits, submodules are not fetched
- [ ] When cache misses, submodules are still fetched and OTR generation works
- [ ] Workflow syntax is valid

🤖 Generated with [Claude Code](https://claude.ai/code)

<!--- section:artifacts:start -->
### Build Artifacts
  - [rsbs-windows.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/5223053523.zip)
  - [rsbs-linux.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/5223094247.zip)
<!--- section:artifacts:end -->