### PR TITLE
Fix Ship::Context singleton for single-exe mode

### DIFF
--- a/games/oot/soh/OTRGlobals.cpp
+++ b/games/oot/soh/OTRGlobals.cpp
@@ -264,6 +264,19 @@ const char* constCameraStrings[] = {
 };
 
 OTRGlobals::OTRGlobals() {
+#ifdef RSBS_SINGLE_EXECUTABLE
+    // In single-exe mode, Ship::Context may already exist from main.cpp.
+    // Reuse it instead of creating a new one to maintain singleton integrity.
+    // This fixes issue #184 where OTRGlobals and MM's BenPort both define
+    // OTRGlobals::Instance, causing the weak_ptr singleton to break.
+    auto existing = Ship::Context::GetInstance();
+    if (existing) {
+        context = existing;
+        fprintf(stderr, "[OoT] Reusing existing Ship::Context singleton\n");
+        return;
+    }
+#endif
+    // Standalone mode: create our own context
     context = Ship::Context::CreateUninitializedInstance("Ship of Harkinian", appShortName, "shipofharkinian.json");
 }
 

--- a/rsbs/src/main.cpp
+++ b/rsbs/src/main.cpp
@@ -239,13 +239,39 @@ int main(int argc, char** argv) {
     }
 
     // ========================================================================
+    // Create Ship::Context singleton early - before any game init (issue #184)
+    // This ensures the singleton exists before OTRGlobals can interfere.
+    // Games will detect the existing context and reuse it.
+    // ========================================================================
+    fprintf(stderr, "[RSBS] About to create Ship::Context singleton...\n");
+    fflush(stderr);
+    auto shipContext = Ship::Context::CreateUninitializedInstance(
+        "RedShip", "redship", "redship.json");
+    fprintf(stderr, "[RSBS] CreateUninitializedInstance returned: %p\n", (void*)shipContext.get());
+    fflush(stderr);
+    if (!shipContext) {
+        fprintf(stderr, "[RSBS] FATAL: Failed to create Ship::Context singleton\n");
+        return 1;
+    }
+    fprintf(stderr, "[RSBS] Ship::Context singleton created successfully at %p\n", (void*)shipContext.get());
+    fflush(stderr);
+
+    // ========================================================================
     // Set up GameRunner with composable lifecycle
     // ========================================================================
 
+    fprintf(stderr, "[RSBS] Creating GameRunner...\n");
+    fflush(stderr);
     GameRunner runner;
     GameRunner_Init(&runner);
+    fprintf(stderr, "[RSBS] Registering OoT...\n");
+    fflush(stderr);
     GameRunner_RegisterGame(&runner, GAME_OOT, OoT_GetGameOps());
+    fprintf(stderr, "[RSBS] Registering MM...\n");
+    fflush(stderr);
     GameRunner_RegisterGame(&runner, GAME_MM, MM_GetGameOps());
+    fprintf(stderr, "[RSBS] Games registered\n");
+    fflush(stderr);
 
     // Determine which game to run
     GameId selectedGame = ParseGameArg(argc, argv);


### PR DESCRIPTION
## Summary
- Create Ship::Context singleton in main.cpp **before** any game init
- OTRGlobals constructor detects existing context and reuses it
- Fixes #184 (OoT crashes on first frame)

## Root Cause
Both OoT (`OTRGlobals.cpp`) and MM (`BenPort.cpp`) define `class OTRGlobals` with `static OTRGlobals* Instance`. In single-exe mode with `--start-group/--end-group` linking, the linker merges these symbols. This causes the `Ship::Context::mContext` weak_ptr singleton pattern to break - the weak_ptr ends up empty even though `OTRGlobals::Instance->context` holds a valid shared_ptr.

## Fix
1. **main.cpp**: Create `Ship::Context` early via `CreateUninitializedInstance()`
2. **OTRGlobals**: Constructor checks `GetInstance()` and reuses existing context
3. `#ifdef RSBS_SINGLE_EXECUTABLE` guards preserve standalone SoH behavior

## Test plan
- [x] All 9 integration tests pass (including 13 lifecycle unit tests)
- [x] OoT boot verified - gets past `CVarGetInteger` crash
- [ ] CI passes

## Notes
Game now hits a different (unrelated) crash in `sqrtf` infinite recursion - that's a separate issue to address next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!--- section:artifacts:start -->
### Build Artifacts
  - [rsbs-linux.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/5332327502.zip)
  - [rsbs-windows.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/5332362719.zip)
<!--- section:artifacts:end -->