### PR TITLE
Add documentation section to README and error handling policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,14 @@ redshipblueship/
 └── OTRExporter/      # OTR generation
 ```
 
+## Documentation
+
+- [Building](docs/BUILDING.md) - Build instructions
+- [Error Handling Policy](docs/error-handling.md) - Error handling patterns and guidelines
+- [Modding](docs/MODDING.md) - Modding guide
+- [Custom Music](docs/CUSTOM_MUSIC.md) - Custom music support
+- [Credits](docs/CREDITS.md) - Full credits
+
 ## Quick Start (Once Built)
 
 1. Place `oot.z64` and `mm.z64` ROMs in the game directory

--- a/docs/error-handling.md
+++ b/docs/error-handling.md
@@ -1,0 +1,60 @@
+# Error Handling Policy
+
+## Principles
+
+1. **No silent failures** - Every error must be surfaced
+2. **Appropriate mechanisms** - Match error handling to context
+3. **Predictable behavior** - Same patterns across codebase
+
+## Patterns by Context
+
+### C APIs (Cross-DLL boundaries)
+- Return error codes (int or enum)
+- Use out parameters for results
+- Document error codes in header comments
+
+### C++ Internals
+- Use exceptions for programming errors (logic bugs)
+- Use `std::optional<T>` for expected "not found" cases
+- Use `std::expected<T, E>` (C++23) or custom `Result<T>` for recoverable errors
+
+### Resource Acquisition
+- Always use RAII (`ScopedLibrary`, smart pointers)
+- Cleanup in destructors, not manual calls
+- Document ownership transfers
+
+### Logging
+- Use libultraship logging, not `std::cerr`
+- Debug output must be gated by log level
+- No unconditional stderr in production code
+
+## Anti-Patterns (Don't Do)
+
+```cpp
+// BAD: Silent null return
+void* GetThing() { return nullptr; }
+
+// BAD: Debug spam
+std::cerr << "[DEBUG]" << x << std::endl;
+
+// BAD: Swallowed exception
+try { ... } catch (...) { }
+```
+
+## Examples
+
+```cpp
+// GOOD: C API with error code
+int Combo_LoadGame(Game game, GameState* out_state) {
+    if (game == Game::None) return COMBO_ERR_INVALID_GAME;
+    // ...
+    return COMBO_SUCCESS;
+}
+
+// GOOD: C++ with optional
+std::optional<Entrance> FindEntrance(uint16_t id) {
+    auto it = entrances.find(id);
+    if (it == entrances.end()) return std::nullopt;
+    return it->second;
+}
+```


### PR DESCRIPTION
## Summary
This PR adds comprehensive documentation to the project by introducing a new Documentation section in the README and establishing a formal Error Handling Policy document.

## Changes
- **README.md**: Added a new "Documentation" section with links to key guides:
  - Building instructions
  - Error handling patterns and guidelines
  - Modding guide
  - Custom music support
  - Credits

- **docs/error-handling.md**: Created a new error handling policy document that establishes:
  - Core principles (no silent failures, appropriate mechanisms, predictable behavior)
  - Context-specific patterns for C APIs, C++ internals, resource acquisition, and logging
  - Anti-patterns to avoid with code examples
  - Best practice examples for both C and C++ code

## Implementation Details
The error handling policy provides clear guidance on:
- Using error codes and out parameters for cross-DLL C APIs
- Leveraging exceptions, `std::optional`, and `std::expected` for C++ internals
- Enforcing RAII patterns for resource management
- Standardizing on libultraship logging instead of direct stderr output

This establishes a foundation for consistent error handling practices across the codebase and makes it easier for contributors to understand expected patterns.

https://claude.ai/code/session_018eCv8WhaBQBN8VLts2NPKm