### PR TITLE
Add LLVM lld-link linker support for faster Windows builds

### DIFF
--- a/.github/workflows/generate-builds.yml
+++ b/.github/workflows/generate-builds.yml
@@ -327,7 +327,7 @@ jobs:
     steps:
     - name: Install dependencies
       run: |
-        choco install ninja -y
+        choco install ninja llvm -y
         Remove-Item -Path "C:\ProgramData\Chocolatey\bin\ccache.exe" -Force -ErrorAction SilentlyContinue
     - name: Git Checkout
       uses: actions/checkout@v4
@@ -366,7 +366,7 @@ jobs:
         VCPKG_ROOT: ${{github.workspace}}/vcpkg
       run: |
         set $env:PATH="$env:USERPROFILE/.cargo/bin;$env:PATH"
-        cmake -S . -B bw -G Ninja -DCMAKE_MAKE_PROGRAM=ninja -DCMAKE_BUILD_TYPE:STRING=Release -DCMAKE_C_COMPILER_LAUNCHER=sccache -DCMAKE_CXX_COMPILER_LAUNCHER=sccache -DBUILD_REMOTE_CONTROL=1 -DREDSHIP_BUILD_SHARED=ON
+        cmake -S . -B bw -G Ninja -DCMAKE_MAKE_PROGRAM=ninja -DCMAKE_BUILD_TYPE:STRING=Release -DCMAKE_C_COMPILER_LAUNCHER=sccache -DCMAKE_CXX_COMPILER_LAUNCHER=sccache -DBUILD_REMOTE_CONTROL=1 -DREDSHIP_BUILD_SHARED=ON -DUSE_LLD_LINKER=ON
         cmake --build bw --config Release --parallel 10
 
         (cd bw && cpack)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,6 +15,7 @@ set(SPDLOG_MIN_CUTOFF SPDLOG_LEVEL_TRACE CACHE STRING "cutoff at trace")
 
 option(SUPPRESS_WARNINGS "Suppress warnings in LUS and src (decomp)" ON)
 option(SINGLE_EXECUTABLE_BUILD "Build single redship executable (replaces dynamic library loading)" ON)
+option(USE_LLD_LINKER "Use LLVM's lld-link instead of MSVC linker (faster linking)" OFF)
 
 # Always enable position-independent code - required for shared library builds
 # This repo is specifically for the unified combo project (shared libraries only)
@@ -35,6 +36,25 @@ if (CMAKE_SYSTEM_NAME STREQUAL "Windows")
             set(CMAKE_MSVC_DEBUG_INFORMATION_FORMAT Embedded)
         else()
             set(CMAKE_MSVC_DEBUG_INFORMATION_FORMAT "")
+        endif()
+    endif()
+
+    # Use LLVM's lld-link for faster linking (2-5x faster than MSVC linker)
+    # Requires LLVM to be installed (e.g., via 'choco install llvm')
+    # lld-link supports /FORCE:MULTIPLE needed for single-exe builds
+    if(USE_LLD_LINKER)
+        find_program(LLD_LINK_EXECUTABLE lld-link
+            HINTS
+                "$ENV{LLVM_PATH}/bin"
+                "C:/Program Files/LLVM/bin"
+            PATHS
+                "$ENV{ProgramFiles}/LLVM/bin"
+        )
+        if(LLD_LINK_EXECUTABLE)
+            message(STATUS "Using lld-link for faster linking: ${LLD_LINK_EXECUTABLE}")
+            set(CMAKE_LINKER "${LLD_LINK_EXECUTABLE}" CACHE FILEPATH "Linker" FORCE)
+        else()
+            message(WARNING "USE_LLD_LINKER enabled but lld-link not found. Install LLVM or set LLVM_PATH.")
         endif()
     endif()
 endif()


### PR DESCRIPTION
## Summary
This PR adds support for using LLVM's `lld-link` linker on Windows builds, which can provide 2-5x faster linking times compared to the default MSVC linker.

## Changes
- **CMakeLists.txt**: Added `USE_LLD_LINKER` CMake option (disabled by default) that:
  - Searches for `lld-link` executable in common LLVM installation paths
  - Configures CMake to use `lld-link` as the linker when found
  - Provides helpful warning if option is enabled but `lld-link` is not available
  - Includes documentation about LLVM installation requirement

- **GitHub Actions Workflow**: Updated Windows build job to:
  - Install LLVM via Chocolatey alongside Ninja
  - Enable `USE_LLD_LINKER=ON` in the CMake configuration

## Implementation Details
- The linker search checks multiple standard LLVM installation paths:
  - `$LLVM_PATH/bin` (environment variable)
  - `C:/Program Files/LLVM/bin` (default Chocolatey installation)
  - `$ProgramFiles/LLVM/bin` (alternative Windows path)
- The feature is opt-in via CMake flag to maintain compatibility with existing builds
- `lld-link` supports the `/FORCE:MULTIPLE` flag needed for single-executable builds

https://claude.ai/code/session_01KebDPPv5qsmru1Woq839y4

<!--- section:artifacts:start -->
### Build Artifacts
  - [rsbs-linux.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/5331013332.zip)
  - [rsbs-windows.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/5331059742.zip)
<!--- section:artifacts:end -->