### PR TITLE
Fix CI: Use gcc-11 instead of gcc-12 for Ubuntu 22.04

### DIFF
--- a/.github/workflows/generate-builds.yml
+++ b/.github/workflows/generate-builds.yml
@@ -302,8 +302,8 @@ jobs:
         mv README.md readme.txt
         mv build-cmake/*.appimage rsbs.appimage
       env:
-        CC: gcc-12
-        CXX: g++-12
+        CC: gcc-11
+        CXX: g++-11
     - name: Upload build
       uses: actions/upload-artifact@v4
       with:


### PR DESCRIPTION
## Summary
Updates CI workflow to use gcc-11/g++-11 instead of gcc-12/g++-12.

## Why
PR #127 upgraded the Docker image from Ubuntu 20.04 to 22.04. Ubuntu 22.04 has gcc-11 as default, not gcc-12. The workflow still referenced gcc-12 which caused build failures:

```
CMake Error: Could not find compiler set in environment variable CC: gcc-12.
```

## Changes
- `.github/workflows/generate-builds.yml`: Changed `CC: gcc-12` to `CC: gcc-11`
- `.github/workflows/generate-builds.yml`: Changed `CXX: g++-12` to `CXX: g++-11`

🤖 Generated with [Claude Code](https://claude.com/claude-code)