### PR TITLE
Add fetch-tags to GitHub Actions checkout (#114)

### DIFF
--- a/.github/workflows/generate-builds.yml
+++ b/.github/workflows/generate-builds.yml
@@ -26,6 +26,7 @@ jobs:
       uses: actions/checkout@v4
       with:
         fetch-depth: 1
+        fetch-tags: true
     - name: Restore soh.o2r Cache
       id: rsbs-otr-cache
       uses: actions/cache@v4
@@ -121,6 +122,7 @@ jobs:
       with:
         submodules: true
         fetch-depth: 1
+        fetch-tags: true
     - name: Configure ccache
       uses: hendrikmuhs/ccache-action@v1.2
       with:
@@ -198,6 +200,7 @@ jobs:
       with:
         submodules: true
         fetch-depth: 1
+        fetch-tags: true
     - name: Install dependencies
       run: |
         sudo apt-get update
@@ -334,6 +337,7 @@ jobs:
       with:
         submodules: true
         fetch-depth: 1
+        fetch-tags: true
     - name: Configure sccache
       uses: hendrikmuhs/ccache-action@v1.2
       with:


### PR DESCRIPTION
## Summary
- Added `fetch-tags: true` to all checkout steps that use `fetch-depth: 1`
- Prepares for future release tagging (CMakeLists.txt uses `git describe --tags`)

## Files Modified
- `.github/workflows/generate-builds.yml` (4 checkout steps)

## Test Plan
- CI should pass with no functional change
- Future release tags will be available during builds

Closes #114

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!--- section:artifacts:start -->
### Build Artifacts
  - [rsbs-linux.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/5335533424.zip)
  - [rsbs-windows.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/5335569223.zip)
<!--- section:artifacts:end -->