### PR TITLE
Implement entrance mapping for cross-game switching (#32)

### DIFF
--- a/games/mm/src/code/z_play.c
+++ b/games/mm/src/code/z_play.c
@@ -51,6 +51,8 @@ u8 sMotionBlurStatus;
 // Cross-game combo support - defined in GameExports.cpp
 extern uint16_t Combo_CheckEntranceSwitch(uint16_t entranceIndex);
 extern bool Combo_IsCrossGameSwitch(void);
+extern uint16_t Combo_GetStartupEntrance(void);
+extern void Combo_ClearStartupEntrance(void);
 
 s32 gDbgCamEnabled = false;
 u8 D_801D0D54 = false;
@@ -2236,6 +2238,16 @@ void MM_Play_Init(GameState* thisx) {
     s32 scene;
     u8 sceneLayer;
     s32 pad2;
+
+    // Cross-game combo: Check if we're entering from another game
+    {
+        uint16_t startupEntrance = Combo_GetStartupEntrance();
+        if (startupEntrance != 0) {
+            gSaveContext.save.entrance = startupEntrance;
+            Combo_ClearStartupEntrance();
+            // Note: Using PRINTF macro if available, or just skip logging
+        }
+    }
 
     if ((gSaveContext.respawnFlag == -4) || (gSaveContext.respawnFlag == -0x63)) {
         if (CHECK_EVENTINF(EVENTINF_TRIGGER_DAYTELOP)) {

--- a/games/oot/src/code/z_play.c
+++ b/games/oot/src/code/z_play.c
@@ -21,6 +21,10 @@
 #include <time.h>
 #include <assert.h>
 
+// Cross-game combo support - check for startup entrance from game switch
+extern uint16_t Combo_GetStartupEntrance(void);
+extern void Combo_ClearStartupEntrance(void);
+
 TransitionUnk sTrnsnUnk;
 s32 gTrnsnUnkState;
 VisMono gPlayVisMono;
@@ -384,6 +388,16 @@ void OoT_Play_Init(GameState* thisx) {
     s32 pad[2];
 
     enableBetaQuest();
+
+    // Cross-game combo: Check if we're entering from another game
+    {
+        uint16_t startupEntrance = Combo_GetStartupEntrance();
+        if (startupEntrance != 0) {
+            gSaveContext.entranceIndex = startupEntrance;
+            Combo_ClearStartupEntrance();
+            osSyncPrintf("[OoT] Cross-game switch: loading entrance 0x%04X\n", startupEntrance);
+        }
+    }
 
     // Properly initialize the frame counter so it doesn't use garbage data
     if (!firstInit) {


### PR DESCRIPTION
## Summary
Completes entrance mapping infrastructure so players can walk through linked doors and switch between games.

**Changes:**
- OoT `Play_Init`: Reads `Combo_GetStartupEntrance()` to load cross-game entrance
- MM `Play_Init`: Same - reads startup entrance on init
- New tests: `midos-house`, `startup-entrance`

## How It Works
1. Player enters Mido's House (OoT) or Happy Mask Shop
2. `Entrance_CheckCrossGame()` detects the link, flags pending switch
3. Game loop exits, launcher sets `Entrance_SetStartupEntrance(target)`
4. MM initializes, reads startup entrance, loads Clock Tower Interior

## Testing
```bash
# Run with test entrances (Mido's House - closer to spawn)
./redship --test-entrance --game oot

# Run automated tests
./redship --test midos-house
./redship --test startup-entrance
./redship --test all
```

## Test Plan
- [ ] `--test midos-house` passes
- [ ] `--test startup-entrance` passes  
- [ ] Manual: Start OoT with `--test-entrance`, enter Mido's House, verify MM loads at Clock Tower

Closes #32

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!--- section:artifacts:start -->
### Build Artifacts
  - [rsbs-linux.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/5247740112.zip)
  - [rsbs-windows.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/5247741967.zip)
<!--- section:artifacts:end -->