### PR TITLE
Phase 1 cleanup: close out #270, #271, #272

### DIFF
--- a/docs/adr/0001-rsbs-vs-src-common.md
+++ b/docs/adr/0001-rsbs-vs-src-common.md
@@ -1,0 +1,121 @@
+# ADR 0001: `rsbs/` is N64 ABI shims, `src/common/` is the unified host layer
+
+- Status: **Accepted** (2026-05-12)
+- Closes: #272 (Phase 1 cleanup follow-up)
+
+## Context
+
+RedShipBlueShip currently has three host-side directories that all sound like
+they could be "the unified game engine layer":
+
+- `rsbs/` — header (`rsbs.h`) claims "unified game engine; OoT mode and MM
+  mode, like the OoTMM romhack". In practice it contains ~8 `libultra/os`
+  thread/event-message shims, 2 `libultra/gu` graphics-utility functions,
+  `combo_context.c` (cross-game state struct), and a `placeholder.c`.
+- `src/common/` — the *actual* unified layer. ~14 files covering game
+  lifecycle (`game_lifecycle.c`), cross-game state freeze/restore
+  (`context.cpp`), entrance-based switching (`entrance.cpp`), unified
+  `gSaveContext` storage (`unified_save.c`), MM stubs (`mm_stubs.c`),
+  integration test hooks, the unified menu bar, etc.
+- `combo/` — legacy directory holding `SharedGraphics.cpp` and a small test
+  suite; on track for removal (T10 in the Phase 2 plan).
+
+The `rsbs/` README and CMakeLists narrate it as the future home of all
+cross-game logic. Every cross-game change since the architecture landed has
+gone into `src/common/` instead. `rsbs/context.h` even re-declares
+`ComboContext`, so the same struct exists in two headers and is the same
+storage at runtime — the duplication is real, not just on-paper.
+
+Phase 2 will add more cross-game work (HMS↔CT switching, archive hot-swap
+regression tests, shared flag plumbing, SharedGraphics migration out of
+`combo/`). Without picking a side now, Phase 2 will either grow the
+`src/common/` vs. `rsbs/` split or revive the original "unified engine"
+intent. Both are reasonable; sliding into whichever happens first is not.
+
+## Decision
+
+**`rsbs/` is N64 ABI compatibility shims; `src/common/` is the unified
+host-side layer.**
+
+- `rsbs/` keeps `src/libultra/os/*.c` and `src/libultra/gu/*.c` — code that
+  emulates the N64 OS/graphics ABI and is identical between the two games.
+  Adding *more* libultra shims to `rsbs/` is the natural growth path.
+- `src/common/` owns everything that lives above `libultraship` and
+  coordinates the two games: game lifecycle, cross-game state, save
+  unification, entrance switching, shared menu, test infrastructure.
+- The aspirational "unified game engine" framing in `rsbs/rsbs.h` and
+  `rsbs/CMakeLists.txt` is retired. It described a future that never
+  materialized and that the codebase has spent a year voting against with
+  every cross-game PR.
+
+This is Option B (Demotion) from the issue.
+
+## Rationale
+
+1. **Match the code as it actually is.** `src/common/` is where every
+   cross-game change has landed since the architecture was established.
+   Telling future contributors to look in `rsbs/` would send them to the
+   wrong place. Telling them `rsbs/` is N64 ABI shims is accurate and easy
+   to verify by reading the directory.
+2. **`rsbs/` has a coherent narrower mission.** The libultra OS/gu shims are
+   genuinely identical between OoT and MM and don't depend on host-side
+   game lifecycle. They're a clean unit. Pulling additional things in would
+   weaken that.
+3. **Lower migration cost.** Option A (move `src/common/` into `rsbs/`)
+   would touch every cross-game file, every CMake target that depends on
+   `redship_common`, every include directive in OoT/MM sources, and every
+   open Phase 2 branch. Option B leaves the working layer where it is and
+   only touches `rsbs/`'s self-narration and the duplicate `combo_context`
+   wiring.
+4. **Removes the duplicate `ComboContext` definition.** The struct currently
+   exists in both `rsbs/include/rsbs/combo_context.h` and
+   `src/common/context.h`. The src/common/ copy is the one Combo\_/
+   Context\_ APIs (`switch.cpp`, `context.cpp`, `main.cpp`) actually use.
+   Demoting the `rsbs/` copy resolves the duplication in the natural
+   direction.
+5. **Points T10 (combo/ removal) at `src/common/`.** When `combo/`'s
+   `SharedGraphics.cpp` migrates out, it goes to `src/common/` (where
+   `shared_graphics_win.cpp` already lives), not to `rsbs/`. That keeps
+   host-side graphics coordination next to the other host-side
+   coordinators.
+
+## Consequences
+
+### Now (this PR, follow-up #272)
+
+- Update `rsbs/include/rsbs/rsbs.h` and `rsbs/CMakeLists.txt` to drop the
+  "unified game engine" framing in favor of "N64 ABI compatibility shims".
+- Leave `combo_context.c` in place for now (moving it is mechanical but
+  touches both games' includes; doing it standalone is cleaner than rolling
+  it into this ADR PR).
+
+### Later (Phase 2 follow-ups, not in this PR)
+
+- Migrate `rsbs/src/combo_context.c` and `rsbs/include/rsbs/combo_context.h`
+  to `src/common/`. Remove the duplicate struct definition from
+  `src/common/context.h` (or remove it from `rsbs/include/rsbs/` if the
+  src/common/ form is the canonical one). Pick a single home.
+- When `combo/src/SharedGraphics.cpp` is removed (T10), its replacement
+  goes to `src/common/` (next to `shared_graphics_win.cpp`).
+- Continue adding `libultra/*` shims to `rsbs/` if more are unified out of
+  OoT/MM. Continue adding cross-game host logic to `src/common/`.
+
+### What the ADR explicitly does *not* do
+
+- Move `combo_context.c` in this PR. The duplication should be resolved,
+  but doing it here would balloon this change into a refactor and obscure
+  the Phase 1 cleanup boundary. Tracked as a Phase 2 follow-up.
+- Rename `rsbs/` itself. The name is fine and used in build artifacts,
+  branch prefixes (`claude/rsbs-*`), and the project's public identity.
+  Only its self-description changes.
+
+## Alternatives considered
+
+- **Option A — Migration:** move `src/common/` contents into `rsbs/` over a
+  series of PRs, formalizing `rsbs/` as the unified engine layer. Rejected:
+  high mechanical cost, would conflict with every open Phase 2 branch, and
+  the working layer is already coherent where it lives.
+- **Option C — Status quo with documentation:** keep `rsbs/`'s aspirational
+  framing and document the split as intentional. Rejected: the framing is
+  inaccurate and would keep generating "where does this go?" decisions for
+  every new cross-game file.

--- a/games/mm/2s2h/GameExports_SingleExe.cpp
+++ b/games/mm/2s2h/GameExports_SingleExe.cpp
@@ -4,8 +4,14 @@
  * This file provides the MM_Game_* functions expected by the redship
  * main.cpp for single-executable builds.
  *
- * In single-exe mode, the libultraship context is shared with OoT.
- * MM skips InitOTR() since OoT already initialized the shared context.
+ * In single-exe mode, the libultraship context is created and owned by the
+ * harness (rsbs/src/main.cpp) before either game's Init runs. MM skips its
+ * own InitOTR() — the shared context is set up by the harness, and OoT's
+ * OTRGlobals layer adds resource factories on top when OoT is the running
+ * game. MM contributes its own resource factories via
+ * RegisterMMResourceFactories() below. This is symmetric with OoT (which
+ * also reuses the harness-provided context) — neither game depends on the
+ * other having booted first (#271).
  */
 
 #ifdef RSBS_SINGLE_EXECUTABLE
@@ -62,9 +68,10 @@ extern "C" {
     void Check_ExpansionPak(void);
     void Regs_Init(void);
 
-    // Audio reset for cross-game switch (issue #157)
+    // Audio reset for cross-game switch (issue #157) and suspend (issue #270)
     extern s32 gAudioCtxInitalized;
     void AudioThread_InitMesgQueues(void);
+    void MM_Audio_PreNMI(void);
 
     // MM's SaveContext (type defined via global.h -> z64save.h).
     // Declared here so MM_Game_Resume() can restore it on return from OoT (#170).
@@ -234,15 +241,20 @@ static void RegisterMMResourceFactories() {
 }
 
 /**
- * Verify the shared Ship::Context from OoT is ready for MM's graph thread.
+ * Verify the shared Ship::Context is ready for MM's graph thread (#271).
+ *
  * MM_Graph_ThreadEntry calls WindowIsRunning(), GfxDebuggerIsDebugging(),
  * WindowGetWidth/Height/AspectRatio() every frame — all route through
- * Ship::Context::GetInstance(). OoT initializes this singleton; MM reuses it.
+ * Ship::Context::GetInstance(). The harness (rsbs/src/main.cpp) creates
+ * the singleton before either game's Init runs, so this check is a
+ * defensive assertion that the harness did its job — *not* a dependency
+ * on OoT having booted first. OoT and MM are symmetric here: both reuse
+ * the harness-provided context.
  */
 static bool VerifySharedContext(void) {
     auto ctx = Ship::Context::GetInstance();
     if (!ctx) {
-        fprintf(stderr, "[MM] ERROR: Ship::Context is null — OoT must init first\n");
+        fprintf(stderr, "[MM] ERROR: Ship::Context is null — harness must init first\n");
         return false;
     }
     if (!ctx->GetWindow()) {
@@ -262,8 +274,11 @@ int MM_Game_Init(int argc, char** argv) {
     fprintf(stderr, "[MM] Game_Init called, argc=%d\n", argc);
     fflush(stderr);
 
-    // In single-exe mode, skip InitOTR() - OoT already initialized libultraship.
-    // Verify the shared context is ready for MM bridge functions (issue #158).
+    // In single-exe mode, skip InitOTR() — the harness (rsbs/src/main.cpp)
+    // creates Ship::Context before either game's Init runs. MM treats the
+    // harness-provided context as a precondition, the same as OoT does
+    // (#158, #271). This used to claim "OoT initialized libultraship"; that
+    // wording was stale — the harness owns initial Context creation.
     if (!VerifySharedContext()) {
         fprintf(stderr, "[MM] FATAL: Cannot start without Ship::Context\n");
         return -1;
@@ -359,12 +374,40 @@ void MM_Game_Run(void) {
     fflush(stderr);
 }
 
+/**
+ * Suspend MM for a game switch (issue #270).
+ * Stops audio to prevent interference with OoT, keeps libultraship context and
+ * MM heaps alive. Mirrors OoT_Game_Suspend so OoT <-> MM round-trips don't
+ * re-init either game.
+ */
 void MM_Game_Suspend(void) {
     fprintf(stderr, "[MM] Game_Suspend called\n");
     fflush(stderr);
-    // TODO: Stop MM audio playback
+
+    // Stop MM audio playback to prevent interference with OoT (issue #270).
+    // MM_Audio_PreNMI calls AudioThread_PreNMIInternal which halts sequence
+    // players and SFX. Same reasoning as OoT side: the SoH/2S2H port doesn't
+    // run a real OS audio thread, so audio is processed synchronously from
+    // the game loop, which has already returned from MM_Graph_ThreadEntry
+    // before suspend is called — no race.
+    fprintf(stderr, "[MM] Stopping audio via PreNMI path...\n");
+    fflush(stderr);
+    MM_Audio_PreNMI();
+
+    // Mark audio as uninitialized so message-queue re-init works on resume.
+    gAudioCtxInitalized = false;
+
+    fprintf(stderr, "[MM] Game_Suspend complete\n");
+    fflush(stderr);
 }
 
+/**
+ * Resume MM after being suspended for a game switch (issue #170, #270).
+ * - Restores frozen MM SaveContext so gameplay state survives the OoT
+ *   round-trip (OoT scribbles over the unified gSaveContext storage while
+ *   it is active — see src/common/unified_save.c).
+ * - Reinitializes audio message queues for clean state.
+ */
 void MM_Game_Resume(void) {
     fprintf(stderr, "[MM] Game_Resume called\n");
     fflush(stderr);
@@ -392,7 +435,16 @@ void MM_Game_Resume(void) {
                 targetEntrance, hasStartup);
     }
 
-    // TODO: Restore MM audio, reload MM-specific resources if needed
+    // Reinitialize audio message queues for clean state (issue #270).
+    // The audio context's queue pointers may be stale after suspend's
+    // PreNMI shutdown — mirrors the same call MM_Game_Init makes on first
+    // entry, and the same Audio_InitMesgQueues call OoT_Game_Resume makes.
+    fprintf(stderr, "[MM] Reinitializing audio message queues...\n");
+    fflush(stderr);
+    AudioThread_InitMesgQueues();
+
+    fprintf(stderr, "[MM] Game_Resume complete\n");
+    fflush(stderr);
 }
 
 void MM_Game_Shutdown(void) {

--- a/rsbs/CMakeLists.txt
+++ b/rsbs/CMakeLists.txt
@@ -1,10 +1,12 @@
 cmake_minimum_required(VERSION 3.14)
 
-# rsbs - RedShipBlueShip unified game engine
-# Contains code shared between OoT and MM
+# rsbs - N64 ABI compatibility shims (libultra/os, libultra/gu)
+# Contains libultra OS and graphics-utility functions that are identical
+# between OoT and MM and shared across both.
 #
-# This library will grow as identical code is migrated from both games.
-# The goal is ONE unified game engine, not two games that switch.
+# This is NOT the unified host-side game layer. Game lifecycle, cross-game
+# state, entrance switching, save unification, etc. live in src/common/.
+# See docs/adr/0001-rsbs-vs-src-common.md for the directory-role decision.
 
 add_library(rsbs STATIC
     # Core shared utilities

--- a/rsbs/include/rsbs/rsbs.h
+++ b/rsbs/include/rsbs/rsbs.h
@@ -1,18 +1,19 @@
 /**
  * @file rsbs.h
- * @brief RedShipBlueShip unified engine header
+ * @brief RedShipBlueShip N64 ABI compatibility shims
  *
- * This is the main header for the rsbs unified game engine.
- * Code that is identical between OoT and MM is migrated here.
+ * `rsbs/` holds libultra (N64 OS / graphics-utility) functions that are
+ * identical between OoT and MM and are shared across both. It is *not*
+ * the unified host-side game layer — that lives in `src/common/` (game
+ * lifecycle, cross-game state, entrance switching, etc.).
  *
- * The goal: ONE unified game engine with OoT mode and MM mode,
- * like the OoTMM romhack.
+ * See docs/adr/0001-rsbs-vs-src-common.md for the directory-role decision.
  */
 
 #ifndef RSBS_H
 #define RSBS_H
 
-// Shared code between OoT and MM will be declared here
-// as it is migrated from the individual game directories.
+// N64 ABI shims live in rsbs/src/libultra/. Host-side cross-game logic
+// lives in src/common/; do not add new files of that kind here.
 
 #endif // RSBS_H

--- a/rsbs/src/main.cpp
+++ b/rsbs/src/main.cpp
@@ -256,9 +256,23 @@ int main(int argc, char** argv) {
     }
 
     // ========================================================================
-    // Create Ship::Context singleton early - before any game init (issue #184)
-    // This ensures the singleton exists before OTRGlobals can interfere.
-    // Games will detect the existing context and reuse it.
+    // Create Ship::Context singleton up front — before either game's Init
+    // runs (issue #184, #271).
+    //
+    // Both OoT (OTRGlobals constructor) and MM (BenPort InitOTR) detect an
+    // existing singleton and reuse it. Creating the placeholder here means
+    // neither game depends on the *other* having booted first — i.e. there
+    // is no "OoT must run before MM" implicit ordering. The user can launch
+    // either `redship --game oot` or `redship --game mm` cold, and the
+    // selected game's Init layers its own factories/heaps onto the shared
+    // context.
+    //
+    // The branding ("Ship of Harkinian", "soh", "shipofharkinian.json") is
+    // kept stable on purpose: it pins the config and savestate directory to
+    // one location across game switches. Re-keying these on the selected
+    // game would split a single user's saves into two app-data folders the
+    // first time they switched games. Asymmetric branding != asymmetric
+    // bootstrap; the bootstrap itself is now game-agnostic.
     // ========================================================================
     fprintf(stderr, "[RSBS] About to create Ship::Context singleton...\n");
     fflush(stderr);
@@ -293,16 +307,13 @@ int main(int argc, char** argv) {
     // Determine which game to run
     GameId selectedGame = GAME_NONE;
 
-    // Integration tests override the game selection
+    // Integration tests override the game selection. Each integration test
+    // boots its target game directly — no implicit OoT-first dance for MM
+    // tests (#271). The harness has already created Ship::Context above, so
+    // either game can be the first to initialize libultraship factories
+    // and resources on top of it.
     if (TestRunner_IsIntegrationTestMode()) {
-        GameId testGame = TestRunner_GetIntegrationTestGame();
-        if (testGame == GAME_MM) {
-            // MM requires OoT's Ship::Context — init OoT first, then switch to MM
-            selectedGame = GAME_OOT;
-            printf("[INT-TEST] MM test: booting OoT first for Ship::Context\n");
-        } else {
-            selectedGame = testGame;
-        }
+        selectedGame = TestRunner_GetIntegrationTestGame();
         printf("[INT-TEST] Using game from integration test: %s\n",
                Game_ToString(selectedGame));
     } else {
@@ -370,22 +381,8 @@ int main(int argc, char** argv) {
     // cross-game entrance hooks dispatch against the right game (issue #170).
     Context_SetCurrentGame(selectedGame);
 
-    // For MM integration tests, OoT is initialized first for Ship::Context,
-    // then we switch to MM (which registers its own hooks in MM_Game_Init)
-    if (TestRunner_IsIntegrationTestMode()) {
-        GameId testGame = TestRunner_GetIntegrationTestGame();
-        if (testGame == GAME_MM) {
-            printf("[INT-TEST] OoT context ready, switching to MM\n");
-            EnsureGameArchivesLoaded(GAME_MM);
-            int switchResult = GameRunner_SwitchTo(&runner, GAME_MM, gameArgc, gameArgv);
-            if (switchResult != 0) {
-                fprintf(stderr, "[INT-TEST] Error: Failed to switch to MM (code %d)\n", switchResult);
-                free(gameArgv);
-                return 1;
-            }
-            Context_SetCurrentGame(GAME_MM);
-        }
-    }
+    // Note: the previous MM-test detour (init OoT then SwitchTo MM) was
+    // removed with #271 — MM integration tests now boot MM directly above.
 
     while (keepRunning) {
         // Run the active game


### PR DESCRIPTION
Closes the three remaining phase-1 follow-ups identified after the Phase 1 status report:

#270 — MM_Game_Suspend/Resume implementation
  Previously TODO stubs. Now mirrors OoT_Game_Suspend/Resume so an
  OoT->MM->OoT round-trip does not re-init either game:
  - MM_Game_Suspend: MM_Audio_PreNMI() to halt sequence players/SFX, then clear gAudioCtxInitalized so message-queue re-init runs on resume.
  - MM_Game_Resume: existing SaveContext restore + entrance set, plus AudioThread_InitMesgQueues() to re-establish queue pointers post PreNMI. Same call MM_Game_Init makes on first entry, and the same Audio_InitMesgQueues call OoT_Game_Resume makes.

#271 — Remove OoT-must-boot-first asymmetry from MM bootstrap
  The integration-test path used to force OoT as the initial game when
  the requested test was an MM test, then immediately SwitchTo MM. With
  main.cpp creating Ship::Context up front (since #184), that detour is
  no longer needed — MM cold-boot uses the harness-provided context the
  same way OoT does.

  - rsbs/src/main.cpp: drop the MM-test OoT-first dance and the follow-up SwitchTo(MM) block; integration tests boot the requested game directly. Reword the Ship::Context creation comment to explain why branding stays stable across game switches (single config dir).
  - games/mm/2s2h/GameExports_SingleExe.cpp: update header comment, VerifySharedContext docstring, and the [MM] FATAL error message so none of them claim "OoT must init first". The harness is now the explicit precondition; OoT and MM are symmetric.

#272 — ADR on rsbs/ vs src/common/ role split (Option B: Demotion)
  docs/adr/0001-rsbs-vs-src-common.md records the decision: rsbs/ is the
  home for N64 libultra/os and libultra/gu ABI shims; src/common/ owns
  host-side cross-game logic (lifecycle, freeze/restore, entrances, save
  unification, menu, integration tests). Retires the "unified game
  engine" framing from rsbs/rsbs.h and rsbs/CMakeLists.txt so future
  cross-game files don't get filed in the wrong directory.

  ComboContext duplication (rsbs/include/rsbs/combo_context.h vs.
  src/common/context.h) is called out as a Phase 2 follow-up — moving
  it now would mix mechanical refactor into the architecture decision.