### PR TITLE
CI: Unit Test Workflow for PR Verification

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,9 +10,18 @@ jobs:
     container:
       image: ghcr.io/spencerduncan/redshipblueship-build:latest
     steps:
+      - name: Install dependencies
+        run: |
+          apt-get update
+          apt-get install -y lsb-release git
+
       - uses: actions/checkout@v4
         with:
           submodules: recursive
+
+      - name: Configure git safe directory
+        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
+
       - name: Configure
         run: cmake -B build -DCMAKE_BUILD_TYPE=Release
       - name: Build


### PR DESCRIPTION
## Summary
- Adds GitHub Actions workflow that runs unit tests on every PR and push to main
- Uses the existing Docker build image (`ghcr.io/spencerduncan/redshipblueship-build:latest`)
- Runs cmake configure, build, and ctest with output on failure

## Test plan
- [ ] Verify workflow runs on this PR
- [ ] Verify ctest executes (may have no tests yet)

Closes #40

🤖 Generated with [Claude Code](https://claude.ai/code)

<!--- section:artifacts:start -->
### Build Artifacts
  - [rsbs-windows.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/5236912587.zip)
  - [rsbs-linux.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/5236935985.zip)
<!--- section:artifacts:end -->