### PR TITLE
Fix randomizer seed generation crash on non-dungeon scenes (#201)

### DIFF
--- a/games/oot/soh/Enhancements/randomizer/3drando/fill.cpp
+++ b/games/oot/soh/Enhancements/randomizer/3drando/fill.cpp
@@ -397,9 +397,10 @@ bool AddCheckToLogic(LocationAccess& locPair, GetAccessibleLocationsStruct& gals
     Rando::ItemLocation* location = ctx->GetItemLocation(loc);
     RandomizerGet locItem = location->GetPlacedRandomizerGet();
     RandomizerCheckQuest quest = Rando::StaticData::GetLocation(loc)->GetQuest();
+    auto dungeon = ctx->GetDungeons()->GetDungeonFromScene(parentRegion->scene);
     assert(quest == RCQUEST_BOTH ||
-           (quest == RCQUEST_VANILLA && ctx->GetDungeons()->GetDungeonFromScene(parentRegion->scene)->IsVanilla()) ||
-           (quest == RCQUEST_MQ && ctx->GetDungeons()->GetDungeonFromScene(parentRegion->scene)->IsMQ()));
+           (dungeon != nullptr && quest == RCQUEST_VANILLA && dungeon->IsVanilla()) ||
+           (dungeon != nullptr && quest == RCQUEST_MQ && dungeon->IsMQ()));
 
     if (!location->IsAddedToPool() && locPair.ConditionsMet(parentRegion, logic->CalculatingAvailableChecks)) {
         location->AddToPool();

--- a/games/oot/soh/Enhancements/randomizer/SeedContext.cpp
+++ b/games/oot/soh/Enhancements/randomizer/SeedContext.cpp
@@ -167,9 +167,10 @@ void Context::AddLocations(const Container& locations, std::vector<RandomizerChe
 
 bool Context::IsQuestOfLocationActive(RandomizerCheck rc) {
     const auto loc = Rando::StaticData::GetLocation(rc);
+    auto dungeon = mDungeons->GetDungeonFromScene(loc->GetScene());
     return loc->GetQuest() == RCQUEST_BOTH ||
-           loc->GetQuest() == RCQUEST_MQ && mDungeons->GetDungeonFromScene(loc->GetScene())->IsMQ() ||
-           loc->GetQuest() == RCQUEST_VANILLA && mDungeons->GetDungeonFromScene(loc->GetScene())->IsVanilla();
+           (dungeon != nullptr && loc->GetQuest() == RCQUEST_MQ && dungeon->IsMQ()) ||
+           (dungeon != nullptr && loc->GetQuest() == RCQUEST_VANILLA && dungeon->IsVanilla());
 }
 
 void Context::GenerateLocationPool() {


### PR DESCRIPTION
## Summary
- Add nullptr guard for `GetDungeonFromScene()` in `fill.cpp` assertion (line 400)
- Fix same pattern in `SeedContext.cpp` `IsQuestOfLocationActive()`
- `GetDungeonFromScene()` returns nullptr for non-dungeon scenes, causing null pointer dereference

Fixes #201

## Test plan
- [ ] Build compiles
- [ ] 7/7 unit tests pass
- [ ] Randomizer seed generation completes without crash

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!--- section:artifacts:start -->
### Build Artifacts
  - [rsbs-windows.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/6074666811.zip)
  - [rsbs-linux.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/6074286991.zip)
<!--- section:artifacts:end -->