### PR TITLE
Port ConfigVersion5/6 Updaters from upstream SOH (#230)

### DIFF
--- a/games/oot/soh/OTRGlobals.cpp
+++ b/games/oot/soh/OTRGlobals.cpp
@@ -1297,6 +1297,8 @@ extern "C" void InitOTR(int argc, char* argv[]) {
     conf->RegisterVersionUpdater(std::make_shared<SOH::ConfigVersion2Updater>());
     conf->RegisterVersionUpdater(std::make_shared<SOH::ConfigVersion3Updater>());
     conf->RegisterVersionUpdater(std::make_shared<SOH::ConfigVersion4Updater>());
+    conf->RegisterVersionUpdater(std::make_shared<SOH::ConfigVersion5Updater>());
+    conf->RegisterVersionUpdater(std::make_shared<SOH::ConfigVersion6Updater>());
     conf->RunVersionUpdates();
 
     SohGui::SetupGuiElements();

--- a/games/oot/soh/config/ConfigMigrators.h
+++ b/games/oot/soh/config/ConfigMigrators.h
@@ -1527,4 +1527,16 @@ std::vector<Migration> version4Migrations = {
     { MigrationAction::Rename, "gAudioEditor.SeqNameOverlay", "gAudioEditor.SeqNameNotification" },
     { MigrationAction::Rename, "gAudioEditor.SeqNameOverlayDuration", "gAudioEditor.SeqNameNotificationDuration" },
 };
+
+std::vector<Migration> version6Migrations = {
+    { MigrationAction::Rename, "gSettings.WalkModifier.SpeedToggle", "gCheats.SpeedModifier.SpeedToggle" },
+    { MigrationAction::Rename, "gSettings.WalkModifier.DoesntChangeJump", "gCheats.SpeedModifier.DoesntChangeJump" },
+    { MigrationAction::Rename, "gSettings.WalkModifier.Mapping1", "gCheats.SpeedModifier.Value" },
+    { MigrationAction::Rename, "gSettings.WalkModifier.Mod1Btn", "gCheats.SpeedModifier.Btn" },
+    { MigrationAction::Remove, "gSettings.WalkModifier.Enabled" },
+    { MigrationAction::Remove, "gSettings.WalkModifier.Mapping2" },
+    { MigrationAction::Remove, "gSettings.WalkModifier.SwimMapping1" },
+    { MigrationAction::Remove, "gSettings.WalkModifier.SwimMapping2" },
+    { MigrationAction::Remove, "gSettings.WalkModifier.Mod2Btn" },
+};
 } // namespace SOH

--- a/games/oot/soh/config/ConfigUpdaters.cpp
+++ b/games/oot/soh/config/ConfigUpdaters.cpp
@@ -11,6 +11,10 @@ ConfigVersion3Updater::ConfigVersion3Updater() : ConfigVersionUpdater(3) {
 }
 ConfigVersion4Updater::ConfigVersion4Updater() : ConfigVersionUpdater(4) {
 }
+ConfigVersion5Updater::ConfigVersion5Updater() : ConfigVersionUpdater(5) {
+}
+ConfigVersion6Updater::ConfigVersion6Updater() : ConfigVersionUpdater(6) {
+}
 
 void ConfigVersion1Updater::Update(Ship::Config* conf) {
     if (conf->GetInt("Window.Width", 640) == 640) {
@@ -116,6 +120,22 @@ void ConfigVersion3Updater::Update(Ship::Config* conf) {
 
 void ConfigVersion4Updater::Update(Ship::Config* conf) {
     for (Migration migration : version4Migrations) {
+        if (migration.action == MigrationAction::Rename) {
+            CVarCopy(migration.from.c_str(), migration.to.value().c_str());
+        }
+        CVarClear(migration.from.c_str());
+    }
+}
+
+void ConfigVersion5Updater::Update(Ship::Config* conf) {
+    // After removal of Vanilla, make sure it doesn't crash because of an out of range on the combobox
+    if (CVarGetInteger("gRandoSettings.LogicRules", 0) == 2) {
+        CVarSetInteger("gRandoSettings.LogicRules", 0);
+    }
+}
+
+void ConfigVersion6Updater::Update(Ship::Config* conf) {
+    for (Migration migration : version6Migrations) {
         if (migration.action == MigrationAction::Rename) {
             CVarCopy(migration.from.c_str(), migration.to.value().c_str());
         }

--- a/games/oot/soh/config/ConfigUpdaters.h
+++ b/games/oot/soh/config/ConfigUpdaters.h
@@ -26,4 +26,16 @@ class ConfigVersion4Updater final : public Ship::ConfigVersionUpdater {
     ConfigVersion4Updater();
     void Update(Ship::Config* conf);
 };
+
+class ConfigVersion5Updater final : public Ship::ConfigVersionUpdater {
+  public:
+    ConfigVersion5Updater();
+    void Update(Ship::Config* conf);
+};
+
+class ConfigVersion6Updater final : public Ship::ConfigVersionUpdater {
+  public:
+    ConfigVersion6Updater();
+    void Update(Ship::Config* conf);
+};
 } // namespace SOH


### PR DESCRIPTION
## Summary
- Ports upstream SOH commits [`5d6314626`](https://github.com/HarbourMasters/Shipwright/commit/5d6314626) and [`2a335b1cd`](https://github.com/HarbourMasters/Shipwright/commit/2a335b1cd), adding `ConfigVersion5Updater` and `ConfigVersion6Updater`.
- v5: clamps `gRandoSettings.LogicRules` from the removed-"Vanilla" value `2` back to `0` so the combobox doesn't render an out-of-range selection.
- v6: migrates `gSettings.WalkModifier.*` CVars to `gCheats.SpeedModifier.*` and drops the retired dual-modifier fields (`Enabled`, `Mapping2`, `SwimMapping1/2`, `Mod2Btn`).
- Both updaters are registered in `InitOTR()` after the v4 updater.
- Foundation work for [#230](https://github.com/spencerduncan/redshipblueship/issues/230) / epic [#202](https://github.com/spencerduncan/redshipblueship/issues/202); unblocks downstream OTRGlobals porting.

## Notes
- The upstream 2a335b1cd commit also refactors migrations from the `std::vector<Migration>` pattern into inline C-array tables (deleting `ConfigMigrators.h`). That refactor is intentionally **not** ported here to keep this change scoped to the foundation work; the v6 migration entries are added to the existing local `version6Migrations` vector following the same pattern as v3/v4.
- `gSettings.WalkModifier.Mod1Btn` appears twice in upstream's v6 list (once as rename → `gCheats.SpeedModifier.Btn`, once as remove). The local pattern only needs the rename entry — `CVarClear` already runs after the rename, so the duplicate remove is redundant and omitted.
- No submodules touched. No CVar consumer changes — SpeedModifier wiring is deferred to the menu/z_player ports tracked separately in the epic.

## Test plan
- [ ] Cloud CI build passes.
- [ ] Existing v4-format config loads and steps through v5 + v6 updaters without crashing.
- [ ] A config with `gRandoSettings.LogicRules=2` is normalized to `0` after v5 runs.
- [ ] A config with `gSettings.WalkModifier.Mapping1`, `.SpeedToggle`, `.DoesntChangeJump`, `.Mod1Btn` has values copied to the matching `gCheats.SpeedModifier.*` keys after v6; `.Enabled`, `.Mapping2`, `.SwimMapping1`, `.SwimMapping2`, `.Mod2Btn` are removed.
- [ ] Fresh install produces a current-version config without running any updater bodies.

<!--- section:artifacts:start -->
### Build Artifacts
  - [rsbs-windows.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/6537793728.zip)
  - [rsbs-linux.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/6537619653.zip)
<!--- section:artifacts:end -->