### PR TITLE
Register MM-only resource factories for single-exe build (#159)

### DIFF
--- a/games/mm/2s2h/GameExports_SingleExe.cpp
+++ b/games/mm/2s2h/GameExports_SingleExe.cpp
@@ -22,8 +22,16 @@
 #include "game_lifecycle.h"
 #include "integration_test_hooks.h"
 #include <ship/resource/ResourceManager.h>
+#include <ship/resource/ResourceLoader.h>
 #include <ship/resource/archive/ArchiveManager.h>
 #include "GameInteractor/GameInteractor.h"
+#include <ship/resource/File.h>
+
+#include "2s2h/resource/type/2shResourceType.h"
+#include "2s2h/resource/importer/PathFactory.h"
+#include "2s2h/resource/importer/TextMMFactory.h"
+#include "2s2h/resource/importer/TextureAnimationFactory.h"
+#include "2s2h/resource/importer/KeyFrameFactory.h"
 
 // From main.c headers
 extern "C" {
@@ -186,6 +194,38 @@ static int LoadMMArchives() {
 }
 
 /**
+ * Register MM-only resource factories into the shared ResourceLoader.
+ * OoT already registered shared types (Animation, Skeleton, etc.).
+ * MM needs its own factories for Path (overwrites OoT's — MM paths have
+ * extra fields), TextMM, TextureAnimation, and KeyFrame types.
+ */
+static void RegisterMMResourceFactories() {
+    auto loader = Ship::Context::GetInstance()->GetResourceManager()->GetResourceLoader();
+
+    // Path — overwrites OoT's PathV0 because MM paths have additional fields
+    loader->RegisterResourceFactory(std::make_shared<SOH::ResourceFactoryBinaryPathMMV0>(), RESOURCE_FORMAT_BINARY,
+                                    "Path", static_cast<uint32_t>(SOH::ResourceType::SOH_Path), 0,
+                                    /*allowOverwrite=*/true);
+
+    // TextMM — MM-only text format
+    loader->RegisterResourceFactory(std::make_shared<SOH::ResourceFactoryBinaryTextMMV0>(), RESOURCE_FORMAT_BINARY,
+                                    "TextMM", static_cast<uint32_t>(SOH::ResourceType::TSH_TextMM), 0);
+
+    // TextureAnimation — MM-only
+    loader->RegisterResourceFactory(std::make_shared<SOH::ResourceFactoryBinaryTextureAnimationV0>(),
+                                    RESOURCE_FORMAT_BINARY, "TextureAnimation",
+                                    static_cast<uint32_t>(SOH::ResourceType::TSH_TexAnim), 0);
+
+    // KeyFrame animation and skeleton — MM-only
+    loader->RegisterResourceFactory(std::make_shared<SOH::ResourceFactoryBinaryKeyFrameAnim>(), RESOURCE_FORMAT_BINARY,
+                                    "KeyFrameAnim", static_cast<uint32_t>(SOH::ResourceType::TSH_CKeyFrameAnim), 0);
+    loader->RegisterResourceFactory(std::make_shared<SOH::ResourceFactoryBinaryKeyFrameSkel>(), RESOURCE_FORMAT_BINARY,
+                                    "KeyFrameSkel", static_cast<uint32_t>(SOH::ResourceType::TSH_CKeyFrameSkel), 0);
+
+    fprintf(stderr, "[MM] Registered MM resource factories\n");
+}
+
+/**
  * Verify the shared Ship::Context from OoT is ready for MM's graph thread.
  * MM_Graph_ThreadEntry calls WindowIsRunning(), GfxDebuggerIsDebugging(),
  * WindowGetWidth/Height/AspectRatio() every frame — all route through
@@ -226,6 +266,9 @@ int MM_Game_Init(int argc, char** argv) {
         fprintf(stderr, "[MM] FATAL: Failed to load MM archives\n");
         return -1;
     }
+
+    // Register MM-only resource factories (issue #159).
+    RegisterMMResourceFactories();
 
     fprintf(stderr, "[MM] Allocating heaps...\n");
     fflush(stderr);

--- a/games/mm/CMakeLists.txt
+++ b/games/mm/CMakeLists.txt
@@ -239,8 +239,36 @@ if(SINGLE_EXECUTABLE_BUILD)
     # Save Manager
     list(FILTER ship__ EXCLUDE REGEX "2s2h/SaveManager/.*\\.cpp$")
 
-    # Resource importers and types (identical between games)
-    list(FILTER ship__ EXCLUDE REGEX "2s2h/resource/.*\\.cpp$")
+    # Resource importers and types — exclude files that overlap with OoT,
+    # but KEEP MM-only resource types and factories (issue #159):
+    #   importer: PathFactory, TextMMFactory, TextureAnimationFactory, KeyFrameFactory
+    #   type:     Path, TextMM, TextureAnimation, KeyFrame
+    list(FILTER ship__ EXCLUDE REGEX "2s2h/resource/importer/AnimationFactory\\.cpp$")
+    list(FILTER ship__ EXCLUDE REGEX "2s2h/resource/importer/ArrayFactory\\.cpp$")
+    list(FILTER ship__ EXCLUDE REGEX "2s2h/resource/importer/AudioSampleFactory\\.cpp$")
+    list(FILTER ship__ EXCLUDE REGEX "2s2h/resource/importer/AudioSequenceFactory\\.cpp$")
+    list(FILTER ship__ EXCLUDE REGEX "2s2h/resource/importer/AudioSoundFontFactory\\.cpp$")
+    list(FILTER ship__ EXCLUDE REGEX "2s2h/resource/importer/BackgroundFactory\\.cpp$")
+    list(FILTER ship__ EXCLUDE REGEX "2s2h/resource/importer/CollisionHeaderFactory\\.cpp$")
+    list(FILTER ship__ EXCLUDE REGEX "2s2h/resource/importer/CutsceneFactory\\.cpp$")
+    list(FILTER ship__ EXCLUDE REGEX "2s2h/resource/importer/PlayerAnimationFactory\\.cpp$")
+    list(FILTER ship__ EXCLUDE REGEX "2s2h/resource/importer/SceneFactory\\.cpp$")
+    list(FILTER ship__ EXCLUDE REGEX "2s2h/resource/importer/SkeletonFactory\\.cpp$")
+    list(FILTER ship__ EXCLUDE REGEX "2s2h/resource/importer/SkeletonLimbFactory\\.cpp$")
+    list(FILTER ship__ EXCLUDE REGEX "2s2h/resource/importer/scenecommand/.*\\.cpp$")
+    list(FILTER ship__ EXCLUDE REGEX "2s2h/resource/type/Animation\\.cpp$")
+    list(FILTER ship__ EXCLUDE REGEX "2s2h/resource/type/Array\\.cpp$")
+    list(FILTER ship__ EXCLUDE REGEX "2s2h/resource/type/AudioSample\\.cpp$")
+    list(FILTER ship__ EXCLUDE REGEX "2s2h/resource/type/AudioSequence\\.cpp$")
+    list(FILTER ship__ EXCLUDE REGEX "2s2h/resource/type/AudioSoundFont\\.cpp$")
+    list(FILTER ship__ EXCLUDE REGEX "2s2h/resource/type/Background\\.cpp$")
+    list(FILTER ship__ EXCLUDE REGEX "2s2h/resource/type/CollisionHeader\\.cpp$")
+    list(FILTER ship__ EXCLUDE REGEX "2s2h/resource/type/Cutscene\\.cpp$")
+    list(FILTER ship__ EXCLUDE REGEX "2s2h/resource/type/PlayerAnimation\\.cpp$")
+    list(FILTER ship__ EXCLUDE REGEX "2s2h/resource/type/Scene\\.cpp$")
+    list(FILTER ship__ EXCLUDE REGEX "2s2h/resource/type/Skeleton\\.cpp$")
+    list(FILTER ship__ EXCLUDE REGEX "2s2h/resource/type/SkeletonLimb\\.cpp$")
+    list(FILTER ship__ EXCLUDE REGEX "2s2h/resource/type/scenecommand/.*\\.cpp$")
 
     # Extractor
     list(FILTER ship__Extractor EXCLUDE REGEX "2s2h/Extractor/.*\\.cpp$")


### PR DESCRIPTION
## Summary
- Replace blanket CMake exclusion of `2s2h/resource/*.cpp` with targeted exclusions that keep MM-only files (PathMM, TextMM, TextureAnimation, KeyFrame)
- Add `RegisterMMResourceFactories()` in `MM_Game_Init()` to register 5 MM-only factories with the shared ResourceLoader
- Add `allowOverwrite` parameter to `ResourceLoader::RegisterResourceFactory()` to handle Path factory conflict (OoT PathV0 vs MM PathMMV0 share type ID)

Without this, MM crashes on first scene load because the ResourceManager can't deserialize MM-specific resource types from mm.o2r.

Fixes #159

## Test plan
- [ ] Build compiles with no errors
- [ ] 7/7 unit tests pass
- [ ] MM boots after game switch (requires ROMs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!--- section:artifacts:start -->
### Build Artifacts
  - [rsbs-windows.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/6522056970.zip)
  - [rsbs-linux.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/6521987867.zip)
<!--- section:artifacts:end -->