### PR TITLE
Fix MSVC runtime library mismatch warning (#172)

### DIFF
--- a/CMake/DefaultCXX.cmake
+++ b/CMake/DefaultCXX.cmake
@@ -6,7 +6,7 @@ if(MSVC)
     create_property_reader("DEFAULT_CXX_EXCEPTION_HANDLING")
     create_property_reader("DEFAULT_CXX_DEBUG_INFORMATION_FORMAT")
 
-    set_target_properties("${PROPS_TARGET}" PROPERTIES MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>DLL")
+    set_target_properties("${PROPS_TARGET}" PROPERTIES MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
     set_config_specific_property("DEFAULT_CXX_EXCEPTION_HANDLING" "/EHsc")
     # Only set debug info for Debug builds - Release without debug info avoids 4GB COFF limit
     # PROPS_CONFIG comes from the CMake invocation context

--- a/games/mm/CMake/DefaultCXX.cmake
+++ b/games/mm/CMake/DefaultCXX.cmake
@@ -6,7 +6,7 @@ if(MSVC)
     create_property_reader("DEFAULT_CXX_EXCEPTION_HANDLING")
     create_property_reader("DEFAULT_CXX_DEBUG_INFORMATION_FORMAT")
 
-    set_target_properties("${PROPS_TARGET}" PROPERTIES MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>DLL")
+    set_target_properties("${PROPS_TARGET}" PROPERTIES MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
     set_config_specific_property("DEFAULT_CXX_EXCEPTION_HANDLING" "/EHsc")
     # Only set debug info for Debug builds - Release without debug info avoids 4GB COFF limit
     if(PROPS_CONFIG STREQUAL "Debug")

--- a/games/oot/CMake/DefaultCXX.cmake
+++ b/games/oot/CMake/DefaultCXX.cmake
@@ -6,7 +6,7 @@ if(MSVC)
     create_property_reader("DEFAULT_CXX_EXCEPTION_HANDLING")
     create_property_reader("DEFAULT_CXX_DEBUG_INFORMATION_FORMAT")
 
-    set_target_properties("${PROPS_TARGET}" PROPERTIES MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>DLL")
+    set_target_properties("${PROPS_TARGET}" PROPERTIES MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
     set_config_specific_property("DEFAULT_CXX_EXCEPTION_HANDLING" "/EHsc")
     # Only set debug info for Debug builds - Release without debug info avoids 4GB COFF limit
     if(PROPS_CONFIG STREQUAL "Debug")


### PR DESCRIPTION
## Summary
- Standardized MSVC runtime to static `/MT` instead of dynamic `/MD`
- Fixes LNK4098 warning about conflicting default libraries

## Files Modified
- `CMake/DefaultCXX.cmake`
- `games/oot/CMake/DefaultCXX.cmake`
- `games/mm/CMake/DefaultCXX.cmake`

## Test Plan
- Windows build should no longer show LNK4098 warning

Closes #172

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!--- section:artifacts:start -->
### Build Artifacts
  - [rsbs-linux.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/5335533760.zip)
  - [rsbs-windows.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/5335570879.zip)
<!--- section:artifacts:end -->