### PR TITLE
Add unified CMake build system for single OoT+MM executable

### DIFF
--- a/pc/CMakeLists.txt
+++ b/pc/CMakeLists.txt
@@ -1,0 +1,287 @@
+# Unified Build System for RedShipBlueShip
+#
+# Produces a SINGLE executable containing both OoT and MM.
+# Both games are compiled as OBJECT libraries and linked together.
+#
+# Usage:
+#   cmake -B build -S pc
+#   cmake --build build
+#   ./build/redship --game oot
+#   ./build/redship --game mm
+
+cmake_minimum_required(VERSION 3.26.0 FATAL_ERROR)
+
+project(RedShipBlueShip VERSION 9.1.1 LANGUAGES C CXX)
+
+set(CMAKE_CXX_STANDARD 20)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_C_STANDARD 23)
+set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+
+# Get source root (parent of pc/)
+get_filename_component(SOURCE_ROOT "${CMAKE_CURRENT_SOURCE_DIR}/.." ABSOLUTE)
+
+# Include cmake modules from root project
+list(APPEND CMAKE_MODULE_PATH "${SOURCE_ROOT}/CMake")
+include(${SOURCE_ROOT}/CMake/Utils.cmake OPTIONAL)
+
+# Suppress warnings for decomp code
+option(SUPPRESS_WARNINGS "Suppress warnings in decomp code" ON)
+if(SUPPRESS_WARNINGS)
+    if(MSVC)
+        set(WARNING_OVERRIDE /w)
+    else()
+        set(WARNING_OVERRIDE -w)
+    endif()
+endif()
+
+# Platform detection
+if(CMAKE_SYSTEM_NAME STREQUAL "Windows")
+    include(${SOURCE_ROOT}/CMake/automate-vcpkg.cmake)
+    set(VCPKG_TRIPLET x64-windows-static)
+    vcpkg_bootstrap()
+    vcpkg_install_packages(zlib bzip2 libzip libpng sdl2 sdl2-net glew glfw3
+        nlohmann-json tinyxml2 spdlog libogg libvorbis opus opusfile)
+endif()
+
+# Find required packages
+find_package(PNG REQUIRED)
+find_package(Threads REQUIRED)
+
+# SDL2 - try multiple methods
+find_package(SDL2 QUIET)
+if(NOT TARGET SDL2::SDL2 AND NOT SDL2_FOUND)
+    find_package(PkgConfig QUIET)
+    if(PKG_CONFIG_FOUND)
+        pkg_check_modules(SDL2 QUIET sdl2)
+    endif()
+endif()
+
+# SDL2 is required but we defer the error to link time if not found
+if(NOT TARGET SDL2::SDL2 AND NOT SDL2_FOUND)
+    message(WARNING "SDL2 not found - build will fail at link time. Install libsdl2-dev.")
+endif()
+
+# GBI configuration
+set(GBI_UCODE F3DEX_GBI_2)
+add_compile_definitions(
+    F3DEX_GBI_2
+    CONTROLLERBUTTONS_T=uint32_t
+)
+
+# ==============================================================================
+# Dependencies (libultraship, ZAPDTR, rsbs)
+# ==============================================================================
+if(NOT TARGET libultraship)
+    add_subdirectory(${SOURCE_ROOT}/libultraship ${CMAKE_BINARY_DIR}/libultraship)
+endif()
+
+if(NOT TARGET ZAPDLib)
+    add_subdirectory(${SOURCE_ROOT}/ZAPDTR/ZAPD ${CMAKE_BINARY_DIR}/ZAPD)
+endif()
+
+if(NOT TARGET rsbs)
+    add_subdirectory(${SOURCE_ROOT}/rsbs ${CMAKE_BINARY_DIR}/rsbs)
+endif()
+
+# ==============================================================================
+# OoT OBJECT Library
+# ==============================================================================
+
+# Collect OoT sources
+file(GLOB_RECURSE OOT_SOH_SOURCES
+    "${SOURCE_ROOT}/games/oot/soh/*.c"
+    "${SOURCE_ROOT}/games/oot/soh/*.cpp"
+)
+file(GLOB_RECURSE OOT_SRC_SOURCES
+    "${SOURCE_ROOT}/games/oot/src/*.c"
+)
+file(GLOB OOT_INCLUDE_HEADERS
+    "${SOURCE_ROOT}/games/oot/include/*.h"
+)
+
+# Filter out excluded OoT sources
+list(FILTER OOT_SRC_SOURCES EXCLUDE REGEX "src/dmadata/")
+list(FILTER OOT_SRC_SOURCES EXCLUDE REGEX "src/elf_message/")
+list(FILTER OOT_SRC_SOURCES EXCLUDE REGEX "src/libultra/io/")
+list(FILTER OOT_SRC_SOURCES EXCLUDE REGEX "src/libultra/libc/")
+list(FILTER OOT_SRC_SOURCES EXCLUDE REGEX "src/libultra/os/")
+list(FILTER OOT_SRC_SOURCES EXCLUDE REGEX "src/libultra/rmon/")
+list(APPEND OOT_SRC_SOURCES "${SOURCE_ROOT}/games/oot/src/libultra/libc/sprintf.c")
+
+# Filter out GameExports.cpp (we use our adapter instead)
+list(FILTER OOT_SOH_SOURCES EXCLUDE REGEX "GameExports\\.cpp")
+
+# Platform-specific filtering for speech synthesizer
+if(CMAKE_SYSTEM_NAME STREQUAL "Windows")
+    list(FILTER OOT_SOH_SOURCES EXCLUDE REGEX "speechsynthesizer/Darwin")
+elseif(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
+    list(FILTER OOT_SOH_SOURCES EXCLUDE REGEX "speechsynthesizer/SAPI")
+else()
+    list(FILTER OOT_SOH_SOURCES EXCLUDE REGEX "speechsynthesizer/(Darwin|SAPI)")
+endif()
+
+add_library(oot_decomp OBJECT
+    ${OOT_SOH_SOURCES}
+    ${OOT_SRC_SOURCES}
+    ${CMAKE_CURRENT_SOURCE_DIR}/oot/GameAdapter.cpp
+)
+
+target_include_directories(oot_decomp PRIVATE
+    ${SOURCE_ROOT}/games/oot/include
+    ${SOURCE_ROOT}/games/oot/src
+    ${SOURCE_ROOT}/games/oot/soh
+    ${SOURCE_ROOT}/games/oot/assets
+    ${SOURCE_ROOT}/games/oot
+    ${SOURCE_ROOT}/libultraship/include
+    ${SOURCE_ROOT}/ZAPDTR/ZAPD/resource/type
+)
+
+target_compile_definitions(oot_decomp PRIVATE
+    INCLUDE_GAME_PRINTF
+    F3DEX_GBI_2
+    ENABLE_OPENGL
+)
+
+target_link_libraries(oot_decomp PRIVATE
+    libultraship
+    rsbs
+)
+
+if(SUPPRESS_WARNINGS)
+    target_compile_options(oot_decomp PRIVATE ${WARNING_OVERRIDE})
+endif()
+
+# ==============================================================================
+# MM OBJECT Library
+# ==============================================================================
+
+# Collect MM sources
+file(GLOB_RECURSE MM_2S2H_SOURCES
+    "${SOURCE_ROOT}/games/mm/2s2h/*.c"
+    "${SOURCE_ROOT}/games/mm/2s2h/*.cpp"
+)
+file(GLOB_RECURSE MM_SRC_SOURCES
+    "${SOURCE_ROOT}/games/mm/src/*.c"
+)
+file(GLOB MM_INCLUDE_HEADERS
+    "${SOURCE_ROOT}/games/mm/include/*.h"
+)
+
+# Filter out excluded MM sources
+list(FILTER MM_SRC_SOURCES EXCLUDE REGEX "src/dmadata/")
+list(FILTER MM_SRC_SOURCES EXCLUDE REGEX "src/elf_message/")
+list(FILTER MM_SRC_SOURCES EXCLUDE REGEX "src/libultra/")
+
+# Filter out GameExports.cpp (we use our adapter instead)
+list(FILTER MM_2S2H_SOURCES EXCLUDE REGEX "GameExports\\.cpp")
+
+add_library(mm_decomp OBJECT
+    ${MM_2S2H_SOURCES}
+    ${MM_SRC_SOURCES}
+    ${CMAKE_CURRENT_SOURCE_DIR}/mm/GameAdapter.cpp
+)
+
+target_include_directories(mm_decomp PRIVATE
+    ${SOURCE_ROOT}/games/mm/include
+    ${SOURCE_ROOT}/games/mm/include/PR
+    ${SOURCE_ROOT}/games/mm/src
+    ${SOURCE_ROOT}/games/mm/2s2h
+    ${SOURCE_ROOT}/games/mm/assets
+    ${SOURCE_ROOT}/games/mm
+    ${SOURCE_ROOT}/libultraship/include
+    ${SOURCE_ROOT}/ZAPDTR/ZAPD/resource/type
+)
+
+target_compile_definitions(mm_decomp PRIVATE
+    INCLUDE_GAME_PRINTF
+    F3DEX_GBI_2
+    ENABLE_OPENGL
+    NON_MATCHING
+    NON_EQUIVALENT
+)
+
+target_link_libraries(mm_decomp PRIVATE
+    libultraship
+    rsbs
+)
+
+if(SUPPRESS_WARNINGS)
+    target_compile_options(mm_decomp PRIVATE ${WARNING_OVERRIDE})
+endif()
+
+# ==============================================================================
+# Unified Executable
+# ==============================================================================
+
+add_executable(redship
+    ${CMAKE_CURRENT_SOURCE_DIR}/common/main.cpp
+    $<TARGET_OBJECTS:oot_decomp>
+    $<TARGET_OBJECTS:mm_decomp>
+)
+
+target_include_directories(redship PRIVATE
+    ${SOURCE_ROOT}/libultraship/include
+)
+
+# Link with SDL2 (handles both modern cmake config and pkg-config fallback)
+if(TARGET SDL2::SDL2)
+    set(SDL2_LINK SDL2::SDL2)
+else()
+    set(SDL2_LINK ${SDL2_LIBRARIES})
+    include_directories(${SDL2_INCLUDE_DIRS})
+endif()
+
+target_link_libraries(redship PRIVATE
+    libultraship
+    ZAPDLib
+    rsbs
+    ${SDL2_LINK}
+    Threads::Threads
+    ${CMAKE_DL_LIBS}
+)
+
+# Platform-specific linking
+if(CMAKE_SYSTEM_NAME STREQUAL "Windows")
+    find_package(glfw3 REQUIRED)
+    find_package(Ogg CONFIG REQUIRED)
+    find_package(Vorbis CONFIG REQUIRED)
+    find_package(Opus CONFIG REQUIRED)
+    find_package(OpusFile CONFIG REQUIRED)
+    target_link_libraries(redship PRIVATE
+        glfw
+        Ogg::ogg
+        Vorbis::vorbis
+        Vorbis::vorbisfile
+        Opus::opus
+        OpusFile::opusfile
+        glu32 winmm imm32 version setupapi
+    )
+elseif(NOT CMAKE_SYSTEM_NAME STREQUAL "Darwin")
+    find_package(Ogg REQUIRED)
+    find_package(Vorbis REQUIRED)
+    find_package(Opus REQUIRED)
+    find_package(OpusFile REQUIRED)
+    target_link_libraries(redship PRIVATE
+        Ogg::ogg
+        Vorbis::vorbis
+        Vorbis::vorbisfile
+        Opus::opus
+        Opusfile::Opusfile
+    )
+    target_link_options(redship PRIVATE -rdynamic)
+endif()
+
+set_target_properties(redship PROPERTIES
+    CXX_STANDARD 20
+    CXX_STANDARD_REQUIRED ON
+    RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}
+)
+
+# Install target
+install(TARGETS redship RUNTIME DESTINATION .)
+
+message(STATUS "Unified build configured:")
+message(STATUS "  OoT sources: ${CMAKE_CURRENT_SOURCE_DIR}/oot/GameAdapter.cpp + decomp")
+message(STATUS "  MM sources:  ${CMAKE_CURRENT_SOURCE_DIR}/mm/GameAdapter.cpp + decomp")
+message(STATUS "  Output:      ${CMAKE_BINARY_DIR}/redship")

--- a/pc/common/main.cpp
+++ b/pc/common/main.cpp
@@ -1,0 +1,188 @@
+/**
+ * RedShipBlueShip Unified Executable Entry Point
+ *
+ * Single executable containing both OoT and MM compiled as OBJECT libraries.
+ * This replaces the dynamic library loading approach with direct linking.
+ *
+ * Usage:
+ *   redship --game oot    # Run Ocarina of Time
+ *   redship --game mm     # Run Majora's Mask
+ *   redship --test boot-oot   # Test OoT boot
+ *   redship --test boot-mm    # Test MM boot
+ */
+
+#include <iostream>
+#include <string>
+#include <cstring>
+
+// Forward declarations for namespaced game functions
+// OoT functions (prefixed OoT_)
+extern "C" {
+    int OoT_Game_Init(int argc, char** argv);
+    void OoT_Game_Run(void);
+    void OoT_Game_Shutdown(void);
+    const char* OoT_Game_GetName(void);
+}
+
+// MM functions (prefixed MM_)
+extern "C" {
+    int MM_Game_Init(int argc, char** argv);
+    void MM_Game_Run(void);
+    void MM_Game_Shutdown(void);
+    const char* MM_Game_GetName(void);
+}
+
+enum class Game { None, OoT, MM };
+
+namespace {
+
+void PrintUsage(const char* progName) {
+    std::cout << "Usage: " << progName << " [OPTIONS]\n\n"
+              << "Options:\n"
+              << "  --game oot      Run Ocarina of Time\n"
+              << "  --game mm       Run Majora's Mask\n"
+              << "  --test boot-oot Test OoT boot sequence\n"
+              << "  --test boot-mm  Test MM boot sequence\n"
+              << "  --help          Show this help message\n\n"
+              << "If no game is specified, a menu will be displayed.\n";
+}
+
+Game ParseGameArg(int argc, char** argv) {
+    for (int i = 1; i < argc; i++) {
+        if (std::strcmp(argv[i], "--game") == 0 && i + 1 < argc) {
+            const char* game = argv[i + 1];
+            if (std::strcmp(game, "oot") == 0) return Game::OoT;
+            if (std::strcmp(game, "mm") == 0) return Game::MM;
+        }
+        if (std::strncmp(argv[i], "--game=", 7) == 0) {
+            const char* game = argv[i] + 7;
+            if (std::strcmp(game, "oot") == 0) return Game::OoT;
+            if (std::strcmp(game, "mm") == 0) return Game::MM;
+        }
+    }
+    return Game::None;
+}
+
+std::string ParseTestArg(int argc, char** argv) {
+    for (int i = 1; i < argc; i++) {
+        if (std::strcmp(argv[i], "--test") == 0 && i + 1 < argc) {
+            return argv[i + 1];
+        }
+        if (std::strncmp(argv[i], "--test=", 7) == 0) {
+            return argv[i] + 7;
+        }
+    }
+    return "";
+}
+
+Game ShowGameMenu() {
+    std::cout << "\n=== RedShipBlueShip ===\n\n"
+              << "Select a game:\n"
+              << "  1) Ocarina of Time\n"
+              << "  2) Majora's Mask\n\n"
+              << "Enter choice (1 or 2): ";
+
+    std::string input;
+    std::getline(std::cin, input);
+
+    if (input == "1" || input == "oot") return Game::OoT;
+    if (input == "2" || input == "mm") return Game::MM;
+
+    std::cerr << "Invalid choice. Defaulting to OoT.\n";
+    return Game::OoT;
+}
+
+int RunGame(Game game, int argc, char** argv) {
+    int result = 0;
+
+    switch (game) {
+        case Game::OoT:
+            std::cout << "Starting Ocarina of Time...\n";
+            result = OoT_Game_Init(argc, argv);
+            if (result != 0) {
+                std::cerr << "OoT initialization failed with code " << result << "\n";
+                return result;
+            }
+            OoT_Game_Run();
+            OoT_Game_Shutdown();
+            break;
+
+        case Game::MM:
+            std::cout << "Starting Majora's Mask...\n";
+            result = MM_Game_Init(argc, argv);
+            if (result != 0) {
+                std::cerr << "MM initialization failed with code " << result << "\n";
+                return result;
+            }
+            MM_Game_Run();
+            MM_Game_Shutdown();
+            break;
+
+        default:
+            std::cerr << "No game selected.\n";
+            return 1;
+    }
+
+    return 0;
+}
+
+int RunTest(const std::string& testName, int argc, char** argv) {
+    if (testName == "boot-oot") {
+        std::cout << "Test: Boot OoT\n";
+        // Initialize OoT but don't run the full loop
+        int result = OoT_Game_Init(argc, argv);
+        if (result == 0) {
+            std::cout << "OoT boot test PASSED\n";
+            OoT_Game_Shutdown();
+        }
+        return result;
+    }
+
+    if (testName == "boot-mm") {
+        std::cout << "Test: Boot MM\n";
+        // Initialize MM but don't run the full loop
+        int result = MM_Game_Init(argc, argv);
+        if (result == 0) {
+            std::cout << "MM boot test PASSED\n";
+            MM_Game_Shutdown();
+        }
+        return result;
+    }
+
+    if (testName == "list") {
+        std::cout << "Available tests:\n"
+                  << "  boot-oot    Boot OoT to initialization\n"
+                  << "  boot-mm     Boot MM to initialization\n";
+        return 0;
+    }
+
+    std::cerr << "Unknown test: " << testName << "\n";
+    return 1;
+}
+
+} // anonymous namespace
+
+int main(int argc, char** argv) {
+    // Check for help
+    for (int i = 1; i < argc; i++) {
+        if (std::strcmp(argv[i], "--help") == 0 || std::strcmp(argv[i], "-h") == 0) {
+            PrintUsage(argv[0]);
+            return 0;
+        }
+    }
+
+    // Check for test mode
+    std::string testArg = ParseTestArg(argc, argv);
+    if (!testArg.empty()) {
+        return RunTest(testArg, argc, argv);
+    }
+
+    // Parse game argument
+    Game selected = ParseGameArg(argc, argv);
+    if (selected == Game::None) {
+        selected = ShowGameMenu();
+    }
+
+    // Run the selected game
+    return RunGame(selected, argc, argv);
+}

--- a/pc/mm/GameAdapter.cpp
+++ b/pc/mm/GameAdapter.cpp
@@ -1,0 +1,126 @@
+/**
+ * MM Game Adapter for Unified Build
+ *
+ * Provides the prefixed game interface (MM_Game_*) for the unified
+ * single-executable build. This adapter bridges the main entry point
+ * to MM's internal initialization and game loop.
+ *
+ * The unified build compiles both OoT and MM as OBJECT libraries,
+ * requiring symbol namespacing to avoid collisions.
+ */
+
+#include <cstdio>
+#include <cstdlib>
+
+// =============================================================================
+// External declarations for MM internal functions
+// These functions come from the MM decomp code compiled as mm_decomp OBJECT
+// Note: MM uses different init paths than OoT - it uses InitOTR() (no args)
+// =============================================================================
+extern "C" {
+    // Initialization functions from 2s2h/
+    void InitOTR(void);
+    void DeinitOTR(void);
+
+    // Heap management from src/buffers/heaps.c (already prefixed)
+    void MM_Heaps_Alloc(void);
+    void MM_Heaps_Free(void);
+
+    // Game loop from src/code/graph.c (already prefixed)
+    void MM_Graph_ThreadEntry(void* arg);
+
+    // Low-level init from src/boot/
+    void Nmi_Init(void);
+    void MM_Fault_Init(void);
+    void Check_RegionIsSupported(void);
+    void Check_ExpansionPak(void);
+    void Regs_Init(void);
+
+    // System heap from src/code/
+    void MM_SystemHeap_Init(void* base, size_t size);
+
+    // Screen dimensions
+    extern int MM_gScreenWidth;
+    extern int MM_gScreenHeight;
+    extern unsigned long MM_gSystemHeap;
+
+    // Crash handler from 2s2h/
+    void CrashHandler_PrintExt(char* buffer, size_t* pos);
+    void CrashHandlerRegisterCallback(void (*callback)(char*, size_t*));
+}
+
+// Constants from MM's headers
+#define SCREEN_WIDTH 320
+#define SCREEN_HEIGHT 240
+#define SYSTEM_HEAP_SIZE 0x29000
+
+// =============================================================================
+// Prefixed game interface for unified executable
+// These are the entry points called by pc/common/main.cpp
+// =============================================================================
+extern "C" {
+
+/**
+ * Initialize MM game subsystems.
+ * Matches the initialization sequence from MM's original main().
+ */
+int MM_Game_Init(int argc, char** argv) {
+    (void)argc;
+    (void)argv;
+
+    fprintf(stderr, "[MM] Initializing...\n");
+
+    // Core initialization from 2s2h
+    InitOTR();
+    CrashHandlerRegisterCallback(CrashHandler_PrintExt);
+    MM_Heaps_Alloc();
+
+    // Set screen dimensions
+    MM_gScreenWidth = SCREEN_WIDTH;
+    MM_gScreenHeight = SCREEN_HEIGHT;
+
+    // Low-level initialization
+    Nmi_Init();
+    MM_Fault_Init();
+    Check_RegionIsSupported();
+    Check_ExpansionPak();
+    MM_SystemHeap_Init((void*)MM_gSystemHeap, SYSTEM_HEAP_SIZE);
+    Regs_Init();
+
+    fprintf(stderr, "[MM] Initialization complete.\n");
+    return 0;
+}
+
+/**
+ * Run MM's main game loop.
+ * This function typically doesn't return until the game exits.
+ */
+void MM_Game_Run(void) {
+    MM_Graph_ThreadEntry(nullptr);
+}
+
+/**
+ * Shutdown MM and release resources.
+ */
+void MM_Game_Shutdown(void) {
+    fprintf(stderr, "[MM] Shutting down...\n");
+    DeinitOTR();
+    MM_Heaps_Free();
+    fprintf(stderr, "[MM] Shutdown complete.\n");
+}
+
+/**
+ * Get the display name for MM.
+ */
+const char* MM_Game_GetName(void) {
+    return "Majora's Mask";
+}
+
+/**
+ * Get the short identifier for MM.
+ */
+const char* MM_Game_GetId(void) {
+    return "mm";
+}
+
+} // extern "C"

--- a/pc/oot/GameAdapter.cpp
+++ b/pc/oot/GameAdapter.cpp
@@ -1,0 +1,93 @@
+/**
+ * OoT Game Adapter for Unified Build
+ *
+ * Provides the prefixed game interface (OoT_Game_*) for the unified
+ * single-executable build. This adapter bridges the main entry point
+ * to OoT's internal initialization and game loop.
+ *
+ * The unified build compiles both OoT and MM as OBJECT libraries,
+ * requiring symbol namespacing to avoid collisions.
+ */
+
+#include <cstdio>
+#include <cstdlib>
+
+// =============================================================================
+// External declarations for OoT internal functions
+// These functions come from the OoT decomp code compiled as oot_decomp OBJECT
+// =============================================================================
+extern "C" {
+    // Initialization functions from soh/
+    void GameConsole_Init(void);
+    void InitOTR(int argc, char* argv[]);
+    void DeinitOTR(void);
+    void BootCommands_Init(void);
+
+    // Game loop from src/code/main.c
+    void Main(void* arg);
+
+    // Heap management from src/buffers/heaps.c
+    void OoT_Heaps_Alloc(void);
+    void OoT_Heaps_Free(void);
+
+    // Crash handler from soh/
+    void CrashHandler_PrintSohData(char* buffer, size_t* pos);
+    void CrashHandlerRegisterCallback(void (*callback)(char*, size_t*));
+}
+
+// =============================================================================
+// Prefixed game interface for unified executable
+// These are the entry points called by pc/common/main.cpp
+// =============================================================================
+extern "C" {
+
+/**
+ * Initialize OoT game subsystems.
+ * Matches the initialization sequence from soh's original main().
+ */
+int OoT_Game_Init(int argc, char** argv) {
+    fprintf(stderr, "[OoT] Initializing...\n");
+
+    GameConsole_Init();
+    InitOTR(argc, argv);
+    CrashHandlerRegisterCallback(CrashHandler_PrintSohData);
+    BootCommands_Init();
+    OoT_Heaps_Alloc();
+
+    fprintf(stderr, "[OoT] Initialization complete.\n");
+    return 0;
+}
+
+/**
+ * Run OoT's main game loop.
+ * This function typically doesn't return until the game exits.
+ */
+void OoT_Game_Run(void) {
+    Main(nullptr);
+}
+
+/**
+ * Shutdown OoT and release resources.
+ */
+void OoT_Game_Shutdown(void) {
+    fprintf(stderr, "[OoT] Shutting down...\n");
+    DeinitOTR();
+    OoT_Heaps_Free();
+    fprintf(stderr, "[OoT] Shutdown complete.\n");
+}
+
+/**
+ * Get the display name for OoT.
+ */
+const char* OoT_Game_GetName(void) {
+    return "Ocarina of Time";
+}
+
+/**
+ * Get the short identifier for OoT.
+ */
+const char* OoT_Game_GetId(void) {
+    return "oot";
+}
+
+} // extern "C"


### PR DESCRIPTION
## Summary
Introduces a new unified build system that compiles both Ocarina of Time and Majora's Mask as OBJECT libraries and links them into a single executable (`redship`). This replaces the previous approach of dynamic library loading with direct static linking, eliminating the need for separate game libraries.

## Key Changes

- **CMakeLists.txt**: New unified build configuration that:
  - Compiles OoT sources as `oot_decomp` OBJECT library
  - Compiles MM sources as `mm_decomp` OBJECT library
  - Links both into a single `redship` executable
  - Handles platform-specific dependencies (Windows VCPKG, Linux pkg-config, macOS)
  - Filters out conflicting sources (dmadata, libultra, GameExports.cpp)
  - Applies appropriate compiler flags and definitions per game

- **pc/common/main.cpp**: New unified entry point that:
  - Provides command-line interface (`--game oot|mm`, `--test boot-oot|boot-mm`)
  - Shows interactive menu if no game specified
  - Calls prefixed game initialization/run/shutdown functions
  - Handles both normal gameplay and boot testing modes

- **pc/oot/GameAdapter.cpp**: OoT adapter providing:
  - `OoT_Game_Init()`, `OoT_Game_Run()`, `OoT_Game_Shutdown()` interface
  - Bridges main entry point to OoT's internal initialization sequence
  - Manages heap allocation and crash handler registration

- **pc/mm/GameAdapter.cpp**: MM adapter providing:
  - `MM_Game_Init()`, `MM_Game_Run()`, `MM_Game_Shutdown()` interface
  - Bridges main entry point to MM's internal initialization sequence
  - Handles MM-specific initialization (InitOTR with no args, different heap setup)

## Implementation Details

- **Symbol Namespacing**: Both games' functions are prefixed (OoT_/MM_) to avoid linker collisions when compiled together
- **OBJECT Libraries**: Uses CMake OBJECT libraries to avoid separate .so/.dll files while maintaining clean separation
- **Platform Support**: Includes Windows (VCPKG), Linux (pkg-config), and macOS configurations
- **Source Filtering**: Carefully excludes conflicting sources (libultra, dmadata) that would cause duplicate symbols
- **Test Mode**: Supports boot testing without running the full game loop for validation

## Usage
```bash
cmake -B build -S pc
cmake --build build
./build/redship --game oot    # Run OoT
./build/redship --game mm     # Run MM
./build/redship               # Show menu
./build/redship --test boot-oot  # Test OoT initialization
```