### PR TITLE
Remove unused get_ast_summary function from ast_comparator

### DIFF
--- a/tools/lib/ast_comparator.py
+++ b/tools/lib/ast_comparator.py
@@ -293,31 +293,3 @@ def _find_differences(
             )
 
     return differences[:10]  # Limit to first 10 differences
-
-
-def get_ast_summary(code: str) -> Optional[str]:
-    """
-    Get a summary representation of the AST for a code snippet.
-
-    Args:
-        code: The C source code
-
-    Returns:
-        A string summary of the AST structure, or None if parsing failed
-    """
-    if not TREE_SITTER_AVAILABLE:
-        return None
-
-    root, valid, _ = parse_code(code)
-    if not valid or root is None:
-        return None
-
-    def summarize_node(node: "Node", depth: int = 0) -> List[str]:
-        indent = "  " * depth
-        lines = [f"{indent}{node.type}"]
-        for child in node.children:
-            if child.type not in ("comment",):
-                lines.extend(summarize_node(child, depth + 1))
-        return lines
-
-    return "\n".join(summarize_node(root))


### PR DESCRIPTION
## Summary
Removed the `get_ast_summary()` function from `tools/lib/ast_comparator.py` as it is no longer used in the codebase.

## Changes
- Deleted the `get_ast_summary()` function and its helper `summarize_node()` that generated a string representation of AST structure
- This function was not being called anywhere in the codebase and appears to have been superseded by other AST comparison functionality

## Rationale
Removing unused code reduces maintenance burden and keeps the codebase clean. The core AST comparison functionality in `_find_differences()` remains intact and provides the necessary AST analysis capabilities.

<!--- section:artifacts:start -->
### Build Artifacts
  - [rsbs-linux.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/5242731004.zip)
  - [rsbs-windows.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/5242734974.zip)
<!--- section:artifacts:end -->