### PR TITLE
feat: port UI enhancements from upstream SOH (#237)

### DIFF
--- a/games/oot/soh/Enhancements/DisableJabuWobble.cpp
+++ b/games/oot/soh/Enhancements/DisableJabuWobble.cpp
@@ -1,0 +1,8 @@
+#include "soh/Enhancements/game-interactor/GameInteractor.h"
+#include "soh/ShipInit.hpp"
+
+void RegisterDisableJabuWobble() {
+    COND_VB_SHOULD(VB_JABU_WOBBLE, CVarGetInteger(CVAR_SETTING("A11yNoJabuWobble"), 0), { *should = false; });
+}
+
+static RegisterShipInitFunc initFunc(RegisterDisableJabuWobble, { CVAR_SETTING("A11yNoJabuWobble") });

--- a/games/oot/soh/Enhancements/UnsheatheWithoutSlashing.cpp
+++ b/games/oot/soh/Enhancements/UnsheatheWithoutSlashing.cpp
@@ -1,0 +1,18 @@
+#include <libultraship/bridge.h>
+#include "soh/Enhancements/game-interactor/GameInteractor.h"
+#include "soh/ShipInit.hpp"
+
+#define CVAR_UNSHEATHE_NAME CVAR_ENHANCEMENT("UnsheatheWithoutSlashing")
+#define CVAR_UNSHEATHE_VALUE CVarGetInteger(CVAR_UNSHEATHE_NAME, 0)
+
+void RegisterUnsheatheWithoutSlashing() {
+    COND_VB_SHOULD(VB_USE_HELD_ITEM_AFTER_CHANGE, CVAR_UNSHEATHE_VALUE, {
+        Player* player = va_arg(args, Player*);
+        ItemID heldItemId = static_cast<ItemID>(player->heldItemId);
+        if ((heldItemId == ITEM_SWORD_KOKIRI) || (heldItemId == ITEM_SWORD_MASTER)) {
+            *should = false;
+        }
+    });
+}
+
+static RegisterShipInitFunc initFunc(RegisterUnsheatheWithoutSlashing, { CVAR_UNSHEATHE_NAME });

--- a/games/oot/soh/Enhancements/cosmetics/CosmeticsEditor.cpp
+++ b/games/oot/soh/Enhancements/cosmetics/CosmeticsEditor.cpp
@@ -1889,11 +1889,11 @@ void DrawSillyTab() {
 
     UIWidgets::Separator(true, true, 2.0f, 2.0f);
 
-    UIWidgets::CVarCheckbox("Let It Snow", CVAR_GENERAL("LetItSnow"),
-                            UIWidgets::CheckboxOptions()
-                                .Color(THEME_COLOR)
-                                .Tooltip("Makes snow fall, changes chest texture colors to red and green, etc, for "
-                                         "December holidays.\nWill reset on restart outside of December 23-25."));
+    UIWidgets::CVarCheckbox(
+        "Let It Snow", CVAR_GENERAL("LetItSnow"),
+        UIWidgets::CheckboxOptions()
+            .Color(THEME_COLOR)
+            .Tooltip("Makes snow fall for December holidays.\nWill reset on restart outside of December 23-25."));
 
     UIWidgets::Separator(true, true, 2.0f, 2.0f);
 

--- a/games/oot/soh/Enhancements/game-interactor/vanilla-behavior/GIVanillaBehavior.h
+++ b/games/oot/soh/Enhancements/game-interactor/vanilla-behavior/GIVanillaBehavior.h
@@ -1288,6 +1288,14 @@ typedef enum {
     // ```
     // #### `args`
     // - None
+    VB_JABU_WOBBLE,
+
+    // #### `result`
+    // ```c
+    // true
+    // ```
+    // #### `args`
+    // - None
     VB_KALEIDO_UNPAUSE_CLOSE,
 
     // #### `result`
@@ -2288,6 +2296,14 @@ typedef enum {
     // #### `args`
     // - `*EnMk`
     VB_USE_EYEDROP_DIALOGUE,
+
+    // #### `result`
+    // ```c
+    // (this->modelAnimType != PLAYER_ANIMTYPE_3) && (play->shootingGalleryStatus == 0)
+    // ```
+    // #### `args`
+    // - `*Player`
+    VB_USE_HELD_ITEM_AFTER_CHANGE,
 
     // #### `result`
     // ```c

--- a/games/oot/soh/Enhancements/randomizer/option_descriptions.cpp
+++ b/games/oot/soh/Enhancements/randomizer/option_descriptions.cpp
@@ -780,7 +780,7 @@ void Settings::CreateOptionDescriptions() {
         "and disabled below.\n"
         "\n"
         "No logic - Item placement is completely random. MAY BE IMPOSSIBLE TO BEAT.";
-    mOptionDescriptions[RSK_ALL_LOCATIONS_REACHABLE] = "When this options is enabled, the randomizer will "
+    mOptionDescriptions[RSK_ALL_LOCATIONS_REACHABLE] = "When this option is enabled, the randomizer will "
                                                        "guarantee that every item is obtainable and every "
                                                        "location is reachable. When disabled, only "
                                                        "required items and locations to beat the game "

--- a/games/oot/soh/Enhancements/randomizer/randomizer_check_tracker.cpp
+++ b/games/oot/soh/Enhancements/randomizer/randomizer_check_tracker.cpp
@@ -1084,12 +1084,20 @@ void CheckTrackerWindow::DrawElement() {
     }
     UIWidgets::PushStyleCombobox(THEME_COLOR);
     if (CVarGetInteger(CVAR_TRACKER_CHECK("SearchInputVisible"), 1)) {
-        if (checkSearch.Draw("", ImGui::GetContentRegionAvail().x - 6)) {
+        if (checkSearch.Draw("", ImGui::GetContentRegionAvail().x - 42)) {
             UpdateFilters();
         }
-        std::string checkSearchText = "";
-        checkSearchText = checkSearch.InputBuf;
+        std::string checkSearchText = checkSearch.InputBuf;
         checkSearchText.erase(std::remove(checkSearchText.begin(), checkSearchText.end(), ' '), checkSearchText.end());
+        ImGui::SameLine();
+        if (UIWidgets::Button(ICON_FA_ERASER, UIWidgets::ButtonOptions()
+                                                  .Size(UIWidgets::Sizes::Inline)
+                                                  .Color(THEME_COLOR)
+                                                  .Padding(ImVec2(10.f, 6.f)))) {
+            checkSearch.Clear();
+            UpdateFilters();
+            doAreaScroll = true;
+        }
         if (checkSearchText.length() < 1) {
             ImGui::SameLine(20.0f);
             ImGui::TextColored(ImVec4(1.0f, 1.0f, 1.0f, 0.4f), "Search...");

--- a/games/oot/soh/Enhancements/randomizer/settings.cpp
+++ b/games/oot/soh/Enhancements/randomizer/settings.cpp
@@ -1268,21 +1268,21 @@ void Settings::CreateOptions() {
     OPT_U8(RSK_DAMAGE_MULTIPLIER, "Damage Multiplier", {"x1/2", "x1", "x2", "x4", "x8", "x16", "OHKO"}, OptionCategory::Setting, "", "", WIDGET_CVAR_SLIDER_INT, RO_DAMAGE_MULTIPLIER_DEFAULT);
     // Don't show any MQ options if both quests aren't available
     if (!(OTRGlobals::Instance->HasMasterQuest() && OTRGlobals::Instance->HasOriginal())) {
-        mOptions[RSK_MQ_DUNGEON_RANDOM].Disable("This Options has been disabled because only one type of OTR has been loaded");
-        mOptions[RSK_MQ_DUNGEON_COUNT].Disable("This Options has been disabled because only one type of OTR has been loaded");
-        mOptions[RSK_MQ_DUNGEON_SET].Disable("This Options has been disabled because only one type of OTR has been loaded");
-        mOptions[RSK_MQ_DEKU_TREE].Disable("This Options has been disabled because only one type of OTR has been loaded");
-        mOptions[RSK_MQ_DODONGOS_CAVERN].Disable("This Options has been disabled because only one type of OTR has been loaded");
-        mOptions[RSK_MQ_JABU_JABU].Disable("This Options has been disabled because only one type of OTR has been loaded");
-        mOptions[RSK_MQ_FOREST_TEMPLE].Disable("This Options has been disabled because only one type of OTR has been loaded");
-        mOptions[RSK_MQ_FIRE_TEMPLE].Disable("This Options has been disabled because only one type of OTR has been loaded");
-        mOptions[RSK_MQ_WATER_TEMPLE].Disable("This Options has been disabled because only one type of OTR has been loaded");
-        mOptions[RSK_MQ_SPIRIT_TEMPLE].Disable("This Options has been disabled because only one type of OTR has been loaded");
-        mOptions[RSK_MQ_SHADOW_TEMPLE].Disable("This Options has been disabled because only one type of OTR has been loaded");
-        mOptions[RSK_MQ_BOTTOM_OF_THE_WELL].Disable("This Options has been disabled because only one type of OTR has been loaded");
-        mOptions[RSK_MQ_ICE_CAVERN].Disable("This Options has been disabled because only one type of OTR has been loaded");
-        mOptions[RSK_MQ_GTG].Disable("This Options has been disabled because only one type of OTR has been loaded");
-        mOptions[RSK_MQ_GANONS_CASTLE].Disable("This Options has been disabled because only one type of OTR has been loaded");
+        mOptions[RSK_MQ_DUNGEON_RANDOM].Disable("This option has been disabled because only one type of O2R has been loaded");
+        mOptions[RSK_MQ_DUNGEON_COUNT].Disable("This option has been disabled because only one type of O2R has been loaded");
+        mOptions[RSK_MQ_DUNGEON_SET].Disable("This option has been disabled because only one type of O2R has been loaded");
+        mOptions[RSK_MQ_DEKU_TREE].Disable("This option has been disabled because only one type of O2R has been loaded");
+        mOptions[RSK_MQ_DODONGOS_CAVERN].Disable("This option has been disabled because only one type of O2R has been loaded");
+        mOptions[RSK_MQ_JABU_JABU].Disable("This option has been disabled because only one type of O2R has been loaded");
+        mOptions[RSK_MQ_FOREST_TEMPLE].Disable("This option has been disabled because only one type of O2R has been loaded");
+        mOptions[RSK_MQ_FIRE_TEMPLE].Disable("This option has been disabled because only one type of O2R has been loaded");
+        mOptions[RSK_MQ_WATER_TEMPLE].Disable("This option has been disabled because only one type of O2R has been loaded");
+        mOptions[RSK_MQ_SPIRIT_TEMPLE].Disable("This option has been disabled because only one type of O2R has been loaded");
+        mOptions[RSK_MQ_SHADOW_TEMPLE].Disable("This option has been disabled because only one type of O2R has been loaded");
+        mOptions[RSK_MQ_BOTTOM_OF_THE_WELL].Disable("This option has been disabled because only one type of O2R has been loaded");
+        mOptions[RSK_MQ_ICE_CAVERN].Disable("This option has been disabled because only one type of O2R has been loaded");
+        mOptions[RSK_MQ_GTG].Disable("This option has been disabled because only one type of O2R has been loaded");
+        mOptions[RSK_MQ_GANONS_CASTLE].Disable("This option has been disabled because only one type of O2R has been loaded");
     } else {
         // If any MQ Options are available, show the MQ Dungeon Randomization Combobox
         mOptions[RSK_MQ_DUNGEON_RANDOM].Enable();

--- a/games/oot/soh/Notification/Notification.cpp
+++ b/games/oot/soh/Notification/Notification.cpp
@@ -131,7 +131,7 @@ void Emit(Options notification) {
         notification.remainingTime = CVarGetFloat(CVAR_SETTING("Notifications.Duration"), 10.0f);
     }
     notifications.push_back(notification);
-    if (!notification.mute) {
+    if (!notification.mute && !CVarGetInteger(CVAR_SETTING("Notifications.Mute"), 0)) {
         Audio_PlaySoundGeneral(NA_SE_SY_METRONOME, &OoT_gSfxDefaultPos, 4, &OoT_gSfxDefaultFreqAndVolScale,
                                &OoT_gSfxDefaultFreqAndVolScale, &OoT_gSfxDefaultReverb);
     }

--- a/games/oot/soh/SohGui/SohMenuEnhancements.cpp
+++ b/games/oot/soh/SohGui/SohMenuEnhancements.cpp
@@ -487,16 +487,18 @@ void SohMenu::AddMenuEnhancements() {
     AddWidget(path, "Skip Tower Escape", WIDGET_CVAR_CHECKBOX)
         .CVar(CVAR_ENHANCEMENT("TimeSavers.SkipTowerEscape"))
         .Options(CheckboxOptions().Tooltip("Skip the tower escape sequence between Ganondorf and Ganon."));
-    AddWidget(path, "Skip Scarecrow's Song", WIDGET_CVAR_CHECKBOX)
+    AddWidget(path, "Skip Playing Scarecrow's Song", WIDGET_CVAR_CHECKBOX)
         .CVar(CVAR_ENHANCEMENT("InstantScarecrow"))
         .PreFunc([](WidgetInfo& info) {
             info.options->disabled =
                 IS_RANDO && OTRGlobals::Instance->gRandoContext->GetOption(RSK_SKIP_SCARECROWS_SONG);
-            info.options->disabledTooltip = "This setting is forcefully enabled because a randomized "
-                                            "save file with the option \"Skip Scarecrow Song\" is currently loaded.";
+            info.options->disabledTooltip = "This setting is forcefully enabled because a randomized save "
+                                            "file with the option \"Skip Scarecrow's Song\" is currently loaded.";
         })
         .Options(CheckboxOptions().Tooltip(
-            "Pierre appears when an Ocarina is pulled out. Requires learning the Scarecrow's Song first."));
+            "Pierre appears when an Ocarina is pulled out. Requires learning the Scarecrow's Song first.\n"
+            "Without the randomizer option \"Skip Scarecrow's Song\" enabled for a seed, this still requires you "
+            "to teach the scarecrow the song as both ages before summoning."));
     AddWidget(path, "Faster Rupee Accumulator", WIDGET_CVAR_CHECKBOX)
         .CVar(CVAR_ENHANCEMENT("FasterRupeeAccumulator"))
         .Options(CheckboxOptions().Tooltip("Causes your Wallet to fill and empty faster when you gain or lose money."));
@@ -772,6 +774,9 @@ void SohMenu::AddMenuEnhancements() {
             "Allows Strength to be toggled on and off by pressing A on the Strength Upgrade "
             "in the Equipment Subscreen of the Pause Menu. This allows performing some glitches "
             "that require the player to not have Strength."));
+    AddWidget(path, "Unsheathe Sword Without Slashing", WIDGET_CVAR_CHECKBOX)
+        .CVar(CVAR_ENHANCEMENT("UnsheatheWithoutSlashing"))
+        .Options(CheckboxOptions().Tooltip("Allows Link to unsheathe sword without slashing automatically."));
     AddWidget(path, "Sword Toggle Options", WIDGET_CVAR_COMBOBOX)
         .CVar(CVAR_ENHANCEMENT("SwordToggle"))
         .PreFunc(
@@ -1435,7 +1440,7 @@ void SohMenu::AddMenuEnhancements() {
         .Options(CheckboxOptions().Tooltip("Turn on/off changes to the Lost Woods Ocarina Game behavior."));
     auto ocarinaMemoryGameDisabledFunc = [](WidgetInfo& info) {
         info.options->disabled = CVarGetInteger(CVAR_ENHANCEMENT("CustomizeOcarinaGame"), 0) == 0;
-        info.options->disabledTooltip = "This options is disabled because \"Customize Behavior\" is turned off.";
+        info.options->disabledTooltip = "This option is disabled because \"Customize Behavior\" is turned off.";
     };
     AddWidget(path, "Instant Win##LostWoods", WIDGET_CVAR_CHECKBOX)
         .CVar(CVAR_ENHANCEMENT("InstantOcarinaGameWin"))
@@ -1674,7 +1679,8 @@ void SohMenu::AddMenuEnhancements() {
     });
     AddWidget(path, "Select all Enemies", WIDGET_CVAR_CHECKBOX)
         .CVar(CVAR_ENHANCEMENT("RandomizedEnemyList.All"))
-        .PreFunc([](WidgetInfo& info) { info.isHidden = !CVarGetInteger(CVAR_ENHANCEMENT("RandomizedEnemies"), 0); });
+        .PreFunc([](WidgetInfo& info) { info.isHidden = !CVarGetInteger(CVAR_ENHANCEMENT("RandomizedEnemies"), 0); })
+        .Callback([](WidgetInfo& info) { GetSelectedEnemies(); });
     AddWidget(path, "Enemy List", WIDGET_SEPARATOR).PreFunc([](WidgetInfo& info) {
         info.isHidden = !CVarGetInteger(CVAR_ENHANCEMENT("RandomizedEnemies"), 0);
     });

--- a/games/oot/soh/SohGui/SohMenuSettings.cpp
+++ b/games/oot/soh/SohGui/SohMenuSettings.cpp
@@ -233,6 +233,10 @@ void SohMenu::AddMenuSettings() {
         .CVar(CVAR_SETTING("A11yNoScreenFlashForFinishingBlow"))
         .RaceDisable(false)
         .Options(CheckboxOptions().Tooltip("Disables the white screen flash on enemy kill."));
+    AddWidget(path, "Disable Jabu Wobble", WIDGET_CVAR_CHECKBOX)
+        .CVar(CVAR_SETTING("A11yNoJabuWobble"))
+        .RaceDisable(false)
+        .Options(CheckboxOptions().Tooltip("Disable the geometry wobble and camera distortion inside Jabu."));
     AddWidget(path, "EXPERIMENTAL", WIDGET_SEPARATOR_TEXT).Options(TextOptions().Color(Colors::Orange));
     AddWidget(path, "ImGui Menu Scaling", WIDGET_CVAR_COMBOBOX)
         .CVar(CVAR_SETTING("ImGuiScale"))
@@ -502,6 +506,10 @@ void SohMenu::AddMenuSettings() {
             });
         })
         .Options(ButtonOptions().Tooltip("Displays a test notification."));
+    AddWidget(path, "Mute Notification Sound", WIDGET_CVAR_CHECKBOX)
+        .CVar(CVAR_SETTING("Notifications.Mute"))
+        .RaceDisable(false)
+        .Options(CheckboxOptions().Tooltip("Prevent notifications from playing a sound."));
 
     // Mod Menu
     path.sidebarName = "Mod Menu";

--- a/games/oot/src/code/z_scene_table.c
+++ b/games/oot/src/code/z_scene_table.c
@@ -25,6 +25,7 @@
 
 #include "soh/mq_asset_hacks.h"
 #include "soh/OTRGlobals.h"
+#include "soh/Enhancements/game-interactor/GameInteractor_Hooks.h"
 #include "soh/ResourceManagerHelpers.h"
 
 // Entrance Table definition
@@ -1556,12 +1557,14 @@ void func_8009FE58(PlayState* play) {
 
     if (OoT_FrameAdvance_IsEnabled(play) != true) {
 
-        D_8012A39C += 1820;
-        D_8012A3A0 += 1820;
+        if (GameInteractor_Should(VB_JABU_WOBBLE, true)) {
+            D_8012A39C += 1820;
+            D_8012A3A0 += 1820;
+        }
 
         temp = 0.020000001f;
 
-        if (play->pauseCtx.state == 0) {
+        if (GameInteractor_Should(VB_JABU_WOBBLE, play->pauseCtx.state == 0)) {
             OoT_View_SetDistortionOrientation(&play->view,
                                           ((360.00018f / 65535.0f) * (M_PI / 180.0f)) * temp * OoT_Math_CosS(D_8012A39C),
                                           ((360.00018f / 65535.0f) * (M_PI / 180.0f)) * temp * OoT_Math_SinS(D_8012A39C),
@@ -1592,7 +1595,7 @@ void func_8009FE58(PlayState* play) {
                 break;
         }
 
-        if (play->pauseCtx.state == 0) {
+        if (GameInteractor_Should(VB_JABU_WOBBLE, play->pauseCtx.state == 0)) {
             D_8012A398 += 0.15f + (play->roomCtx.unk_74[1] * 0.001f);
         }
     }

--- a/games/oot/src/overlays/actors/ovl_player_actor/z_player.c
+++ b/games/oot/src/overlays/actors/ovl_player_actor/z_player.c
@@ -2835,8 +2835,10 @@ s32 Player_UpperAction_Sword(Player* this, PlayState* play) {
 s32 OoT_Player_UpperAction_ChangeHeldItem(Player* this, PlayState* play) {
     if (LinkAnimation_Update(play, &this->upperSkelAnime) ||
         ((OoT_Player_ItemToItemAction(this->heldItemId) == this->heldItemAction) &&
-         (sUseHeldItem =
-              (sUseHeldItem || ((this->modelAnimType != PLAYER_ANIMTYPE_3) && (play->shootingGalleryStatus == 0)))))) {
+         (sUseHeldItem = (sUseHeldItem || GameInteractor_Should(VB_USE_HELD_ITEM_AFTER_CHANGE,
+                                                                ((this->modelAnimType != PLAYER_ANIMTYPE_3) &&
+                                                                 (play->shootingGalleryStatus == 0)),
+                                                                this))))) {
         Player_SetUpperActionFunc(this, sItemActionUpdateFuncs[this->heldItemAction]);
         this->unk_834 = 0;
         this->idleType = PLAYER_IDLE_DEFAULT;


### PR DESCRIPTION
## Summary

Ports 8 independent UI/enhancement toggles and small improvements from upstream HarbourMasters/Shipwright `develop` into RSBS. Resolves #237.

| # | Upstream PR | Change |
|---|---|---|
| 1 | [#6390](https://github.com/HarbourMasters/Shipwright/pull/6390) | New **Mute Notification Sound** toggle in Settings |
| 2 | [#6219](https://github.com/HarbourMasters/Shipwright/pull/6219) | Reset randomized-enemy selection when toggling **Select all Enemies** |
| 3 | [#6401](https://github.com/HarbourMasters/Shipwright/pull/6401) | Compact eraser-icon **Clear** button next to Check Tracker search |
| 4 | [#6300](https://github.com/HarbourMasters/Shipwright/pull/6300) | "Options"→"option" / OTR→O2R wording fixes in randomizer & menu tooltips |
| 5 | [#6423](https://github.com/HarbourMasters/Shipwright/pull/6423) | Rename **Skip Scarecrow's Song** → **Skip Playing Scarecrow's Song**; clarify tooltip |
| 6 | [#6216](https://github.com/HarbourMasters/Shipwright/pull/6216) | New **Unsheathe Sword Without Slashing** toggle (adds `VB_USE_HELD_ITEM_AFTER_CHANGE` hook) |
| 7 | [#6280](https://github.com/HarbourMasters/Shipwright/pull/6280) | New **Disable Jabu Wobble** accessibility toggle (adds `VB_JABU_WOBBLE` hook) |
| 8 | [#6488](https://github.com/HarbourMasters/Shipwright/pull/6488) | Trim outdated "chests turn red and green" text from **Let It Snow** tooltip |

Each toggle is self-contained and gated by its own CVar. The two new `Enhancements/` files (`UnsheatheWithoutSlashing.cpp`, `DisableJabuWobble.cpp`) follow the existing `RegisterShipInitFunc` pattern and are picked up by the CMake glob — no CMakeLists changes needed. No submodule, workflow, or root CMake changes.

Out-of-scope (excluded per #237):
- Save Editor search boxes (high integration risk)
- Entrance Tracker work (issue #239, separate worker)
- Surround sound, arrow-cycling rewrite, value-viewer rework — all required either a LUS bump or had diverged too far from RSBS to apply cleanly.

## Test plan

- [ ] CI passes (`build-windows`, `build-linux`, `build-macos`, `clang-format`)
- [ ] **Settings → Audio**: "Mute Notification Sound" silences the test notification chime
- [ ] **Settings → Accessibility**: "Disable Jabu Wobble" stops geometry/camera distortion inside Jabu-Jabu
- [ ] **Enhancements → Player**: "Unsheathe Sword Without Slashing" — equipping Kokiri/Master sword via item swap no longer triggers an automatic slash
- [ ] **Enhancements → Time Savers**: Scarecrow widget shows new label "Skip Playing Scarecrow's Song" with updated tooltip
- [ ] **Enhancements → Cheats → Enemy Rando**: Toggling "Select all Enemies" updates the cached selected-enemy list immediately
- [ ] **Check Tracker**: Eraser button next to search field clears text, refilters, and re-scrolls the area list
- [ ] **Cosmetics → Silly tab**: "Let It Snow" tooltip no longer mentions chest recoloring
- [ ] **Randomizer settings**: MQ-disabled tooltips read "This option … one type of O2R …"

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!--- section:artifacts:start -->
### Build Artifacts
  - [rsbs-windows.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/6544734093.zip)
  - [rsbs-linux.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/6544637332.zip)
<!--- section:artifacts:end -->