### PR TITLE
Reduce Windows CI time (#177)

### DIFF
--- a/.github/workflows/generate-builds.yml
+++ b/.github/workflows/generate-builds.yml
@@ -354,7 +354,10 @@ jobs:
       with:
         variant: sccache
         max-size: "5G"
-        save: ${{ github.ref_name == github.event.repository.default_branch }}
+        # Save on every branch (default), not just main, so subsequent pushes to
+        # the same PR pick up the previous push's cache instead of cold-restoring
+        # from main. Issue #177 — Phase 2 iteration on Windows-only integration
+        # tests will rebuild many times per PR.
         key: ${{ runner.os }}-sccache-${{ github.ref }}
         restore-keys: |
           ${{ runner.os }}-sccache-${{ github.ref }}
@@ -376,15 +379,28 @@ jobs:
       with:
         name: soh.o2r
         path: bw/soh
-    - name: Build SoH
+    # Build is split into Configure / Build / Package so the GitHub Actions UI
+    # surfaces per-stage timing. Issue #177 — previously a single ~24 min step,
+    # making it impossible to tell whether time was going to vcpkg, compile, link
+    # or cpack. Keep these as separate steps even after tuning is done; the cost
+    # is negligible (~1s of step overhead) and the diagnostic value is permanent.
+    - name: CMake configure (Windows)
       env:
         VCPKG_ROOT: ${{github.workspace}}/vcpkg
       run: |
-        set $env:PATH="$env:USERPROFILE/.cargo/bin;$env:PATH"
+        $env:PATH="$env:USERPROFILE/.cargo/bin;$env:PATH"
         cmake -S . -B bw -G Ninja -DCMAKE_MAKE_PROGRAM=ninja -DCMAKE_BUILD_TYPE:STRING=Release -DCMAKE_C_COMPILER_LAUNCHER=sccache -DCMAKE_CXX_COMPILER_LAUNCHER=sccache -DBUILD_REMOTE_CONTROL=1 -DREDSHIP_BUILD_SHARED=ON -DUSE_LLD_LINKER=ON
-        cmake --build bw --config Release --parallel 10
-
-        (cd bw && cpack)
+    - name: CMake build (Windows)
+      env:
+        VCPKG_ROOT: ${{github.workspace}}/vcpkg
+      run: cmake --build bw --config Release --parallel 10
+    - name: sccache stats (Windows)
+      if: always()
+      run: sccache --show-stats
+    - name: Package (Windows)
+      run: |
+        cd bw
+        cpack
         cd ..
         mv _packages/*.zip _packages/rsbs-windows.zip
     - name: Unzip package


### PR DESCRIPTION
Closes work tracked by #177 (does not close the issue — leaving open until follow-ups land).

## Timing breakdown (current `main`)

Average of 3 most recent successful `build-windows` runs on `main`
(run IDs `24916122335`, `24912636601`, `24699295115`):

| Step | Avg duration | % of job |
| --- | --- | --- |
| Set up job | 3s | 0.2% |
| Install dependencies (choco ninja+llvm) | 12s | 0.7% |
| Git Checkout | 22s | 1.3% |
| Configure sccache | 16s | 0.9% |
| Restore Cached VCPKG | 25s | 1.5% |
| Configure Developer Command Prompt | 16s | 0.9% |
| Download soh.o2r | 1s | 0.1% |
| **Build SoH (configure + compile + link + cpack)** | **24:23** | **88.4%** |
| Unzip package | 14s | 0.8% |
| Upload build | 13s | 0.8% |
| Save Cache VCPKG | 60s | 3.6% |
| Post Configure sccache | 39s | 2.4% |
| Post Git Checkout | 4s | 0.2% |
| **Total job** | **~28:10** | |

Run-to-run jitter on `Build SoH`: **20:32 → 29:25** (~9 min spread). Likely sccache hit-rate variance, but invisible because everything was bundled into one step and no `sccache --show-stats` was emitted.

## What's already in place (so this PR doesn't repeat)

- `USE_LLD_LINKER=ON` — lld-link already used (#224 era)
- `/MP` — already set in `games/oot/CMakeLists.txt:515,531`, but no-op under Ninja (Ninja parallelizes itself)
- `--parallel 10` — already wired through; `windows-latest` is 4-core, so already over-subscribed
- vcpkg binary cache via `x-gha` — already enabled (#224)
- sccache cap 5G — already in place (#224)
- Release builds skip `/Zi` so sccache works (`CMake/DefaultCXX.cmake:13-19`)
- `docs-bypass.yml` already short-circuits docs-only PRs

## Changes in this PR

### 1. Split the monolithic Build SoH step + emit sccache stats (diagnostic)

The 24-minute "Build SoH" step is now four steps: `CMake configure (Windows)` / `CMake build (Windows)` / `sccache stats (Windows)` / `Package (Windows)`. Per-stage timing shows up in the Actions UI for free, and the cache hit ratio becomes measurable instead of inferred. Directly addresses the "Data to collect" checklist in #177.

Direct savings: 0. **Required prerequisite for any further optimization, including measuring the impact of this PR.**

### 2. Save sccache on PR branches, not just `main` (real perf)

Removed `save: ${{ github.ref_name == github.event.repository.default_branch }}` from the sccache configure step. Previously PR branches restored from main but never persisted their own state, so every push to the same PR cold-started from main's cache. Phase 2's Windows-only `int-switch-oot-mm` / `int-switch-mm-oot` integration tests will push to the same PR many times; with save enabled, push N+1 picks up sccache from push N.

Expected: **subsequent PR pushes drop from ~24 min Build SoH to ~5 min** (link- and cpack-dominated). First push to a fresh branch and `main` builds are unchanged.

Also fixed a stray `set ` prefix on `$env:PATH=...` that was a PowerShell no-op (carried over unchanged into the new Configure step).

## Diff

```yaml
# .github/workflows/generate-builds.yml — build-windows job

  - Configure sccache: dropped `save: <main-only>` guard (defaults to save: true)
  - Build SoH (single step, ~24 min) split into:
      - CMake configure (Windows)
      - CMake build  (Windows)
      - sccache stats (Windows)         # if: always()
      - Package (Windows)                # cpack + zip rename
```

1 file changed, 22 insertions(+), 6 deletions(-).

## Before / after table — to be filled in once CI runs land

| Scenario | Before (main) | After (this PR, run 1) | After (this PR, run 2 — same branch) |
| --- | ---: | ---: | ---: |
| Total `build-windows` job | ~28:10 | _tbd_ | _tbd_ |
| `CMake configure` | (bundled) | _tbd_ | _tbd_ |
| `CMake build` | (bundled) | _tbd_ | _tbd_ |
| `Package` (cpack) | (bundled) | _tbd_ | _tbd_ |
| sccache hit rate | unknown | _tbd_ | _tbd_ |

**Validation plan:**
1. First run after merge: same speed as today (cold against main's sccache); confirms no regression and gives baseline per-stage numbers.
2. Push an empty/whitespace commit to the same branch: should be drastically faster (sccache hit on most TUs); validates change #2.
3. Update the table in this PR description once both runs are complete.

## Follow-ups (separate PRs, do not block this one)

- **Remove `/FORCE:MULTIPLE`** in `games/oot/CMakeLists.txt:547,562`. Currently masks duplicate-symbol bugs that surface on Linux (see history of #247, #249). Switching to lld-link without it requires fixing those root causes first; this PR keeps the flag deliberately. Tracked separately.
- **Skip `Save Cache VCPKG`** when `steps.restore-cache-vcpkg.outputs.cache-hit == 'true'`. Saves ~60s per `main` run. Trivial diff, but skipped here to keep this PR tightly scoped to the two highest-leverage items.
- Once data from change #1 lands, revisit whether vcpkg install or compile dominates and target the larger of the two.

## Test plan

- [ ] PR triggers `generate-builds` — confirm `build-windows` succeeds with new step layout.
- [ ] Inspect the new per-step timings in the Actions UI; record numbers in the table above.
- [ ] Inspect `sccache stats (Windows)` step output; record cache hit ratio.
- [ ] Push a no-op follow-up commit; confirm second run on the same branch is materially faster (validates change #2).
- [ ] Confirm `rsbs-windows.zip` artifact is still produced and matches main's structure.

Do NOT merge until the validation pushes complete and the table is filled in.

https://claude.ai/code/session_01BhYPie7ZL6DxsEWPUnGvCU

---
_Generated by [Claude Code](https://claude.ai/code/session_01BhYPie7ZL6DxsEWPUnGvCU)_

<!--- section:artifacts:start -->
### Build Artifacts
  - [rsbs-windows.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/6668966481.zip)
  - [rsbs-linux.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/6668817395.zip)
<!--- section:artifacts:end -->