### PR TITLE
Wire up cross-game entrance hooks for single-exe mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -459,3 +459,5 @@ soh/properties.h
 /clang-format
 /clang-format.exe
 *.o2r
+Randomizer/
+.venv/

--- a/rsbs/src/main.cpp
+++ b/rsbs/src/main.cpp
@@ -242,12 +242,12 @@ int main(int argc, char** argv) {
     ComboContext_Init();
     Entrance_Init();
 
-    // Register entrance links (test or production)
+    // Register entrance links
+    Entrance_RegisterDefaultLinks();
+    // Also register test links (Mido's House) for easy testing
+    Entrance_RegisterTestLinks();
     if (HasTestEntranceFlag(argc, argv)) {
-        printf("Using TEST entrance: Mido's House <-> Clock Tower\n");
-        Entrance_RegisterTestLinks();
-    } else {
-        Entrance_RegisterDefaultLinks();
+        printf("Test entrance links also registered (Mido's House <-> Clock Tower)\n");
     }
 
     // Determine which game to run

--- a/src/common/mm_stubs.c
+++ b/src/common/mm_stubs.c
@@ -190,9 +190,8 @@ void SavingEnhancements_AdvancePlaytime(void) {}
 /* PauseOwlWarp stub */
 int PauseOwlWarp_IsOwlWarpEnabled(void) { return 0; }
 
-/* Combo stubs */
-int Combo_CheckEntranceSwitch(void) { return 0; }
-int Combo_CheckHotSwap(void) { return 0; }
+/* Combo_CheckEntranceSwitch and Combo_CheckHotSwap are now in
+ * GameExports_SingleExe.cpp (they need real cross-game logic) */
 
 /* OTR stubs */
 float OTRConvertHUDXToScreenX(float x) { return x; }


### PR DESCRIPTION
## Summary
- Move `Combo_CheckEntranceSwitch` and `Combo_CheckHotSwap` from guarded-out `GameExports.cpp` into `GameExports_SingleExe.cpp` with real cross-game logic
- Register Mido's House test links alongside default links for easy testing
- Remove broken stubs from `mm_stubs.c` (had wrong signatures)
- Add `Randomizer/` and `.venv/` to `.gitignore`

## Test plan
- [x] 8/8 infrastructure tests pass (`--test all`)
- [x] OoT boots and runs normally
- [x] Walking into Mido's House triggers cross-game switch (`[COMBO] Cross-game switch! entrance=0x0433`)
- [x] MM init begins (crashes during `MM_PadMgr_Init` — next PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!--- section:artifacts:start -->
### Build Artifacts
  - [rsbs-linux.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/5330360846.zip)
  - [rsbs-windows.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/5330392048.zip)
<!--- section:artifacts:end -->