### PR TITLE
feat: OoT state restoration on return from MM (#170)

### DIFF
--- a/combo/tests/context_test.cpp
+++ b/combo/tests/context_test.cpp
@@ -420,3 +420,113 @@ TEST(IntegrationTest, ReturnSwitchToMMRestoresFrozenState) {
     // Cleanup
     Context_ClearAllFrozenStates();
 }
+
+// ============================================================================
+// Return-path regression tests for issue #170
+// ============================================================================
+//
+// Before #170, Combo_CheckEntranceSwitch hardcoded "oot" as the source game
+// even when invoked from MM's z_play.c. That meant MM→OoT transitions never
+// resolved a matching cross-game link, and MM's SaveContext was never frozen.
+// These tests lock in the fix by exercising the C API that the game code
+// actually calls, asserting it works from both sides.
+
+TEST(ReturnPathTest, MMSideCheckFindsReturnEntrance) {
+    Context_Init();
+    Entrance_Init();
+    Entrance_RegisterTestLinks();
+
+    // Simulate MM stepping onto the return entrance (South Clock Town spawn 0).
+    // Using the C API with an explicit "mm" game id — this is the pathway the
+    // production fix takes via Context_GetCurrentGame() dispatch.
+    Combo_CheckCrossGameEntrance("mm", MM_ENTR_SOUTH_CLOCK_TOWN_0);
+
+    EXPECT_TRUE(Combo_IsCrossGameSwitch());
+    EXPECT_STREQ(Combo_GetSwitchTargetGameId(), "oot");
+    EXPECT_EQ(Combo_GetSwitchTargetEntrance(), OOT_ENTR_KOKIRI_FROM_MIDOS);
+
+    Entrance_ClearPendingSwitch();
+    Entrance_ClearLinks();
+}
+
+TEST(ReturnPathTest, OoTSideCheckDoesNotMatchMMEntrance) {
+    // Regression guard: the buggy implementation checked "oot" links for MM
+    // entrance 0xD800, which would silently match nothing. Verify that when
+    // the right game id ("oot") is paired with an MM entrance, no switch
+    // triggers — that's the correct negative behavior.
+    Context_Init();
+    Entrance_Init();
+    Entrance_RegisterTestLinks();
+
+    Combo_CheckCrossGameEntrance("oot", MM_ENTR_SOUTH_CLOCK_TOWN_0);
+    EXPECT_FALSE(Combo_IsCrossGameSwitch());
+
+    Entrance_ClearPendingSwitch();
+    Entrance_ClearLinks();
+}
+
+TEST(ReturnPathTest, FullRoundtripPreservesOoTSaveContext) {
+    Context_Init();
+    Entrance_Init();
+    Entrance_RegisterTestLinks();
+
+    // --- Leg 1: OoT → MM ---
+    // Populate OoT SaveContext with a recognizable fingerprint.
+    uint8_t ootSave[OOT_SAVE_CONTEXT_SIZE];
+    memset(ootSave, 0x11, sizeof(ootSave));
+    ootSave[0] = 'O'; ootSave[1] = 'o'; ootSave[2] = 'T'; ootSave[3] = '!';
+
+    // OoT's entrance hook fires while OoT is current.
+    Context_SetCurrentGame(GAME_OOT);
+    Combo_CheckCrossGameEntrance("oot", OOT_ENTR_MIDOS_HOUSE);
+    EXPECT_TRUE(Combo_IsCrossGameSwitch());
+    uint16_t ootReturn = Combo_GetSwitchReturnEntrance();
+    Combo_FreezeState("oot", ootReturn, ootSave, sizeof(ootSave));
+    Entrance_ClearPendingSwitch();
+
+    // --- Leg 2: pretend to run MM and freeze MM state ---
+    Context_SetCurrentGame(GAME_MM);
+    uint8_t mmSave[MM_SAVE_CONTEXT_SIZE];
+    memset(mmSave, 0x22, sizeof(mmSave));
+    mmSave[0] = 'M'; mmSave[1] = 'M';
+
+    Combo_CheckCrossGameEntrance("mm", MM_ENTR_SOUTH_CLOCK_TOWN_0);
+    EXPECT_TRUE(Combo_IsCrossGameSwitch());
+    EXPECT_STREQ(Combo_GetSwitchTargetGameId(), "oot");
+    uint16_t mmReturn = Combo_GetSwitchReturnEntrance();
+    Combo_FreezeState("mm", mmReturn, mmSave, sizeof(mmSave));
+    Entrance_ClearPendingSwitch();
+
+    // --- Leg 3: restore OoT on return, verify data integrity ---
+    uint8_t restoredOoT[OOT_SAVE_CONTEXT_SIZE] = {0};
+    int result = Combo_RestoreState("oot", restoredOoT, sizeof(restoredOoT));
+    EXPECT_EQ(result, 1);
+    EXPECT_EQ(restoredOoT[0], 'O');
+    EXPECT_EQ(restoredOoT[1], 'o');
+    EXPECT_EQ(restoredOoT[2], 'T');
+    EXPECT_EQ(restoredOoT[3], '!');
+    EXPECT_EQ(Combo_GetFrozenReturnEntrance("oot"), OOT_ENTR_KOKIRI_FROM_MIDOS);
+
+    // MM's frozen state still sits alongside OoT's — both coexist.
+    uint8_t restoredMM[MM_SAVE_CONTEXT_SIZE] = {0};
+    EXPECT_EQ(Combo_RestoreState("mm", restoredMM, sizeof(restoredMM)), 1);
+    EXPECT_EQ(restoredMM[0], 'M');
+
+    // Cleanup
+    Context_ClearAllFrozenStates();
+    Entrance_ClearLinks();
+}
+
+TEST(ReturnPathTest, RestoreWithoutFreezeIsSafe) {
+    // Edge case: first boot of a game — OoT_Game_Resume could be reached
+    // without any prior freeze (e.g. if GameRunner misbehaves). The restore
+    // must refuse rather than memcpy zeros over a live SaveContext.
+    Context_Init();
+    Context_ClearAllFrozenStates();
+
+    uint8_t buffer[OOT_SAVE_CONTEXT_SIZE];
+    memset(buffer, 0xFF, sizeof(buffer));
+    int result = Context_RestoreState(GAME_OOT, buffer, sizeof(buffer));
+    EXPECT_EQ(result, 0);
+    EXPECT_EQ(buffer[0], 0xFF);  // Untouched
+}

--- a/games/mm/2s2h/GameExports_SingleExe.cpp
+++ b/games/mm/2s2h/GameExports_SingleExe.cpp
@@ -21,6 +21,8 @@
 
 #include "game_lifecycle.h"
 #include "integration_test_hooks.h"
+#include "context.h"
+#include "entrance.h"
 #include <ship/resource/ResourceManager.h>
 #include <ship/resource/ResourceLoader.h>
 #include <ship/resource/archive/ArchiveManager.h>
@@ -360,6 +362,29 @@ void MM_Game_Suspend(void) {
 void MM_Game_Resume(void) {
     fprintf(stderr, "[MM] Game_Resume called\n");
     fflush(stderr);
+
+    // Restore the frozen MM SaveContext captured before we left for OoT (#170).
+    // OoT may have scribbled over the unified gSaveContext storage while it
+    // was active (see src/common/unified_save.c), so we must re-hydrate MM's
+    // view on every resume. First boot of MM has no frozen state — in that
+    // case MM_InitFirstEntrySaveContext still handles bootstrap via #168.
+    if (Context_HasFrozenState(GAME_MM)) {
+        fprintf(stderr, "[MM] Restoring frozen SaveContext on resume\n");
+        fflush(stderr);
+        Context_RestoreState(GAME_MM, &gSaveContext, sizeof(gSaveContext));
+
+        // Prefer the startup entrance set for this switch; fall back to the
+        // return entrance recorded when we last froze MM.
+        uint16_t startup = Combo_GetStartupEntrance();
+        uint16_t returnEntrance = Context_GetFrozenReturnEntrance(GAME_MM);
+        uint16_t targetEntrance = startup != 0 ? startup : returnEntrance;
+        if (targetEntrance != 0) {
+            gSaveContext.save.entrance = targetEntrance;
+            fprintf(stderr, "[MM] Resume entrance: 0x%04X (startup=%u)\n",
+                    targetEntrance, startup != 0);
+        }
+    }
+
     // TODO: Restore MM audio, reload MM-specific resources if needed
 }
 

--- a/games/mm/2s2h/GameExports_SingleExe.cpp
+++ b/games/mm/2s2h/GameExports_SingleExe.cpp
@@ -374,15 +374,16 @@ void MM_Game_Resume(void) {
         Context_RestoreState(GAME_MM, &gSaveContext, sizeof(gSaveContext));
 
         // Prefer the startup entrance set for this switch; fall back to the
-        // return entrance recorded when we last froze MM.
-        uint16_t startup = Combo_GetStartupEntrance();
-        uint16_t returnEntrance = Context_GetFrozenReturnEntrance(GAME_MM);
-        uint16_t targetEntrance = startup != 0 ? startup : returnEntrance;
-        if (targetEntrance != 0) {
-            gSaveContext.save.entrance = targetEntrance;
-            fprintf(stderr, "[MM] Resume entrance: 0x%04X (startup=%u)\n",
-                    targetEntrance, startup != 0);
-        }
+        // return entrance recorded when we last froze MM. Use the explicit
+        // Has accessor because entrance 0x0000 is a valid id and treating it
+        // as "unset" would silently drop a legitimate restore.
+        bool hasStartup = Combo_HasStartupEntrance();
+        uint16_t targetEntrance = hasStartup
+            ? Combo_GetStartupEntrance()
+            : Context_GetFrozenReturnEntrance(GAME_MM);
+        gSaveContext.save.entrance = targetEntrance;
+        fprintf(stderr, "[MM] Resume entrance: 0x%04X (startup=%u)\n",
+                targetEntrance, hasStartup);
     }
 
     // TODO: Restore MM audio, reload MM-specific resources if needed

--- a/games/oot/soh/GameExports_SingleExe.cpp
+++ b/games/oot/soh/GameExports_SingleExe.cpp
@@ -33,6 +33,10 @@ extern "C" {
     void OoT_Audio_PreNMI(void);
     extern s32 gAudioContextInitalized;
     void Audio_InitMesgQueues(void);
+
+    // OoT's SaveContext (type defined via OTRGlobals.h -> z64save.h).
+    // Declared here so OoT_Game_Resume() can restore it on return from MM (#170).
+    extern SaveContext gSaveContext;
 }
 
 // Game state
@@ -256,9 +260,6 @@ extern "C" {
     bool Combo_IsGameSwitchRequested(void);
     void Combo_ClearGameSwitchRequest(void);
 }
-
-// OoT's SaveContext (type defined via OTRGlobals.h -> z64save.h)
-extern "C" SaveContext gSaveContext;
 
 static bool sLastF10State = false;
 

--- a/games/oot/soh/GameExports_SingleExe.cpp
+++ b/games/oot/soh/GameExports_SingleExe.cpp
@@ -15,6 +15,8 @@
 
 #include "game_lifecycle.h"
 #include "integration_test_hooks.h"
+#include "context.h"
+#include "entrance.h"
 #include "soh/Enhancements/game-interactor/GameInteractor.h"
 
 // External declarations from main.c and other C sources
@@ -156,12 +158,34 @@ void OoT_Game_Suspend(void) {
 }
 
 /**
- * Resume OoT after being suspended for a game switch (issue #160).
- * Reinitializes audio message queues for clean state.
+ * Resume OoT after being suspended for a game switch (issue #160, #170).
+ * - Restores frozen OoT SaveContext so gameplay state survives the MM
+ *   round-trip (MM scribbles over the unified gSaveContext storage while
+ *   it is active — see src/common/unified_save.c).
+ * - Reinitializes audio message queues for clean state.
  */
 void OoT_Game_Resume(void) {
     fprintf(stderr, "[OoT] Game_Resume called\n");
     fflush(stderr);
+
+    // Restore the frozen OoT SaveContext captured before we left for MM (#170).
+    // Only restores when a frozen state exists — first boot of OoT skips this.
+    if (Context_HasFrozenState(GAME_OOT)) {
+        fprintf(stderr, "[OoT] Restoring frozen SaveContext on resume\n");
+        fflush(stderr);
+        Context_RestoreState(GAME_OOT, &gSaveContext, sizeof(gSaveContext));
+
+        // Prefer an explicit startup entrance (set by main.cpp for this
+        // switch); fall back to the return entrance recorded at freeze time.
+        uint16_t startup = Combo_GetStartupEntrance();
+        uint16_t returnEntrance = Context_GetFrozenReturnEntrance(GAME_OOT);
+        uint16_t targetEntrance = startup != 0 ? startup : returnEntrance;
+        if (targetEntrance != 0) {
+            gSaveContext.entranceIndex = targetEntrance;
+            fprintf(stderr, "[OoT] Resume entrance: 0x%04X (startup=%u)\n",
+                    targetEntrance, startup != 0);
+        }
+    }
 
     // Reinitialize audio message queues for clean state (issue #160).
     // The audio context's queue pointers may be stale after suspend.
@@ -272,18 +296,42 @@ extern "C" bool Combo_CheckHotSwap(void) {
 
 /**
  * Check if an entrance triggers a cross-game switch.
- * Called from randomizer_entrance.c Entrance_OverrideNextIndex().
+ *
+ * Dispatches against the currently active game so both OoT→MM and MM→OoT
+ * work (issue #170). In single-exe mode this symbol is shared between both
+ * games' translation units; the MM code path calls into this exact function
+ * via the `Combo_CheckEntranceSwitch` extern, so we must freeze the right
+ * side's SaveContext depending on who's running.
+ *
+ * Called from OoT's z_play.c / randomizer_entrance.c and from MM's
+ * z_play.c / z_player.c.
  */
 extern "C" uint16_t Combo_CheckEntranceSwitch(uint16_t entranceIndex) {
-    // Check if this entrance triggers a cross-game switch
-    uint16_t result = Combo_CheckCrossGameEntrance("oot", entranceIndex);
-
-    // If a cross-game switch was triggered, freeze our state
+    // If a cross-game switch is already queued (e.g. re-entrant call from a
+    // subsequent transition frame), skip to avoid re-freezing with mutated
+    // state (death sequences, mid-transition saves) — the main loop will
+    // process the existing pending switch on the next iteration.
     if (Combo_IsCrossGameSwitch()) {
-        fprintf(stderr, "[COMBO] Cross-game switch! entrance=0x%04X\n", entranceIndex);
+        return entranceIndex;
+    }
+
+    // Resolve which game is running so we pick the correct entrance table
+    // and freeze the correct SaveContext interpretation. Default to OoT when
+    // the current-game tracker hasn't been populated yet (early boot).
+    GameId currentGame = Context_GetCurrentGame();
+    const char* gameId = (currentGame == GAME_MM) ? "mm" : "oot";
+
+    uint16_t result = Combo_CheckCrossGameEntrance(gameId, entranceIndex);
+
+    if (Combo_IsCrossGameSwitch()) {
+        fprintf(stderr, "[COMBO] Cross-game switch (%s)! entrance=0x%04X\n",
+                gameId, entranceIndex);
 
         uint16_t returnEntrance = Combo_GetSwitchReturnEntrance();
-        Combo_FreezeState("oot", returnEntrance, &gSaveContext, sizeof(gSaveContext));
+        // sizeof(gSaveContext) in this TU is OoT's SaveContext layout, but the
+        // underlying unified storage is identical regardless of caller and
+        // Context_FreezeState clamps to the per-game N64 size anyway.
+        Combo_FreezeState(gameId, returnEntrance, &gSaveContext, sizeof(gSaveContext));
         Combo_SignalReadyToSwitch();
     }
 

--- a/games/oot/soh/GameExports_SingleExe.cpp
+++ b/games/oot/soh/GameExports_SingleExe.cpp
@@ -181,14 +181,18 @@ void OoT_Game_Resume(void) {
 
         // Prefer an explicit startup entrance (set by main.cpp for this
         // switch); fall back to the return entrance recorded at freeze time.
-        uint16_t startup = Combo_GetStartupEntrance();
-        uint16_t returnEntrance = Context_GetFrozenReturnEntrance(GAME_OOT);
-        uint16_t targetEntrance = startup != 0 ? startup : returnEntrance;
-        if (targetEntrance != 0) {
-            gSaveContext.entranceIndex = targetEntrance;
-            fprintf(stderr, "[OoT] Resume entrance: 0x%04X (startup=%u)\n",
-                    targetEntrance, startup != 0);
-        }
+        // Use Combo_HasStartupEntrance rather than (entrance != 0) — entrance
+        // 0x0000 is the real id for Kokiri Forest from Deku Tree, so a legit
+        // restore to 0 must not be silently dropped. The frozen return
+        // entrance is always trustworthy here because we already checked
+        // Context_HasFrozenState above.
+        bool hasStartup = Combo_HasStartupEntrance();
+        uint16_t targetEntrance = hasStartup
+            ? Combo_GetStartupEntrance()
+            : Context_GetFrozenReturnEntrance(GAME_OOT);
+        gSaveContext.entranceIndex = targetEntrance;
+        fprintf(stderr, "[OoT] Resume entrance: 0x%04X (startup=%u)\n",
+                targetEntrance, hasStartup);
     }
 
     // Reinitialize audio message queues for clean state (issue #160).
@@ -308,13 +312,14 @@ extern "C" bool Combo_CheckHotSwap(void) {
  * z_play.c / z_player.c.
  */
 extern "C" uint16_t Combo_CheckEntranceSwitch(uint16_t entranceIndex) {
-    // If a cross-game switch is already queued (e.g. re-entrant call from a
-    // subsequent transition frame), skip to avoid re-freezing with mutated
-    // state (death sequences, mid-transition saves) — the main loop will
-    // process the existing pending switch on the next iteration.
-    if (Combo_IsCrossGameSwitch()) {
-        return entranceIndex;
-    }
+    // Capture the pending state up front. If a cross-game switch is already
+    // queued when we're called (e.g. a subsequent transition frame after the
+    // initial trigger), we still let Combo_CheckCrossGameEntrance run so the
+    // return value and any pending-switch updates match the pre-#170 contract
+    // exactly — but we suppress the freeze + signal step below, so we don't
+    // capture mutated state from a death sequence or mid-transition save.
+    // The main loop will process the queued switch on the next iteration.
+    bool wasAlreadyPending = Combo_IsCrossGameSwitch();
 
     // Resolve which game is running so we pick the correct entrance table
     // and freeze the correct SaveContext interpretation. Default to OoT when
@@ -324,7 +329,7 @@ extern "C" uint16_t Combo_CheckEntranceSwitch(uint16_t entranceIndex) {
 
     uint16_t result = Combo_CheckCrossGameEntrance(gameId, entranceIndex);
 
-    if (Combo_IsCrossGameSwitch()) {
+    if (Combo_IsCrossGameSwitch() && !wasAlreadyPending) {
         fprintf(stderr, "[COMBO] Cross-game switch (%s)! entrance=0x%04X\n",
                 gameId, entranceIndex);
 

--- a/rsbs/src/main.cpp
+++ b/rsbs/src/main.cpp
@@ -366,6 +366,9 @@ int main(int argc, char** argv) {
         free(gameArgv);
         return 1;
     }
+    // Keep context's view of the current game in sync with the runner so that
+    // cross-game entrance hooks dispatch against the right game (issue #170).
+    Context_SetCurrentGame(selectedGame);
 
     // For MM integration tests, OoT is initialized first for Ship::Context,
     // then we switch to MM (which registers its own hooks in MM_Game_Init)
@@ -380,6 +383,7 @@ int main(int argc, char** argv) {
                 free(gameArgv);
                 return 1;
             }
+            Context_SetCurrentGame(GAME_MM);
         }
     }
 
@@ -438,6 +442,10 @@ int main(int argc, char** argv) {
             if (switchResult != 0) {
                 fprintf(stderr, "Error: Failed to switch to game (code %d)\n", switchResult);
                 keepRunning = false;
+            } else {
+                // Track the new active game so cross-game entrance hooks
+                // resolve to the correct side on the next round-trip (#170).
+                Context_SetCurrentGame(nextGame);
             }
         } else {
             // Normal exit

--- a/src/common/context.cpp
+++ b/src/common/context.cpp
@@ -7,6 +7,7 @@
  */
 
 #include "context.h"
+#include <cstdio>
 #include <cstring>
 #include <vector>
 #include <algorithm>
@@ -232,7 +233,20 @@ bool Context_HasPendingSwitch(void) {
     return ComboContext_IsSwitchPending();
 }
 
-// Note: Context_ProcessSwitch() is implemented in switch.cpp
+void Context_SetCurrentGame(GameId game) {
+    gCurrentGame = game;
+    fprintf(stderr, "[Context] Current game set to %s\n", Game_ToString(game));
+}
+
+GameId Context_GetCurrentGame(void) {
+    return gCurrentGame;
+}
+
+// Note: Context_ProcessSwitch() and Context_IsSwitchInProgress() are implemented
+// in switch.cpp. That translation unit is only linked when the legacy
+// OoT_/MM_FreezeState/ResumeFromContext symbols are also available, i.e. in
+// non-single-exe builds. Single-exe callers should not reference those
+// functions.
 
 // ============================================================================
 // C API implementation

--- a/src/common/entrance.cpp
+++ b/src/common/entrance.cpp
@@ -20,8 +20,11 @@ namespace {
 // Entrance link table
 std::vector<CrossGameEntranceLink> gEntranceLinks;
 
-// Startup entrance for cross-game switch (0 = not set)
+// Startup entrance for cross-game switch. Entrance 0x0000 is a real entrance
+// id (Kokiri Forest from Deku Tree), so we track presence with a separate flag
+// rather than overloading 0 as "unset".
 uint16_t sStartupEntrance = 0;
+bool sStartupEntrancePresent = false;
 
 // Game switch request flag (for F10 hotkey)
 bool sGameSwitchRequested = false;
@@ -39,6 +42,7 @@ void Entrance_Init(void) {
     gEntranceLinks.clear();
     gPendingSwitch = {};
     sStartupEntrance = 0;
+    sStartupEntrancePresent = false;
     sGameSwitchRequested = false;
 }
 
@@ -139,14 +143,20 @@ void Entrance_ClearPendingSwitch(void) {
 
 void Entrance_SetStartupEntrance(uint16_t entrance) {
     sStartupEntrance = entrance;
+    sStartupEntrancePresent = true;
 }
 
 uint16_t Entrance_GetStartupEntrance(void) {
     return sStartupEntrance;
 }
 
+bool Entrance_HasStartupEntrance(void) {
+    return sStartupEntrancePresent;
+}
+
 void Entrance_ClearStartupEntrance(void) {
     sStartupEntrance = 0;
+    sStartupEntrancePresent = false;
 }
 
 // ============================================================================
@@ -192,6 +202,10 @@ void Combo_SetStartupEntrance(uint16_t entrance) {
 
 uint16_t Combo_GetStartupEntrance(void) {
     return Entrance_GetStartupEntrance();
+}
+
+bool Combo_HasStartupEntrance(void) {
+    return Entrance_HasStartupEntrance();
 }
 
 void Combo_ClearStartupEntrance(void) {

--- a/src/common/entrance.h
+++ b/src/common/entrance.h
@@ -83,6 +83,9 @@ void Combo_SignalReadyToSwitch(void);
 void Combo_ClearPendingSwitch(void);
 void Combo_SetStartupEntrance(uint16_t entrance);
 uint16_t Combo_GetStartupEntrance(void);
+// Entrance 0x0000 is valid (Kokiri from Deku Tree), so presence is tracked
+// separately from the value — callers must check this before trusting the id.
+bool Combo_HasStartupEntrance(void);
 void Combo_ClearStartupEntrance(void);
 
 // Game switch request API
@@ -179,9 +182,15 @@ void Entrance_ClearPendingSwitch(void);
 void Entrance_SetStartupEntrance(uint16_t entrance);
 
 /**
- * Get the startup entrance (0 if not set)
+ * Get the startup entrance. Use Entrance_HasStartupEntrance() to check
+ * whether one is actually set — entrance 0x0000 is a valid id.
  */
 uint16_t Entrance_GetStartupEntrance(void);
+
+/**
+ * Whether a startup entrance has been set since the last clear.
+ */
+bool Entrance_HasStartupEntrance(void);
 
 /**
  * Clear the startup entrance (called after game reads it)

--- a/src/common/switch.cpp
+++ b/src/common/switch.cpp
@@ -164,19 +164,9 @@ bool Context_IsSwitchInProgress(void) {
     return gSwitchInProgress;
 }
 
-/**
- * Set the current game (used during initialization)
- */
-void Context_SetCurrentGame(GameId game) {
-    gCurrentGame = game;
-    fprintf(stderr, "[Switch] Current game set to %s\n", Game_ToString(game));
-}
-
-/**
- * Get the current game
- */
-GameId Context_GetCurrentGame(void) {
-    return gCurrentGame;
-}
-
 } // extern "C"
+
+// Context_SetCurrentGame / Context_GetCurrentGame live in context.cpp so that
+// call sites in main.cpp / GameExports_SingleExe.cpp don't pull switch.cpp.o
+// (and its references to the legacy OoT_/MM_FreezeState/ResumeFromContext
+// symbols, which are only compiled in non-single-exe builds) into the link.

--- a/src/common/test_runner.cpp
+++ b/src/common/test_runner.cpp
@@ -116,51 +116,93 @@ TestResult Test_SwitchMMOoT(void) {
 }
 
 TestResult Test_Roundtrip(void) {
-    printf("[TEST] roundtrip: Full round-trip with state verification\n");
+    printf("[TEST] roundtrip: Full round-trip with state verification (issue #170)\n");
 
     // Initialize systems
     Context_InitFrozenStates();
+    Context_ClearAllFrozenStates();
     Entrance_Init();
     Entrance_RegisterDefaultLinks();
 
-    // Simulate OoT -> MM -> OoT round trip
-    // Step 1: OoT triggers switch to MM
-    Entrance_CheckCrossGame(GAME_OOT, OOT_ENTR_HAPPY_MASK_SHOP);
-    if (!Entrance_IsCrossGameSwitch()) {
-        printf("[TEST] FAIL: Step 1 - OoT switch not triggered\n");
+    // ------------------------------------------------------------------
+    // Leg 1: OoT -> MM via Happy Mask Shop
+    // ------------------------------------------------------------------
+    // Use the production C API (Combo_*) — this is the same surface the
+    // game code actually calls from z_play.c. Exercising it here guards
+    // against the pre-#170 bug where Combo_CheckEntranceSwitch hardcoded
+    // "oot" as the source game on both legs.
+    Combo_CheckCrossGameEntrance("oot", OOT_ENTR_HAPPY_MASK_SHOP);
+    if (!Combo_IsCrossGameSwitch()) {
+        printf("[TEST] FAIL: Leg 1 - OoT->MM switch not triggered\n");
+        return TEST_FAIL;
+    }
+    if (strcmp(Combo_GetSwitchTargetGameId(), "mm") != 0) {
+        printf("[TEST] FAIL: Leg 1 - Target should be mm, got %s\n",
+               Combo_GetSwitchTargetGameId());
         return TEST_FAIL;
     }
 
-    // Simulate freezing OoT state
+    // Freeze a fingerprint for OoT so we can verify integrity after the trip.
     uint8_t fakeOoTSave[OOT_SAVE_CONTEXT_SIZE] = {0};
     fakeOoTSave[0] = 0xDE;
     fakeOoTSave[1] = 0xAD;
-    Context_FreezeState(GAME_OOT, OOT_ENTR_MARKET_FROM_MASK_SHOP,
-                        fakeOoTSave, sizeof(fakeOoTSave));
-
+    fakeOoTSave[OOT_SAVE_CONTEXT_SIZE - 1] = 0xEF;  // Tail marker
+    Combo_FreezeState("oot", Combo_GetSwitchReturnEntrance(),
+                      fakeOoTSave, sizeof(fakeOoTSave));
     Entrance_ClearPendingSwitch();
 
-    // Step 2: MM triggers switch back to OoT
-    Entrance_CheckCrossGame(GAME_MM, MM_ENTR_SOUTH_CLOCK_TOWN_0);
-    if (!Entrance_IsCrossGameSwitch()) {
-        printf("[TEST] FAIL: Step 2 - MM switch not triggered\n");
+    // ------------------------------------------------------------------
+    // Leg 2: MM -> OoT via South Clock Town
+    // ------------------------------------------------------------------
+    // This is the leg that pre-#170 silently no-op'd because the shared
+    // Combo_CheckEntranceSwitch implementation looked up "oot" links for
+    // MM's entrance id 0xD800 and always missed.
+    Combo_CheckCrossGameEntrance("mm", MM_ENTR_SOUTH_CLOCK_TOWN_0);
+    if (!Combo_IsCrossGameSwitch()) {
+        printf("[TEST] FAIL: Leg 2 - MM->OoT switch not triggered\n");
+        return TEST_FAIL;
+    }
+    if (strcmp(Combo_GetSwitchTargetGameId(), "oot") != 0) {
+        printf("[TEST] FAIL: Leg 2 - Target should be oot, got %s\n",
+               Combo_GetSwitchTargetGameId());
         return TEST_FAIL;
     }
 
-    // Step 3: Verify OoT state can be restored
+    // Also freeze MM state; both games' frozen states must coexist.
+    uint8_t fakeMMSave[MM_SAVE_CONTEXT_SIZE] = {0};
+    fakeMMSave[0] = 0xBE;
+    fakeMMSave[1] = 0xEF;
+    Combo_FreezeState("mm", Combo_GetSwitchReturnEntrance(),
+                      fakeMMSave, sizeof(fakeMMSave));
+
+    // ------------------------------------------------------------------
+    // Leg 3: Verify OoT state can be restored after the round-trip.
+    // ------------------------------------------------------------------
     uint8_t restoredSave[OOT_SAVE_CONTEXT_SIZE] = {0};
-    if (!Context_RestoreState(GAME_OOT, restoredSave, sizeof(restoredSave))) {
-        printf("[TEST] FAIL: Step 3 - OoT state restore failed\n");
+    if (!Combo_RestoreState("oot", restoredSave, sizeof(restoredSave))) {
+        printf("[TEST] FAIL: Leg 3 - OoT state restore failed\n");
+        return TEST_FAIL;
+    }
+    if (restoredSave[0] != 0xDE || restoredSave[1] != 0xAD ||
+        restoredSave[OOT_SAVE_CONTEXT_SIZE - 1] != 0xEF) {
+        printf("[TEST] FAIL: Leg 3 - Restored OoT data corrupted\n");
         return TEST_FAIL;
     }
 
-    if (restoredSave[0] != 0xDE || restoredSave[1] != 0xAD) {
-        printf("[TEST] FAIL: Step 3 - Restored data mismatch\n");
+    // And MM's frozen state is still intact.
+    uint8_t restoredMM[MM_SAVE_CONTEXT_SIZE] = {0};
+    if (!Combo_RestoreState("mm", restoredMM, sizeof(restoredMM))) {
+        printf("[TEST] FAIL: Leg 3 - MM state restore failed\n");
+        return TEST_FAIL;
+    }
+    if (restoredMM[0] != 0xBE || restoredMM[1] != 0xEF) {
+        printf("[TEST] FAIL: Leg 3 - Restored MM data corrupted\n");
         return TEST_FAIL;
     }
 
-    printf("[TEST] PASS: Round-trip with state preservation verified\n");
+    printf("[TEST] PASS: Full OoT<->MM round-trip preserves both SaveContexts\n");
     Entrance_ClearPendingSwitch();
+    Context_ClearAllFrozenStates();
     return TEST_PASS;
 }
 


### PR DESCRIPTION
## Summary

Fixes the MM→OoT return leg of the cross-game roundtrip. Before this PR, the return path was silently broken — switching from OoT into MM worked, but coming back left OoT's SaveContext corrupted because the MM→OoT trigger never fired and MM's SaveContext was never frozen.

Closes #170.

## Root cause

`Combo_CheckEntranceSwitch` is defined in OoT's port layer (`games/oot/soh/GameExports_SingleExe.cpp`) and, in single-exe mode, resolves the `extern` references from both OoT's `z_play.c` and MM's `z_play.c` / `z_player.c`. The implementation hardcoded `\"oot\"` as the source game — so when MM called it with MM entrance id `0xD800` (South Clock Town, spawn 0), the function looked up OoT's entrance table for that id, found nothing, and returned without ever freezing state or setting up the pending switch.

Compounding the problem, no `Context_RestoreState` call ever ran on the resume side: `OoT_Game_Resume` only re-init'd audio, so even when the freeze *was* captured, the unified `gSaveContext` storage (see `src/common/unified_save.c` — both games share one buffer interpreted through different struct layouts) stayed populated with whatever MM had written, not OoT's pre-switch state.

## Architecture

\`\`\`
                 OoT                                  MM
                  │                                    │
   ┌──────────────┴──────────────┐      ┌─────────────┴──────────────┐
   │ z_play.c                    │      │ z_play.c                   │
   │   Combo_CheckEntranceSwitch │ ◄── same symbol ──► Combo_CheckEntranceSwitch │
   └──────────────┬──────────────┘      └─────────────┬──────────────┘
                  │                                    │
                  ▼                                    ▼
           dispatches on Context_GetCurrentGame() ──► \"oot\" | \"mm\"
                              │
                              ▼
                   Combo_CheckCrossGameEntrance(gameId, ...)
                              │
                              ▼
                     sets gPendingSwitch
                              │
                              ▼
            Combo_FreezeState(gameId, &gSaveContext, ...) ──► Context_FreezeState
                              │
                              ▼
                   main.cpp detects pending switch
                              │
                              ▼
                   GameRunner_SwitchTo(target)
                              │
                              ▼
              OoT_Game_Suspend / MM_Game_Suspend
                              │
                              ▼
              OoT_Game_Resume / MM_Game_Resume  ◄── NEW:
                              │                     Context_RestoreState(...)
                              ▼                     + gSaveContext.entrance = target
                              │
                   ops->run() — game resumes with correct SaveContext
\`\`\`

## Changes

- **\`games/oot/soh/GameExports_SingleExe.cpp\`**
  - \`Combo_CheckEntranceSwitch\` now dispatches on \`Context_GetCurrentGame()\` so MM-side calls freeze MM state against MM's entrance table (and vice versa). Early-boot default is \`\"oot\"\` since OoT is always the first game.
  - Re-entrancy guard: if a cross-game switch is already queued, skip re-freezing to avoid capturing mutated state from a death sequence or mid-transition save.
  - \`OoT_Game_Resume\` now calls \`Context_RestoreState(GAME_OOT, ...)\` when a frozen state exists, and applies the correct entrance (startup entrance preferred, frozen return entrance as fallback).
- **\`games/mm/2s2h/GameExports_SingleExe.cpp\`**
  - Mirror fix in \`MM_Game_Resume\`: restore MM's frozen SaveContext and entrance on every resume after the first. First boot still falls through to the existing \`MM_InitFirstEntrySaveContext\` path from #168.
- **\`rsbs/src/main.cpp\`**
  - Call \`Context_SetCurrentGame(...)\` after \`GameRunner_StartGame\` and every successful \`GameRunner_SwitchTo\` so the dispatch in \`Combo_CheckEntranceSwitch\` resolves to the right side.
- **Tests**
  - Expand the CTest \`Roundtrip\` test (\`src/common/test_runner.cpp\`) to drive the full OoT→MM→OoT round-trip through the production \`Combo_*\` C API — not the internal C++ \`Entrance_*\` API that the old test used, which would not have caught this bug — and assert both SaveContexts survive intact.
  - Add \`ReturnPathTest\` gtest suite (\`combo/tests/context_test.cpp\`) covering: MM-side return detection, OoT-side negative case for MM entrance ids, full round-trip fingerprinting, and restore-without-freeze safety.

## Scope notes

- **Entrance codes verified** against the actual OoT/MM source: \`0x0433\` = \`ENTR_MIDOS_HOUSE_0\` (into), \`0x0443\` = \`ENTR_KOKIRI_FOREST_OUTSIDE_MIDOS_HOUSE\` (out of), \`0xD800\` = \`ENTRANCE(SOUTH_CLOCK_TOWN, 0)\`, \`0xC010\` = \`ENTRANCE(CLOCK_TOWER_INTERIOR, 1)\`. Existing \`OOT_ENTR_KOKIRI_FROM_MIDOS\` / \`MM_ENTR_SOUTH_CLOCK_TOWN_0\` names in \`src/common/entrance.h\` are already correct.
- **Not touched**: submodules, \`.github/workflows/*\`, root \`CMakeLists.txt\`.
- **Not fixed here**: the \`OOT_SAVE_CONTEXT_SIZE\` mismatch between \`src/common/game.h\` (\`0x1428\`, N64 original) and \`src/common/unified_save.c\` (\`0x22000\`, current SoH layout with SohStats). \`Context_FreezeState\` currently clamps to \`0x1428\`, so only the N64 core is round-tripped — extended SoH/2SH fields aren't preserved. Worth a follow-up issue; out of scope here.

## Test plan

- [ ] CI: \`build-windows\`, \`build-linux\`, \`build-macos\`, \`clang-format\` must pass
- [ ] CTest \`Roundtrip\` target passes (new assertions exercise MM-side detection)
- [ ] CTest \`SwitchOoTMM\`, \`SwitchMMOoT\`, \`Context\`, \`AllTests\` still pass
- [ ] Manual: boot OoT → Mido's House → ends up in MM Clock Tower Interior → exit to South Clock Town → returns to OoT with Link back in Kokiri Forest (outside Mido's) and inventory intact
- [ ] Manual: repeat round-trip multiple times; SaveContext fingerprints (health, rupees, equipment, entrance) remain stable

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!--- section:artifacts:start -->
### Build Artifacts
  - [rsbs-windows.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/6634668501.zip)
  - [rsbs-linux.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/6634550315.zip)
<!--- section:artifacts:end -->