### PR TITLE
ci: optimize Windows build time (#177)

### DIFF
--- a/.github/workflows/generate-builds.yml
+++ b/.github/workflows/generate-builds.yml
@@ -327,7 +327,18 @@ jobs:
   build-windows:
     needs: generate-rsbs-otr
     runs-on: windows-latest
+    env:
+      # vcpkg binary caching via GitHub Actions cache. vcpkg stores prebuilt port
+      # binaries keyed by their ABI hash, so unchanged deps skip source compilation.
+      # Requires ACTIONS_CACHE_URL and ACTIONS_RUNTIME_TOKEN, exported below.
+      VCPKG_BINARY_SOURCES: "clear;x-gha,readwrite"
     steps:
+    - name: Export GitHub Actions cache env vars for vcpkg
+      uses: actions/github-script@v7
+      with:
+        script: |
+          core.exportVariable('ACTIONS_CACHE_URL', process.env.ACTIONS_CACHE_URL || '');
+          core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env.ACTIONS_RUNTIME_TOKEN || '');
     - name: Install dependencies
       run: |
         choco install ninja llvm -y
@@ -342,8 +353,7 @@ jobs:
       uses: hendrikmuhs/ccache-action@v1.2
       with:
         variant: sccache
-        max-size: "2G"
-        evict-old-files: job
+        max-size: "5G"
         save: ${{ github.ref_name == github.event.repository.default_branch }}
         key: ${{ runner.os }}-sccache-${{ github.ref }}
         restore-keys: |
@@ -354,8 +364,9 @@ jobs:
       id: restore-cache-vcpkg
       uses: actions/cache/restore@v4
       with:
-        key: ${{ runner.os }}-vcpkg-v1-${{ hashFiles('CMakeLists.txt') }}
+        key: ${{ runner.os }}-vcpkg-v2-${{ hashFiles('CMakeLists.txt', 'CMake/automate-vcpkg.cmake') }}
         restore-keys: |
+          ${{ runner.os }}-vcpkg-v2-
           ${{ runner.os }}-vcpkg-v1-
         path: vcpkg
     - name: Configure Developer Command Prompt
@@ -387,5 +398,5 @@ jobs:
       if: ${{ github.ref_name == github.event.repository.default_branch }}
       uses: actions/cache/save@v4
       with:
-        key: ${{ runner.os }}-vcpkg-v1-${{ hashFiles('CMakeLists.txt') }}
+        key: ${{ runner.os }}-vcpkg-v2-${{ hashFiles('CMakeLists.txt', 'CMake/automate-vcpkg.cmake') }}
         path: vcpkg


### PR DESCRIPTION
## Summary

Windows CI runs are dominated by vcpkg compiling static deps (sdl2, glew, libzip, boost, etc.) from source on every run. This enables vcpkg's **GitHub Actions binary cache provider** so unchanged ports are fetched pre-built via the GHA cache instead of rebuilt. Also widens the sccache cap so MSVC object caching survives across jobs.

Fixes issue #177.

## Changes (`.github/workflows/generate-builds.yml`, `build-windows` job only)

- **vcpkg binary caching**: job-level `VCPKG_BINARY_SOURCES=clear;x-gha,readwrite`, plus `actions/github-script@v7` step to export `ACTIONS_CACHE_URL` / `ACTIONS_RUNTIME_TOKEN` (required — vcpkg runs inside CMake, not an action step, so these have to be re-exported to the job env).
- **sccache**: bump `max-size` 2G → 5G and drop `evict-old-files: job` so stored objects persist across jobs (sccache's own LRU still enforces the cap).
- **vcpkg folder cache**: key bumped to `v2-` and now hashes `CMake/automate-vcpkg.cmake` in addition to `CMakeLists.txt` (so bootstrap-script changes invalidate it); old `v1-` key kept as a restore fallback so the first run after merge still warms from the existing cache.

No changes to application code, submodules, or other workflow jobs.

## Expected time savings

- **vcpkg binary cache hit** (steady state on a PR branch or post-warmup on `main`): ~10–20 min removed from the run — `vcpkg install` goes from compiling every port from source to unpacking prebuilt binaries.
- **sccache cap bump**: fewer evictions → higher hit rate on deep edits, expected additional 1–3 min saved on typical PRs.
- **First run on `main` after merge**: no speed-up (cold cache warms); **subsequent runs**: the big win lands.

## Test plan

- [ ] CI runs green on this PR; confirm the `build-windows` job still produces `rsbs-windows.zip`.
- [ ] Check `build-windows` logs for lines like `Restored from GHA cache` / `Stored in GHA cache` during the vcpkg install phase — confirms the x-gha provider is wired.
- [ ] Compare `build-windows` duration against a recent `main` run (before) and a re-run on this branch once the cache is warm (after).
- [ ] Verify sccache stats line near end of build shows non-zero hit rate on re-runs.
- [ ] Confirm the produced `rsbs-windows` artifact is identical in contents to pre-change builds (no dependency ABI drift from the binary cache).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!--- section:artifacts:start -->
### Build Artifacts
  - [rsbs-windows.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/6522371827.zip)
  - [rsbs-linux.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/6522275314.zip)
<!--- section:artifacts:end -->