### PR TITLE
Mirror OoT extern SaveContext on MM side (follows up #240)

### DIFF
--- a/games/mm/2s2h/GameExports_SingleExe.cpp
+++ b/games/mm/2s2h/GameExports_SingleExe.cpp
@@ -66,6 +66,12 @@ extern "C" {
     extern s32 gAudioCtxInitalized;
     void AudioThread_InitMesgQueues(void);
 
+    // MM's SaveContext (type defined via global.h -> z64save.h).
+    // Declared here so MM_Game_Resume() can restore it on return from OoT (#170).
+    // Mirrors the explicit extern on the OoT TU — keeps the symbol's visibility
+    // independent of whether global.h ever stops including z64save.h transitively.
+    extern SaveContext gSaveContext;
+
     // Globals from main.c
     extern s32 MM_gScreenWidth;
     extern s32 MM_gScreenHeight;


### PR DESCRIPTION
## Summary

PR #240 added an explicit `extern SaveContext gSaveContext;` declaration to the OoT TU at `games/oot/soh/GameExports_SingleExe.cpp` so that `OoT_Game_Resume` could reliably restore the SaveContext on return from MM (issue #170). The MM TU at `games/mm/2s2h/GameExports_SingleExe.cpp` was not updated in the same way, even though `MM_Game_Resume` performs the equivalent restore (also added in #240).

Today the MM TU builds because the symbol is pulled in transitively via `extern "C" { ... #include "global.h" }` → `games/mm/include/z64save.h:1881`, which contains `extern SaveContext gSaveContext;`. This works by accident.

## Why it matters

If `global.h` ever stops including `z64save.h`, or the include order shifts (e.g. someone reorganises the header pyramid as part of an MM cleanup), `MM_Game_Resume`'s restore path silently loses the declaration and fails to compile — and the breakage points at MM_Game_Resume rather than at the real cause. Mirroring OoT's explicit extern makes MM's view of `gSaveContext` independent of header transitivity, matching the pattern already established for OoT.

## Change

One six-line block added inside the existing `extern "C" {}` declarations block in `games/mm/2s2h/GameExports_SingleExe.cpp`, immediately after the audio-related externs and before the screen-dimension globals — the same relative position as the OoT mirror.

## Verification

Relying on CI to validate the build (no local cmake available on author's machine). No behaviour change is expected; this is a pure declaration hardening that mirrors an already-merged OoT change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!--- section:artifacts:start -->
### Build Artifacts
  - [rsbs-windows.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/6671686605.zip)
  - [rsbs-linux.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/6671503716.zip)
<!--- section:artifacts:end -->