### PR TITLE
Thread-safety guard on SohModalWindow::RegisterPopup (follows up #250)

### DIFF
--- a/games/oot/soh/SohGui/SohModals.cpp
+++ b/games/oot/soh/SohGui/SohModals.cpp
@@ -1,5 +1,6 @@
 #include "SohModals.h"
 #include <imgui.h>
+#include <mutex>
 #include <vector>
 #include <string>
 #include <libultraship/bridge.h>
@@ -22,6 +23,14 @@ std::vector<SohModal> modals;
 
 bool closePopup = false;
 
+// Guards the `modals` queue and `closePopup` flag. Recursive because
+// DrawElement invokes user-supplied button callbacks while holding the
+// lock, and several callsites legitimately register another popup from
+// inside one of those callbacks (e.g. OTRGlobals.cpp's "Confirm
+// Re-extract" path). Added so any future thread-pool worker that calls
+// RegisterPopup can do so safely against the main-thread DrawElement.
+static std::recursive_mutex modalsMutex;
+
 void SohModalWindow::Draw() {
     if (!IsVisible()) {
         return;
@@ -32,6 +41,7 @@ void SohModalWindow::Draw() {
 }
 
 void SohModalWindow::DrawElement() {
+    std::lock_guard<std::recursive_mutex> lock(modalsMutex);
     if (modals.size() > 0) {
         SohModal curModal = modals.at(0);
         if (!ImGui::IsPopupOpen(curModal.title_.c_str())) {
@@ -76,17 +86,21 @@ void SohModalWindow::DrawElement() {
 
 void SohModalWindow::RegisterPopup(std::string title, std::string message, std::string button1, std::string button2,
                                    std::function<void()> button1callback, std::function<void()> button2callback) {
+    std::lock_guard<std::recursive_mutex> lock(modalsMutex);
     modals.push_back({ title, message, button1, button2, button1callback, button2callback });
 }
 
 size_t SohModalWindow::PopupsQueued() {
+    std::lock_guard<std::recursive_mutex> lock(modalsMutex);
     return modals.size();
 }
 
 bool SohModalWindow::IsPopupOpen(std::string title) {
+    std::lock_guard<std::recursive_mutex> lock(modalsMutex);
     return !modals.empty() && modals.at(0).title_ == title;
 }
 
 void SohModalWindow::DismissPopup() {
+    std::lock_guard<std::recursive_mutex> lock(modalsMutex);
     closePopup = true;
 }


### PR DESCRIPTION
## Summary

PR #250 ("ImGui-Driven Extraction Flow") introduced four `threadPool->detach_task` bodies inside `OTRGlobals::RunExtract` (around lines 471/480/534/554 of the merged diff) that call `Extractor::CallZapd` from a worker thread. PR #250's commit message explicitly investigated whether `SohModalWindow::RegisterPopup` races with those workers and concluded that **today** it does not — the four detach_task bodies surface errors via native `MessageBoxA` / `SDL_ShowSimpleMessageBox` in `Extractor::ShowErrorBox`, not `SohGui::RegisterPopup`. All RegisterPopup callsites today run on the main state-machine thread.

So the queue is currently race-free, but only by accident. Any future detached worker that decides to call `SohGui::RegisterPopup` (or `mModalWindow->RegisterPopup` directly) would silently introduce a data race against `DrawElement` on the main thread, with no compile-time or runtime warning.

## Change

Adds a `static std::recursive_mutex modalsMutex` to `games/oot/soh/SohGui/SohModals.cpp` covering the `modals` queue and the `closePopup` flag. Every public entry point on `SohModalWindow` now takes the lock: `DrawElement`, `RegisterPopup`, `IsPopupOpen`, `PopupsQueued`, `DismissPopup`.

The mutex is recursive because `DrawElement` invokes user-supplied button callbacks while holding the lock, and several existing callsites legitimately register another popup from inside one of those callbacks (the most prominent example is the "Confirm Re-extract" path in `OTRGlobals::RunExtract` itself, which inside its button1callback calls `threadPool->detach_task` whose body then doesn't re-enter — but the recursive pattern also covers e.g. `mod_menu.cpp`'s "Apply & Close" flow). A non-recursive mutex would deadlock those flows.

## Why mutex (not "main thread only" assert)

The user's audit asked for the simpler/safer of: (a) mutex, or (b) `assert(IsMainThread())` plus a documentation block. The codebase has no main-thread tracking primitive to assert against (`grep -rn IsMainThread games/oot/soh` returns nothing), so option (b) would degrade to a comment-only fix that the type system can't enforce. The mutex covers a small, low-frequency surface (one push_back per popup, one frame's worth of reads per draw) and actually enforces the invariant.

## Scope

Touches only `games/oot/soh/SohGui/SohModals.cpp`. The MM-side equivalent (`games/mm/2s2h/BenGui/BenModals.cpp`) has the same shape but is not currently exposed to detach_task callers — leaving that for a separate follow-up if/when MM gains worker-thread popup paths.

## Verification

Relying on CI to validate the build (no local cmake available on author's machine).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!--- section:artifacts:start -->
### Build Artifacts
  - [rsbs-windows.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/6672189252.zip)
  - [rsbs-linux.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/6672057625.zip)
<!--- section:artifacts:end -->