### PR TITLE
Improve extractor error handling and debugging (#119)

### DIFF
--- a/games/mm/2s2h/Extractor/Extract.cpp
+++ b/games/mm/2s2h/Extractor/Extract.cpp
@@ -600,6 +600,17 @@ bool Extractor::CallZapd(std::string installPath, std::string exportdir) {
     argv[20] = "-osf";
     argv[21] = "placeholder";
 
+    // Validate config XML exists before calling zapd_main
+    if (!std::filesystem::exists(confPath)) {
+        std::string errMsg = "Extractor config not found: " + std::string(confPath) +
+                             "\n\nThis may indicate an incomplete installation.";
+        fprintf(stderr, "Extractor config not found: %s. This may indicate an incomplete installation.\n", confPath);
+        ShowErrorBox("Extraction Failed", errMsg.c_str());
+        std::filesystem::current_path(curdir);
+        std::filesystem::remove_all(tempdir);
+        return false;
+    }
+
 #ifdef _WIN32
     // Grab a handle to the command window.
     HWND cmdWindow = GetConsoleWindow();
@@ -613,7 +624,28 @@ bool Extractor::CallZapd(std::string installPath, std::string exportdir) {
     mbThread.detach();
 #endif
 
-    zapd_main(argc, (char**)argv.data());
+    try {
+        zapd_main(argc, (char**)argv.data());
+    } catch (const std::exception& e) {
+        fprintf(stderr, "Extraction failed: %s\n", e.what());
+        std::string errMsg = "ZAPD extraction failed with error: " + std::string(e.what());
+        ShowErrorBox("Extraction Failed", errMsg.c_str());
+#ifdef _WIN32
+        ShowWindow(cmdWindow, SW_HIDE);
+#endif
+        std::filesystem::current_path(curdir);
+        std::filesystem::remove_all(tempdir);
+        return false;
+    } catch (...) {
+        fprintf(stderr, "Extraction failed with unknown error\n");
+        ShowErrorBox("Extraction Failed", "ZAPD extraction failed with an unknown error.");
+#ifdef _WIN32
+        ShowWindow(cmdWindow, SW_HIDE);
+#endif
+        std::filesystem::current_path(curdir);
+        std::filesystem::remove_all(tempdir);
+        return false;
+    }
 
 #ifdef _WIN32
     // Hide the command window again.


### PR DESCRIPTION
## Summary
- Wrapped `zapd_main()` calls in try/catch blocks
- Added config XML validation before calling ZAPD
- User-friendly error dialogs via ShowErrorBox()
- Proper temp directory cleanup on failure

## Files Modified
- `games/mm/2s2h/Extractor/Extract.cpp`
- `games/oot/soh/Extractor/Extract.cpp`

## Test Plan
- Extraction failures now show actionable error messages
- Invalid ROM or missing config produces clear error instead of crash

Closes #119

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!--- section:artifacts:start -->
### Build Artifacts
  - [rsbs-linux.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/5335534611.zip)
  - [rsbs-windows.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/5335571090.zip)
<!--- section:artifacts:end -->