### PR TITLE
Mirror SohModalWindow thread-safety on MM-side BenModalWindow (follows up #268)

### DIFF
--- a/games/mm/2s2h/BenGui/BenModals.cpp
+++ b/games/mm/2s2h/BenGui/BenModals.cpp
@@ -1,5 +1,6 @@
 #include "BenModals.h"
 #include <imgui.h>
+#include <mutex>
 #include <vector>
 #include <string>
 #include "UIWidgets.hpp"
@@ -17,6 +18,14 @@ std::vector<BenModal> modals;
 
 bool closePopup = false;
 
+// Guards the `modals` queue and `closePopup` flag. Recursive because
+// DrawElement invokes user-supplied button callbacks while holding the
+// lock, and a callback may legitimately register another popup from
+// inside one of those callbacks. Added so any future thread-pool worker
+// that calls RegisterPopup can do so safely against the main-thread
+// DrawElement. Mirrors the SohModalWindow guard added in #268.
+static std::recursive_mutex modalsMutex;
+
 void BenModalWindow::Draw() {
     if (!IsVisible()) {
         return;
@@ -27,6 +36,7 @@ void BenModalWindow::Draw() {
 }
 
 void BenModalWindow::DrawElement() {
+    std::lock_guard<std::recursive_mutex> lock(modalsMutex);
     if (modals.size() > 0) {
         BenModal curModal = modals.at(0);
         if (!ImGui::IsPopupOpen(curModal.title_.c_str())) {
@@ -70,13 +80,16 @@ void BenModalWindow::DrawElement() {
 
 void BenModalWindow::RegisterPopup(std::string title, std::string message, std::string button1, std::string button2,
                                    std::function<void()> button1callback, std::function<void()> button2callback) {
+    std::lock_guard<std::recursive_mutex> lock(modalsMutex);
     modals.push_back({ title, message, button1, button2, button1callback, button2callback });
 }
 
 bool BenModalWindow::IsPopupOpen(std::string title) {
+    std::lock_guard<std::recursive_mutex> lock(modalsMutex);
     return !modals.empty() && modals.at(0).title_ == title;
 }
 
 void BenModalWindow::DismissPopup() {
+    std::lock_guard<std::recursive_mutex> lock(modalsMutex);
     closePopup = true;
 }


### PR DESCRIPTION
## Summary

MM-side mirror of the thread-safety guard applied in #268 to `SohModalWindow::RegisterPopup`. `BenModals.cpp` has the same shape and the same lack of synchronization on the shared `modals` queue and `closePopup` flag — closing the gap so MM doesn't ship the same footgun.

The PR #268 worker explicitly flagged the MM-side as out of scope for that change; this is the follow-up.

## Change

Adds a `static std::recursive_mutex modalsMutex` and a `std::lock_guard` at the top of every public method that touches the `modals` collection or `closePopup` bool:

- `BenModalWindow::DrawElement`
- `BenModalWindow::RegisterPopup`
- `BenModalWindow::IsPopupOpen`
- `BenModalWindow::DismissPopup`

Recursive for the same reason as #268: `DrawElement` invokes user-supplied button callbacks while holding the lock, and a callback may re-enter `RegisterPopup`.

13 insertions, 0 deletions. No behavior change on the single-threaded path.

## Test plan

- [ ] CI build (Linux / Windows / macOS) succeeds
- [ ] No new warnings on the touched file

Verification: relying on CI to validate (no local cmake on author's machine).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!--- section:artifacts:start -->
### Build Artifacts
  - [rsbs-windows.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/6672841709.zip)
  - [rsbs-linux.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/6672716618.zip)
<!--- section:artifacts:end -->