### PR TITLE
Phase 2 T1: int-switch-oot-hms-to-mm integration test (#260)

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -203,6 +203,24 @@ jobs:
       env:
         DISPLAY: :99
 
+    # T1 (#260): needs both oot.o2r and mm.o2r — boots OoT, triggers the Happy
+    # Mask Shop entrance, expects spawn at MM Clock Tower Interior (0xC010).
+    - name: Integration Test - Switch OoT (HMS) to MM
+      if: steps.check-archives.outputs.has_oot == 'true' && steps.check-archives.outputs.has_mm == 'true'
+      run: |
+        timeout 120 ./build-cmake/redship --integration-test int-switch-oot-hms-to-mm || exit_code=$?
+        if [ "${exit_code:-0}" -eq 0 ]; then
+          echo "HMS->MM switch test PASSED"
+        elif [ "${exit_code:-0}" -eq 124 ]; then
+          echo "HMS->MM switch test TIMEOUT"
+          exit 1
+        else
+          echo "HMS->MM switch test FAILED with exit code $exit_code"
+          exit $exit_code
+        fi
+      env:
+        DISPLAY: :99
+
   # Reuse the OTR generation from main build workflow
   generate-rsbs-otr:
     runs-on: ubuntu-22.04

--- a/CMake/SingleExecutable.cmake
+++ b/CMake/SingleExecutable.cmake
@@ -211,9 +211,11 @@ if(BUILD_TESTING)
 
     add_test(NAME IntBootOoT COMMAND redship --integration-test int-boot-oot)
     add_test(NAME IntBootMM COMMAND redship --integration-test int-boot-mm)
+    add_test(NAME IntSwitchOoTHmsToMm
+             COMMAND redship --integration-test int-switch-oot-hms-to-mm)
 
     set_tests_properties(
-        IntBootOoT IntBootMM
+        IntBootOoT IntBootMM IntSwitchOoTHmsToMm
         PROPERTIES
         TIMEOUT ${REDSHIP_INTEGRATION_TEST_TIMEOUT}
         LABELS "integration"

--- a/games/mm/2s2h/GameExports_SingleExe.cpp
+++ b/games/mm/2s2h/GameExports_SingleExe.cpp
@@ -117,7 +117,6 @@ static void MM_RegisterIntegrationTestHooks(void) {
 
     IntegrationTestMode mode = IntegrationTest_GetMode();
 
-    // Only register hooks for MM boot test
     if (mode == INT_TEST_BOOT_MM) {
         fprintf(stderr, "[MM] Registering integration test hooks for boot detection\n");
         fflush(stderr);
@@ -153,6 +152,32 @@ static void MM_RegisterIntegrationTestHooks(void) {
         );
 
         fprintf(stderr, "[MM] Integration test hooks registered\n");
+        fflush(stderr);
+    } else if (mode == INT_TEST_SWITCH_OOT_HMS_TO_MM) {
+        // T1 (#260) leg 2: MM has been booted via the cross-game switch from
+        // OoT's HMS trigger. Reaching this hook means OoT's freeze + main
+        // loop's hand-off + MM_Game_Init all succeeded end-to-end. Signal pass
+        // once MM's graph thread is running steady frames.
+        fprintf(stderr, "[MM] Registering integration test hooks for HMS->MM switch completion (T1)\n");
+        fflush(stderr);
+
+        sConsoleLogoFrameCount = 0;
+        sGameStateMainFrameCount = 0;
+
+        GameInteractor::Instance->RegisterGameHook<GameInteractor::OnGameStateMainStart>(
+            []() {
+                sGameStateMainFrameCount++;
+                if (sGameStateMainFrameCount >= 10) {
+                    fprintf(stderr,
+                            "[MM-INT-TEST] MM stable after HMS->MM switch (frame %d)\n",
+                            sGameStateMainFrameCount);
+                    fflush(stderr);
+                    IntegrationTest_SignalBootComplete(GAME_MM, "MM stable after HMS->MM switch");
+                }
+            }
+        );
+
+        fprintf(stderr, "[MM] HMS->MM switch hooks registered\n");
         fflush(stderr);
     }
 }

--- a/games/oot/soh/GameExports_SingleExe.cpp
+++ b/games/oot/soh/GameExports_SingleExe.cpp
@@ -58,7 +58,6 @@ static void OoT_RegisterIntegrationTestHooks(void) {
 
     IntegrationTestMode mode = IntegrationTest_GetMode();
 
-    // Only register hooks for OoT boot test
     if (mode == INT_TEST_BOOT_OOT) {
         fprintf(stderr, "[OoT] Registering integration test hooks for boot detection\n");
         fflush(stderr);
@@ -82,6 +81,64 @@ static void OoT_RegisterIntegrationTestHooks(void) {
         );
 
         fprintf(stderr, "[OoT] Integration test hooks registered\n");
+        fflush(stderr);
+    } else if (mode == INT_TEST_SWITCH_OOT_HMS_TO_MM) {
+        // T1 (#260): Boot OoT, programmatically trigger the Happy Mask Shop
+        // entrance, assert the cross-game switch resolves to MM Clock Tower
+        // Interior. Leg 1 of the test passes when routing is verified here;
+        // final pass is signaled from the MM-side hook after MM stabilizes
+        // post-switch.
+        fprintf(stderr, "[OoT] Registering integration test hooks for HMS->MM switch (T1)\n");
+        fflush(stderr);
+
+        GameInteractor::Instance->RegisterGameHook<GameInteractor::OnPresentFileSelect>(
+            []() {
+                fprintf(stderr, "[OoT-INT-TEST] File select reached; triggering HMS entrance 0x%04X\n",
+                        OOT_ENTR_HAPPY_MASK_SHOP);
+                fflush(stderr);
+
+                // Same call OoT's z_play.c makes when the player walks into the
+                // Happy Mask Shop door — minus the freeze, which T3 covers.
+                Combo_CheckCrossGameEntrance("oot", OOT_ENTR_HAPPY_MASK_SHOP);
+
+                if (!Combo_IsCrossGameSwitch()) {
+                    fprintf(stderr, "[OoT-INT-TEST] FAIL: HMS entrance did not register a cross-game switch\n");
+                    fflush(stderr);
+                    IntegrationTest_RequestExit();
+                    return;
+                }
+
+                const char* target = Combo_GetSwitchTargetGameId();
+                uint16_t targetEntrance = Combo_GetSwitchTargetEntrance();
+
+                if (!target || strcmp(target, "mm") != 0) {
+                    fprintf(stderr, "[OoT-INT-TEST] FAIL: target should be 'mm', got '%s'\n",
+                            target ? target : "(null)");
+                    fflush(stderr);
+                    IntegrationTest_RequestExit();
+                    return;
+                }
+
+                if (targetEntrance != MM_ENTR_CLOCK_TOWER_INTERIOR_1) {
+                    fprintf(stderr,
+                            "[OoT-INT-TEST] FAIL: target entrance should be 0x%04X (Clock Tower Interior), got 0x%04X\n",
+                            MM_ENTR_CLOCK_TOWER_INTERIOR_1, targetEntrance);
+                    fflush(stderr);
+                    IntegrationTest_RequestExit();
+                    return;
+                }
+
+                fprintf(stderr,
+                        "[OoT-INT-TEST] PASS leg 1: HMS routes to MM 0x%04X; main loop will run the switch\n",
+                        targetEntrance);
+                fflush(stderr);
+                // Intentionally NOT signaling boot complete here. The main loop
+                // will see the pending cross-game switch on Combo_CheckHotSwap
+                // and hand off to MM. The MM-side hook signals the final pass.
+            }
+        );
+
+        fprintf(stderr, "[OoT] HMS->MM switch hooks registered\n");
         fflush(stderr);
     }
 }

--- a/src/common/integration_test_hooks.cpp
+++ b/src/common/integration_test_hooks.cpp
@@ -44,7 +44,7 @@ void IntegrationTest_SetMode(IntegrationTestMode mode) {
         case INT_TEST_NONE: modeName = "none"; break;
         case INT_TEST_BOOT_OOT: modeName = "boot-oot"; break;
         case INT_TEST_BOOT_MM: modeName = "boot-mm"; break;
-        case INT_TEST_SWITCH_OOT_MM: modeName = "switch-oot-mm"; break;
+        case INT_TEST_SWITCH_OOT_HMS_TO_MM: modeName = "switch-oot-hms-to-mm"; break;
         case INT_TEST_SWITCH_MM_OOT: modeName = "switch-mm-oot"; break;
     }
 

--- a/src/common/integration_test_hooks.h
+++ b/src/common/integration_test_hooks.h
@@ -22,10 +22,10 @@ extern "C" {
  */
 typedef enum {
     INT_TEST_NONE = 0,
-    INT_TEST_BOOT_OOT,      // Boot OoT, exit on title/file select
-    INT_TEST_BOOT_MM,       // Boot MM, exit on title/file select
-    INT_TEST_SWITCH_OOT_MM, // Boot OoT, warp, switch to MM
-    INT_TEST_SWITCH_MM_OOT  // Boot MM, warp, switch to OoT
+    INT_TEST_BOOT_OOT,            // Boot OoT, exit on title/file select
+    INT_TEST_BOOT_MM,             // Boot MM, exit on title/file select
+    INT_TEST_SWITCH_OOT_HMS_TO_MM,// Boot OoT, trigger HMS entrance, verify MM Clock Tower Interior spawn
+    INT_TEST_SWITCH_MM_OOT        // Boot MM, warp, switch to OoT (T2 — not yet implemented)
 } IntegrationTestMode;
 
 /**

--- a/src/common/test_runner.cpp
+++ b/src/common/test_runner.cpp
@@ -354,8 +354,11 @@ struct IntegrationTestDescriptor {
 const IntegrationTestDescriptor gIntegrationTests[] = {
     {"int-boot-oot", "Boot OoT and verify title screen (integration)", INT_TEST_BOOT_OOT, GAME_OOT},
     {"int-boot-mm", "Boot MM and verify title screen (integration)", INT_TEST_BOOT_MM, GAME_MM},
-    {"int-switch-oot-mm", "Boot OoT, switch to MM (integration)", INT_TEST_SWITCH_OOT_MM, GAME_OOT},
-    {"int-switch-mm-oot", "Boot MM, switch to OoT (integration)", INT_TEST_SWITCH_MM_OOT, GAME_MM},
+    {"int-switch-oot-hms-to-mm",
+     "Boot OoT, trigger Happy Mask Shop entrance (0x0530), verify spawn at MM Clock Tower Interior (0xC010)",
+     INT_TEST_SWITCH_OOT_HMS_TO_MM, GAME_OOT},
+    {"int-switch-mm-oot", "Boot MM, switch to OoT (integration) - T2, not yet implemented",
+     INT_TEST_SWITCH_MM_OOT, GAME_MM},
     {nullptr, nullptr, INT_TEST_NONE, GAME_NONE}  // Sentinel
 };
 


### PR DESCRIPTION
Adds an end-to-end integration test that exercises the production
cross-game switch path from a booted OoT, validating that the Happy
Mask Shop entrance (0x0530) routes to MM Clock Tower Interior (0xC010).

Distinct from the existing in-memory unit test `switch-oot-mm` — this
boots OoT under SDL, fires the production Combo_CheckCrossGameEntrance
call from a GameInteractor hook, lets the main loop hand off to MM,
and waits for MM's graph thread to stabilize before signaling pass.

Changes:
- Renamed INT_TEST_SWITCH_OOT_MM → INT_TEST_SWITCH_OOT_HMS_TO_MM for a
  crisper contract; the generic name was an unimplemented stub.
- Registry: new --integration-test name `int-switch-oot-hms-to-mm`.
- OoT hook: on OnPresentFileSelect, trigger HMS entrance and assert
  the switch resolves to mm/0xC010. Failures call IntegrationTest_
  RequestExit() without setting BootPassed, producing a fast non-zero
  exit instead of a timeout.
- MM hook: on OnGameStateMainStart, signal pass after 10 stable frames.
  Reaching this hook means OoT freeze + main-loop handoff + MM_Game_
  Init all succeeded.
- CTest: IntSwitchOoTHmsToMm, 120s timeout, integration label.
- CI: new workflow step gated on both oot.o2r AND mm.o2r being present;
  silently skips when only one game's archive is available.

Freeze fidelity is intentionally out of scope here — that's T3 (#262).

Closes #260

Verification: relying on CI to validate the build (no local cmake on author's machine).


<!--- section:artifacts:start -->
### Build Artifacts
  - [rsbs-windows.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/7182480993.zip)
  - [rsbs-linux.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/7182108104.zip)
<!--- section:artifacts:end -->