### PR TITLE
Add shallow clone to GitHub Actions checkout

### DIFF
--- a/.github/workflows/generate-builds.yml
+++ b/.github/workflows/generate-builds.yml
@@ -24,6 +24,8 @@ jobs:
     steps:
     - name: Git Checkout
       uses: actions/checkout@v4
+      with:
+        fetch-depth: 1
     - name: Restore soh.o2r Cache
       id: rsbs-otr-cache
       uses: actions/cache@v4
@@ -118,6 +120,7 @@ jobs:
       uses: actions/checkout@v4
       with:
         submodules: true
+        fetch-depth: 1
     - name: Configure ccache
       uses: hendrikmuhs/ccache-action@v1.2
       with:
@@ -194,6 +197,7 @@ jobs:
       uses: actions/checkout@v4
       with:
         submodules: true
+        fetch-depth: 1
     - name: Install dependencies
       run: |
         sudo apt-get update
@@ -326,6 +330,7 @@ jobs:
       uses: actions/checkout@v4
       with:
         submodules: true
+        fetch-depth: 1
     - name: Configure sccache
       uses: hendrikmuhs/ccache-action@v1.2
       with:


### PR DESCRIPTION
## Summary
- Adds fetch-depth: 1 to Git Checkout steps for faster CI
- Shallow clone significantly reduces checkout time
- Full history is not needed for builds

Closes #79

## Test plan
- [ ] All build jobs still work with shallow clone
- [ ] Checkout time is reduced
- [ ] Workflow syntax is valid

🤖 Generated with [Claude Code](https://claude.ai/code)

<!--- section:artifacts:start -->
### Build Artifacts
  - [rsbs-windows.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/5223036555.zip)
  - [rsbs-linux.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/5223062396.zip)
<!--- section:artifacts:end -->