### PR TITLE
Phase 2 T2: int-switch-mm-clocktown-south-to-oot test (#261)

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -221,6 +221,24 @@ jobs:
       env:
         DISPLAY: :99
 
+    # T2 (#261): mirror of T1 — boots MM, triggers South Clock Town south exit,
+    # expects spawn at OoT Market from Mask Shop (0x01D1).
+    - name: Integration Test - Switch MM (Clock Town South) to OoT
+      if: steps.check-archives.outputs.has_oot == 'true' && steps.check-archives.outputs.has_mm == 'true'
+      run: |
+        timeout 120 ./build-cmake/redship --integration-test int-switch-mm-clocktown-south-to-oot || exit_code=$?
+        if [ "${exit_code:-0}" -eq 0 ]; then
+          echo "MM(SCT-south)->OoT switch test PASSED"
+        elif [ "${exit_code:-0}" -eq 124 ]; then
+          echo "MM(SCT-south)->OoT switch test TIMEOUT"
+          exit 1
+        else
+          echo "MM(SCT-south)->OoT switch test FAILED with exit code $exit_code"
+          exit $exit_code
+        fi
+      env:
+        DISPLAY: :99
+
   # Reuse the OTR generation from main build workflow
   generate-rsbs-otr:
     runs-on: ubuntu-22.04

--- a/CMake/SingleExecutable.cmake
+++ b/CMake/SingleExecutable.cmake
@@ -213,9 +213,11 @@ if(BUILD_TESTING)
     add_test(NAME IntBootMM COMMAND redship --integration-test int-boot-mm)
     add_test(NAME IntSwitchOoTHmsToMm
              COMMAND redship --integration-test int-switch-oot-hms-to-mm)
+    add_test(NAME IntSwitchMmClockTownSouthToOoT
+             COMMAND redship --integration-test int-switch-mm-clocktown-south-to-oot)
 
     set_tests_properties(
-        IntBootOoT IntBootMM IntSwitchOoTHmsToMm
+        IntBootOoT IntBootMM IntSwitchOoTHmsToMm IntSwitchMmClockTownSouthToOoT
         PROPERTIES
         TIMEOUT ${REDSHIP_INTEGRATION_TEST_TIMEOUT}
         LABELS "integration"

--- a/games/mm/2s2h/GameExports_SingleExe.cpp
+++ b/games/mm/2s2h/GameExports_SingleExe.cpp
@@ -179,6 +179,79 @@ static void MM_RegisterIntegrationTestHooks(void) {
 
         fprintf(stderr, "[MM] HMS->MM switch hooks registered\n");
         fflush(stderr);
+    } else if (mode == INT_TEST_SWITCH_MM_CLOCKTOWN_SOUTH_TO_OOT) {
+        // T2 (#261): Boot MM, programmatically trigger the South Clock Town
+        // south exit, assert the cross-game switch resolves to OoT Market.
+        // Mirror of T1: MM is the trigger side here, OoT is the receiver.
+        // MM has no OnPresentFileSelect analog, so we wait N stable frames in
+        // OnGameStateMainStart and then fire the trigger once. Final pass is
+        // signaled from the OoT-side hook after OoT stabilizes post-switch.
+        fprintf(stderr, "[MM] Registering integration test hooks for SCT-south->OoT switch (T2)\n");
+        fflush(stderr);
+
+        sConsoleLogoFrameCount = 0;
+        sGameStateMainFrameCount = 0;
+
+        GameInteractor::Instance->RegisterGameHook<GameInteractor::OnGameStateMainStart>(
+            []() {
+                static bool sTriggered = false;
+                if (sTriggered) {
+                    return;
+                }
+                sGameStateMainFrameCount++;
+                if (sGameStateMainFrameCount < 10) {
+                    return;
+                }
+                sTriggered = true;
+
+                fprintf(stderr,
+                        "[MM-INT-TEST] MM stable; triggering SCT-south entrance 0x%04X\n",
+                        MM_ENTR_SOUTH_CLOCK_TOWN_0);
+                fflush(stderr);
+
+                // Same call MM's z_play.c makes when the player walks south
+                // out of South Clock Town — minus the freeze, which T3 covers.
+                Combo_CheckCrossGameEntrance("mm", MM_ENTR_SOUTH_CLOCK_TOWN_0);
+
+                if (!Combo_IsCrossGameSwitch()) {
+                    fprintf(stderr, "[MM-INT-TEST] FAIL: SCT-south entrance did not register a cross-game switch\n");
+                    fflush(stderr);
+                    IntegrationTest_RequestExit();
+                    return;
+                }
+
+                const char* target = Combo_GetSwitchTargetGameId();
+                uint16_t targetEntrance = Combo_GetSwitchTargetEntrance();
+
+                if (!target || strcmp(target, "oot") != 0) {
+                    fprintf(stderr, "[MM-INT-TEST] FAIL: target should be 'oot', got '%s'\n",
+                            target ? target : "(null)");
+                    fflush(stderr);
+                    IntegrationTest_RequestExit();
+                    return;
+                }
+
+                if (targetEntrance != OOT_ENTR_MARKET_FROM_MASK_SHOP) {
+                    fprintf(stderr,
+                            "[MM-INT-TEST] FAIL: target entrance should be 0x%04X (Market from Mask Shop), got 0x%04X\n",
+                            OOT_ENTR_MARKET_FROM_MASK_SHOP, targetEntrance);
+                    fflush(stderr);
+                    IntegrationTest_RequestExit();
+                    return;
+                }
+
+                fprintf(stderr,
+                        "[MM-INT-TEST] PASS leg 1: SCT-south routes to OoT 0x%04X; main loop will run the switch\n",
+                        targetEntrance);
+                fflush(stderr);
+                // Intentionally NOT signaling boot complete here. The main loop
+                // will see the pending cross-game switch on Combo_CheckHotSwap
+                // and hand off to OoT. The OoT-side hook signals the final pass.
+            }
+        );
+
+        fprintf(stderr, "[MM] SCT-south->OoT switch hooks registered\n");
+        fflush(stderr);
     }
 }
 

--- a/games/oot/soh/GameExports_SingleExe.cpp
+++ b/games/oot/soh/GameExports_SingleExe.cpp
@@ -43,6 +43,9 @@ extern "C" {
 static int sArgc = 0;
 static char** sArgv = nullptr;
 
+// Integration test hook frame counter (reset each time hooks are registered)
+static int sOoTGameStateMainFrameCount = 0;
+
 // ============================================================================
 // Integration Test Hooks
 // ============================================================================
@@ -139,6 +142,31 @@ static void OoT_RegisterIntegrationTestHooks(void) {
         );
 
         fprintf(stderr, "[OoT] HMS->MM switch hooks registered\n");
+        fflush(stderr);
+    } else if (mode == INT_TEST_SWITCH_MM_CLOCKTOWN_SOUTH_TO_OOT) {
+        // T2 (#261) leg 2: OoT has been booted via the cross-game switch from
+        // MM's SCT-south trigger. Reaching this hook means MM's freeze + main
+        // loop's hand-off + OoT_Game_Init all succeeded end-to-end. Signal pass
+        // once OoT's graph thread is running steady frames.
+        fprintf(stderr, "[OoT] Registering integration test hooks for SCT-south->OoT switch completion (T2)\n");
+        fflush(stderr);
+
+        sOoTGameStateMainFrameCount = 0;
+
+        GameInteractor::Instance->RegisterGameHook<GameInteractor::OnGameStateMainStart>(
+            []() {
+                sOoTGameStateMainFrameCount++;
+                if (sOoTGameStateMainFrameCount >= 10) {
+                    fprintf(stderr,
+                            "[OoT-INT-TEST] OoT stable after SCT-south->OoT switch (frame %d)\n",
+                            sOoTGameStateMainFrameCount);
+                    fflush(stderr);
+                    IntegrationTest_SignalBootComplete(GAME_OOT, "OoT stable after SCT-south->OoT switch");
+                }
+            }
+        );
+
+        fprintf(stderr, "[OoT] SCT-south->OoT switch hooks registered\n");
         fflush(stderr);
     }
 }

--- a/src/common/integration_test_hooks.cpp
+++ b/src/common/integration_test_hooks.cpp
@@ -45,7 +45,7 @@ void IntegrationTest_SetMode(IntegrationTestMode mode) {
         case INT_TEST_BOOT_OOT: modeName = "boot-oot"; break;
         case INT_TEST_BOOT_MM: modeName = "boot-mm"; break;
         case INT_TEST_SWITCH_OOT_HMS_TO_MM: modeName = "switch-oot-hms-to-mm"; break;
-        case INT_TEST_SWITCH_MM_OOT: modeName = "switch-mm-oot"; break;
+        case INT_TEST_SWITCH_MM_CLOCKTOWN_SOUTH_TO_OOT: modeName = "switch-mm-clocktown-south-to-oot"; break;
     }
 
     if (mode != INT_TEST_NONE) {

--- a/src/common/integration_test_hooks.h
+++ b/src/common/integration_test_hooks.h
@@ -24,8 +24,8 @@ typedef enum {
     INT_TEST_NONE = 0,
     INT_TEST_BOOT_OOT,            // Boot OoT, exit on title/file select
     INT_TEST_BOOT_MM,             // Boot MM, exit on title/file select
-    INT_TEST_SWITCH_OOT_HMS_TO_MM,// Boot OoT, trigger HMS entrance, verify MM Clock Tower Interior spawn
-    INT_TEST_SWITCH_MM_OOT        // Boot MM, warp, switch to OoT (T2 — not yet implemented)
+    INT_TEST_SWITCH_OOT_HMS_TO_MM,        // Boot OoT, trigger HMS entrance, verify MM Clock Tower Interior spawn
+    INT_TEST_SWITCH_MM_CLOCKTOWN_SOUTH_TO_OOT // Boot MM, trigger South Clock Town south exit, verify OoT Market spawn
 } IntegrationTestMode;
 
 /**

--- a/src/common/test_runner.cpp
+++ b/src/common/test_runner.cpp
@@ -357,8 +357,9 @@ const IntegrationTestDescriptor gIntegrationTests[] = {
     {"int-switch-oot-hms-to-mm",
      "Boot OoT, trigger Happy Mask Shop entrance (0x0530), verify spawn at MM Clock Tower Interior (0xC010)",
      INT_TEST_SWITCH_OOT_HMS_TO_MM, GAME_OOT},
-    {"int-switch-mm-oot", "Boot MM, switch to OoT (integration) - T2, not yet implemented",
-     INT_TEST_SWITCH_MM_OOT, GAME_MM},
+    {"int-switch-mm-clocktown-south-to-oot",
+     "Boot MM, trigger South Clock Town south exit (0xD800), verify spawn at OoT Market from Mask Shop (0x01D1)",
+     INT_TEST_SWITCH_MM_CLOCKTOWN_SOUTH_TO_OOT, GAME_MM},
     {nullptr, nullptr, INT_TEST_NONE, GAME_NONE}  // Sentinel
 };
 


### PR DESCRIPTION
Mirrors T1 (#260) in the opposite direction. MM-side hook triggers the
South Clock Town south exit (0xD800); OoT-side hook asserts arrival at
`OOT_ENTR_MARKET_FROM_MASK_SHOP` (0x01D1). New mode enum, registry
entry, CTest entry, and CI step parallel T1's.

## Design notes

- **MM-side trigger:** MM has no `OnPresentFileSelect` analog, so the
  trigger fires once from `OnGameStateMainStart` after 10 stable frames
  (one-shot `static bool` guard so it can't refire). Same call MM's
  `z_play.c` makes when the player walks south out of South Clock Town —
  minus the freeze, which T3 covers.
- **OoT-side receiver:** waits 10 stable frames in `OnGameStateMainStart`
  then signals pass — symmetric with T1's MM-side receiver hook.
- **No main loop changes:** the shared cross-game switch dispatch in
  `rsbs/src/main.cpp` is direction-agnostic (just checks
  `Entrance_IsCrossGameSwitch()`), and `Combo_CheckHotSwap()` is called
  from MM's graph thread the same way it's called from OoT's.

## Enum rename

Renamed `INT_TEST_SWITCH_MM_OOT` → `INT_TEST_SWITCH_MM_CLOCKTOWN_SOUTH_TO_OOT`
for a crisper contract; the generic name was an unimplemented stub. Same
rename pattern T1 used for its half (`INT_TEST_SWITCH_OOT_MM` →
`INT_TEST_SWITCH_OOT_HMS_TO_MM`). The CLI name parallels: `int-switch-mm-oot`
→ `int-switch-mm-clocktown-south-to-oot`.

## Files changed

- `src/common/integration_test_hooks.h` — enum rename
- `src/common/integration_test_hooks.cpp` — case label
- `src/common/test_runner.cpp` — registry entry
- `CMake/SingleExecutable.cmake` — `IntSwitchMmClockTownSouthToOoT`
  CTest, 120s timeout, `integration` label
- `.github/workflows/integration-tests.yml` — CI step gated on both
  oot.o2r AND mm.o2r being present (silently skips when only one is
  available); same shape as T1's step
- `games/mm/2s2h/GameExports_SingleExe.cpp` — MM-side trigger hook
- `games/oot/soh/GameExports_SingleExe.cpp` — OoT-side receiver hook +
  new `sOoTGameStateMainFrameCount` static counter

## Out of scope

T3 (save-context roundtrip), T4 (archive hot-swap), T5 (shared
flag/item smoke) all depend on T1 + T2 and follow separately.

Closes #261

Verification: relying on CI to validate the build (no local cmake on author's machine).


<!--- section:artifacts:start -->
### Build Artifacts
  - [rsbs-windows.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/7182946854.zip)
  - [rsbs-linux.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/7182543487.zip)
<!--- section:artifacts:end -->