### PR TITLE
Implement cross-game switching infrastructure for single-executable build

### DIFF
--- a/CMake/SingleExecutable.cmake
+++ b/CMake/SingleExecutable.cmake
@@ -18,6 +18,7 @@ message(STATUS "=== Single Executable Architecture Enabled ===")
 set(REDSHIP_COMMON_SOURCES
     ${CMAKE_SOURCE_DIR}/src/common/game.c
     ${CMAKE_SOURCE_DIR}/src/common/context.cpp
+    ${CMAKE_SOURCE_DIR}/src/common/switch.cpp
     ${CMAKE_SOURCE_DIR}/src/common/entrance.cpp
     ${CMAKE_SOURCE_DIR}/src/common/test_runner.cpp
     # Stub implementations for game entry points (until full integration)

--- a/games/mm/2s2h/BenPort.cpp
+++ b/games/mm/2s2h/BenPort.cpp
@@ -2111,3 +2111,56 @@ extern "C" bool Ship_HandleConsoleCrashAsReset() {
 
     return true;
 }
+
+// ============================================================================
+// Cross-game switching support (for single-executable architecture)
+// ============================================================================
+
+#ifdef SINGLE_EXECUTABLE_BUILD
+
+#include "common/context.h"
+
+extern "C" {
+
+/**
+ * Freeze MM game state before switching to OoT
+ * Called by Context_ProcessSwitch() in switch.cpp
+ *
+ * TODO: Implement actual state freezing:
+ * - Save the current SaveContext to frozen state
+ * - Save any additional transient state (actor positions, etc.)
+ * - Prepare for clean shutdown of MM systems
+ */
+void MM_FreezeState(ComboContext* ctx) {
+    (void)ctx; // Suppress unused parameter warning
+
+    // Stub implementation - actual implementation will:
+    // 1. Get pointer to gSaveContext
+    // 2. Call Context_FreezeState(GAME_MM, returnEntrance, &gSaveContext, sizeof(gSaveContext))
+    // 3. Save any additional state needed
+    fprintf(stderr, "[MM] FreezeState called (stub)\n");
+}
+
+/**
+ * Resume MM from a frozen state or start fresh from OoT
+ * Called by Context_ProcessSwitch() in switch.cpp
+ *
+ * TODO: Implement actual state resumption:
+ * - If returning (has frozen state): restore SaveContext and spawn at return entrance
+ * - If first switch: start fresh at the target entrance
+ * - Initialize MM systems as needed
+ */
+void MM_ResumeFromContext(ComboContext* ctx) {
+    (void)ctx; // Suppress unused parameter warning
+
+    // Stub implementation - actual implementation will:
+    // 1. Check if Context_HasFrozenState(GAME_MM)
+    // 2. If yes: Context_RestoreState(GAME_MM, &gSaveContext, sizeof(gSaveContext))
+    // 3. Set entrance to ctx->targetEntrance or return entrance
+    // 4. Trigger scene load
+    fprintf(stderr, "[MM] ResumeFromContext called (stub)\n");
+}
+
+} // extern "C"
+
+#endif // SINGLE_EXECUTABLE_BUILD

--- a/games/oot/soh/OTRGlobals.cpp
+++ b/games/oot/soh/OTRGlobals.cpp
@@ -2901,3 +2901,56 @@ bool SoH_HandleConfigDrop(char* filePath) {
 extern "C" void CheckTracker_RecalculateAvailableChecks() {
     CheckTracker::RecalculateAvailableChecks();
 }
+
+// ============================================================================
+// Cross-game switching support (for single-executable architecture)
+// ============================================================================
+
+#ifdef SINGLE_EXECUTABLE_BUILD
+
+#include "common/context.h"
+
+extern "C" {
+
+/**
+ * Freeze OoT game state before switching to MM
+ * Called by Context_ProcessSwitch() in switch.cpp
+ *
+ * TODO: Implement actual state freezing:
+ * - Save the current SaveContext to frozen state
+ * - Save any additional transient state (actor positions, etc.)
+ * - Prepare for clean shutdown of OoT systems
+ */
+void OoT_FreezeState(ComboContext* ctx) {
+    (void)ctx; // Suppress unused parameter warning
+
+    // Stub implementation - actual implementation will:
+    // 1. Get pointer to gSaveContext
+    // 2. Call Context_FreezeState(GAME_OOT, returnEntrance, &gSaveContext, sizeof(gSaveContext))
+    // 3. Save any additional state needed
+    fprintf(stderr, "[OoT] FreezeState called (stub)\n");
+}
+
+/**
+ * Resume OoT from a frozen state or start fresh from MM
+ * Called by Context_ProcessSwitch() in switch.cpp
+ *
+ * TODO: Implement actual state resumption:
+ * - If returning (has frozen state): restore SaveContext and spawn at return entrance
+ * - If first switch: start fresh at the target entrance
+ * - Initialize OoT systems as needed
+ */
+void OoT_ResumeFromContext(ComboContext* ctx) {
+    (void)ctx; // Suppress unused parameter warning
+
+    // Stub implementation - actual implementation will:
+    // 1. Check if Context_HasFrozenState(GAME_OOT)
+    // 2. If yes: Context_RestoreState(GAME_OOT, &gSaveContext, sizeof(gSaveContext))
+    // 3. Set entrance to ctx->targetEntrance or return entrance
+    // 4. Trigger scene load
+    fprintf(stderr, "[OoT] ResumeFromContext called (stub)\n");
+}
+
+} // extern "C"
+
+#endif // SINGLE_EXECUTABLE_BUILD

--- a/src/common/context.cpp
+++ b/src/common/context.cpp
@@ -168,6 +168,7 @@ FrozenStateManager gFrozenStates;
 #define COMBO_CONTEXT_VERSION 1
 
 ComboContext gComboCtx;
+GameId gCurrentGame = GAME_NONE;
 
 extern "C" {
 
@@ -198,6 +199,27 @@ void ComboContext_ClearSwitch(void) {
     gComboCtx.targetGame = GAME_NONE;
     gComboCtx.targetEntrance = 0;
 }
+
+// ============================================================================
+// High-level context API
+// ============================================================================
+
+void Context_Init(void) {
+    ComboContext_Init();
+    Context_InitFrozenStates();
+    gCurrentGame = GAME_NONE;
+}
+
+void Context_RequestSwitch(GameId target, uint16_t entrance) {
+    gComboCtx.sourceGame = gCurrentGame;
+    ComboContext_RequestSwitch(target, entrance);
+}
+
+bool Context_HasPendingSwitch(void) {
+    return ComboContext_IsSwitchPending();
+}
+
+// Note: Context_ProcessSwitch() is implemented in switch.cpp
 
 // ============================================================================
 // C API implementation

--- a/src/common/context.h
+++ b/src/common/context.h
@@ -104,11 +104,52 @@ typedef struct {
 } ComboContext;
 
 extern ComboContext gComboCtx;
+extern GameId gCurrentGame;
 
 void ComboContext_Init(void);
 void ComboContext_RequestSwitch(GameId target, uint16_t entrance);
 bool ComboContext_IsSwitchPending(void);
 void ComboContext_ClearSwitch(void);
+
+// ============================================================================
+// High-level context API (for switch.cpp and external use)
+// ============================================================================
+
+/**
+ * Initialize all context systems (frozen states + combo context)
+ */
+void Context_Init(void);
+
+/**
+ * Request a game switch to the target game at the specified entrance
+ */
+void Context_RequestSwitch(GameId target, uint16_t entrance);
+
+/**
+ * Check if a game switch has been requested
+ */
+bool Context_HasPendingSwitch(void);
+
+/**
+ * Process the pending game switch (called by main loop)
+ * This coordinates freezing current game state and launching target game
+ */
+void Context_ProcessSwitch(void);
+
+/**
+ * Check if a switch is currently being processed
+ */
+bool Context_IsSwitchInProgress(void);
+
+/**
+ * Set the current game (used during initialization)
+ */
+void Context_SetCurrentGame(GameId game);
+
+/**
+ * Get the current game
+ */
+GameId Context_GetCurrentGame(void);
 
 // ============================================================================
 // Legacy C API compatibility (maps to new functions)

--- a/src/common/switch.cpp
+++ b/src/common/switch.cpp
@@ -1,0 +1,182 @@
+/**
+ * @file switch.cpp
+ * @brief Game switching logic for cross-game transitions
+ *
+ * Coordinates the process of switching between OoT and MM:
+ * 1. Freeze current game state (save context + return entrance)
+ * 2. Update gCurrentGame to target
+ * 3. Resume target game from frozen state (or fresh start if first switch)
+ *
+ * The freeze/resume functions are implemented in each game's port layer:
+ * - OoT: games/oot/soh/OTRGlobals.cpp
+ * - MM:  games/mm/2s2h/BenPort.cpp
+ */
+
+#include "context.h"
+#include "entrance.h"
+#include <cstdio>
+
+// ============================================================================
+// Game-specific freeze/resume functions (implemented in game port layers)
+// ============================================================================
+
+extern "C" {
+
+/**
+ * Freeze OoT game state before switching away
+ * Saves the current SaveContext and any other necessary state
+ */
+void OoT_FreezeState(ComboContext* ctx);
+
+/**
+ * Resume OoT from a frozen state or start fresh
+ * Called when switching back to OoT (or starting OoT from MM)
+ */
+void OoT_ResumeFromContext(ComboContext* ctx);
+
+/**
+ * Freeze MM game state before switching away
+ * Saves the current SaveContext and any other necessary state
+ */
+void MM_FreezeState(ComboContext* ctx);
+
+/**
+ * Resume MM from a frozen state or start fresh
+ * Called when switching back to MM (or starting MM from OoT)
+ */
+void MM_ResumeFromContext(ComboContext* ctx);
+
+} // extern "C"
+
+// ============================================================================
+// Internal state
+// ============================================================================
+
+namespace {
+
+/**
+ * Track whether a switch is currently in progress
+ * Prevents re-entrancy during the switch process
+ */
+bool gSwitchInProgress = false;
+
+/**
+ * Freeze the current game's state
+ */
+void FreezeCurrentGame(void) {
+    if (gCurrentGame == GAME_NONE) {
+        return;
+    }
+
+    // Record source game info in combo context
+    gComboCtx.sourceGame = gCurrentGame;
+    gComboCtx.sourceEntrance = Entrance_GetSwitchReturnEntrance();
+
+    // Call game-specific freeze function
+    if (gCurrentGame == GAME_OOT) {
+        OoT_FreezeState(&gComboCtx);
+    } else if (gCurrentGame == GAME_MM) {
+        MM_FreezeState(&gComboCtx);
+    }
+
+    fprintf(stderr, "[Switch] Froze %s state, return entrance: 0x%04X\n",
+            Game_ToString(gCurrentGame), gComboCtx.sourceEntrance);
+}
+
+/**
+ * Resume the target game
+ */
+void ResumeTargetGame(GameId target) {
+    fprintf(stderr, "[Switch] Resuming %s at entrance 0x%04X\n",
+            Game_ToString(target), gComboCtx.targetEntrance);
+
+    // Set the startup entrance for the target game
+    Entrance_SetStartupEntrance(gComboCtx.targetEntrance);
+
+    // Call game-specific resume function
+    if (target == GAME_OOT) {
+        OoT_ResumeFromContext(&gComboCtx);
+    } else if (target == GAME_MM) {
+        MM_ResumeFromContext(&gComboCtx);
+    }
+
+    // Update current game
+    gCurrentGame = target;
+}
+
+} // anonymous namespace
+
+// ============================================================================
+// Public API
+// ============================================================================
+
+extern "C" {
+
+void Context_ProcessSwitch(void) {
+    // Check if a switch was requested
+    if (!Context_HasPendingSwitch()) {
+        return;
+    }
+
+    // Prevent re-entrancy
+    if (gSwitchInProgress) {
+        fprintf(stderr, "[Switch] Warning: Switch already in progress\n");
+        return;
+    }
+    gSwitchInProgress = true;
+
+    GameId target = gComboCtx.targetGame;
+    uint16_t targetEntrance = gComboCtx.targetEntrance;
+
+    fprintf(stderr, "[Switch] Processing switch: %s -> %s (entrance 0x%04X)\n",
+            Game_ToString(gCurrentGame),
+            Game_ToString(target),
+            targetEntrance);
+
+    // Validate target
+    if (target == GAME_NONE || target == gCurrentGame) {
+        fprintf(stderr, "[Switch] Invalid target game, aborting\n");
+        ComboContext_ClearSwitch();
+        gSwitchInProgress = false;
+        return;
+    }
+
+    // Step 1: Freeze current game state
+    FreezeCurrentGame();
+
+    // Step 2: Resume target game
+    ResumeTargetGame(target);
+
+    // Step 3: Clear the switch request
+    ComboContext_ClearSwitch();
+    Entrance_ClearPendingSwitch();
+
+    fprintf(stderr, "[Switch] Switch complete, now in %s\n",
+            Game_ToString(gCurrentGame));
+
+    gSwitchInProgress = false;
+}
+
+/**
+ * Get whether a switch is currently in progress
+ */
+bool Context_IsSwitchInProgress(void) {
+    return gSwitchInProgress;
+}
+
+/**
+ * Set the current game (used during initialization)
+ */
+void Context_SetCurrentGame(GameId game) {
+    gCurrentGame = game;
+    fprintf(stderr, "[Switch] Current game set to %s\n", Game_ToString(game));
+}
+
+/**
+ * Get the current game
+ */
+GameId Context_GetCurrentGame(void) {
+    return gCurrentGame;
+}
+
+} // extern "C"


### PR DESCRIPTION
## Summary
This PR implements the core infrastructure for switching between OoT and MM games in the single-executable architecture. It introduces a centralized game switching system that coordinates freezing the current game's state and resuming the target game.

## Key Changes

- **New `switch.cpp` module**: Implements `Context_ProcessSwitch()` which orchestrates the game switching process:
  - Freezes current game state (saves context and return entrance)
  - Calls game-specific resume functions to initialize the target game
  - Manages switch state to prevent re-entrancy
  - Provides logging for debugging

- **Extended `context.h/cpp`**: Added high-level context API:
  - `Context_Init()`: Initialize all context systems
  - `Context_RequestSwitch()`: Request a game switch with target and entrance
  - `Context_ProcessSwitch()`: Process pending switch (main entry point)
  - `Context_HasPendingSwitch()`: Check if switch requested
  - `Context_IsSwitchInProgress()`: Check if switch is being processed
  - `Context_SetCurrentGame()` / `Context_GetCurrentGame()`: Track active game
  - Added `gCurrentGame` global to track which game is currently running

- **Game-specific stubs**: Added placeholder freeze/resume functions in both game ports:
  - `OoT_FreezeState()` / `OoT_ResumeFromContext()` in `OTRGlobals.cpp`
  - `MM_FreezeState()` / `MM_ResumeFromContext()` in `BenPort.cpp`
  - These are marked with TODO comments for actual implementation
  - Currently log debug messages and suppress unused parameter warnings

- **CMake integration**: Added `switch.cpp` to `REDSHIP_COMMON_SOURCES` in `SingleExecutable.cmake`

## Implementation Details

The switching process follows this flow:
1. Game requests switch via `Context_RequestSwitch(target, entrance)`
2. Main loop calls `Context_ProcessSwitch()` at appropriate time
3. Current game state is frozen (SaveContext + return entrance saved)
4. Target game is resumed from frozen state or started fresh
5. `gCurrentGame` is updated to reflect new active game
6. Switch request is cleared

The actual state freezing/restoration logic is deferred to game-specific implementations, allowing each game to handle its unique save format and initialization requirements.

<!--- section:artifacts:start -->
### Build Artifacts
  - [rsbs-linux.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/5242896985.zip)
  - [rsbs-windows.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/5242898697.zip)
<!--- section:artifacts:end -->