### PR TITLE
Upgrade base image and compiler to Ubuntu 22.04 with GCC 11

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
-FROM ubuntu:20.04 as build
+FROM ubuntu:22.04 as build
 
 ENV LANG C.UTF-8
 ARG DEBIAN_FRONTEND=noninteractive
 
-ENV GCCVER=10
+ENV GCCVER=11
 RUN apt-get update && \
 	apt-get upgrade -y && \
 	apt-get install -y \
@@ -29,7 +29,7 @@ RUN apt-get update && \
 		ninja-build && \
 	apt-get install -y software-properties-common && \ 
 	wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null | gpg --dearmor - | tee /etc/apt/trusted.gpg.d/kitware.gpg >/dev/null && \
-	apt-add-repository "deb https://apt.kitware.com/ubuntu/ focal main" && \
+	apt-add-repository "deb https://apt.kitware.com/ubuntu/ jammy main" && \
 	apt-get update && \
 	apt-get upgrade -y && \
 	update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-${GCCVER} 10 && \


### PR DESCRIPTION
## Summary
This pull request updates the Docker build environment to use Ubuntu 22.04 LTS (Jammy) as the base image and upgrades the GCC compiler from version 10 to version 11.

## Key Changes
- **Base Image**: Updated from `ubuntu:20.04` (Focal) to `ubuntu:22.04` (Jammy)
- **Compiler**: Upgraded GCC from version 10 to version 11
- **Package Repository**: Updated CMake/Kitware APT repository from Focal to Jammy to match the new base image

## Details
These changes modernize the build environment to use a more recent Ubuntu LTS release and a newer compiler version. The Kitware repository URL was updated to use the correct Ubuntu codename (jammy) for the new base image, ensuring compatibility with the package manager and avoiding potential installation issues.