### PR TITLE
Test: Re-enable macOS build with single-exe architecture

### DIFF
--- a/.github/workflows/generate-builds.yml
+++ b/.github/workflows/generate-builds.yml
@@ -109,10 +109,6 @@ jobs:
         path: deps
 
   build-macos:
-    # DISABLED: macOS build is currently broken - see GitHub issue for tracking
-    # Error: OoT shared library not linking against libultraship properly
-    # Re-enable once issue is resolved
-    if: false
     needs: generate-rsbs-otr
     runs-on: macos-14
     steps:
@@ -169,7 +165,7 @@ jobs:
     - name: Build SoH
       run: |
         export PATH="/usr/lib/ccache:/opt/homebrew/opt/ccache/libexec:/usr/local/opt/ccache/libexec:$PATH"
-        cmake --no-warn-unused-cli -H. -Bbuild-cmake -GNinja -DCMAKE_BUILD_TYPE:STRING=Release -DCMAKE_OSX_ARCHITECTURES="x86_64;arm64" -DBUILD_REMOTE_CONTROL=1 -DREDSHIP_BUILD_SHARED=ON
+        cmake --no-warn-unused-cli -H. -Bbuild-cmake -GNinja -DCMAKE_BUILD_TYPE:STRING=Release -DCMAKE_OSX_ARCHITECTURES="x86_64;arm64" -DBUILD_REMOTE_CONTROL=1
         cmake --build build-cmake --config Release --parallel 10
         (cd build-cmake && cpack)
 


### PR DESCRIPTION
Testing if macOS build works now that we use single-exe instead of shared libs.

Issues #75 and #112 were closed as obsolete - this tests that assumption.

<!--- section:artifacts:start -->
### Build Artifacts
  - [rsbs-linux.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/5331054781.zip)
  - [rsbs-windows.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/5331107206.zip)
<!--- section:artifacts:end -->