### PR TITLE
fix: sync 2S2H save buffer size to 128KB (#203)

### DIFF
--- a/games/mm/include/z64save.h
+++ b/games/mm/include/z64save.h
@@ -33,8 +33,8 @@ typedef enum RespawnMode {
     /* 8 */ RESPAWN_MODE_MAX
 } RespawnMode;
 
-// 2S2H [Port] Quadruple the size of the Save Buffer to support more data, eg rando
-#define SAVE_BUFFER_SIZE 0x4000 * 4
+// 2S2H [Port] Octuple the size of the Save Buffer to support more data, eg rando
+#define SAVE_BUFFER_SIZE 0x4000 * 8
 #define SAVE_BUFFER_SIZE_HALF (SAVE_BUFFER_SIZE / 2)
 
 // 2S2H [Enhancement] Extended for file 3 support


### PR DESCRIPTION
## Summary
- Grow MM `SAVE_BUFFER_SIZE` from `0x4000 * 4` (64KB) to `0x4000 * 8` (128KB) in `games/mm/include/z64save.h` to sync with upstream 2Ship2Harkinian commit `1fdc7ba6d`.
- `SAVE_BUFFER_SIZE_HALF` is derived (`SAVE_BUFFER_SIZE / 2`) and auto-updates.
- Swept `games/mm/` for hardcoded save-buffer literals — all call sites (allocation in `z_sram_NES.c`, memset/memcpy throughout) reference the macros symbolically, so no additional changes are required.

Closes #203.

## Test plan
- [ ] CI build passes on all platforms
- [ ] Save file load/save works in MM (manual smoke test)
- [ ] Rando save data (which motivated the larger buffer upstream) fits correctly
- [ ] No regressions in file-select / copy / erase flows

Per-platform build commands verified locally are unavailable (no cmake/ninja in this environment); relying on CI for compile verification. The change is a single macro value; all consumers use the symbol.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!--- section:artifacts:start -->
### Build Artifacts
  - [rsbs-windows.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/6522384063.zip)
  - [rsbs-linux.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/6522286645.zip)
<!--- section:artifacts:end -->