### PR TITLE
Fix Docker image to use CMake 3.26+ from Kitware repo

### DIFF
--- a/.github/docker/build-base.Dockerfile
+++ b/.github/docker/build-base.Dockerfile
@@ -3,6 +3,7 @@
 #
 # Build versions:
 #   - Ubuntu 22.04 (base)
+#   - CMake 3.26+ (from Kitware APT repo)
 #   - SDL2 2.30.3 (with hidapi-libusb support)
 #   - SDL2_net 2.2.0
 #   - tinyxml2 10.0.0 (with position-independent code)
@@ -16,6 +17,14 @@ LABEL org.opencontainers.image.description="Build environment for redshipblueshi
 # Prevent interactive prompts during package installation
 ENV DEBIAN_FRONTEND=noninteractive
 
+# Add Kitware APT repository for CMake 3.26+
+# Ubuntu 22.04's default cmake is 3.22.x, but we need 3.26+
+RUN apt-get update && apt-get install -y ca-certificates gpg wget \
+    && wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null | gpg --dearmor - | tee /usr/share/keyrings/kitware-archive-keyring.gpg >/dev/null \
+    && echo 'deb [signed-by=/usr/share/keyrings/kitware-archive-keyring.gpg] https://apt.kitware.com/ubuntu/ jammy main' | tee /etc/apt/sources.list.d/kitware.list >/dev/null \
+    && apt-get update \
+    && rm -rf /var/lib/apt/lists/*
+
 # Install apt dependencies
 # Note: We install libtinyxml2-dev initially but will replace it with a newer version
 RUN apt-get update && apt-get install -y \
@@ -23,7 +32,6 @@ RUN apt-get update && apt-get install -y \
     build-essential \
     cmake \
     git \
-    wget \
     # From apt-deps.txt
     libusb-dev \
     libusb-1.0-0-dev \


### PR DESCRIPTION
## Summary
- Adds Kitware APT repository for Ubuntu 22.04 (jammy)
- CMake is now installed from Kitware repo (provides 3.26+) instead of Ubuntu default (3.22)

## Why
CI workflows fail with:
```
CMake 3.26.0 or higher is required. You are running version 3.22.1
```

This was because `.github/docker/build-base.Dockerfile` used Ubuntu 22.04's default cmake package which is 3.22.x.

Note: PR #126 edited the wrong Dockerfile (root `/Dockerfile` instead of `.github/docker/build-base.Dockerfile`). This PR fixes the correct file.

## Test plan
- [ ] CI builds pass after Docker image is rebuilt
- [ ] Verify: `docker run <new-image> cmake --version` shows 3.26+

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!--- section:artifacts:start -->
### Build Artifacts
  - [rsbs-windows.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/5231930116.zip)
  - [rsbs-linux.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/5231961656.zip)
<!--- section:artifacts:end -->