### PR TITLE
Phase 2 T4: wire INT_TEST_ARCHIVE_HOTSWAP_CYCLE runtime integration test (#263)

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -239,6 +239,24 @@ jobs:
       env:
         DISPLAY: :99
 
+    # T4 (#263): needs both archives — boots OoT, hot-swaps OoT<->MM >=3 times,
+    # asserts healthy runtime (no missing assets, bounded RSS).
+    - name: Integration Test - Archive Hotswap Cycle
+      if: steps.check-archives.outputs.has_oot == 'true' && steps.check-archives.outputs.has_mm == 'true'
+      run: |
+        timeout 120 ./build-cmake/redship --integration-test int-archive-hotswap-cycle || exit_code=$?
+        if [ "${exit_code:-0}" -eq 0 ]; then
+          echo "Archive hotswap cycle test PASSED"
+        elif [ "${exit_code:-0}" -eq 124 ]; then
+          echo "Archive hotswap cycle test TIMEOUT"
+          exit 1
+        else
+          echo "Archive hotswap cycle test FAILED with exit code $exit_code"
+          exit $exit_code
+        fi
+      env:
+        DISPLAY: :99
+
   # Reuse the OTR generation from main build workflow
   generate-rsbs-otr:
     runs-on: ubuntu-22.04

--- a/games/mm/2s2h/GameExports_SingleExe.cpp
+++ b/games/mm/2s2h/GameExports_SingleExe.cpp
@@ -94,6 +94,16 @@ extern "C" {
 
 }
 
+// Archive hot-swap cycle helpers (#263). Defined in
+// src/common/tests/test_archive_hotswap.c (compiled into redship_common via
+// test_runner.cpp); resolved at final link. Record this MM arrival, query the
+// RSS bound, and read the target arrival count for the cycle-complete check.
+extern "C" {
+    int ArchiveHotswap_RecordArrival(void);
+    int ArchiveHotswap_RssExceeded(void);
+    int ArchiveHotswap_TargetArrivals(void);
+}
+
 // Track if MM has been initialized (for re-entry after game switch)
 static bool sMMInitialized = false;
 static bool sMMArchivesLoaded = false;
@@ -251,6 +261,70 @@ static void MM_RegisterIntegrationTestHooks(void) {
         );
 
         fprintf(stderr, "[MM] SCT-south->OoT switch hooks registered\n");
+        fflush(stderr);
+    } else if (mode == INT_TEST_ARCHIVE_HOTSWAP_CYCLE) {
+        // T4 (#263): MM side of the OoT<->MM archive hot-swap cycle. OoT boots
+        // first, so MM is arrivals #2 and #4 (the last) of the
+        // OoT->MM->OoT->MM cycle (4 arrivals == 3 transitions). Because the
+        // target arrival count is even, the FINAL arrival lands on MM, so this
+        // is the side that signals the cycle-complete PASS.
+        //
+        // Registration runs from MM_Game_Init, which fires only on MM's FIRST
+        // entry — later MM arrivals come back through MM_Game_Resume (see
+        // GameRunner_SwitchTo: a suspended game is resumed, not re-init'd), so
+        // this hook is registered exactly once and the persistent frame counter
+        // is NOT reset per arrival. The hook therefore re-arms itself: it fires
+        // ~10 stable frames after each (re)entry, then resets the counter so the
+        // next arrival reached via resume is detected the same way.
+        fprintf(stderr, "[MM] Registering integration test hooks for archive-hotswap cycle (T4)\n");
+        fflush(stderr);
+
+        sConsoleLogoFrameCount = 0;
+        sGameStateMainFrameCount = 0;
+
+        GameInteractor::Instance->RegisterGameHook<GameInteractor::OnGameStateMainStart>(
+            []() {
+                // Fire once per arrival, ~10 stable frames after (re)entry, then
+                // re-arm for the next MM arrival (reached via MM_Game_Resume).
+                sGameStateMainFrameCount++;
+                if (sGameStateMainFrameCount < 10) {
+                    return;
+                }
+                sGameStateMainFrameCount = 0;
+
+                int n = ArchiveHotswap_RecordArrival();
+                fprintf(stderr, "[MM-INT-TEST] MM stable; archive-hotswap arrival #%d of %d\n",
+                        n, ArchiveHotswap_TargetArrivals());
+                fflush(stderr);
+
+                if (ArchiveHotswap_RssExceeded()) {
+                    // Steady-state RSS blew the bound — the #154 per-switch leak
+                    // regression. Fail fast: RequestExit does NOT set the pass
+                    // flag, so the run returns non-zero. Combo_RequestGameSwitch()
+                    // right after unblocks the main loop promptly (known fix).
+                    fprintf(stderr, "[MM-INT-TEST] FAIL: steady-state RSS bound exceeded after %d arrivals\n", n);
+                    fflush(stderr);
+                    IntegrationTest_RequestExit();
+                    Combo_RequestGameSwitch();
+                } else if (n >= ArchiveHotswap_TargetArrivals()) {
+                    // Target arrivals reached with a healthy runtime — PASS.
+                    // SignalBootComplete sets the pass flag and requests the
+                    // switch that unblocks the main loop.
+                    fprintf(stderr, "[MM-INT-TEST] archive-hotswap cycle complete after %d arrivals\n", n);
+                    fflush(stderr);
+                    IntegrationTest_SignalBootComplete(GAME_MM, "archive-hotswap cycle complete");
+                } else {
+                    // Keep the cycle going: re-trigger the MM->OoT switch via the
+                    // South Clock Town south exit — same call the T2 branch makes.
+                    fprintf(stderr, "[MM-INT-TEST] re-triggering SCT-south entrance 0x%04X to continue cycle\n",
+                            MM_ENTR_SOUTH_CLOCK_TOWN_0);
+                    fflush(stderr);
+                    Combo_CheckCrossGameEntrance("mm", MM_ENTR_SOUTH_CLOCK_TOWN_0);
+                }
+            }
+        );
+
+        fprintf(stderr, "[MM] archive-hotswap cycle hooks registered\n");
         fflush(stderr);
     }
 }

--- a/games/oot/soh/GameExports_SingleExe.cpp
+++ b/games/oot/soh/GameExports_SingleExe.cpp
@@ -39,6 +39,16 @@ extern "C" {
     extern SaveContext gSaveContext;
 }
 
+// Archive hot-swap cycle helpers (#263). Defined in
+// src/common/tests/test_archive_hotswap.c (compiled into redship_common via
+// test_runner.cpp); resolved at final link. Record this OoT arrival, query the
+// RSS bound, and read the target arrival count for the cycle-complete check.
+extern "C" {
+    int ArchiveHotswap_RecordArrival(void);
+    int ArchiveHotswap_RssExceeded(void);
+    int ArchiveHotswap_TargetArrivals(void);
+}
+
 // Game state
 static int sArgc = 0;
 static char** sArgv = nullptr;
@@ -167,6 +177,67 @@ static void OoT_RegisterIntegrationTestHooks(void) {
         );
 
         fprintf(stderr, "[OoT] SCT-south->OoT switch hooks registered\n");
+        fflush(stderr);
+    } else if (mode == INT_TEST_ARCHIVE_HOTSWAP_CYCLE) {
+        // T4 (#263): drive >=3 OoT<->MM archive hot-swaps and assert a healthy
+        // runtime. OoT boots first, so OoT is arrivals #1 and #3 of the
+        // OoT->MM->OoT->MM cycle (4 arrivals == 3 transitions).
+        //
+        // Registration runs from OoT_Game_Init, which fires only on OoT's FIRST
+        // entry — later OoT arrivals come back through OoT_Game_Resume (see
+        // GameRunner_SwitchTo: a suspended game is resumed, not re-init'd), so
+        // this hook is registered exactly once and the persistent frame counter
+        // is NOT reset per arrival. The hook therefore re-arms itself: it fires
+        // ~10 stable frames after each (re)entry, then resets the counter so the
+        // next arrival reached via resume is detected the same way.
+        fprintf(stderr, "[OoT] Registering integration test hooks for archive-hotswap cycle (T4)\n");
+        fflush(stderr);
+
+        sOoTGameStateMainFrameCount = 0;
+
+        GameInteractor::Instance->RegisterGameHook<GameInteractor::OnGameStateMainStart>(
+            []() {
+                // Fire once per arrival, ~10 stable frames after (re)entry, then
+                // re-arm for the next OoT arrival (reached via OoT_Game_Resume).
+                sOoTGameStateMainFrameCount++;
+                if (sOoTGameStateMainFrameCount < 10) {
+                    return;
+                }
+                sOoTGameStateMainFrameCount = 0;
+
+                int n = ArchiveHotswap_RecordArrival();
+                fprintf(stderr, "[OoT-INT-TEST] OoT stable; archive-hotswap arrival #%d of %d\n",
+                        n, ArchiveHotswap_TargetArrivals());
+                fflush(stderr);
+
+                if (ArchiveHotswap_RssExceeded()) {
+                    // Steady-state RSS blew the bound — the #154 per-switch leak
+                    // regression. Fail fast: RequestExit does NOT set the pass
+                    // flag, so the run returns non-zero. Combo_RequestGameSwitch()
+                    // right after unblocks the main loop promptly (known fix).
+                    fprintf(stderr, "[OoT-INT-TEST] FAIL: steady-state RSS bound exceeded after %d arrivals\n", n);
+                    fflush(stderr);
+                    IntegrationTest_RequestExit();
+                    Combo_RequestGameSwitch();
+                } else if (n >= ArchiveHotswap_TargetArrivals()) {
+                    // Target arrivals reached with a healthy runtime — PASS.
+                    // SignalBootComplete sets the pass flag and requests the
+                    // switch that unblocks the main loop.
+                    fprintf(stderr, "[OoT-INT-TEST] archive-hotswap cycle complete after %d arrivals\n", n);
+                    fflush(stderr);
+                    IntegrationTest_SignalBootComplete(GAME_OOT, "archive-hotswap cycle complete");
+                } else {
+                    // Keep the cycle going: re-trigger the OoT->MM switch via the
+                    // Happy Mask Shop entrance — same call the T1 branch makes.
+                    fprintf(stderr, "[OoT-INT-TEST] re-triggering HMS entrance 0x%04X to continue cycle\n",
+                            OOT_ENTR_HAPPY_MASK_SHOP);
+                    fflush(stderr);
+                    Combo_CheckCrossGameEntrance("oot", OOT_ENTR_HAPPY_MASK_SHOP);
+                }
+            }
+        );
+
+        fprintf(stderr, "[OoT] archive-hotswap cycle hooks registered\n");
         fflush(stderr);
     }
 }

--- a/src/common/integration_test_hooks.cpp
+++ b/src/common/integration_test_hooks.cpp
@@ -19,6 +19,11 @@
 // Game switch request (to signal game to exit)
 extern "C" {
     void Combo_RequestGameSwitch(void);
+
+    // Archive hot-swap cycle helpers (defined in src/common/tests/test_archive_hotswap.c,
+    // compiled into redship_common via test_runner.cpp). Reset the cycle counters
+    // when the archive-hotswap integration test mode is selected (#263).
+    void ArchiveHotswap_ResetCycle(void);
 }
 
 namespace {
@@ -46,6 +51,13 @@ void IntegrationTest_SetMode(IntegrationTestMode mode) {
         case INT_TEST_BOOT_MM: modeName = "boot-mm"; break;
         case INT_TEST_SWITCH_OOT_HMS_TO_MM: modeName = "switch-oot-hms-to-mm"; break;
         case INT_TEST_SWITCH_MM_CLOCKTOWN_SOUTH_TO_OOT: modeName = "switch-mm-clocktown-south-to-oot"; break;
+        case INT_TEST_ARCHIVE_HOTSWAP_CYCLE: modeName = "archive-hotswap-cycle"; break;
+    }
+
+    // Archive hot-swap cycle keeps a running arrival count / RSS baseline across
+    // multiple OoT<->MM switches; reset it whenever this mode is (re)selected (#263).
+    if (mode == INT_TEST_ARCHIVE_HOTSWAP_CYCLE) {
+        ArchiveHotswap_ResetCycle();
     }
 
     if (mode != INT_TEST_NONE) {

--- a/src/common/integration_test_hooks.h
+++ b/src/common/integration_test_hooks.h
@@ -25,7 +25,8 @@ typedef enum {
     INT_TEST_BOOT_OOT,            // Boot OoT, exit on title/file select
     INT_TEST_BOOT_MM,             // Boot MM, exit on title/file select
     INT_TEST_SWITCH_OOT_HMS_TO_MM,        // Boot OoT, trigger HMS entrance, verify MM Clock Tower Interior spawn
-    INT_TEST_SWITCH_MM_CLOCKTOWN_SOUTH_TO_OOT // Boot MM, trigger South Clock Town south exit, verify OoT Market spawn
+    INT_TEST_SWITCH_MM_CLOCKTOWN_SOUTH_TO_OOT, // Boot MM, trigger South Clock Town south exit, verify OoT Market spawn
+    INT_TEST_ARCHIVE_HOTSWAP_CYCLE        // Boot OoT, hot-swap OoT<->MM >=3 times, verify healthy runtime (#263)
 } IntegrationTestMode;
 
 /**

--- a/src/common/test_runner.cpp
+++ b/src/common/test_runner.cpp
@@ -391,6 +391,9 @@ const IntegrationTestDescriptor gIntegrationTests[] = {
     {"int-switch-mm-clocktown-south-to-oot",
      "Boot MM, trigger South Clock Town south exit (0xD800), verify spawn at OoT Market from Mask Shop (0x01D1)",
      INT_TEST_SWITCH_MM_CLOCKTOWN_SOUTH_TO_OOT, GAME_MM},
+    {"int-archive-hotswap-cycle",
+     "Boot OoT, hot-swap OoT<->MM >=3 times, verify healthy runtime (no missing assets, bounded RSS) (#263)",
+     INT_TEST_ARCHIVE_HOTSWAP_CYCLE, GAME_OOT},
     {nullptr, nullptr, INT_TEST_NONE, GAME_NONE}  // Sentinel
 };
 


### PR DESCRIPTION
## What

Wires the deferred **runtime** half of Phase 2 T4 (#263): the `INT_TEST_ARCHIVE_HOTSWAP_CYCLE` integration-test mode that drives a real OoT↔MM archive hot-swap cycle end-to-end. The headless `ArchiveHotswapLogic` unit test and the `IntArchiveHotswapCycle` CTest target already landed on `main`; this connects the runtime path so that, when ROMs are present, CI exercises ≥3 consecutive cross-game switches and asserts a healthy runtime (no missing assets, bounded steady-state RSS).

Closes the runtime portion of #263. Part of Phase 2 (#259).

## Changes

- **`src/common/integration_test_hooks.h`** — add `INT_TEST_ARCHIVE_HOTSWAP_CYCLE` enum value.
- **`src/common/integration_test_hooks.cpp`** — handle it in the `IntegrationTest_SetMode` switch (keeps `-Wswitch` clean) and call `ArchiveHotswap_ResetCycle()` when the mode is selected.
- **`src/common/test_runner.cpp`** — register the `int-archive-hotswap-cycle` integration test (target game OoT — OoT boots first); name matches the existing CMake `add_test` argument.
- **`games/oot/soh/GameExports_SingleExe.cpp`** and **`games/mm/2s2h/GameExports_SingleExe.cpp`** — add the per-game `INT_TEST_ARCHIVE_HOTSWAP_CYCLE` hook branch, mirroring the existing T1/T2 switch branches.
- **`.github/workflows/integration-tests.yml`** — add the archive-hotswap-cycle CI step, guarded on **both** `oot.o2r` and `mm.o2r` (auto-skips without ROMs, mirroring T1/T2).

No CMake change — the `IntArchiveHotswapCycle` CTest target already exists on `main`. No semantic change to existing tests.

## How it works

OoT boots first, so the cycle is OoT→MM→OoT→MM = **4 arrivals == 3 transitions** (`ArchiveHotswap_TargetArrivals() == 4`). Each game's `OnGameStateMainStart` hook records an arrival ~10 stable frames after (re)entry, then:

- **RSS bound breached** → fail fast: `IntegrationTest_RequestExit()` (does not set the pass flag → non-zero exit) immediately followed by `Combo_RequestGameSwitch()` so the main loop unblocks promptly.
- **Target arrivals reached** → `IntegrationTest_SignalBootComplete()` (sets the pass flag → exit 0).
- **Otherwise** → re-trigger the cross-game entrance (HMS / South Clock Town) to continue.

Two subtleties handled explicitly:
1. **Re-entry uses `*_Game_Resume`, not `*_Game_Init`** (per `GameRunner_SwitchTo`), so the hook is registered once and **re-arms its own frame counter** after each fire — otherwise the cycle would stall at the first post-resume arrival and time out.
2. The terminal arrival (#4) lands on **MM** (even target), so the MM side carries the cycle-complete `SignalBootComplete`; getting this wrong would make a *healthy* run exit non-zero.

## Verification / residual

CI here can only confirm this **compiles** and that the new step **auto-skips** without ROMs (integration tests require ROM-derived `oot.o2r`/`mm.o2r`, which cannot be distributed). The **192 MB steady-state RSS threshold** and the **multi-switch timing** can only be validated on a machine with original ROMs — those are not exercised by this PR's CI run. The control flow was cross-checked against `GameRunner_SwitchTo`, the `ArchiveHotswap_*` helper contract, and `main.cpp`'s exit-code path (`TestRunner_GetIntegrationTestResult` → `IntegrationTest_BootPassed() ? 0 : 1`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!--- section:artifacts:start -->
### Build Artifacts
  - [rsbs-windows.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/7306585588.zip)
  - [rsbs-linux.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/7306532498.zip)
<!--- section:artifacts:end -->