### PR TITLE
docs: strip agent thinking-preamble from Phase 2 T6/T10 plan docs

### DIFF
--- a/docs/phase2-T10-combo-removal-plan.md
+++ b/docs/phase2-T10-combo-removal-plan.md
@@ -1,11 +1,3 @@
-I now have everything needed. The investigation is conclusive:
-
-- The `combo_tests` gtest suite (`context_test.cpp`, `sanity_test.cpp`) covers the same `Context_*`/`Entrance_*`/`Combo_*`/`Game_*` APIs that the single-exe `test_runner.cpp` (`--test context`, `roundtrip`, `switch-*`, `lifecycle`) already exercises via CTest — but with finer-grained gtest assertions. The gtest suite ONLY builds in the retired dynamic-library path (`add_subdirectory(combo)` in the `else()` branch, further gated by `NOT WIN32`), so in the default `SINGLE_EXECUTABLE_BUILD=ON` it is dead and never compiled.
-- `Export.h` is live (one consumer: `src/common/SharedGraphics.h:12`). `GameExports.h` and `placeholder.cpp` are fully dead.
-- `COMBO_API` expands to empty on non-Windows; on Windows it's `__declspec(dllexport)` when `COMBO_BUILDING_DLL` is defined (which `redship_common` does at `SingleExecutable.cmake:81`), else `dllimport`.
-
-I have enough to produce the plan. No file writes, no execution.
-
 # T10 / #265 — Remove `combo/` directory (PLAN ONLY — GATED ON T6)
 
 > **Status: BLOCKED — do not execute.** This is the last Phase 2 task. It must run **after T6 (#35)** lands (unified-save layout) and after T8 (#274, done) and T9 (#275, done). The plan below is a pure, no-semantic-change relocation + dead-code deletion. Nothing here should be applied until T6 is merged. See *Execution gate* for why.

--- a/docs/phase2-T6-unified-save-plan.md
+++ b/docs/phase2-T6-unified-save-plan.md
@@ -1,16 +1,3 @@
-I now have everything needed to write a concrete, implementation-ready plan. I have:
-
-- ComboContext struct (magic `"OoT+MM<3"`, version, sharedFlags[64], sharedItems[32], saveSlot, sharedRandoSeed) — `sizeof` ≈ 8+4+...+ items = ~430B (need to note it's larger than the issue's "~256B").
-- The size discrepancy: `game.h` defines `OOT_SAVE_CONTEXT_SIZE 0x1428` (5160B, real), while `unified_save.c` redefines it `0x22000` (SoH-extended) — a real conflict to resolve.
-- Both games are JSON-based SaveManagers (`fileN.sav`), with `Save_SaveFile`/`Save_LoadFile`-style C bridges and `OnSaveFile`/`OnLoadFile`/`OnExitGame` GameInteractor hooks.
-- Concrete save trigger sites: OoT `Save_SaveFile`→`SaveManager::Instance->SaveFile(gSaveContext.fileNum)`; MM `SaveManager_SysFlashrom_WriteData`.
-- File-select: `games/oot/.../ovl_file_choose/z_file_choose.c`, `games/mm/.../ovl_file_choose/z_file_choose_NES.c`; ComboMenuBar in src/common.
-- CTest registration pattern in `SingleExecutable.cmake`; test registry in `test_runner.cpp` (`gTests[]`); `unified_save.c` compiled in `SingleExecutable.cmake` line 28.
-- Playtime fields: OoT `gSaveContext.playTime` (u32) + `totalDays`; MM `gSaveContext.save.time`/`day`. Names: OoT `playerName[8]`, MM `playerName[8]`.
-- T10 (#265) dependency chain confirmed.
-
-Now I'll produce the plan.
-
 # PLAN — Phase 2 T6 / Issue #35: Unified Save System
 
 ## 0. TL;DR


### PR DESCRIPTION
## Summary
Cosmetic cleanup of two docs added in #280. The Phase 2 T6 and T10 plan docs accidentally committed the generating agent's thinking-preamble (the "I now have everything needed…" scratch notes) before the actual plan heading. This strips those lines so each doc opens directly on its title.

No change to the plan content itself — pure preamble removal (T6 −13 lines, T10 −8 lines).

🤖 Generated with [Claude Code](https://claude.com/claude-code)