### PR TITLE
Add curl and pre-cache gamecontrollerdb.txt in Docker image

### DIFF
--- a/.github/docker/build-base.Dockerfile
+++ b/.github/docker/build-base.Dockerfile
@@ -56,6 +56,7 @@ RUN apt-get update && apt-get install -y \
     libzstd-dev \
     # Tools
     ccache \
+    curl \
     && rm -rf /var/lib/apt/lists/*
 
 # Create build directory for dependencies
@@ -110,6 +111,12 @@ RUN wget -q https://github.com/nih-at/libzip/releases/download/v1.10.1/libzip-1.
     && cp -av /usr/local/lib/libzip* /lib/x86_64-linux-gnu/ \
     && cd ../.. \
     && rm -rf libzip-1.10.1 libzip-1.10.1.tar.gz
+
+# Pre-download gamecontrollerdb.txt for SDL controller mappings
+# This avoids needing network access during cmake configure
+RUN mkdir -p /opt/redshipblueship \
+    && curl -sSfL -o /opt/redshipblueship/gamecontrollerdb.txt \
+       https://raw.githubusercontent.com/mdqinc/SDL_GameControllerDB/master/gamecontrollerdb.txt
 
 # Update library cache
 RUN ldconfig


### PR DESCRIPTION
## Summary
- Add curl to apt packages (needed by cmake for file downloads)
- Pre-download gamecontrollerdb.txt for SDL controller mappings

This prepares the Docker image for use as CI build container. The gamecontrollerdb.txt
is downloaded at image build time to avoid network access during cmake configure.

## Context
This is a prerequisite for #124 which switches Linux CI to use the Docker container.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!--- section:artifacts:start -->
### Build Artifacts
  - [rsbs-linux.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/5241410375.zip)
  - [rsbs-windows.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/5241411372.zip)
<!--- section:artifacts:end -->