### PR TITLE
feat: port ImGui-driven extraction flow from upstream SOH (#5892)

### DIFF
--- a/games/oot/soh/Extractor/Extract.cpp
+++ b/games/oot/soh/Extractor/Extract.cpp
@@ -406,7 +406,6 @@ bool Extractor::ManuallySearchForRom() {
     std::ifstream inFile;
 
     if (!GetRomPathFromBox()) {
-        ShowErrorBox("Ocarina of Time - No rom selected", "No Ocarina of Time ROM selected. Exiting");
         return false;
     }
 
@@ -486,11 +485,16 @@ bool Extractor::RunFileStandalone(std::string rom) {
     return true;
 }
 
+void Extractor::SetSearchPath(const std::string& path) {
+    mSearchPath = path;
+}
+
 bool Extractor::Run(std::string searchPath, RomSearchMode searchMode, std::string installPath) {
     std::vector<std::string> roms;
     std::ifstream inFile;
 
-    mSearchPath = searchPath;
+    SetSearchPath(searchPath);
+
     GetRoms(roms);
 
     // On Linux AppImage (and for users who drop a ROM next to the install), also
@@ -648,9 +652,11 @@ std::string Extractor::Mkdtemp() {
 }
 
 extern "C" int zapd_main(int argc, char** argv);
-static void MessageboxWorker();
 
-bool Extractor::CallZapd(std::string installPath, std::string exportdir) {
+bool Extractor::CallZapd(std::string installPath, std::string exportdir, std::atomic<size_t>* extractCount,
+                         std::atomic<size_t>* totalExtract) {
+    (void)extractCount;
+    (void)totalExtract;
     constexpr int argc = 22;
     char xmlPath[1024];
     char confPath[1024];
@@ -723,47 +729,25 @@ bool Extractor::CallZapd(std::string installPath, std::string exportdir) {
         return false;
     }
 
-#ifdef _WIN32
-    // Grab a handle to the command window.
-    HWND cmdWindow = GetConsoleWindow();
-
-    // Normally the command window is hidden. We want the window to be shown here so the user can see the progess of the
-    // extraction.
-    ShowWindow(cmdWindow, SW_SHOW);
-    SetWindowPos(cmdWindow, HWND_NOTOPMOST, 0, 0, 0, 0, SWP_NOSIZE | SWP_NOMOVE);
-#else
-    // Show extraction in background message until linux/mac can have visual progress
-    std::thread mbThread(MessageboxWorker);
-    mbThread.detach();
-#endif
-
+    // NOTE: progress reporting via zapd_report is not yet wired up in this tree; the ZAPD submodule
+    // pinned here still exposes only zapd_main. The ImGui progress popup owned by RunExtract will
+    // show an indeterminate "Starting Up" state until ZAPD is uplifted.
     try {
         zapd_main(argc, (char**)argv.data());
     } catch (const std::exception& e) {
         fprintf(stderr, "Extraction failed: %s\n", e.what());
         std::string errMsg = "ZAPD extraction failed with error: " + std::string(e.what());
         ShowErrorBox("Extraction Failed", errMsg.c_str());
-#ifdef _WIN32
-        ShowWindow(cmdWindow, SW_HIDE);
-#endif
         std::filesystem::current_path(curdir);
         std::filesystem::remove_all(tempdir);
         return false;
     } catch (...) {
         fprintf(stderr, "Extraction failed with unknown error\n");
         ShowErrorBox("Extraction Failed", "ZAPD extraction failed with an unknown error.");
-#ifdef _WIN32
-        ShowWindow(cmdWindow, SW_HIDE);
-#endif
         std::filesystem::current_path(curdir);
         std::filesystem::remove_all(tempdir);
         return false;
     }
-
-#ifdef _WIN32
-    // Hide the command window again.
-    ShowWindow(cmdWindow, SW_HIDE);
-#endif
 
     // Verify the output file was created before attempting to copy
     if (!std::filesystem::exists(otrFile)) {
@@ -782,11 +766,4 @@ bool Extractor::CallZapd(std::string installPath, std::string exportdir) {
     std::filesystem::remove_all(tempdir);
 
     return true;
-}
-
-static void MessageboxWorker() {
-    SDL_ShowSimpleMessageBox(SDL_MESSAGEBOX_INFORMATION, "Extracting",
-                             "Extraction will now begin in the background.\n\nPlease be patient for the process to "
-                             "finish. Do not close the main program.",
-                             nullptr);
 }

--- a/games/oot/soh/Extractor/Extract.cpp
+++ b/games/oot/soh/Extractor/Extract.cpp
@@ -682,88 +682,98 @@ bool Extractor::CallZapd(std::string installPath, std::string exportdir, std::at
     // Work this out in the temporary folder
     std::string tempdir = Mkdtemp();
     std::string curdir = std::filesystem::current_path().string();
+
+    // CallZapd is invoked from a detached worker thread by the ImGui extraction flow, so any
+    // uncaught exception would std::terminate the process. Wrap the whole body and guarantee
+    // cwd + tempdir cleanup on every exit path (including std::filesystem::copy failures).
+    bool success = false;
+    try {
 #ifdef _WIN32
-    std::filesystem::copy(assetsPath, tempdir + "/assets",
-                          std::filesystem::copy_options::recursive | std::filesystem::copy_options::update_existing);
+        std::filesystem::copy(
+            assetsPath, tempdir + "/assets",
+            std::filesystem::copy_options::recursive | std::filesystem::copy_options::update_existing);
 #else
-    std::filesystem::create_symlink(assetsPath, tempdir + "/assets");
+        std::filesystem::create_symlink(assetsPath, tempdir + "/assets");
 #endif
 
-    std::filesystem::current_path(tempdir);
+        std::filesystem::current_path(tempdir);
 
-    snprintf(xmlPath, 1024, "assets/xml/%s", version);
-    snprintf(confPath, 1024, "assets/Config_%s.xml", version);
-    snprintf(portVersion, 18, "%d.%d.%d", OoT_gBuildVersionMajor, OoT_gBuildVersionMinor, OoT_gBuildVersionPatch);
+        snprintf(xmlPath, 1024, "assets/xml/%s", version);
+        snprintf(confPath, 1024, "assets/Config_%s.xml", version);
+        snprintf(portVersion, 18, "%d.%d.%d", OoT_gBuildVersionMajor, OoT_gBuildVersionMinor, OoT_gBuildVersionPatch);
 
-    argv[0] = "ZAPD";
-    argv[1] = "ed";
-    argv[2] = "-i";
-    argv[3] = xmlPath;
-    argv[4] = "-b";
-    argv[5] = romPath.c_str();
-    argv[6] = "-fl";
-    argv[7] = "assets/filelists";
-    argv[8] = "-gsf";
-    argv[9] = "0";
-    argv[10] = "-rconf";
-    argv[11] = confPath;
-    argv[12] = "-se";
-    argv[13] = "OTR";
-    argv[14] = "--otrfile";
-    argv[15] = otrFile;
-    argv[16] = "--portVer";
-    argv[17] = portVersion;
-    argv[18] = "-o";
-    argv[19] = "placeholder";
-    argv[20] = "-osf";
-    argv[21] = "placeholder";
+        argv[0] = "ZAPD";
+        argv[1] = "ed";
+        argv[2] = "-i";
+        argv[3] = xmlPath;
+        argv[4] = "-b";
+        argv[5] = romPath.c_str();
+        argv[6] = "-fl";
+        argv[7] = "assets/filelists";
+        argv[8] = "-gsf";
+        argv[9] = "0";
+        argv[10] = "-rconf";
+        argv[11] = confPath;
+        argv[12] = "-se";
+        argv[13] = "OTR";
+        argv[14] = "--otrfile";
+        argv[15] = otrFile;
+        argv[16] = "--portVer";
+        argv[17] = portVersion;
+        argv[18] = "-o";
+        argv[19] = "placeholder";
+        argv[20] = "-osf";
+        argv[21] = "placeholder";
 
-    // Validate config XML exists before calling zapd_main
-    if (!std::filesystem::exists(confPath)) {
-        std::string errMsg = "Extractor config not found: " + std::string(confPath) +
-                             "\n\nThis may indicate an incomplete installation.";
-        fprintf(stderr, "Extractor config not found: %s. This may indicate an incomplete installation.\n", confPath);
-        ShowErrorBox("Extraction Failed", errMsg.c_str());
-        std::filesystem::current_path(curdir);
-        std::filesystem::remove_all(tempdir);
-        return false;
-    }
+        // Validate config XML exists before calling zapd_main
+        if (!std::filesystem::exists(confPath)) {
+            std::string errMsg = "Extractor config not found: " + std::string(confPath) +
+                                 "\n\nThis may indicate an incomplete installation.";
+            fprintf(stderr, "Extractor config not found: %s. This may indicate an incomplete installation.\n",
+                    confPath);
+            ShowErrorBox("Extraction Failed", errMsg.c_str());
+        } else {
+            // NOTE: progress reporting via zapd_report is not yet wired up in this tree; the ZAPD
+            // submodule pinned here still exposes only zapd_main. The ImGui progress popup owned by
+            // RunExtract will show an indeterminate "Starting Up" state until ZAPD is uplifted.
+            try {
+                zapd_main(argc, (char**)argv.data());
+            } catch (const std::exception& e) {
+                fprintf(stderr, "Extraction failed: %s\n", e.what());
+                std::string errMsg = "ZAPD extraction failed with error: " + std::string(e.what());
+                ShowErrorBox("Extraction Failed", errMsg.c_str());
+                throw;
+            } catch (...) {
+                fprintf(stderr, "Extraction failed with unknown error\n");
+                ShowErrorBox("Extraction Failed", "ZAPD extraction failed with an unknown error.");
+                throw;
+            }
 
-    // NOTE: progress reporting via zapd_report is not yet wired up in this tree; the ZAPD submodule
-    // pinned here still exposes only zapd_main. The ImGui progress popup owned by RunExtract will
-    // show an indeterminate "Starting Up" state until ZAPD is uplifted.
-    try {
-        zapd_main(argc, (char**)argv.data());
+            if (!std::filesystem::exists(otrFile)) {
+                std::string errMsg = "ZAPD extraction failed - output file was not created: " +
+                                     std::string(otrFile) +
+                                     "\n\nCheck that the ROM file is valid and the assets directory is complete.";
+                ShowErrorBox("Extraction Failed", errMsg.c_str());
+            } else {
+                std::filesystem::copy(otrFile, exportdir + "/" + otrFile,
+                                      std::filesystem::copy_options::overwrite_existing);
+                success = true;
+            }
+        }
     } catch (const std::exception& e) {
-        fprintf(stderr, "Extraction failed: %s\n", e.what());
-        std::string errMsg = "ZAPD extraction failed with error: " + std::string(e.what());
-        ShowErrorBox("Extraction Failed", errMsg.c_str());
-        std::filesystem::current_path(curdir);
-        std::filesystem::remove_all(tempdir);
-        return false;
+        fprintf(stderr, "Extraction failed during file setup/copy: %s\n", e.what());
     } catch (...) {
-        fprintf(stderr, "Extraction failed with unknown error\n");
-        ShowErrorBox("Extraction Failed", "ZAPD extraction failed with an unknown error.");
-        std::filesystem::current_path(curdir);
-        std::filesystem::remove_all(tempdir);
-        return false;
+        fprintf(stderr, "Extraction failed during file setup/copy with unknown error\n");
     }
 
-    // Verify the output file was created before attempting to copy
-    if (!std::filesystem::exists(otrFile)) {
-        std::string errMsg = "ZAPD extraction failed - output file was not created: " + std::string(otrFile) +
-                             "\n\nCheck that the ROM file is valid and the assets directory is complete.";
-        ShowErrorBox("Extraction Failed", errMsg.c_str());
+    // Cleanup on all paths, including exception unwind. Swallow errors so a failing cleanup
+    // does not propagate and terminate the worker thread.
+    try {
         std::filesystem::current_path(curdir);
+    } catch (...) {}
+    try {
         std::filesystem::remove_all(tempdir);
-        return false;
-    }
+    } catch (...) {}
 
-    std::filesystem::copy(otrFile, exportdir + "/" + otrFile, std::filesystem::copy_options::overwrite_existing);
-
-    // Go back to where this game was executed from
-    std::filesystem::current_path(curdir);
-    std::filesystem::remove_all(tempdir);
-
-    return true;
+    return success;
 }

--- a/games/oot/soh/Extractor/Extract.h
+++ b/games/oot/soh/Extractor/Extract.h
@@ -1,6 +1,7 @@
 #ifndef EXTRACT_H
 #define EXTRACT_H
 
+#include <atomic>
 #include <stdint.h>
 #include <string>
 #include <memory>
@@ -45,23 +46,25 @@ class Extractor {
     void SetRomInfo(const std::string& path);
 
     void FilterRoms(std::vector<std::string>& roms, RomSearchMode searchMode);
-    void GetRoms(std::vector<std::string>& roms);
     void ShowSizeErrorBox() const;
     void ShowCrcErrorBox() const;
     void ShowCompressedErrorBox() const;
     int ShowRomPickBox(uint32_t verCrc) const;
     bool ManuallySearchForRom();
-    bool ManuallySearchForRomMatchingType(RomSearchMode searchMode);
 
   public:
     // TODO create some kind of abstraction for message boxes.
     static int ShowYesNoBox(const char* title, const char* text);
     static void ShowErrorBox(const char* title, const char* text);
     bool IsMasterQuest() const;
+    bool ManuallySearchForRomMatchingType(RomSearchMode searchMode);
 
+    void SetSearchPath(const std::string& path);
+    void GetRoms(std::vector<std::string>& roms);
     bool RunFileStandalone(std::string file);
     bool Run(std::string searchPath, RomSearchMode searchMode = RomSearchMode::Both, std::string installPath = "");
-    bool CallZapd(std::string installPath, std::string exportdir);
+    bool CallZapd(std::string installPath, std::string exportdir, std::atomic<size_t>* extractCount = nullptr,
+                  std::atomic<size_t>* totalExtract = nullptr);
     const char* GetZapdStr();
     std::string Mkdtemp();
 };

--- a/games/oot/soh/OTRGlobals.cpp
+++ b/games/oot/soh/OTRGlobals.cpp
@@ -2,8 +2,10 @@
 #include "OTRAudio.h"
 #include <iostream>
 #include <algorithm>
+#include <atomic>
 #include <filesystem>
 #include <fstream>
+#include <vector>
 #include <chrono>
 
 #include "ResourceManagerHelpers.h"
@@ -13,6 +15,7 @@
 #include <ship/window/Window.h>
 #include <soh/GameVersions.h>
 #include <spdlog/sinks/rotating_file_sink.h>
+#include <spdlog/fmt/fmt.h>
 
 #include "Enhancements/gameconsole.h"
 #ifdef _WIN32
@@ -37,6 +40,9 @@
 #include "Enhancements/gameplaystats.h"
 #include "ObjectExtension/ObjectExtension.h"
 #include "frame_interpolation.h"
+#include "SohGui/SohMenu.h"
+#include "SohGui/SohGui.hpp"
+#include "SohGui/UIWidgets.hpp"
 #include "variables.h"
 #include "z64.h"
 #include "macros.h"
@@ -271,6 +277,54 @@ const char* constCameraStrings[] = {
     GFXP_KATAKANA "ｷ-     /   ",
 };
 
+typedef struct {
+    uint16_t major;
+    uint16_t minor;
+    uint16_t patch;
+} OTRVersion;
+
+std::shared_ptr<Fast::Fast3dWindow> sohFast3dWindow;
+OTRVersion DetectOTRVersion(std::string path, bool isMq);
+bool VerifyArchiveVersion(OTRVersion version);
+std::string portArchivePath = "";
+static bool sohArchiveVersionMatch = false;
+
+bool IsSubpath(const std::filesystem::path& path, const std::filesystem::path& base) {
+    auto rel = std::filesystem::relative(path, base);
+    return !rel.empty() && rel.native()[0] != '.';
+}
+
+bool PathTestCleanup(FILE* tfile) {
+    try {
+        if (std::filesystem::exists("./text.txt"))
+            std::filesystem::remove("./text.txt");
+        if (std::filesystem::exists("./test/"))
+            std::filesystem::remove("./test/");
+    } catch (std::filesystem::filesystem_error const& ex) { return false; }
+    return true;
+}
+
+void CheckAndCreateModFolder() {
+    try {
+        std::string modsPath = Ship::Context::LocateFileAcrossAppDirs("mods", appShortName);
+        if (!std::filesystem::exists(modsPath)) {
+            // Create mods folder relative to app dir
+            modsPath = Ship::Context::GetPathRelativeToAppDirectory("mods", appShortName);
+            std::string filePath = modsPath + "/custom_mod_files_go_here.txt";
+            if (std::filesystem::create_directories(modsPath)) {
+                std::ofstream(filePath).close();
+            }
+        }
+    } catch (std::filesystem::filesystem_error const& ex) {
+        // Couldn't make the folder, continue silently
+        return;
+    }
+}
+
+namespace SohGui {
+extern std::shared_ptr<SohGui::SohMenu> mSohMenu;
+}
+
 OTRGlobals::OTRGlobals() {
 #ifdef RSBS_SINGLE_EXECUTABLE
     // In single-exe mode, Ship::Context may already exist from main.cpp.
@@ -286,50 +340,15 @@ OTRGlobals::OTRGlobals() {
 #endif
     // Standalone mode: create our own context
     context = Ship::Context::CreateUninitializedInstance("Ship of Harkinian", appShortName, "shipofharkinian.json");
-}
 
-void OTRGlobals::Initialize() {
-    std::vector<std::string> OTRFiles;
-    std::string mqPath = Ship::Context::LocateFileAcrossAppDirs("oot-mq.o2r", appShortName);
-    if (std::filesystem::exists(mqPath)) {
-        OTRFiles.push_back(mqPath);
-    }
-    std::string ootPath = Ship::Context::LocateFileAcrossAppDirs("oot.o2r", appShortName);
-    if (std::filesystem::exists(ootPath)) {
-        OTRFiles.push_back(ootPath);
-    }
+    portArchivePath = Ship::Context::LocateFileAcrossAppDirs("soh.o2r");
+    OTRVersion portArchiveVersion = DetectOTRVersion(portArchivePath, false);
+    sohArchiveVersionMatch = portArchiveVersion.major == OoT_gBuildVersionMajor &&
+                             portArchiveVersion.minor == OoT_gBuildVersionMinor &&
+                             portArchiveVersion.patch == OoT_gBuildVersionPatch;
 
-    std::string sohOtrPath = Ship::Context::LocateFileAcrossAppDirs("soh.o2r");
-
-    if (std::filesystem::exists(sohOtrPath)) {
-        OTRFiles.push_back(sohOtrPath);
-    }
-
-    std::unordered_set<uint32_t> ValidHashes = {
-        OOT_PAL_MQ,     OOT_NTSC_JP_MQ, OOT_NTSC_US_MQ, OOT_PAL_GC_MQ_DBG, OOT_NTSC_US_10,
-        OOT_NTSC_US_11, OOT_NTSC_US_12, OOT_PAL_10,     OOT_PAL_11,        OOT_NTSC_JP_GC_CE,
-        OOT_NTSC_JP_GC, OOT_NTSC_US_GC, OOT_PAL_GC,     OOT_PAL_GC_DBG1,   OOT_PAL_GC_DBG2,
-    };
-
-#if (_DEBUG)
-    auto defaultLogLevel = spdlog::level::trace;
-#else
-    auto defaultLogLevel = spdlog::level::info;
-#endif
     context->InitConfiguration();
     context->InitConsoleVariables();
-    auto logLevel =
-        static_cast<spdlog::level::level_enum>(CVarGetInteger(CVAR_DEVELOPER_TOOLS("LogLevel"), defaultLogLevel));
-    context->InitLogging(logLevel, logLevel);
-    Ship::Context::GetInstance()->GetLogger()->set_pattern("[%H:%M:%S.%e] [%s:%#] [%l] %v");
-
-    context->InitGfxDebugger();
-    context->InitFileDropMgr();
-
-    // tell LUS to reserve 3 SoH specific threads (Game, Audio, Save)
-    context->InitResourceManager(OTRFiles, {}, 3);
-    prevAltAssets = CVarGetInteger(CVAR_SETTING("AltAssets"), 1);
-    context->GetResourceManager()->SetAltAssetsEnabled(prevAltAssets);
 
     auto controlDeck = std::make_shared<LUS::ControlDeck>(std::vector<CONTROLLERBUTTONS_T>({
         BTN_CUSTOM_MODIFIER1,
@@ -344,24 +363,483 @@ void OTRGlobals::Initialize() {
         BTN_CUSTOM_OCARINA_PITCH_DOWN,
     }));
     context->InitControlDeck(controlDeck);
-
-    context->InitCrashHandler();
+    context->InitResourceManager({ portArchivePath }, {}, 3, true);
     context->InitConsole();
 
     auto sohInputEditorWindow =
         std::make_shared<SohInputEditorWindow>(CVAR_WINDOW("ControllerConfiguration"), "Configure Controller");
-    auto sohFast3dWindow =
+    sohFast3dWindow =
         std::make_shared<Fast::Fast3dWindow>(std::vector<std::shared_ptr<Ship::GuiWindow>>({ sohInputEditorWindow }));
     context->InitWindow(sohFast3dWindow);
+
+    SohGui::SetupMenu();
+
+    if (sohArchiveVersionMatch) {
+
+        auto overlay = context->GetInstance()->GetWindow()->GetGui()->GetGameOverlay();
+        overlay->LoadFont("Press Start 2P", 12.0f, "fonts/PressStart2P-Regular.ttf");
+        overlay->LoadFont("Fipps", 32.0f, "fonts/Fipps-Regular.otf");
+        overlay->SetCurrentFont(CVarGetString(CVAR_GAME_OVERLAY_FONT, "Press Start 2P"));
+
+        fontMonoSmall = CreateFontWithSize(14.0f, "fonts/Inconsolata-Regular.ttf");
+        fontMono = CreateFontWithSize(16.0f, "fonts/Inconsolata-Regular.ttf");
+        fontMonoLarger = CreateFontWithSize(20.0f, "fonts/Inconsolata-Regular.ttf");
+        fontMonoLargest = CreateFontWithSize(24.0f, "fonts/Inconsolata-Regular.ttf");
+        fontStandard = CreateFontWithSize(16.0f, "fonts/Montserrat-Regular.ttf");
+        fontStandardLarger = CreateFontWithSize(20.0f, "fonts/Montserrat-Regular.ttf");
+        fontStandardLargest = CreateFontWithSize(24.0f, "fonts/Montserrat-Regular.ttf");
+        fontJapanese = CreateFontWithSize(24.0f, "fonts/NotoSansJP-Regular.ttf", true);
+        ImGui::GetIO().FontDefault = fontStandardLarger;
+    }
+
+    previousImGuiScaleIndex = -1;
+    previousImGuiScale = defaultImGuiScale;
+    ScaleImGui();
+}
+
+typedef enum ExtractSteps {
+    ES_PORT_ARCHIVE,
+    ES_WINDOWS,
+    ES_EXTRACT_ARGS,
+    ES_EXTRACT,
+    ES_VERIFY,
+} ExtractSteps;
+
+typedef enum PromptSteps {
+    PS_FILE_CHECK,
+    PS_LOCAL,
+    PS_FIRST,
+    PS_SECOND,
+    PS_DUPE,
+    PS_WAIT,
+    PS_NONE,
+} PromptSteps;
+
+typedef enum WindowsSteps {
+    WS_TEMP,
+    WS_PERMS,
+    WS_ONEDRIVE,
+    WS_DONE,
+} WindowsSteps;
+
+void OTRGlobals::RunExtract(int argc, char* argv[]) {
+#ifdef RSBS_SINGLE_EXECUTABLE
+    // In single-exe mode the shared Ship::Context is reused from the parent launcher, so
+    // sohFast3dWindow was never initialized here and the launcher is responsible for any
+    // ROM extraction. Skipping this whole flow avoids dereferencing a null window.
+    if (sohFast3dWindow == nullptr) {
+        return;
+    }
+#endif
+    bool extractDone = false;
+    ExtractSteps extractStep = ES_PORT_ARCHIVE;
+    WindowsSteps windowsStep = WS_TEMP;
+    auto wnd = std::dynamic_pointer_cast<Fast::Fast3dWindow>(OTRGlobals::Instance->context->GetWindow());
+    auto gui = wnd->GetGui();
+
+    OTRVersion vanillaVersion = DetectOTRVersion("oot.o2r", false);
+    OTRVersion mqVersion = DetectOTRVersion("oot-mq.o2r", true);
+
+    bool shouldRegen = VerifyArchiveVersion(vanillaVersion) || VerifyArchiveVersion(mqVersion);
+
+    std::filesystem::path ownPath;
+    std::vector<std::string> args;
+    if (argc > 1) {
+        for (int i = 1; i < argc; i++) {
+            args.push_back(argv[i]);
+        }
+    }
+    Extractor extract;
+    PromptSteps promptStep = PS_FILE_CHECK;
+    bool generatedIsMQ = false;
+    std::atomic<bool> extracting = false;
+    std::atomic<size_t> extractCount = 0, totalExtract = 0;
+
+    std::string installPath = Ship::Context::GetAppBundlePath();
+    std::string file;
+
+#if defined(__SWITCH__)
+    SohGui::RegisterPopup("Outdated ROM Archives",
+                          "\x1b[2;2HYou've launched the Ship with an old ROM O2R file."
+                          "\x1b[4;2HPlease regenerate a new ROM O2R and relaunch."
+                          "\x1b[6;2HPress the Home button to exit...",
+                          "OK", "", [&]() { exit(1); });
+#elif defined(__WIIU__)
+    SohGui::RegisterPopup("Outdated ROM Archives",
+                          "You've launched the Ship with an old a ROM O2R file.\n\n"
+                          "Please generate a ROM O2R and relaunch.\n\n"
+                          "Press and hold the Power button to shutdown...",
+                          "OK", "", [&]() { exit(1); });
+    OSFatal();
+#endif
+
+    if (!std::filesystem::exists(installPath + "/assets")) {
+        SohGui::RegisterPopup("Extractor assets not found",
+                              "No O2R files found. Missing 'assets/' folder needed to generate OTR file.\nPlease "
+                              "re-extract them from the download or.\n\nExiting...",
+                              "OK", "", [&]() { exit(1); });
+    } else if (shouldRegen) {
+        SohGui::RegisterPopup("Outdated ROM Archives",
+                              "Your oot.o2r or oot-mq.o2r were created with incompatible versions of SoH.\nYou will "
+                              "now be redirected to re-extract them.");
+        std::filesystem::remove("oot.o2r");
+        std::filesystem::remove("oot-mq.o2r");
+    }
+
+    std::shared_ptr<BS::thread_pool> threadPool = std::make_shared<BS::thread_pool>(1);
+    while (!extractDone) {
+        if (SohGui::PopupsQueued() > 0 || extracting) {
+            goto render;
+        }
+        switch (extractStep) {
+            case ES_PORT_ARCHIVE: {
+                if (sohArchiveVersionMatch) {
+#ifdef _WIN32
+                    extractStep = ES_WINDOWS;
+#elif (defined(__WIIU__) || defined(__SWITCH__))
+                    extractStep = ES_VERIFY;
+#else
+                    extractStep = ES_EXTRACT;
+#endif
+                } else {
+                    std::string msg;
+
+#if defined(__SWITCH__)
+                    msg = "\x1b[4;2HPlease re-extract it from the download.\n"
+                          "\x1b[6;2HPress the Home button to exit...";
+#elif defined(__WIIU__)
+                    msg = "Please extract the soh.o2r from the Ship of Harkinian download\nto your folder.\n\nPress "
+                          "and hold the power\n"
+                          "button to shutdown...";
+#else
+                    msg =
+                        "Please extract the soh.o2r from the Ship of Harkinian download to your folder.\n\nExiting...";
+#endif
+                    std::string title =
+                        !std::filesystem::exists(portArchivePath) ? "Missing soh.o2r" : "soh.o2r is outdated";
+                    SohGui::RegisterPopup(title, msg, "OK", "", [&]() { exit(1); });
+                }
+                continue;
+            }
+            case ES_WINDOWS: {
+                switch (windowsStep) {
+                    case WS_TEMP: {
+#ifdef _WIN32
+                        char* tempVar = getenv("TEMP");
+                        std::filesystem::path tempPath;
+                        try {
+                            tempPath = std::filesystem::canonical(tempVar);
+                        } catch (std::filesystem::filesystem_error const& ex) {
+                            std::string userPath = getenv("USERPROFILE");
+                            userPath.append("\\AppData\\Local\\Temp");
+                            tempPath = std::filesystem::canonical(userPath);
+                        }
+                        wchar_t buffer[MAX_PATH];
+                        GetModuleFileName(NULL, buffer, _countof(buffer));
+                        ownPath = std::filesystem::canonical(buffer).parent_path();
+                        if (IsSubpath(ownPath, tempPath)) {
+                            SohGui::RegisterPopup("SoH Path Error",
+                                                  "SoH is running in a temp folder.\nExtract the .zip and run again.",
+                                                  "OK", "", [&]() { exit(0); });
+                        } else {
+                            windowsStep = WS_PERMS;
+                        }
+#endif
+                        continue;
+                    }
+                    case WS_PERMS: {
+                        FILE* tfile = fopen("./text.txt", "w");
+                        std::filesystem::path tfolder = std::filesystem::path("./test/");
+                        bool error = false;
+                        try {
+                            create_directories(tfolder);
+                        } catch (std::filesystem::filesystem_error const& ex) { error = true; }
+                        if (tfile == NULL || error) {
+                            SohGui::RegisterPopup("SoH Permissions Error",
+                                                  "SoH does not have proper file permissions.\nPlease move it to a "
+                                                  "folder that does and run again.",
+                                                  "OK", "", [&]() {
+                                                      fclose(tfile);
+                                                      PathTestCleanup(tfile);
+                                                      exit(0);
+                                                  });
+                        } else {
+                            fclose(tfile);
+                            if (!PathTestCleanup(tfile)) {
+                                SohGui::RegisterPopup("SoH Permissions Error",
+                                                      "SoH does not have proper file permissions.\nPlease move it to a "
+                                                      "folder that does and run again.",
+                                                      "OK", "", [&]() { exit(0); });
+                            }
+                            windowsStep = WS_ONEDRIVE;
+                        }
+                        continue;
+                    }
+                    case WS_ONEDRIVE: {
+                        if (ownPath.string().find("OneDrive") != std::string::npos) {
+                            SohGui::RegisterPopup("SoH Path Error",
+                                                  "SoH appears to be in a OneDrive folder, which will cause issues.\n"
+                                                  "Please move it to a folder outside of OneDrive, like the root of a\n"
+                                                  "drive (e.g. \"C:\\Games\\SoH\").",
+                                                  "OK", "", [&]() { exit(0); });
+                        } else {
+                            windowsStep = WS_DONE;
+                            if (args.size() > 0) {
+                                extractStep = ES_EXTRACT_ARGS;
+                            } else {
+                                extractStep = ES_EXTRACT;
+                            }
+                        }
+                        continue;
+                    }
+                    default:
+                        continue;
+                }
+                break;
+            }
+            case ES_EXTRACT_ARGS: {
+#if !defined(__SWITCH__) && !defined(__WIIU__)
+                if (args.size() == 0) {
+                    SohGui::RegisterPopup(
+                        "Run Ship of Harkinian", "All files have been processed. Run SoH?", "Yes", "No",
+                        [&]() {
+                            if (!std::filesystem::exists(Ship::Context::GetAppDirectoryPath(appShortName) +
+                                                         "/oot.o2r") &&
+                                !std::filesystem::exists(Ship::Context::GetAppDirectoryPath(appShortName) +
+                                                         "/oot-mq.o2r")) {
+                                extractStep = ES_EXTRACT;
+                                promptStep = PS_FILE_CHECK;
+                            } else {
+                                extractStep = ES_VERIFY;
+                            }
+                        },
+                        [&]() { exit(0); });
+                    break;
+                }
+                file = args.at(0);
+                args.erase(args.begin());
+                extract = Extractor();
+                if (extract.RunFileStandalone(file)) {
+                    std::string archive = (extract.IsMasterQuest() ? "oot-mq.o2r" : "oot.o2r");
+                    if (std::filesystem::exists(Ship::Context::GetAppDirectoryPath(appShortName) + "/" + archive)) {
+                        std::string msg = "Archive for current ROM, " + archive + ", already exists.\nExtract again?";
+                        SohGui::RegisterPopup("Confirm Re-extract", msg.c_str(), "Yes", "No", [&]() {
+                            extracting = true;
+                            threadPool->detach_task([&]() -> void {
+                                extract.CallZapd(installPath, Ship::Context::GetAppDirectoryPath(appShortName),
+                                                 &extractCount, &totalExtract);
+                                extracting = false;
+                                extractCount = totalExtract = 0;
+                            });
+                        });
+                    } else {
+                        extracting = true;
+                        threadPool->detach_task([&]() -> void {
+                            extract.CallZapd(installPath, Ship::Context::GetAppDirectoryPath(appShortName),
+                                             &extractCount, &totalExtract);
+                            extracting = false;
+                            extractCount = totalExtract = 0;
+                        });
+                    }
+                } else {
+                    std::string msg = "File\n" + std::string(file) + "\nis not a ROM or does not match supported ROMs.";
+                    SohGui::RegisterPopup("SoH ROM Error", msg.c_str());
+                }
+#else
+                extractStep = ES_VERIFY;
+#endif
+                break;
+            }
+            case ES_EXTRACT: {
+                switch (promptStep) {
+                    case PS_FILE_CHECK: {
+                        const bool ootO2RExists =
+                            std::filesystem::exists(
+                                Ship::Context::LocateFileAcrossAppDirs("oot-mq.o2r", appShortName)) ||
+                            std::filesystem::exists(Ship::Context::LocateFileAcrossAppDirs("oot.o2r", appShortName));
+
+                        if (!ootO2RExists) {
+                            SohGui::RegisterPopup(
+                                "No O2R Files", "No O2R files found. Generate one now?", "Yes", "No",
+                                [&]() { promptStep = PS_LOCAL; }, [&]() { exit(0); });
+                        } else {
+                            extractStep = ES_VERIFY;
+                        }
+                        continue;
+                    }
+                    case PS_LOCAL: {
+                        extract = Extractor();
+                        extract.SetSearchPath(installPath);
+                        extract.GetRoms(args);
+                        if (!args.empty()) {
+                            promptStep = PS_WAIT;
+                            SohGui::RegisterPopup(
+                                "ROMs found", "ROMs found in application directory. Would you like to process them?",
+                                "Yes", "No", [&]() { extractStep = ES_EXTRACT_ARGS; },
+                                [&]() { promptStep = PS_FIRST; });
+                        } else {
+                            promptStep = PS_FIRST;
+                        }
+                        continue;
+                    }
+                    case PS_FIRST: {
+                        if (!extract.ManuallySearchForRomMatchingType(RomSearchMode::Both)) {
+                            promptStep = PS_FILE_CHECK;
+                            continue;
+                        }
+                        extracting = true;
+                        threadPool->detach_task([&]() -> void {
+                            extract.CallZapd(installPath, Ship::Context::GetAppDirectoryPath(appShortName),
+                                             &extractCount, &totalExtract);
+                            generatedIsMQ = extract.IsMasterQuest();
+                            extracting = false;
+                            promptStep = PS_SECOND;
+                            extractCount = 0;
+                            totalExtract = 0;
+                        });
+                        continue;
+                    }
+                    case PS_SECOND: {
+                        SohGui::RegisterPopup(
+                            "Extraction Complete", "ROM Extracted. Extract another?", "Yes", "No",
+                            [&]() {
+                                if (!extract.ManuallySearchForRomMatchingType(generatedIsMQ ? RomSearchMode::Vanilla
+                                                                                            : RomSearchMode::MQ)) {
+                                    extractStep = ES_VERIFY;
+                                } else {
+                                    extracting = true;
+                                    threadPool->detach_task([&]() -> void {
+                                        extract.CallZapd(installPath, Ship::Context::GetAppDirectoryPath(appShortName),
+                                                         &extractCount, &totalExtract);
+                                        extracting = false;
+                                        extractStep = ES_VERIFY;
+                                        extractCount = 0;
+                                        totalExtract = 0;
+                                    });
+                                }
+                            },
+                            [&]() { extractStep = ES_VERIFY; });
+                        continue;
+                    }
+                    default:
+                        break;
+                }
+                break;
+            }
+            case ES_VERIFY: {
+                const bool ootO2RExists =
+                    std::filesystem::exists(Ship::Context::LocateFileAcrossAppDirs("oot-mq.o2r", appShortName)) ||
+                    std::filesystem::exists(Ship::Context::LocateFileAcrossAppDirs("oot.o2r", appShortName));
+
+                if (!ootO2RExists) {
+                    SohGui::RegisterPopup("No ROM Archives",
+                                          "No ROM O2R files detected. Please generate a ROM O2R and relaunch.", "OK",
+                                          "", [&]() { exit(0); });
+                }
+                extractDone = true;
+                continue;
+            }
+            default:
+                break;
+        }
+
+    render:
+        if (!WindowIsRunning()) {
+            exit(0);
+        }
+        // Process window events for resize, mouse, keyboard events
+        wnd->HandleEvents();
+        UIWidgets::Colors themeColor =
+            static_cast<UIWidgets::Colors>(CVarGetInteger(CVAR_SETTING("Menu.Theme"), UIWidgets::Colors::LightBlue));
+        ImGui::PushStyleColor(ImGuiCol_TitleBgActive, UIWidgets::ColorValues.at(themeColor));
+        ImGui::PushStyleColor(ImGuiCol_ModalWindowDimBg, UIWidgets::ColorValues.at(UIWidgets::Colors::DarkGray));
+
+        // Skip dropped frames
+        if (!wnd->IsFrameReady()) {
+            continue;
+        }
+        gui->StartDraw();
+        sohFast3dWindow->StartFrame();
+        sohFast3dWindow->RunGuiOnly();
+        if (extracting && !ImGui::IsPopupOpen("ROM Extraction")) {
+            ImGui::OpenPopup("ROM Extraction");
+        }
+        if (extracting) {
+            ImGui::PushStyleVar(ImGuiStyleVar_FrameRounding, 3.0f);
+            ImGui::PushStyleVar(ImGuiStyleVar_FramePadding, ImVec2(10.0f, 8.0f));
+            auto color = UIWidgets::ColorValues.at(THEME_COLOR);
+            ImGui::PushStyleColor(ImGuiCol_FrameBg, ImVec4(color.x, color.y, color.z, 0.6f));
+            ImGui::PushStyleColor(ImGuiCol_PlotHistogram, ImVec4(color.x, color.y, color.z, 1.0f));
+            ImGui::PushStyleColor(ImGuiCol_Border, ImVec4(0.0f, 0.0f, 0.0f, 0.3f));
+            if (ImGui::BeginPopupModal("ROM Extraction", NULL,
+                                       ImGuiWindowFlags_AlwaysAutoResize | ImGuiWindowFlags_NoResize |
+                                           ImGuiWindowFlags_NoMove | ImGuiWindowFlags_NoScrollbar |
+                                           ImGuiWindowFlags_NoSavedSettings)) {
+                float progress = (totalExtract > 0.0f ? (float)extractCount / (float)totalExtract : 0) * 100.0f;
+                auto filename = std::filesystem::path(file).filename().string();
+                ImGui::Text("Extracting %s...%s", filename.c_str(),
+                            roundf(progress) == 100.0f ? " Done. Finishing up." : "");
+                std::string overlay = extractCount > 0 ? fmt::format("{:.0f}%", progress) : "Starting Up";
+                ImGui::ProgressBar(progress / 100.0f, ImVec2(600.0f, 50.0f), overlay.c_str());
+                ImGui::EndPopup();
+            }
+            ImGui::PopStyleColor(3);
+            ImGui::PopStyleVar(2);
+        }
+        gui->EndDraw();
+        sohFast3dWindow->EndFrame();
+        ImGui::PopStyleColor(2);
+    }
+
+#ifdef __SWITCH__
+    Ship::Switch::Init(Ship::PreInitPhase);
+#elif defined(__WIIU__)
+    Ship::WiiU::Init(appShortName);
+#endif
+
+#if not defined(__SWITCH__) && not defined(__WIIU__)
+    CheckAndCreateModFolder();
+#endif
+}
+
+void OTRGlobals::Initialize() {
+    std::string mqPath = Ship::Context::LocateFileAcrossAppDirs("oot-mq.o2r", appShortName);
+    if (std::filesystem::exists(mqPath)) {
+        context->GetResourceManager()->GetArchiveManager()->AddArchive(mqPath);
+    }
+    std::string ootPath = Ship::Context::LocateFileAcrossAppDirs("oot.o2r", appShortName);
+    if (std::filesystem::exists(ootPath)) {
+        context->GetResourceManager()->GetArchiveManager()->AddArchive(ootPath);
+    }
+
+    std::unordered_set<uint32_t> ValidHashes = {
+        OOT_PAL_MQ,     OOT_NTSC_JP_MQ, OOT_NTSC_US_MQ, OOT_PAL_GC_MQ_DBG, OOT_NTSC_US_10,
+        OOT_NTSC_US_11, OOT_NTSC_US_12, OOT_PAL_10,     OOT_PAL_11,        OOT_NTSC_JP_GC_CE,
+        OOT_NTSC_JP_GC, OOT_NTSC_US_GC, OOT_PAL_GC,     OOT_PAL_GC_DBG1,   OOT_PAL_GC_DBG2,
+    };
+
+#if (_DEBUG)
+    auto defaultLogLevel = spdlog::level::trace;
+#else
+    auto defaultLogLevel = spdlog::level::info;
+#endif
+    auto logLevel =
+        static_cast<spdlog::level::level_enum>(CVarGetInteger(CVAR_DEVELOPER_TOOLS("LogLevel"), defaultLogLevel));
+    context->InitLogging(logLevel, logLevel);
+    Ship::Context::GetInstance()->GetLogger()->set_pattern("[%H:%M:%S.%e] [%s:%#] [%l] %v");
+
+    context->InitGfxDebugger();
+    context->InitFileDropMgr();
+
+    // tell LUS to reserve 3 SoH specific threads (Game, Audio, Save)
+    prevAltAssets = CVarGetInteger(CVAR_SETTING("AltAssets"), 1);
+    context->GetResourceManager()->SetAltAssetsEnabled(prevAltAssets);
+
+    context->InitCrashHandler();
 
     context->GetWindow()->SetAutoCaptureMouse(CVarGetInteger(CVAR_SETTING("EnableMouse"), 0) &&
                                               CVarGetInteger(CVAR_SETTING("AutoCaptureMouse"), 1));
     context->GetWindow()->SetForceCursorVisibility(CVarGetInteger(CVAR_SETTING("CursorVisibility"), 0));
-
-    auto overlay = context->GetInstance()->GetWindow()->GetGui()->GetGameOverlay();
-    overlay->LoadFont("Press Start 2P", 12.0f, "fonts/PressStart2P-Regular.ttf");
-    overlay->LoadFont("Fipps", 32.0f, "fonts/Fipps-Regular.otf");
-    overlay->SetCurrentFont(CVarGetString(CVAR_GAME_OVERLAY_FONT, "Press Start 2P"));
 
     if (RsbsFeatureEnabled("RSBS_DISABLE_AUDIO")) {
         context->InitAudio({ .SampleRate = 32000, .SampleLength = 1024, .DesiredBuffered = 1680 });
@@ -454,20 +932,6 @@ void OTRGlobals::Initialize() {
     gRandomizer = std::make_shared<Randomizer>();
 
     hasMasterQuest = hasOriginal = false;
-
-    previousImGuiScaleIndex = -1;
-    previousImGuiScale = defaultImGuiScale;
-
-    fontMonoSmall = CreateFontWithSize(14.0f, "fonts/Inconsolata-Regular.ttf", false);
-    fontMono = CreateFontWithSize(16.0f, "fonts/Inconsolata-Regular.ttf", false);
-    fontMonoLarger = CreateFontWithSize(20.0f, "fonts/Inconsolata-Regular.ttf", false);
-    fontMonoLargest = CreateFontWithSize(24.0f, "fonts/Inconsolata-Regular.ttf", false);
-    fontStandard = CreateFontWithSize(16.0f, "fonts/Montserrat-Regular.ttf", false);
-    fontStandardLarger = CreateFontWithSize(20.0f, "fonts/Montserrat-Regular.ttf", false);
-    fontStandardLargest = CreateFontWithSize(24.0f, "fonts/Montserrat-Regular.ttf", false);
-    fontJapanese = CreateFontWithSize(24.0f, "fonts/NotoSansJP-Regular.ttf", true);
-    ImGui::GetIO().FontDefault = fontStandardLarger;
-    ScaleImGui();
 
     // Move the camera strings from read only memory onto the heap (writable memory)
     // This is in OTRGlobals right now because this is a place that will only ever be run once at the beginning of
@@ -985,12 +1449,6 @@ extern "C" void OTRExtScanner() {
     }
 }
 
-typedef struct {
-    uint16_t major;
-    uint16_t minor;
-    uint16_t patch;
-} OTRVersion;
-
 // Read the port version from an OTR file
 OTRVersion ReadPortVersionFromOTR(std::string otrPath) {
     OTRVersion version = {};
@@ -1013,281 +1471,32 @@ OTRVersion ReadPortVersionFromOTR(std::string otrPath) {
     return version;
 }
 
-// Check that a soh.o2r exists and matches the version of soh running
-// Otherwise show a message and exit
-void CheckSoHOTRVersion(std::string otrPath) {
-    std::string msg;
-
-#if defined(__SWITCH__)
-    msg = "\x1b[4;2HPlease re-extract it from the download."
-          "\x1b[6;2HPress the Home button to exit...";
-#elif defined(__WIIU__)
-    msg = "Please extract the soh.o2r from the Ship of Harkinian download\nto your folder.\n\nPress and hold the power "
-          "button to shutdown...";
-#else
-    msg = "Please extract the soh.o2r from the Ship of Harkinian download to your folder.\n\nExiting...";
-#endif
-
-    if (!std::filesystem::exists(otrPath)) {
-#if not defined(__SWITCH__) && not defined(__WIIU__)
-        Extractor::ShowErrorBox("soh.o2r file is missing", msg.c_str());
-        exit(1);
-#elif defined(__SWITCH__)
-        Ship::Switch::PrintErrorMessageToScreen(("\x1b[2;2HYou are missing the soh.o2r file." + msg).c_str());
-#elif defined(__WIIU__)
-        OSFatal(("You are missing the soh.o2r file\n\n" + msg).c_str());
-#endif
-    }
-
-    OTRVersion otrVersion = ReadPortVersionFromOTR(otrPath);
-
-    if (otrVersion.major != OoT_gBuildVersionMajor || otrVersion.minor != OoT_gBuildVersionMinor ||
-        otrVersion.patch != OoT_gBuildVersionPatch) {
-#if not defined(__SWITCH__) && not defined(__WIIU__)
-        Extractor::ShowErrorBox("soh.o2r file version does not match", msg.c_str());
-        exit(1);
-#elif defined(__SWITCH__)
-        Ship::Switch::PrintErrorMessageToScreen(("\x1b[2;2HYou have an old soh.o2r file." + msg).c_str());
-#elif defined(__WIIU__)
-        OSFatal(("You have an old soh.o2r file\n\n" + msg).c_str());
-#endif
-    }
-}
-
 // Checks the program version stored in the otr and compares the major value to soh
-// For Windows/Mac/Linux if the version doesn't match, offer to
-void DetectOTRVersion(std::string fileName, bool isMQ) {
-    bool isOtrOld = false;
+OTRVersion DetectOTRVersion(std::string fileName, bool isMQ) {
     std::string otrPath = Ship::Context::LocateFileAcrossAppDirs(fileName, appShortName);
 
     // Doesn't exist so nothing to do here
     if (!std::filesystem::exists(otrPath)) {
-        return;
+        return { INT16_MAX, INT16_MAX, INT16_MAX };
     }
 
-    OTRVersion otrVersion = ReadPortVersionFromOTR(otrPath);
-
-    if (otrVersion.major != OoT_gBuildVersionMajor) {
-        isOtrOld = true;
-    }
-
-    if (isOtrOld) {
-#if not defined(__SWITCH__) && not defined(__WIIU__)
-        char msgBuf[250];
-        char version[18]; // 5 digits for int16_max (x3) + separators + terminator
-
-        if (otrVersion.major != 0 || otrVersion.minor != 0 || otrVersion.patch != 0) {
-            snprintf(version, 18, "%d.%d.%d", otrVersion.major, otrVersion.minor, otrVersion.patch);
-        } else {
-            snprintf(version, 18, "no version found");
-        }
-
-        snprintf(msgBuf, 250,
-                 "The %s file was generated with a different version of Ship of Harkinian.\nOTR version: %s\n\n"
-                 "You must regenerate to be able to play, otherwise the program will exit.\nWould you like to "
-                 "regenerate it now?",
-                 fileName.c_str(), version);
-
-        if (Extractor::ShowYesNoBox("Old OTR File Found", msgBuf) == IDYES) {
-            std::string installPath = Ship::Context::GetAppBundlePath();
-            if (!std::filesystem::exists(installPath + "/assets")) {
-                Extractor::ShowErrorBox(
-                    "Extractor assets not found",
-                    "Unable to regenerate. Missing assets/ folder needed to generate OTR file.\n\nExiting...");
-                exit(1);
-            }
-
-            Extractor extract;
-            if (!extract.Run(Ship::Context::GetAppDirectoryPath(appShortName),
-                             isMQ ? RomSearchMode::MQ : RomSearchMode::Vanilla, installPath)) {
-                Extractor::ShowErrorBox("Error", "An error occured, no OTR file was generated.\n\nExiting...");
-                exit(1);
-            }
-            extract.CallZapd(installPath, Ship::Context::GetAppDirectoryPath(appShortName));
-        } else {
-            exit(1);
-        }
-
-#elif defined(__SWITCH__)
-        Ship::Switch::PrintErrorMessageToScreen("\x1b[2;2HYou've launched the Ship with an old game OTR file."
-                                                "\x1b[4;2HPlease regenerate a new game OTR and relaunch."
-                                                "\x1b[6;2HPress the Home button to exit...");
-#elif defined(__WIIU__)
-        OSFatal("You've launched the Ship with an old a game OTR file.\n\n"
-                "Please generate a game OTR and relaunch.\n\n"
-                "Press and hold the Power button to shutdown...");
-#endif
-    }
+    return ReadPortVersionFromOTR(otrPath);
 }
 
 extern "C" void Messagebox_ShowErrorBox(char* title, char* body) {
     Extractor::ShowErrorBox(title, body);
 }
 
-bool IsSubpath(const std::filesystem::path& path, const std::filesystem::path& base) {
-    auto rel = std::filesystem::relative(path, base);
-    return !rel.empty() && rel.native()[0] != '.';
-}
-
-bool PathTestCleanup(FILE* tfile) {
-    try {
-        if (std::filesystem::exists("./text.txt"))
-            std::filesystem::remove("./text.txt");
-        if (std::filesystem::exists("./test/"))
-            std::filesystem::remove("./test/");
-    } catch (std::filesystem::filesystem_error const& ex) { return false; }
-    return true;
-}
-
-void CheckAndCreateModFolder() {
-    try {
-        std::string modsPath = Ship::Context::LocateFileAcrossAppDirs("mods", appShortName);
-        if (!std::filesystem::exists(modsPath)) {
-            // Create mods folder relative to app dir
-            modsPath = Ship::Context::GetPathRelativeToAppDirectory("mods", appShortName);
-            std::string filePath = modsPath + "/custom_mod_files_go_here.txt";
-            if (std::filesystem::create_directories(modsPath)) {
-                std::ofstream(filePath).close();
-            }
-        }
-    } catch (std::filesystem::filesystem_error const& ex) {
-        // Couldn't make the folder, continue silently
-        return;
+bool VerifyArchiveVersion(OTRVersion version) {
+    if (version.major != INT16_MAX && version.major != OoT_gBuildVersionMajor) {
+        return true;
     }
+    return false;
 }
 
 extern "C" void InitOTR(int argc, char* argv[]) {
-#if !defined(__SWITCH__) && !defined(__WIIU__)
-    if (argc > 1) {
-        for (int i = 1; i < argc; i++) {
-            std::string installPath = Ship::Context::GetAppBundlePath();
-            Extractor extract;
-            if (extract.RunFileStandalone(argv[i])) {
-                bool doExtract = true;
-                std::string archive = (extract.IsMasterQuest() ? "oot-mq.o2r" : "oot.o2r");
-                if (std::filesystem::exists(Ship::Context::GetAppBundlePath() + "/" + archive)) {
-                    std::string msg = "Archive for current ROM, " + archive + ", already exists. Extract again?";
-                    doExtract = extract.ShowYesNoBox("Confirm Re-extract", msg.c_str()) == IDYES;
-                }
-                if (doExtract) {
-                    extract.CallZapd(installPath, Ship::Context::GetAppDirectoryPath(appShortName));
-                }
-            } else {
-                std::string msg = "File " + std::string(argv[i]) + " is not a ROM or does not match supported ROMs.";
-                extract.ShowErrorBox("Incompatible File", msg.c_str());
-            }
-        }
-        if (Extractor::ShowYesNoBox("Run Ship of Harkinian", "All files have been processed. Run SoH?") != IDYES) {
-            exit(0);
-        }
-    }
-#endif
     OTRGlobals::Instance = new OTRGlobals();
-#ifdef __SWITCH__
-    Ship::Switch::Init(Ship::PreInitPhase);
-#elif defined(__WIIU__)
-    Ship::WiiU::Init(appShortName);
-#endif
-
-#ifdef _WIN32
-    char* tempVar = getenv("TEMP");
-    std::filesystem::path tempPath;
-    try {
-        tempPath = std::filesystem::canonical(tempVar);
-    } catch (std::filesystem::filesystem_error const& ex) {
-        std::string userPath = getenv("USERPROFILE");
-        userPath.append("\\AppData\\Local\\Temp");
-        tempPath = std::filesystem::canonical(userPath);
-    }
-    wchar_t buffer[MAX_PATH];
-    GetModuleFileName(NULL, buffer, _countof(buffer));
-    auto ownPath = std::filesystem::canonical(buffer).parent_path();
-    if (IsSubpath(ownPath, tempPath)) {
-        Extractor::ShowErrorBox("Error", "SoH is running in a temp folder. Extract the .zip and run again.");
-        exit(1);
-    }
-    FILE* tfile = fopen("./text.txt", "w");
-    std::filesystem::path tfolder = std::filesystem::path("./test/");
-    bool error = false;
-    try {
-        create_directories(tfolder);
-    } catch (std::filesystem::filesystem_error const& ex) { error = true; }
-    if (tfile == NULL || error) {
-        Extractor::ShowErrorBox(
-            "Error", "SoH does not have proper file permissions. Please move it to a folder that does and run again.");
-        PathTestCleanup(tfile);
-        exit(1);
-    }
-    fclose(tfile);
-    if (!PathTestCleanup(tfile)) {
-        Extractor::ShowErrorBox(
-            "Error", "SoH does not have proper file permissions. Please move it to a folder that does and run again.");
-        exit(1);
-    }
-    if (ownPath.string().find("OneDrive") != std::string::npos) {
-        Extractor::ShowErrorBox(
-            "Error",
-            "SoH appears to be in a OneDrive folder, which will cause issues. "
-            "Please move it to a folder outside of OneDrive, like the root of a drive (e.g. \"C:\\Games\\SoH\").");
-        exit(1);
-    }
-#endif
-
-#if not defined(__SWITCH__) && not defined(__WIIU__)
-    CheckAndCreateModFolder();
-#endif
-    const bool ootO2RExists =
-        std::filesystem::exists(Ship::Context::LocateFileAcrossAppDirs("oot-mq.o2r", appShortName)) ||
-        std::filesystem::exists(Ship::Context::LocateFileAcrossAppDirs("oot.o2r", appShortName));
-
-    if (!ootO2RExists) {
-
-#if not defined(__SWITCH__) && not defined(__WIIU__)
-        std::string installPath = Ship::Context::GetAppBundlePath();
-        if (!std::filesystem::exists(installPath + "/assets")) {
-            Extractor::ShowErrorBox(
-                "Extractor assets not found",
-                "No OTR files found. Missing assets/ folder needed to generate OTR file.\n\nExiting...");
-            exit(1);
-        }
-
-        bool generatedOtrIsMQ = false;
-        if (Extractor::ShowYesNoBox("No OTR Files", "No OTR files found. Generate one now?") == IDYES) {
-            Extractor extract;
-            if (!extract.Run(Ship::Context::GetAppDirectoryPath(appShortName), RomSearchMode::Both, installPath)) {
-                Extractor::ShowErrorBox("Error", "An error occured, no OTR file was generated.\n\nExiting...");
-                exit(1);
-            }
-            extract.CallZapd(installPath, Ship::Context::GetAppDirectoryPath(appShortName));
-            generatedOtrIsMQ = extract.IsMasterQuest();
-        } else {
-            exit(1);
-        }
-        if (Extractor::ShowYesNoBox("Extraction Complete", "ROM Extracted. Extract another?") == IDYES) {
-            Extractor extract;
-            if (!extract.Run(Ship::Context::GetAppDirectoryPath(appShortName),
-                             generatedOtrIsMQ ? RomSearchMode::Vanilla : RomSearchMode::MQ, installPath)) {
-                Extractor::ShowErrorBox(
-                    "Error",
-                    "An error occured, an OTR file may have been generated by a different step.\n\nContinuing...");
-            } else {
-                extract.CallZapd(installPath, Ship::Context::GetAppDirectoryPath(appShortName));
-            }
-        }
-
-#elif defined(__SWITCH__)
-        Ship::Switch::PrintErrorMessageToScreen("\x1b[2;2HYou've launched the Ship without a game OTR file."
-                                                "\x1b[4;2HPlease generate a game OTR and relaunch."
-                                                "\x1b[6;2HPress the Home button to exit...");
-#elif defined(__WIIU__)
-        OSFatal("You've launched the Ship without a game OTR file.\n\n"
-                "Please generate a game OTR and relaunch.\n\n"
-                "Press and hold the Power button to shutdown...");
-#endif
-    }
-
-    DetectOTRVersion("oot.o2r", false);
-    DetectOTRVersion("oot-mq.o2r", true);
+    OTRGlobals::Instance->RunExtract(argc, argv);
 
     OTRGlobals::Instance->Initialize();
     CustomMessageManager::Instance = new CustomMessageManager();
@@ -1305,9 +1514,7 @@ extern "C" void InitOTR(int argc, char* argv[]) {
     conf->RunVersionUpdates();
 
     SohGui::SetupGuiElements();
-    if (RsbsFeatureEnabled("RSBS_DISABLE_SHIPINIT")) {
-        ShipInit::InitAll();
-    }
+    SohGui::SetupMenuElements();
 
     if (RsbsFeatureEnabled("RSBS_DISABLE_RANDO")) {
         Rando::StaticData::InitHashMaps();
@@ -1384,6 +1591,9 @@ extern "C" void InitOTR(int argc, char* argv[]) {
     }
     if (CVarGetInteger(CVAR_REMOTE_ANCHOR("Enabled"), 0)) {
         Anchor::Instance->Enable();
+    }
+    if (RsbsFeatureEnabled("RSBS_DISABLE_SHIPINIT")) {
+        ShipInit::InitAll();
     }
 }
 

--- a/games/oot/soh/OTRGlobals.cpp
+++ b/games/oot/soh/OTRGlobals.cpp
@@ -559,7 +559,9 @@ void OTRGlobals::RunExtract(int argc, char* argv[]) {
                                                   "SoH does not have proper file permissions.\nPlease move it to a "
                                                   "folder that does and run again.",
                                                   "OK", "", [&]() {
-                                                      fclose(tfile);
+                                                      if (tfile) {
+                                                          fclose(tfile);
+                                                      }
                                                       PathTestCleanup(tfile);
                                                       exit(0);
                                                   });

--- a/games/oot/soh/OTRGlobals.h
+++ b/games/oot/soh/OTRGlobals.h
@@ -59,20 +59,21 @@ class OTRGlobals {
     ImFont* defaultFontLarger;
     ImFont* defaultFontLargest;
 
-    ImFont* fontMonoSmall;
-    ImFont* fontStandard;
-    ImFont* fontStandardLarger;
-    ImFont* fontStandardLargest;
-    ImFont* fontMono;
-    ImFont* fontMonoLarger;
-    ImFont* fontMonoLargest;
-    ImFont* fontJapanese;
+    ImFont* fontMonoSmall = nullptr;
+    ImFont* fontStandard = nullptr;
+    ImFont* fontStandardLarger = nullptr;
+    ImFont* fontStandardLargest = nullptr;
+    ImFont* fontMono = nullptr;
+    ImFont* fontMonoLarger = nullptr;
+    ImFont* fontMonoLargest = nullptr;
+    ImFont* fontJapanese = nullptr;
 
     OTRGlobals();
     ~OTRGlobals();
 
     void ScaleImGui();
     void Initialize();
+    void RunExtract(int argc, char* argv[]);
     bool HasMasterQuest();
     bool HasOriginal();
     uint32_t GetInterpolationFPS();
@@ -83,7 +84,7 @@ class OTRGlobals {
     bool hasMasterQuest;
     bool hasOriginal;
     ImFont* CreateDefaultFontWithSize(float size);
-    ImFont* CreateFontWithSize(float size, std::string fontPath, bool isJapaneseFont);
+    ImFont* CreateFontWithSize(float size, std::string fontPath, bool isJapaneseFont = false);
 };
 #endif
 

--- a/games/oot/soh/SohGui/Menu.cpp
+++ b/games/oot/soh/SohGui/Menu.cpp
@@ -559,6 +559,9 @@ void Menu::Draw() {
 
 static bool freshOpen = true;
 void Menu::DrawElement() {
+    if (OTRGlobals::Instance->fontStandardLargest == nullptr) {
+        return;
+    }
     for (auto& [reason, info] : disabledMap) {
         info.active = info.evaluation(info);
     }

--- a/games/oot/soh/SohGui/SohGui.cpp
+++ b/games/oot/soh/SohGui/SohGui.cpp
@@ -105,11 +105,22 @@ std::shared_ptr<SohMenu> GetSohMenu() {
     return mSohMenu;
 }
 
-void SetupGuiElements() {
+void SetupMenu() {
     auto gui = Ship::Context::GetInstance()->GetWindow()->GetGui();
-
     mSohMenu = std::make_shared<SohMenu>(CVAR_WINDOW("Menu"), "Port Menu");
     gui->SetMenu(mSohMenu);
+
+    mModalWindow = std::make_shared<SohModalWindow>(CVAR_WINDOW("ModalWindow"), "Modal Window");
+    gui->AddGuiWindow(mModalWindow);
+    mModalWindow->Show();
+}
+
+void SetupMenuElements() {
+    mSohMenu->AddMenuElements();
+}
+
+void SetupGuiElements() {
+    auto gui = Ship::Context::GetInstance()->GetWindow()->GetGui();
 
     mConsoleWindow = std::make_shared<SohConsoleWindow>(CVAR_WINDOW("SohConsole"), "Console##SoH", ImVec2(820, 630));
     gui->AddGuiWindow(mConsoleWindow);
@@ -184,9 +195,6 @@ void SetupGuiElements() {
     mPlandomizerWindow =
         std::make_shared<PlandomizerWindow>(CVAR_WINDOW("PlandomizerEditor"), "Plandomizer Editor", ImVec2(850, 760));
     gui->AddGuiWindow(mPlandomizerWindow);
-    mModalWindow = std::make_shared<SohModalWindow>(CVAR_WINDOW("ModalWindow"), "Modal Window");
-    gui->AddGuiWindow(mModalWindow);
-    mModalWindow->Show();
     mNotificationWindow = std::make_shared<Notification::Window>(CVAR_WINDOW("Notifications"), "Notifications Window");
     gui->AddGuiWindow(mNotificationWindow);
     mNotificationWindow->Show();
@@ -233,6 +241,18 @@ void Destroy() {
 void RegisterPopup(std::string title, std::string message, std::string button1, std::string button2,
                    std::function<void()> button1callback, std::function<void()> button2callback) {
     mModalWindow->RegisterPopup(title, message, button1, button2, button1callback, button2callback);
+}
+
+size_t PopupsQueued() {
+    return mModalWindow->PopupsQueued();
+}
+
+bool DismissPopup(std::string title) {
+    if (mModalWindow->IsPopupOpen(title)) {
+        mModalWindow->DismissPopup();
+        return true;
+    }
+    return false;
 }
 
 void ShowRandomizerSettingsMenu() {

--- a/games/oot/soh/SohGui/SohGui.hpp
+++ b/games/oot/soh/SohGui/SohGui.hpp
@@ -32,11 +32,15 @@
 
 namespace SohGui {
 void SetupHooks();
+void SetupMenu();
+void SetupMenuElements();
 void SetupGuiElements();
 void Draw();
 void Destroy();
 void RegisterPopup(std::string title, std::string message, std::string button1 = "OK", std::string button2 = "",
                    std::function<void()> button1callback = nullptr, std::function<void()> button2callback = nullptr);
+size_t PopupsQueued();
+bool DismissPopup(std::string title);
 void ShowRandomizerSettingsMenu();
 void ShowEscMenu();
 UIWidgets::Colors GetMenuThemeColor();

--- a/games/oot/soh/SohGui/SohMenu.cpp
+++ b/games/oot/soh/SohGui/SohMenu.cpp
@@ -81,8 +81,7 @@ SohMenu::SohMenu(const std::string& consoleVariable, const std::string& name)
     : Menu(consoleVariable, name, 0, UIWidgets::Colors::LightBlue) {
 }
 
-void SohMenu::InitElement() {
-    Ship::Menu::InitElement();
+void SohMenu::AddMenuElements() {
     AddMenuSettings();
     AddMenuEnhancements();
     AddMenuRandomizer();
@@ -96,6 +95,12 @@ void SohMenu::InitElement() {
     for (auto& initFunc : MenuInit::GetInitFuncs()) {
         initFunc();
     }
+
+    mMenuElementsInitialized = true;
+}
+
+void SohMenu::InitElement() {
+    Ship::Menu::InitElement();
 
     disabledMap = {
         { DISABLE_FOR_NO_VSYNC,
@@ -166,6 +171,8 @@ void SohMenu::Draw() {
 }
 
 void SohMenu::DrawElement() {
-    Ship::Menu::DrawElement();
+    if (mMenuElementsInitialized) {
+        Ship::Menu::DrawElement();
+    }
 }
 } // namespace SohGui

--- a/games/oot/soh/SohGui/SohMenu.h
+++ b/games/oot/soh/SohGui/SohMenu.h
@@ -38,6 +38,7 @@ class SohMenu : public Ship::Menu {
 
     void AddSidebarEntry(std::string sectionName, std::string sidbarName, uint32_t columnCount);
     WidgetInfo& AddWidget(WidgetPath& pathInfo, std::string widgetName, WidgetType widgetType);
+    void AddMenuElements();
     void AddMenuSettings();
     void AddMenuEnhancements();
     void AddMenuDevTools();
@@ -48,6 +49,7 @@ class SohMenu : public Ship::Menu {
   private:
     char mGitCommitHashTruncated[8];
     bool mIsTaggedVersion;
+    bool mMenuElementsInitialized = false;
 };
 } // namespace SohGui
 

--- a/games/oot/soh/SohGui/SohModals.cpp
+++ b/games/oot/soh/SohGui/SohModals.cpp
@@ -42,6 +42,7 @@ void SohModalWindow::DrawElement() {
             modals.erase(modals.begin());
             closePopup = false;
         }
+        ImGui::SetNextWindowPos(ImGui::GetMainViewport()->GetCenter(), ImGuiCond_Always, ImVec2(0.5f, 0.5f));
         if (ImGui::BeginPopupModal(curModal.title_.c_str(), NULL,
                                    ImGuiWindowFlags_AlwaysAutoResize | ImGuiWindowFlags_NoResize |
                                        ImGuiWindowFlags_NoMove | ImGuiWindowFlags_NoScrollbar |
@@ -68,14 +69,18 @@ void SohModalWindow::DrawElement() {
                 }
                 UIWidgets::PopStyleButton();
             }
+            ImGui::EndPopup();
         }
-        ImGui::EndPopup();
     }
 }
 
 void SohModalWindow::RegisterPopup(std::string title, std::string message, std::string button1, std::string button2,
                                    std::function<void()> button1callback, std::function<void()> button2callback) {
     modals.push_back({ title, message, button1, button2, button1callback, button2callback });
+}
+
+size_t SohModalWindow::PopupsQueued() {
+    return modals.size();
 }
 
 bool SohModalWindow::IsPopupOpen(std::string title) {

--- a/games/oot/soh/SohGui/SohModals.h
+++ b/games/oot/soh/SohGui/SohModals.h
@@ -16,5 +16,6 @@ class SohModalWindow final : public Ship::GuiWindow {
                        std::function<void()> button1callback = nullptr,
                        std::function<void()> button2callback = nullptr);
     bool IsPopupOpen(std::string title);
+    size_t PopupsQueued();
     void DismissPopup();
 };


### PR DESCRIPTION
## Summary

Closes #227. Ports upstream SOH commit [`704ace8fd`](https://github.com/HarbourMasters/Shipwright/pull/5892) — ImGui-Driven Extraction Flow and Progress Reporting — while preserving all RSBS overlays documented in [apps#226](https://github.com/spencerduncan/redshipblueship/pull/226). This is foundation work that unblocks linux appimage fix (#6215 → #231), segfault-on-quit (#6212 → #233), and the scrolling-texture-interpolation-stacking follow-ups.

### What changes

- **`OTRGlobals::OTRGlobals`** now performs most window/GUI setup that previously lived in `Initialize()`, so there is a `Fast::Fast3dWindow` ready **before** any ROM extraction runs. This lets the extraction UI be driven from ImGui instead of OS dialogs and SDL message boxes.
- **New `OTRGlobals::RunExtract`** drives a state machine (`ES_PORT_ARCHIVE → ES_WINDOWS → ES_EXTRACT_ARGS → ES_EXTRACT → ES_VERIFY`) with `PromptSteps` / `WindowsSteps` sub-states. Replaces the big inline block of Windows/macOS/Linux/Switch/WiiU branches that used to live inside `InitOTR`.
- **`SohGui::SetupGuiElements`** is split into `SetupMenu` / `SetupMenuElements` / `SetupGuiElements`. `SohMenu::DrawElement` now guards on a `mMenuElementsInitialized` flag so the menu does not attempt to draw before its entries are populated.
- **`SohModals`** gains `PopupsQueued()` and centers modals on the main viewport (fixes the early-startup modals being off-screen). `SohGui` gains matching `PopupsQueued()` / `DismissPopup()` wrappers used by the new state machine.
- **`Extract.h/cpp`** match the upstream `CallZapd` signature with optional `std::atomic<size_t>*` progress pointers. The pinned ZAPDTR submodule still only exposes `zapd_main` (not `zapd_report`), so those pointers currently pass through without being updated and the progress popup shows an indeterminate \"Starting Up\" state during extraction. Wiring up real progress reporting requires an independent ZAPD uplift — intentionally out of scope for this PR.

### RSBS overlays preserved (verified)

- `RsbsFeatureEnabled()` and all 11 `RSBS_DISABLE_*` guards inside `InitOTR` and `Graph_ProcessGfxCommands`.
- `#ifdef RSBS_SINGLE_EXECUTABLE` early-return in the `OTRGlobals` constructor. `RunExtract` also checks `sohFast3dWindow == nullptr` under the same ifdef, so single-exe mode skips the extraction flow entirely — the parent launcher owns that.
- `#ifdef SINGLE_EXECUTABLE_BUILD` freeze/resume block at the bottom of the file.
- `OoT_` prefixed references to `gBuildVersion*` and `gPlayState`.
- `ShipInit::InitAll()` moves to the end of `InitOTR` (matching upstream's move) while keeping the `RSBS_DISABLE_SHIPINIT` guard.

### Deliberate omissions from upstream `704ace8fd`

- `Randomizer::CreateCustomMessages()` is **not** re-added. [apps#226](https://github.com/spencerduncan/redshipblueship/pull/226) noted that target line is already absent locally (removed by upstream `9c1a1728e` before the fork baseline) and deferred any restoration to a follow-up.
- Local `Extract.cpp` keeps its existing `try`/`catch` safety around `zapd_main` but drops the Win32 `ShowConsoleWindow` dance and the linux `MessageboxWorker` thread — the ImGui progress popup replaces them.
- `extern \"C\" void PadMgr_ThreadEntry(PadMgr*);` from upstream is unrelated to this refactor and unused inside the commit; skipped.

## Test plan

- [ ] `build-windows` passes
- [ ] `build-linux` passes
- [ ] `build-macos` passes
- [ ] `clang-format` passes
- [ ] Manual smoke: fresh profile — OoT ROM extraction dialog appears on first run, completes, and the O2R is generated
- [ ] Manual smoke: relaunch on existing O2R cache boots straight into the title screen without re-prompting
- [ ] Manual smoke: cross-game switching still functions after extraction
- [ ] Manual verification: all `RSBS_DISABLE_*` env-var toggles still skip their subsystems (spot-check `RSBS_DISABLE_AUDIO`, `RSBS_DISABLE_SHIPINIT`, `RSBS_DISABLE_RANDO`)
- [ ] Manual verification: single-exe build boots OoT without null-deref on `sohFast3dWindow`

Refs #227. Part of epic #202. Follow-ups on #231, #233 unblocked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!--- section:artifacts:start -->
### Build Artifacts
  - [rsbs-windows.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/6634528647.zip)
  - [rsbs-linux.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/6634450142.zip)
<!--- section:artifacts:end -->