### PR TITLE
Harden Docker worker scripts with timeouts, logging, and dry-run

### DIFF
--- a/.claude-sandbox/Dockerfile
+++ b/.claude-sandbox/Dockerfile
@@ -1,0 +1,41 @@
+# Claude Code worker sandbox — extends the CI base image
+# with Node.js + Claude Code for autonomous agent work.
+#
+# Build:  docker build -t rsbs-claude-sandbox .claude-sandbox/
+# Usage:  .claude-sandbox/run-sandboxed-claude.sh --shell
+#
+FROM ghcr.io/spencerduncan/redshipblueship-build:latest
+
+# ============================================================
+# Claude Code + Node.js
+# ============================================================
+RUN curl -fsSL https://deb.nodesource.com/setup_20.x | bash - \
+    && apt-get install -y nodejs \
+    && npm install -g @anthropic-ai/claude-code \
+    && rm -rf /var/lib/apt/lists/*
+
+# Python for tooling/tests
+RUN apt-get update && apt-get install -y python3 python3-pip \
+    && pip3 install pytest \
+    && rm -rf /var/lib/apt/lists/*
+
+# Git (needed for worker commits inside container)
+RUN apt-get update && apt-get install -y gh \
+    && rm -rf /var/lib/apt/lists/* \
+    || true  # gh may not be in default repos
+
+# ============================================================
+# Non-root user for Claude Code
+# ============================================================
+RUN useradd -m -s /bin/bash claude \
+    && chown -R claude:claude /home/claude
+
+# Allow git operations on the mounted workspace
+RUN git config --global --add safe.directory /workspace
+
+USER claude
+
+# Create the .claude dir so credentials can be mounted in
+RUN mkdir -p /home/claude/.claude
+
+WORKDIR /workspace

--- a/.claude-sandbox/Dockerfile
+++ b/.claude-sandbox/Dockerfile
@@ -30,8 +30,9 @@ RUN apt-get update && apt-get install -y gh \
 RUN useradd -m -s /bin/bash claude \
     && chown -R claude:claude /home/claude
 
-# Allow git operations on the mounted workspace
-RUN git config --global --add safe.directory /workspace
+# Allow git operations on the mounted workspace (--system writes to
+# /etc/gitconfig so the entry survives the USER switch below)
+RUN git config --system --add safe.directory /workspace
 
 USER claude
 

--- a/.claude-sandbox/run-sandboxed-claude.sh
+++ b/.claude-sandbox/run-sandboxed-claude.sh
@@ -75,10 +75,12 @@ case "${1:-}" in
         BRANCH_NAME="claude/fix-issue-${ISSUE_NUM}"
         echo "Starting worker for issue #${ISSUE_NUM}..."
 
-        # Check if the target branch already exists remotely
+        # Check if the target branch already exists remotely — skip to avoid
+        # overwriting existing work (matches the PR test plan's "skip" behavior)
         if git ls-remote --exit-code --heads origin "$BRANCH_NAME" &>/dev/null; then
-            echo "WARNING: Branch '$BRANCH_NAME' already exists on remote."
-            echo "The worker may encounter conflicts or overwrite existing work."
+            echo "SKIP: Branch '$BRANCH_NAME' already exists on remote."
+            echo "Delete the remote branch first if you want to re-run this worker."
+            exit 0
         fi
 
         # Set up log capture

--- a/.claude-sandbox/run-sandboxed-claude.sh
+++ b/.claude-sandbox/run-sandboxed-claude.sh
@@ -1,0 +1,139 @@
+#!/usr/bin/env bash
+# Run a headless Claude Code instance in a sandboxed Docker container.
+#
+# Uses your Max/Pro plan OAuth credentials from ~/.claude/.credentials.json
+# — no API key needed.
+#
+# Usage:
+#   ./run-sandboxed-claude.sh "implement feature X in combo/"
+#   ./run-sandboxed-claude.sh --interactive    # drop into interactive Claude
+#   ./run-sandboxed-claude.sh --shell          # drop into bash for debugging
+#   ./run-sandboxed-claude.sh --worker 201     # work on issue #201
+#
+# Environment:
+#   RSBS_IMAGE  - override image name (default: rsbs-claude-sandbox)
+#   RSBS_GPU    - set to 1 for GPU passthrough (for running the game)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
+IMAGE_NAME="${RSBS_IMAGE:-rsbs-claude-sandbox}"
+CLAUDE_HOME="${HOME}/.claude"
+
+# Verify credentials exist
+if [[ ! -f "$CLAUDE_HOME/.credentials.json" ]]; then
+    echo "ERROR: No credentials found at $CLAUDE_HOME/.credentials.json"
+    echo "Run 'claude' on the host and log in first."
+    exit 1
+fi
+
+# Build image if it doesn't exist
+if ! docker image inspect "$IMAGE_NAME" &>/dev/null; then
+    echo "Building sandbox image..."
+    docker build -t "$IMAGE_NAME" "$SCRIPT_DIR"
+fi
+
+# Base docker args
+DOCKER_ARGS=(
+    --rm
+    -v "$PROJECT_DIR:/workspace"
+    -w /workspace
+    # Persistent ccache volume
+    -v redship-ccache:/root/.ccache
+    # Mount credentials + onboarding state read-only
+    -v "$CLAUDE_HOME/.credentials.json:/home/claude/.claude/.credentials.json:ro"
+    -v "$CLAUDE_HOME/.claude.json:/home/claude/.claude/.claude.json:ro"
+    # Git config for worker commits
+    -e GIT_AUTHOR_NAME="Claude Worker"
+    -e GIT_AUTHOR_EMAIL="noreply@anthropic.com"
+    -e GIT_COMMITTER_NAME="Claude Worker"
+    -e GIT_COMMITTER_EMAIL="noreply@anthropic.com"
+)
+
+# GPU passthrough if requested
+if [[ "${RSBS_GPU:-0}" == "1" ]]; then
+    DOCKER_ARGS+=(--gpus all -e DISPLAY="$DISPLAY" -v /tmp/.X11-unix:/tmp/.X11-unix)
+fi
+
+case "${1:-}" in
+    --shell)
+        echo "Dropping into container shell..."
+        docker run -it --stop-timeout 3600 "${DOCKER_ARGS[@]}" "$IMAGE_NAME" bash
+        ;;
+    --interactive)
+        echo "Starting interactive Claude Code..."
+        docker run -it --stop-timeout 3600 "${DOCKER_ARGS[@]}" "$IMAGE_NAME" \
+            claude --dangerously-skip-permissions
+        ;;
+    --worker)
+        if [[ -z "${2:-}" ]]; then
+            echo "Usage: $0 --worker <issue-number>"
+            exit 1
+        fi
+        ISSUE_NUM="$2"
+        BRANCH_NAME="claude/fix-issue-${ISSUE_NUM}"
+        echo "Starting worker for issue #${ISSUE_NUM}..."
+
+        # Check if the target branch already exists remotely
+        if git ls-remote --exit-code --heads origin "$BRANCH_NAME" &>/dev/null; then
+            echo "WARNING: Branch '$BRANCH_NAME' already exists on remote."
+            echo "The worker may encounter conflicts or overwrite existing work."
+        fi
+
+        # Set up log capture
+        LOG_DIR="$SCRIPT_DIR/logs"
+        mkdir -p "$LOG_DIR"
+        LOG_FILE="$LOG_DIR/worker-$(date +%Y%m%d-%H%M%S).log"
+        echo "Logging worker output to: $LOG_FILE"
+
+        # Get issue details from GitHub
+        ISSUE_TITLE=$(gh issue view "$ISSUE_NUM" --json title -q .title 2>/dev/null || echo "Unknown")
+        ISSUE_BODY=$(gh issue view "$ISSUE_NUM" --json body -q .body 2>/dev/null || echo "No description")
+
+        PROMPT="You are an autonomous worker fixing issue #${ISSUE_NUM}: ${ISSUE_TITLE}
+
+Issue description:
+${ISSUE_BODY}
+
+Instructions:
+1. Create a branch: ${BRANCH_NAME}
+2. Read the relevant code and understand the problem
+3. Implement the fix
+4. Build and test:
+   cmake -B build -S . -GNinja -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
+   cmake --build build --parallel
+   ctest --test-dir build --output-on-failure --label-exclude '^integration$'
+5. Commit your changes with a descriptive message
+6. Push the branch (do NOT create a PR)
+
+Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>"
+
+        docker run --stop-timeout 3600 "${DOCKER_ARGS[@]}" "$IMAGE_NAME" \
+            claude -p "$PROMPT" \
+            --dangerously-skip-permissions \
+            --output-format stream-json \
+            2>&1 | tee "$LOG_FILE"
+        ;;
+    "")
+        echo "Usage: $0 <prompt> | --interactive | --shell | --worker <issue>"
+        echo ""
+        echo "Options:"
+        echo "  <prompt>            Run headless Claude with the given task"
+        echo "  --interactive       Start interactive Claude session in container"
+        echo "  --shell             Drop into container bash for debugging"
+        echo "  --worker <issue>    Work on a GitHub issue autonomously"
+        echo ""
+        echo "Environment:"
+        echo "  RSBS_GPU=1          Enable GPU passthrough"
+        exit 1
+        ;;
+    *)
+        # Headless mode: pass prompt, get results
+        echo "Running sandboxed Claude with prompt: $1"
+        docker run --stop-timeout 3600 "${DOCKER_ARGS[@]}" "$IMAGE_NAME" \
+            claude -p "$1" \
+            --dangerously-skip-permissions \
+            --output-format stream-json
+        ;;
+esac

--- a/.claude-sandbox/run-worker.sh
+++ b/.claude-sandbox/run-worker.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+# Dispatch one or more autonomous Claude Code workers for GitHub issues.
+#
+# Usage:
+#   ./run-worker.sh 201                    # Work on issue #201
+#   ./run-worker.sh --parallel 201 170 168 # Multiple workers in parallel
+#   ./run-worker.sh --list                 # List worker-ready open issues
+#
+# Each worker:
+#   1. Fetches issue details from GitHub
+#   2. Creates a branch claude/fix-issue-<num>
+#   3. Implements the fix inside a Docker container
+#   4. Builds and runs tests
+#   5. Pushes the branch
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
+DRY_RUN=0
+
+list_issues() {
+    echo "Open issues:"
+    echo ""
+    gh issue list -R spencerduncan/redshipblueship --state open --limit 30 \
+        --json number,title,labels \
+        --jq '.[] | "  #\(.number)\t\(.title)\t[\(.labels | map(.name) | join(", "))]"'
+}
+
+run_worker() {
+    local issue_num="$1"
+    if [[ "$DRY_RUN" -eq 1 ]]; then
+        echo "[dry-run] Would dispatch worker for issue #${issue_num}"
+        echo "[dry-run]   Command: $SCRIPT_DIR/run-sandboxed-claude.sh --worker $issue_num"
+        return 0
+    fi
+    echo "=== Dispatching worker for issue #${issue_num} ==="
+    "$SCRIPT_DIR/run-sandboxed-claude.sh" --worker "$issue_num"
+    echo "=== Worker for issue #${issue_num} complete ==="
+}
+
+# Parse leading flags
+while [[ "${1:-}" == --dry-run ]]; do
+    DRY_RUN=1
+    shift
+done
+
+case "${1:-}" in
+    --list)
+        list_issues
+        ;;
+    --parallel)
+        shift
+        if [[ $# -eq 0 ]]; then
+            echo "Usage: $0 [--dry-run] --parallel <issue1> <issue2> ..."
+            exit 1
+        fi
+        pids=()
+        issues=("$@")
+        for issue in "$@"; do
+            run_worker "$issue" &
+            pids+=($!)
+            echo "  Started worker PID ${pids[-1]} for issue #${issue}"
+        done
+        echo ""
+        echo "Waiting for ${#pids[@]} workers..."
+        failed=0
+        for i in "${!pids[@]}"; do
+            pid="${pids[$i]}"
+            issue_num="${issues[$i]}"
+            if wait "$pid"; then
+                echo "  Worker for issue #${issue_num} (PID $pid): SUCCESS"
+            else
+                status=$?
+                echo "  Worker for issue #${issue_num} (PID $pid): FAILED (exit $status)"
+                ((failed++))
+            fi
+        done
+        echo ""
+        echo "Done. $((${#pids[@]} - failed))/${#pids[@]} workers succeeded."
+        exit $failed
+        ;;
+    "")
+        echo "Usage: $0 [--dry-run] <issue-number> | --parallel <issues...> | --list"
+        exit 1
+        ;;
+    *)
+        run_worker "$1"
+        ;;
+esac

--- a/.claude-sandbox/run-worker.sh
+++ b/.claude-sandbox/run-worker.sh
@@ -73,7 +73,7 @@ case "${1:-}" in
             else
                 status=$?
                 echo "  Worker for issue #${issue_num} (PID $pid): FAILED (exit $status)"
-                ((failed++))
+                failed=$((failed + 1))
             fi
         done
         echo ""


### PR DESCRIPTION
## Summary
- `Dockerfile`: mark `/workspace` as a `safe.directory` so git works inside the sandbox.
- `run-sandboxed-claude.sh`: add `--stop-timeout 3600`, capture logs, and pre-check for an existing remote branch before entering `--worker` mode.
- `run-worker.sh`: add `--dry-run` flag and per-worker exit status reporting.

## Test plan
- [ ] `run-sandboxed-claude.sh` — verify remote branch pre-check skips workers whose branch already exists.
- [ ] `run-sandboxed-claude.sh` — verify `--stop-timeout 3600` is applied and logs are captured to the expected path.
- [ ] `run-worker.sh --dry-run` — confirm it prints the planned invocation without launching containers.
- [ ] `run-worker.sh` — confirm per-worker exit statuses are reported at end of run.
- [ ] Rebuild the sandbox image and run a one-shot sandboxed task end-to-end to confirm `/workspace` git operations still work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!--- section:artifacts:start -->
### Build Artifacts
  - [rsbs-windows.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/6522919357.zip)
  - [rsbs-linux.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/6522851508.zip)
<!--- section:artifacts:end -->