### PR TITLE
Update CMakeLists.txt comment to reflect actual library purpose

### DIFF
--- a/rsbs/CMakeLists.txt
+++ b/rsbs/CMakeLists.txt
@@ -7,7 +7,7 @@ cmake_minimum_required(VERSION 3.14)
 # The goal is ONE unified game engine, not two games that switch.
 
 add_library(rsbs STATIC
-    # Placeholder (remove once real code is added)
+    # Core shared utilities
     src/placeholder.c
     src/combo_context.c
 


### PR DESCRIPTION
## Summary
Updated the placeholder comment in CMakeLists.txt to accurately describe the library's purpose as containing core shared utilities rather than being a temporary placeholder.

## Changes
- Changed comment from "Placeholder (remove once real code is added)" to "Core shared utilities" in the rsbs library definition
- This better reflects the current state of the library which now contains actual implementation files (combo_context.c and placeholder.c)

## Details
The comment update clarifies that the rsbs library is now a functional component containing shared utilities for the unified game engine, rather than a temporary placeholder awaiting implementation.

<!--- section:artifacts:start -->
### Build Artifacts
  - [rsbs-linux.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/5242718621.zip)
  - [rsbs-windows.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/5242722834.zip)
<!--- section:artifacts:end -->