### PR TITLE
Fix extractor asset paths and improve error handling

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -299,12 +299,15 @@ if(NOT SINGLE_EXECUTABLE_BUILD)
     install(TARGETS 2ship LIBRARY DESTINATION . COMPONENT ship)
 endif()
 install(FILES "${CMAKE_BINARY_DIR}/soh/soh.o2r" DESTINATION . COMPONENT ship)
-install(TARGETS ZAPD_OoT DESTINATION ./assets/extractor COMPONENT extractor)
-install(DIRECTORY "${CMAKE_SOURCE_DIR}/games/oot/assets/extractor/" DESTINATION ./assets COMPONENT extractor)
-install(DIRECTORY "${CMAKE_SOURCE_DIR}/games/oot/assets/xml/" DESTINATION ./assets/xml COMPONENT extractor)
-install(TARGETS ZAPD_MM DESTINATION ./assets/extractor COMPONENT extractor)
-install(DIRECTORY "${CMAKE_SOURCE_DIR}/games/mm/assets/extractor/" DESTINATION ./assets COMPONENT extractor)
-install(DIRECTORY "${CMAKE_SOURCE_DIR}/games/mm/assets/xml/" DESTINATION ./assets/xml COMPONENT extractor)
+# Install extractor assets to usr/bin/assets/ so they are relative to the executable.
+# linuxdeploy places the executable at usr/bin/, and GetAppBundlePath() returns that path.
+# The extraction code looks for assets at GetAppBundlePath() + "/assets".
+install(TARGETS ZAPD_OoT DESTINATION usr/bin/assets/extractor COMPONENT extractor)
+install(DIRECTORY "${CMAKE_SOURCE_DIR}/games/oot/assets/extractor/" DESTINATION usr/bin/assets COMPONENT extractor)
+install(DIRECTORY "${CMAKE_SOURCE_DIR}/games/oot/assets/xml/" DESTINATION usr/bin/assets/xml COMPONENT extractor)
+install(TARGETS ZAPD_MM DESTINATION usr/bin/assets/extractor COMPONENT extractor)
+install(DIRECTORY "${CMAKE_SOURCE_DIR}/games/mm/assets/extractor/" DESTINATION usr/bin/assets COMPONENT extractor)
+install(DIRECTORY "${CMAKE_SOURCE_DIR}/games/mm/assets/xml/" DESTINATION usr/bin/assets/xml COMPONENT extractor)
 endif()
 
 if ("${CMAKE_SYSTEM_NAME}" STREQUAL "Windows")

--- a/games/mm/2s2h/Extractor/Extract.cpp
+++ b/games/mm/2s2h/Extractor/Extract.cpp
@@ -550,14 +550,25 @@ bool Extractor::CallZapd(std::string installPath, std::string exportdir) {
     std::string romPath = std::filesystem::absolute(mCurrentRomPath).string();
     installPath = std::filesystem::absolute(installPath).string();
     exportdir = std::filesystem::absolute(exportdir).string();
+
+    std::string assetsPath = installPath + "/assets";
+
+    // Verify assets directory exists before proceeding
+    if (!std::filesystem::exists(assetsPath)) {
+        std::string errMsg = "Extractor assets not found at: " + assetsPath +
+                             "\n\nThis may indicate a packaging issue with the AppImage or installation.";
+        ShowErrorBox("Extraction Failed", errMsg.c_str());
+        return false;
+    }
+
     // Work this out in the temporary folder
     std::string tempdir = Mkdtemp();
     std::string curdir = std::filesystem::current_path().string();
 #ifdef _WIN32
-    std::filesystem::copy(installPath + "/assets", tempdir + "/assets",
+    std::filesystem::copy(assetsPath, tempdir + "/assets",
                           std::filesystem::copy_options::recursive | std::filesystem::copy_options::update_existing);
 #else
-    std::filesystem::create_symlink(installPath + "/assets", tempdir + "/assets");
+    std::filesystem::create_symlink(assetsPath, tempdir + "/assets");
 #endif
 
     std::filesystem::current_path(tempdir);
@@ -609,13 +620,23 @@ bool Extractor::CallZapd(std::string installPath, std::string exportdir) {
     ShowWindow(cmdWindow, SW_HIDE);
 #endif
 
+    // Verify the output file was created before attempting to copy
+    if (!std::filesystem::exists(otrFile)) {
+        std::string errMsg = "ZAPD extraction failed - output file was not created: " + std::string(otrFile) +
+                             "\n\nCheck that the ROM file is valid and the assets directory is complete.";
+        ShowErrorBox("Extraction Failed", errMsg.c_str());
+        std::filesystem::current_path(curdir);
+        std::filesystem::remove_all(tempdir);
+        return false;
+    }
+
     std::filesystem::copy(otrFile, exportdir + "/" + otrFile, std::filesystem::copy_options::overwrite_existing);
 
     // Go back to where this game was executed from
     std::filesystem::current_path(curdir);
     std::filesystem::remove_all(tempdir);
 
-    return false;
+    return true;
 }
 
 static void MessageboxWorker() {


### PR DESCRIPTION
## Summary
This PR fixes the installation paths for extractor assets to be relative to the executable location and improves error handling in the extraction process. The changes ensure that packaged applications (like AppImages) can correctly locate their assets at runtime.

## Key Changes

- **CMakeLists.txt**: Updated install destinations for ZAPD extractor and assets from relative paths (`./assets/`) to absolute paths under `usr/bin/assets/` to align with how linuxdeploy packages executables and how `GetAppBundlePath()` resolves asset locations.

- **Extract.cpp (both OoT and MM)**: 
  - Added validation to verify the assets directory exists before attempting extraction, with a user-friendly error message if missing
  - Refactored asset path handling to use a variable (`assetsPath`) for consistency and clarity
  - Added verification that ZAPD successfully created the output file before attempting to copy it, with detailed error messaging
  - Fixed the return value from `false` to `true` on successful extraction completion

## Implementation Details

The extractor now performs two critical validation checks:
1. **Pre-extraction**: Verifies that the assets directory exists at the expected location relative to the executable
2. **Post-extraction**: Confirms that ZAPD successfully generated the output file before attempting to copy it

These changes improve robustness when dealing with incomplete or misconfigured installations, providing clear feedback to users about what went wrong rather than silently failing.

https://claude.ai/code/session_01EvfEoLN7EMqWmSbbZveSur

<!--- section:artifacts:start -->
### Build Artifacts
  - [rsbs-linux.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/5332332943.zip)
  - [rsbs-windows.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/5332372967.zip)
<!--- section:artifacts:end -->