### PR TITLE
Only run redship tests, exclude submodule tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,4 +27,4 @@ jobs:
       - name: Build
         run: cmake --build build -j$(nproc)
       - name: Test
-        run: ctest --test-dir build --output-on-failure
+        run: ctest --test-dir build --output-on-failure --label-regex "^redship$"

--- a/CMake/SingleExecutable.cmake
+++ b/CMake/SingleExecutable.cmake
@@ -133,12 +133,13 @@ if(BUILD_TESTING)
     add_test(NAME Context COMMAND redship --test context)
     add_test(NAME AllTests COMMAND redship --test all)
 
-    # Set reasonable timeout
+    # Set reasonable timeout and label our tests
     set(REDSHIP_TEST_TIMEOUT 60 CACHE STRING "Test timeout in seconds")
     set_tests_properties(
         BootOoT BootMM SwitchOoTMM SwitchMMOoT Roundtrip Context AllTests
         PROPERTIES
         TIMEOUT ${REDSHIP_TEST_TIMEOUT}
+        LABELS "redship"
     )
 endif()
 


### PR DESCRIPTION
## Summary
- Add 'redship' label to our tests in SingleExecutable.cmake
- Use `--label-regex` in CI to only run labeled tests
- Fixes prism test failure (libultraship dependency test that wasn't being built)

## Problem
The `prism` test from libultraship's `prism-processor` dependency was being registered via CTest but the executable wasn't built (since `PRISM_STANDALONE=OFF`). This caused CI failures.

## Solution
Label our tests with "redship" and only run tests with that label. This ensures we test our code, not our dependencies' tests.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)