### PR TITLE
fix: macOS libultraship linking with -force_load (#75)

### DIFF
--- a/.github/workflows/generate-builds.yml
+++ b/.github/workflows/generate-builds.yml
@@ -110,10 +110,6 @@ jobs:
         path: deps
 
   build-macos:
-    # DISABLED: macOS build is currently broken - see GitHub issue for tracking
-    # Error: OoT shared library not linking against libultraship properly
-    # Re-enable once issue is resolved
-    if: false
     needs: generate-rsbs-otr
     runs-on: macos-14
     steps:

--- a/CMake/SingleExecutable.cmake
+++ b/CMake/SingleExecutable.cmake
@@ -178,6 +178,16 @@ if(UNIX AND NOT APPLE)
     target_link_options(redship PRIVATE -rdynamic)
 endif()
 
+if(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
+    # libultraship is a static archive containing the N64 OS stubs
+    # (osCreateMesgQueue, osRecvMesg, osStartThread, ...). ld64 drops archive
+    # members whose symbols look unreferenced; -force_load pulls them all in.
+    # Linux uses -Wl,-export-dynamic via -rdynamic above; macOS requires -force_load.
+    target_link_options(redship PRIVATE
+        "LINKER:-force_load,$<TARGET_FILE:libultraship>"
+    )
+endif()
+
 # ============================================================================
 # CTest Integration
 # ============================================================================
@@ -234,7 +244,13 @@ endif()
 # Installation
 # ============================================================================
 
-install(TARGETS redship RUNTIME DESTINATION . COMPONENT ship)
+if(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
+    # CPack Bundle maps CMAKE_INSTALL_PREFIX to Contents/Resources; the executable
+    # belongs in Contents/MacOS for a valid .app bundle.
+    install(TARGETS redship RUNTIME DESTINATION ../MacOS COMPONENT ship)
+else()
+    install(TARGETS redship RUNTIME DESTINATION . COMPONENT ship)
+endif()
 
 message(STATUS "Single executable 'redship' will be built")
 message(STATUS "Use --test option to run integration tests")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -416,7 +416,11 @@ add_custom_target(CreateOSXIcons
     WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
     COMMENT "Creating OSX icons ..."
     )
-add_dependencies(soh CreateOSXIcons)
+if(SINGLE_EXECUTABLE_BUILD)
+    add_dependencies(redship CreateOSXIcons)
+else()
+    add_dependencies(soh CreateOSXIcons)
+endif()
 
 install(TARGETS ZAPD_OoT DESTINATION ${CMAKE_BINARY_DIR}/assets)
 
@@ -425,13 +429,20 @@ set(PROGRAM_PERMISSIONS_EXECUTE OWNER_EXECUTE OWNER_WRITE OWNER_READ GROUP_EXECU
 install(DIRECTORY "${CMAKE_SOURCE_DIR}/games/oot/assets/extractor/" DESTINATION ./assets/)
 install(DIRECTORY "${CMAKE_SOURCE_DIR}/games/oot/assets/xml/" DESTINATION ./assets/xml)
 
-# Rename the installed soh binary to drop the macos suffix
-INSTALL(CODE "FILE(RENAME \${CMAKE_INSTALL_PREFIX}/../MacOS/soh-macos \${CMAKE_INSTALL_PREFIX}/../MacOS/soh)")
+if(SINGLE_EXECUTABLE_BUILD)
+    install(CODE "
+        include(BundleUtilities)
+        fixup_bundle(\"\${CMAKE_INSTALL_PREFIX}/../MacOS/redship\" \"\" \"${dirs}\")
+        ")
+else()
+    # Rename the installed soh binary to drop the macos suffix
+    INSTALL(CODE "FILE(RENAME \${CMAKE_INSTALL_PREFIX}/../MacOS/soh-macos \${CMAKE_INSTALL_PREFIX}/../MacOS/soh)")
 
-install(CODE "
-    include(BundleUtilities)
-    fixup_bundle(\"\${CMAKE_INSTALL_PREFIX}/../MacOS/soh\" \"\" \"${dirs}\")
-    ")
+    install(CODE "
+        include(BundleUtilities)
+        fixup_bundle(\"\${CMAKE_INSTALL_PREFIX}/../MacOS/soh\" \"\" \"${dirs}\")
+        ")
+endif()
 
 endif()
 

--- a/games/mm/CMakeLists.txt
+++ b/games/mm/CMakeLists.txt
@@ -849,7 +849,11 @@ execute_process(COMMAND ${CURL} -sSfL https://raw.githubusercontent.com/gabomdq/
 
 if("${CMAKE_SYSTEM_NAME}" STREQUAL "Darwin")
 configure_file( ${CMAKE_CURRENT_SOURCE_DIR}/macosx/Info.plist.in ${CMAKE_BINARY_DIR}/macosx/Info.plist @ONLY)
-INSTALL(TARGETS 2ship DESTINATION ../MacOS COMPONENT 2s2h)
+if(NOT SINGLE_EXECUTABLE_BUILD)
+    # 2ship is a SHARED library in legacy mode; in single-exec mode it's OBJECT libs
+    # linked into redship, so there's nothing to install by that name.
+    INSTALL(TARGETS 2ship DESTINATION ../MacOS COMPONENT 2s2h)
+endif()
 INSTALL(FILES ${CMAKE_BINARY_DIR}/gamecontrollerdb.txt DESTINATION ../MacOS COMPONENT 2s2h)
 INSTALL(FILES ${CMAKE_BINARY_DIR}/mm/2ship.o2r DESTINATION ../Resources COMPONENT 2s2h)
 elseif(NOT "${CMAKE_SYSTEM_NAME}" MATCHES "NintendoSwitch|CafeOS")

--- a/games/mm/CMakeLists.txt
+++ b/games/mm/CMakeLists.txt
@@ -557,8 +557,13 @@ if (CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang|AppleClang")
             -pthread
         )
 
+        # On macOS, we need to force-load libultraship to ensure all N64 OS
+        # function stubs (osCreateMesgQueue, osRecvMesg, etc.) are included
+        # in the shared library. Unlike Linux which uses -Wl,-export-dynamic,
+        # macOS requires -force_load to include all symbols from static archives.
         target_link_options(${_t} PRIVATE
             -pthread
+            "LINKER:-force_load,$<TARGET_FILE:libultraship>"
         )
     elseif (CMAKE_SYSTEM_NAME STREQUAL "NintendoSwitch")
         target_compile_options(${_t} PRIVATE

--- a/games/oot/CMakeLists.txt
+++ b/games/oot/CMakeLists.txt
@@ -595,8 +595,13 @@ if (CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang|AppleClang")
             -pthread
         )
 
+        # On macOS, we need to force-load libultraship to ensure all N64 OS
+        # function stubs (osCreateMesgQueue, osRecvMesg, etc.) are included
+        # in the shared library. Unlike Linux which uses -Wl,-export-dynamic,
+        # macOS requires -force_load to include all symbols from static archives.
         target_link_options(${_t} PRIVATE
             -pthread
+            "LINKER:-force_load,$<TARGET_FILE:libultraship>"
         )
     elseif (CMAKE_SYSTEM_NAME STREQUAL "NintendoSwitch")
         target_compile_options(${_t} PRIVATE

--- a/games/oot/CMakeLists.txt
+++ b/games/oot/CMakeLists.txt
@@ -828,7 +828,11 @@ execute_process(COMMAND ${CURL} -sSfL https://raw.githubusercontent.com/mdqinc/S
 
 if("${CMAKE_SYSTEM_NAME}" STREQUAL "Darwin")
 configure_file( ${CMAKE_CURRENT_SOURCE_DIR}/macosx/Info.plist.in ${CMAKE_BINARY_DIR}/macosx/Info.plist @ONLY)
-INSTALL(TARGETS soh DESTINATION ../MacOS COMPONENT ship)
+if(NOT SINGLE_EXECUTABLE_BUILD)
+    # soh is a SHARED library in legacy mode; in single-exec mode it's OBJECT libs
+    # linked into redship, so there's nothing to install by that name.
+    INSTALL(TARGETS soh DESTINATION ../MacOS COMPONENT ship)
+endif()
 INSTALL(FILES ${CMAKE_BINARY_DIR}/gamecontrollerdb.txt DESTINATION ../MacOS COMPONENT ship)
 INSTALL(FILES ${CMAKE_BINARY_DIR}/soh/soh.o2r DESTINATION ../Resources COMPONENT ship)
 elseif(NOT "${CMAKE_SYSTEM_NAME}" MATCHES "NintendoSwitch|CafeOS")


### PR DESCRIPTION
## Summary

- Fix macOS link failures where N64 OS stubs (`osCreateMesgQueue`, `osRecvMesg`, `osStartThread`, etc.) from libultraship were dropped by the linker when building `soh.dylib` / `2ship.dylib`.
- Add `-force_load` for libultraship on macOS (`games/oot/CMakeLists.txt`, `games/mm/CMakeLists.txt`). Unlike Linux's `-Wl,-export-dynamic`, macOS's ld requires `-force_load` to pull in all symbols from a static archive into a shared library.
- Re-enable the `build-macos` job in `.github/workflows/generate-builds.yml`, which was previously gated on `if: false` as a workaround.

Fixes #75.

## Test plan

- [ ] CI `build-macos` job passes on this PR (previously disabled).
- [ ] CI `build-linux` and `build-windows` jobs still pass (change is behind `CMAKE_SYSTEM_NAME STREQUAL "Darwin"`).
- [ ] Resulting `SoH.dmg` artifact launches and loads both OoT and MM without undefined-symbol errors at dlopen time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!--- section:artifacts:start -->
### Build Artifacts
  - [rsbs-windows.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/6634623319.zip)
  - [rsbs-linux.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/6634558013.zip)
<!--- section:artifacts:end -->