### PR TITLE
Phase 2 T6: unified .redsave save format + SaveManager (headless core) (#35)

### DIFF
--- a/CMake/SingleExecutable.cmake
+++ b/CMake/SingleExecutable.cmake
@@ -26,6 +26,8 @@ set(REDSHIP_COMMON_SOURCES
     # games/oot/soh/GameExports_SingleExe.cpp and games/mm/2s2h/GameExports_SingleExe.cpp
     # Unified SaveContext storage for both games
     ${CMAKE_SOURCE_DIR}/src/common/unified_save.c
+    # Unified cross-game save file (.redsave) — Phase 2 T6 (#35)
+    ${CMAKE_SOURCE_DIR}/src/common/save.cpp
     # SharedGraphics for cross-game graphics context sharing
     ${CMAKE_SOURCE_DIR}/src/common/SharedGraphics.cpp
     # Unified menu bar for single executable
@@ -52,6 +54,7 @@ set(REDSHIP_COMMON_HEADERS
     ${CMAKE_SOURCE_DIR}/src/common/ComboMenuBar.h
     ${CMAKE_SOURCE_DIR}/src/common/game_lifecycle.h
     ${CMAKE_SOURCE_DIR}/src/common/SharedGraphics.h
+    ${CMAKE_SOURCE_DIR}/src/common/save.h
 )
 
 # ============================================================================
@@ -195,13 +198,22 @@ if(BUILD_TESTING)
     add_test(NAME RoundtripIntegrity COMMAND redship --test roundtrip-integrity)
     add_test(NAME SharedRoundtrip COMMAND redship --test shared-roundtrip)
     add_test(NAME ArchiveHotswapLogic COMMAND redship --test archive-hotswap-logic)
+    # Unified save (.redsave) headless tests — Phase 2 T6 (#35)
+    add_test(NAME SaveRoundtripTiers COMMAND redship --test save-roundtrip-tiers)
+    add_test(NAME SaveHeader COMMAND redship --test save-header)
+    add_test(NAME SaveHasDelete COMMAND redship --test save-has-delete)
+    add_test(NAME SaveVersionReject COMMAND redship --test save-version-reject)
+    add_test(NAME SaveSizeMismatch COMMAND redship --test save-size-mismatch)
+    add_test(NAME SaveCrcCorrupt COMMAND redship --test save-crc-corrupt)
     add_test(NAME Context COMMAND redship --test context)
     add_test(NAME AllTests COMMAND redship --test all)
 
     # Set reasonable timeout and label our tests
     set(REDSHIP_TEST_TIMEOUT 60 CACHE STRING "Test timeout in seconds")
     set_tests_properties(
-        BootOoT BootMM SwitchOoTMM SwitchMMOoT Roundtrip RoundtripIntegrity SharedRoundtrip ArchiveHotswapLogic Context AllTests
+        BootOoT BootMM SwitchOoTMM SwitchMMOoT Roundtrip RoundtripIntegrity SharedRoundtrip ArchiveHotswapLogic
+        SaveRoundtripTiers SaveHeader SaveHasDelete SaveVersionReject SaveSizeMismatch SaveCrcCorrupt
+        Context AllTests
         PROPERTIES
         TIMEOUT ${REDSHIP_TEST_TIMEOUT}
         LABELS "redship"

--- a/src/common/save.cpp
+++ b/src/common/save.cpp
@@ -1,0 +1,274 @@
+/**
+ * @file save.cpp
+ * @brief Unified cross-game save file (.redsave) implementation (Phase 2 T6, #35).
+ *
+ * See save.h for the format. This file depends only on src/common (context +
+ * game headers) and the standard library — never on either game's z64save.h.
+ */
+
+#include "save.h"
+
+#include "context.h"
+#include "game.h"
+
+#include <cstdio>
+#include <cstring>
+#include <filesystem>
+#include <fstream>
+#include <string>
+#include <system_error>
+#include <vector>
+
+namespace rsbs {
+
+namespace {
+
+// Tier sizes as this build understands them. A loaded file must match these
+// exactly (guarded in Load); the constants come from game.h, which is also what
+// the context-layer shadow buffers are sized at, so reading the shadows here is
+// always in-bounds.
+constexpr uint32_t kComboSize = static_cast<uint32_t>(sizeof(ComboContext));
+constexpr uint32_t kOoTSize = static_cast<uint32_t>(OOT_SAVE_CONTEXT_SIZE);
+constexpr uint32_t kMMSize = static_cast<uint32_t>(MM_SAVE_CONTEXT_SIZE);
+
+bool SlotInRange(int slot) {
+    return slot >= 0 && slot < RSBS_SAVE_MAX_SLOTS;
+}
+
+}  // namespace
+
+SaveManager& SaveManager::Instance() {
+    static SaveManager sInstance;
+    return sInstance;
+}
+
+void SaveManager::SetSaveDirectory(const std::string& dir) {
+    mSaveDir = dir.empty() ? std::string(".") : dir;
+}
+
+std::string SaveManager::SlotPath(int slot) const {
+    return (std::filesystem::path(mSaveDir) /
+            ("redship_slot" + std::to_string(slot) + ".redsave"))
+        .string();
+}
+
+// CRC32 (reflected, polynomial 0xEDB88320 — the zlib/PNG variant). Table-free
+// so there is no static-init ordering concern; the payload is only ~24KB.
+uint32_t SaveManager::Crc32(const uint8_t* data, size_t len) {
+    uint32_t crc = 0xFFFFFFFFu;
+    for (size_t i = 0; i < len; i++) {
+        crc ^= data[i];
+        for (int bit = 0; bit < 8; bit++) {
+            uint32_t mask = 0u - (crc & 1u);
+            crc = (crc >> 1) ^ (0xEDB88320u & mask);
+        }
+    }
+    return ~crc;
+}
+
+bool SaveManager::Save(int slot) {
+    if (!SlotInRange(slot)) {
+        return false;
+    }
+
+    // Serialization source = the context-layer shadow copies. Both must be
+    // present (Context_InitFrozenStates run); otherwise there is nothing to
+    // capture and we refuse rather than write a half-empty file.
+    const void* ootShadow = Context_GetOoTSaveContext();
+    const void* mmShadow = Context_GetMMSaveContext();
+    if (ootShadow == nullptr || mmShadow == nullptr) {
+        return false;
+    }
+
+    // Assemble Tiers 1..3 contiguously so the CRC covers exactly the bytes we
+    // write, in write order: ComboContext, OoT blob, MM blob.
+    std::vector<uint8_t> payload;
+    payload.reserve(kComboSize + kOoTSize + kMMSize);
+    const uint8_t* comboBytes = reinterpret_cast<const uint8_t*>(&gComboCtx);
+    payload.insert(payload.end(), comboBytes, comboBytes + kComboSize);
+    payload.insert(payload.end(), static_cast<const uint8_t*>(ootShadow),
+                   static_cast<const uint8_t*>(ootShadow) + kOoTSize);
+    payload.insert(payload.end(), static_cast<const uint8_t*>(mmShadow),
+                   static_cast<const uint8_t*>(mmShadow) + kMMSize);
+
+    RsbsSaveHeader header;
+    std::memset(&header, 0, sizeof(header));
+    std::memcpy(header.magic, RSBS_SAVE_MAGIC, sizeof(header.magic));
+    header.version = RSBS_SAVE_VERSION;
+    header.endian = RSBS_SAVE_ENDIAN_LE;
+    header.slot = static_cast<uint8_t>(slot);
+    header.headerSize = static_cast<uint16_t>(sizeof(RsbsSaveHeader));
+    header.comboSize = kComboSize;
+    header.ootSize = kOoTSize;
+    header.mmSize = kMMSize;
+    header.crc32 = Crc32(payload.data(), payload.size());
+
+    std::error_code ec;
+    std::filesystem::create_directories(mSaveDir, ec);
+
+    // Atomic write: fill a temp file, then rename over the real slot so a
+    // crash mid-write never leaves a half-written slot.
+    const std::string finalPath = SlotPath(slot);
+    const std::string tmpPath = finalPath + ".tmp";
+    {
+        std::ofstream out(tmpPath, std::ios::binary | std::ios::trunc);
+        if (!out) {
+            return false;
+        }
+        out.write(reinterpret_cast<const char*>(&header), sizeof(header));
+        out.write(reinterpret_cast<const char*>(payload.data()),
+                  static_cast<std::streamsize>(payload.size()));
+        out.flush();
+        if (!out) {
+            out.close();
+            std::filesystem::remove(tmpPath, ec);
+            return false;
+        }
+    }
+
+    std::filesystem::rename(tmpPath, finalPath, ec);
+    if (ec) {
+        std::filesystem::remove(tmpPath, ec);
+        return false;
+    }
+    return true;
+}
+
+bool SaveManager::DeserializeHeader(std::istream& in, RsbsSaveHeader& outHeader) const {
+    RsbsSaveHeader h;
+    in.read(reinterpret_cast<char*>(&h), sizeof(h));
+    if (!in || in.gcount() != static_cast<std::streamsize>(sizeof(h))) {
+        return false;
+    }
+
+    if (std::memcmp(h.magic, RSBS_SAVE_MAGIC, sizeof(h.magic)) != 0) {
+        return false;
+    }
+    if (h.version != RSBS_SAVE_VERSION) {
+        return false;  // older/newer layout — refuse rather than guess
+    }
+    if (h.endian != RSBS_SAVE_ENDIAN_LE) {
+        return false;
+    }
+    if (h.headerSize != sizeof(RsbsSaveHeader)) {
+        return false;
+    }
+    // Tier sizes must match this build exactly; a mismatch means the struct
+    // layout changed, so the blobs are not safe to memcpy back.
+    if (h.comboSize != kComboSize || h.ootSize != kOoTSize || h.mmSize != kMMSize) {
+        return false;
+    }
+
+    outHeader = h;
+    return true;
+}
+
+bool SaveManager::Load(int slot) {
+    if (!SlotInRange(slot)) {
+        return false;
+    }
+
+    std::ifstream in(SlotPath(slot), std::ios::binary);
+    if (!in) {
+        return false;
+    }
+
+    RsbsSaveHeader header;
+    if (!DeserializeHeader(in, header)) {
+        return false;
+    }
+
+    // Read the whole payload into locals FIRST and validate everything before
+    // committing — a bad file (short read, CRC mismatch, bad inner magic) must
+    // not clobber live state.
+    ComboContext combo;
+    std::vector<uint8_t> ootBlob(kOoTSize);
+    std::vector<uint8_t> mmBlob(kMMSize);
+
+    in.read(reinterpret_cast<char*>(&combo), kComboSize);
+    if (!in || in.gcount() != static_cast<std::streamsize>(kComboSize)) {
+        return false;
+    }
+    in.read(reinterpret_cast<char*>(ootBlob.data()), kOoTSize);
+    if (!in || in.gcount() != static_cast<std::streamsize>(kOoTSize)) {
+        return false;
+    }
+    in.read(reinterpret_cast<char*>(mmBlob.data()), kMMSize);
+    if (!in || in.gcount() != static_cast<std::streamsize>(kMMSize)) {
+        return false;
+    }
+
+    // CRC over Tiers 1..3, in the same contiguous order they were written.
+    std::vector<uint8_t> payload;
+    payload.reserve(kComboSize + kOoTSize + kMMSize);
+    const uint8_t* comboBytes = reinterpret_cast<const uint8_t*>(&combo);
+    payload.insert(payload.end(), comboBytes, comboBytes + kComboSize);
+    payload.insert(payload.end(), ootBlob.begin(), ootBlob.end());
+    payload.insert(payload.end(), mmBlob.begin(), mmBlob.end());
+    if (Crc32(payload.data(), payload.size()) != header.crc32) {
+        return false;
+    }
+
+    // Inner ComboContext magic guards against a structurally-valid file whose
+    // Tier-1 contents are not actually a ComboContext.
+    if (std::memcmp(combo.magic, COMBO_CONTEXT_MAGIC, sizeof(combo.magic)) != 0) {
+        return false;
+    }
+
+    // All checks passed — commit. gComboCtx and both shadows are updated; the
+    // active game's live SaveContext is re-hydrated from its shadow by the
+    // existing freeze/restore path on the next cross-game switch.
+    std::memcpy(&gComboCtx, &combo, sizeof(ComboContext));
+    Context_UpdateShadowCopy(GAME_OOT, ootBlob.data(), kOoTSize);
+    Context_UpdateShadowCopy(GAME_MM, mmBlob.data(), kMMSize);
+    return true;
+}
+
+bool SaveManager::HasSave(int slot) const {
+    if (!SlotInRange(slot)) {
+        return false;
+    }
+    std::ifstream in(SlotPath(slot), std::ios::binary);
+    if (!in) {
+        return false;
+    }
+    RsbsSaveHeader header;
+    return DeserializeHeader(in, header);
+}
+
+void SaveManager::DeleteSave(int slot) {
+    if (!SlotInRange(slot)) {
+        return;
+    }
+    std::error_code ec;
+    const std::string path = SlotPath(slot);
+    std::filesystem::remove(path, ec);
+    std::filesystem::remove(path + ".tmp", ec);
+    std::filesystem::remove(path + ".bak", ec);
+}
+
+}  // namespace rsbs
+
+// ============================================================================
+// C shim
+// ============================================================================
+
+extern "C" {
+
+int RsbsSave_Save(int slot) {
+    return rsbs::SaveManager::Instance().Save(slot) ? 1 : 0;
+}
+
+int RsbsSave_Load(int slot) {
+    return rsbs::SaveManager::Instance().Load(slot) ? 1 : 0;
+}
+
+int RsbsSave_HasSave(int slot) {
+    return rsbs::SaveManager::Instance().HasSave(slot) ? 1 : 0;
+}
+
+void RsbsSave_DeleteSave(int slot) {
+    rsbs::SaveManager::Instance().DeleteSave(slot);
+}
+
+}  // extern "C"

--- a/src/common/save.h
+++ b/src/common/save.h
@@ -1,0 +1,128 @@
+/**
+ * @file save.h
+ * @brief Unified cross-game save file (.redsave) for the single executable
+ *        (Phase 2 T6, issue #35).
+ *
+ * A `.redsave` file holds, in one slot, three tiers:
+ *   Tier 0  RsbsSaveHeader   (fixed 32 bytes: magic, version, slot, sizes, crc)
+ *   Tier 1  ComboContext     (cross-game flags / shared items / last game)
+ *   Tier 2  OoT SaveContext  (OOT_SAVE_CONTEXT_SIZE bytes)
+ *   Tier 3  MM  SaveContext  (MM_SAVE_CONTEXT_SIZE bytes)
+ *
+ * This is the HEADLESS CORE: the format, the SaveManager, and round-trip /
+ * validation unit tests. It serializes the cross-game shadow copies that the
+ * context layer already maintains (Context_GetOoTSaveContext /
+ * Context_GetMMSaveContext / gComboCtx) and restores them via
+ * Context_UpdateShadowCopy, so it depends only on src/common and never on
+ * either game's z64save.h. The OoT/MM save-flow hooks (OnSaveFile/OnLoadFile)
+ * and the unified file-select panel are a deliberate follow-up; see issue #35.
+ *
+ * Format notes:
+ * - Little-endian, host-native. Both shipped targets are LE (x86-64 / arm64);
+ *   the header records endian=1 and Load asserts it so a future big-endian port
+ *   fails loudly instead of silently corrupting.
+ * - A `.redsave` is tied to the SaveContext struct sizes of the build that
+ *   wrote it: the header stores each tier's byte length and Load rejects a file
+ *   whose tier sizes or version do not match the current build (fail-safe, no
+ *   partial load) rather than memcpy-ing a mismatched blob.
+ */
+
+#ifndef RSBS_COMMON_SAVE_H
+#define RSBS_COMMON_SAVE_H
+
+#include "game.h"     // GameId, OOT_SAVE_CONTEXT_SIZE, MM_SAVE_CONTEXT_SIZE
+#include "context.h"  // ComboContext, gComboCtx, Context_* shadow API
+
+#include <stdint.h>
+
+// On-disk constants (visible to both C and C++).
+#define RSBS_SAVE_MAGIC      "REDSHIP1"  // 8 bytes, NOT NUL-terminated on disk
+#define RSBS_SAVE_VERSION    1u          // bump on any layout change
+#define RSBS_SAVE_ENDIAN_LE  1
+#define RSBS_SAVE_MAX_SLOTS  3           // matches each game's MaxFiles
+
+#ifdef __cplusplus
+
+#include <cstddef>
+#include <iosfwd>
+#include <string>
+
+namespace rsbs {
+
+#pragma pack(push, 1)
+/**
+ * Tier-0 header. Fixed 32 bytes, packed so its layout is stable across
+ * compilers. All multi-byte integers little-endian.
+ */
+struct RsbsSaveHeader {
+    char     magic[8];    // "REDSHIP1"
+    uint32_t version;     // RSBS_SAVE_VERSION
+    uint8_t  endian;      // RSBS_SAVE_ENDIAN_LE (1)
+    uint8_t  slot;        // 0..RSBS_SAVE_MAX_SLOTS-1
+    uint16_t headerSize;  // sizeof(RsbsSaveHeader) == 32 (forward-compat probe)
+    uint32_t comboSize;   // Tier-1 bytes == sizeof(ComboContext)
+    uint32_t ootSize;     // Tier-2 bytes == OOT_SAVE_CONTEXT_SIZE at write time
+    uint32_t mmSize;      // Tier-3 bytes == MM_SAVE_CONTEXT_SIZE at write time
+    uint32_t crc32;       // CRC32 over Tiers 1..3 (the payload after the header)
+};
+#pragma pack(pop)
+
+static_assert(sizeof(RsbsSaveHeader) == 32, "RsbsSaveHeader must be exactly 32 bytes");
+
+/**
+ * Reads/writes the three-tier unified save file. Process-wide singleton.
+ *
+ * Serialization source/sink is the context layer's shadow copies, so a Save
+ * captures whatever cross-game state is currently resident and a Load primes
+ * both shadows + gComboCtx for the next cross-game switch to pick up.
+ */
+class SaveManager {
+public:
+    static SaveManager& Instance();
+
+    bool Save(int slot);
+    bool Load(int slot);
+    bool HasSave(int slot) const;
+    void DeleteSave(int slot);
+
+    /**
+     * Directory the .redsave files live in. Defaults to "Save" relative to the
+     * working directory so the headless --test path (which never creates a
+     * Ship::Context) can round-trip to a writable location. The game-integration
+     * follow-up injects the real per-app save directory here.
+     */
+    void SetSaveDirectory(const std::string& dir);
+    std::string SlotPath(int slot) const;
+
+    static uint32_t Crc32(const uint8_t* data, size_t len);
+
+private:
+    SaveManager() = default;
+
+    // Validates magic / version / endian / headerSize / tier sizes against the
+    // current build. Returns true and fills outHeader only on a fully valid
+    // header; never mutates live state.
+    bool DeserializeHeader(std::istream& in, RsbsSaveHeader& outHeader) const;
+
+    std::string mSaveDir = "Save";
+};
+
+}  // namespace rsbs
+
+#endif  // __cplusplus
+
+// ---- C shim for game-side hook code (used by the deferred integration PR) ----
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+int  RsbsSave_Save(int slot);
+int  RsbsSave_Load(int slot);
+int  RsbsSave_HasSave(int slot);
+void RsbsSave_DeleteSave(int slot);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // RSBS_COMMON_SAVE_H

--- a/src/common/test_runner.cpp
+++ b/src/common/test_runner.cpp
@@ -37,6 +37,10 @@ extern "C" {
 // in their own extern "C" inside the file.
 #include "tests/test_archive_hotswap.c"
 
+// Unified save (.redsave) headless tests (issue #35, Phase 2 T6). Included at
+// FILE SCOPE (compiled as C++): they drive the C++-linkage rsbs::SaveManager.
+#include "tests/test_save_roundtrip.c"
+
 // ============================================================================
 // Internal state
 // ============================================================================
@@ -368,6 +372,13 @@ const TestDescriptor gTests[] = {
     {"shared-roundtrip", "Shared flag/seed survive OoT->MM switch (issue #264)", Test_SharedStateRoundtrip},
     {"context", "Test context/state management", Test_Context},
     {"lifecycle", "Game lifecycle unit tests", Test_Lifecycle},
+    // Unified save (.redsave) headless coverage (issue #35, Phase 2 T6).
+    {"save-roundtrip-tiers", "Unified .redsave preserves ComboContext + both SaveContexts (#35)", Test_SaveRoundtripTiers},
+    {"save-header", "Unified .redsave header fields + CRC are well-formed (#35)", Test_SaveHeader},
+    {"save-has-delete", "Unified save HasSave/DeleteSave lifecycle (#35)", Test_SaveHasDelete},
+    {"save-version-reject", "Unified save Load rejects unknown version, no clobber (#35)", Test_SaveVersionReject},
+    {"save-size-mismatch", "Unified save Load rejects mismatched tier size, no clobber (#35)", Test_SaveSizeMismatch},
+    {"save-crc-corrupt", "Unified save Load rejects corrupt payload, no clobber (#35)", Test_SaveCrcCorrupt},
     // Keep archive-hotswap-logic LAST: it re-inits the entrance table, so it
     // must not run before any test that relies on the default links.
     {"archive-hotswap-logic", "Headless multi-switch archive/state regression (#263)", Test_ArchiveHotswapLogic},

--- a/src/common/tests/test_save_roundtrip.c
+++ b/src/common/tests/test_save_roundtrip.c
@@ -1,0 +1,299 @@
+/**
+ * @file test_save_roundtrip.c
+ * @brief Headless unit tests for the unified .redsave format (Phase 2 T6, #35).
+ *
+ * Exercises rsbs::SaveManager end-to-end with NO ROMs and NO display: seed the
+ * cross-game shadow copies + gComboCtx, Save to a temp directory, wipe live
+ * state, Load, and assert a byte-exact round-trip — plus the header contents and
+ * the fail-safe rejection paths (bad version, bad tier size, corrupt CRC), each
+ * of which must leave live state untouched.
+ *
+ * Linkage note: like test_roundtrip_integrity.c / test_archive_hotswap.c, this
+ * file is #included into test_runner.cpp at FILE SCOPE (compiled as C++, NOT
+ * inside an extern "C" block) so it can call the C++ rsbs::SaveManager API. The
+ * Test_Save* entry points keep C++ linkage; they are referenced only from this
+ * TU's gTests[] table.
+ */
+
+#include "../context.h"
+#include "../game.h"
+#include "../save.h"
+#include "../test_runner.h"
+
+#include <cstddef>
+#include <cstdint>
+#include <cstdio>
+#include <cstring>
+#include <filesystem>
+#include <fstream>
+#include <string>
+#include <vector>
+
+#define SAVE_ASSERT(cond, msg)                  \
+    do {                                        \
+        if (!(cond)) {                          \
+            printf("[TEST] FAIL: %s\n", (msg)); \
+            return TEST_FAIL;                   \
+        }                                       \
+    } while (0)
+
+namespace {
+
+const char* const kSaveTestDir = "rsbs_test_saves";
+
+// Deterministic, position-dependent fill so a swapped/truncated byte is obvious.
+uint8_t SaveTestOoTByte(size_t i) {
+    return static_cast<uint8_t>(0xA1u + i * 31u);
+}
+uint8_t SaveTestMMByte(size_t i) {
+    return static_cast<uint8_t>(0x5Cu + i * 17u);
+}
+
+// Seed gComboCtx + both shadow copies with recognizable, distinct content.
+void SaveTestSeed(uint32_t tag) {
+    Context_InitFrozenStates();
+    ComboContext_Init();  // stamps magic "OoT+MM<3" + version, zeroes the rest
+    gComboCtx.saveSlot = static_cast<int32_t>(tag);
+    gComboCtx.sharedFlags[5] = tag;
+    gComboCtx.sharedRandoSeed = tag ^ 0xA5A5A5A5u;
+    gComboCtx.sourceGame = GAME_OOT;
+    gComboCtx.sourceIsRando = true;
+
+    std::vector<uint8_t> oot(OOT_SAVE_CONTEXT_SIZE);
+    std::vector<uint8_t> mm(MM_SAVE_CONTEXT_SIZE);
+    for (size_t i = 0; i < oot.size(); i++) {
+        oot[i] = SaveTestOoTByte(i);
+    }
+    for (size_t i = 0; i < mm.size(); i++) {
+        mm[i] = SaveTestMMByte(i);
+    }
+    Context_UpdateShadowCopy(GAME_OOT, oot.data(), oot.size());
+    Context_UpdateShadowCopy(GAME_MM, mm.data(), mm.size());
+}
+
+// Overwrite a 4-byte little-endian field at the given header offset, in place,
+// without disturbing the rest of the file. Used to craft fail-safe inputs.
+bool SaveTestPatchU32(const std::string& path, size_t offset, uint32_t value) {
+    std::fstream f(path, std::ios::in | std::ios::out | std::ios::binary);
+    if (!f) {
+        return false;
+    }
+    f.seekp(static_cast<std::streamoff>(offset), std::ios::beg);
+    uint8_t bytes[4] = {static_cast<uint8_t>(value & 0xFFu), static_cast<uint8_t>((value >> 8) & 0xFFu),
+                        static_cast<uint8_t>((value >> 16) & 0xFFu), static_cast<uint8_t>((value >> 24) & 0xFFu)};
+    f.write(reinterpret_cast<const char*>(bytes), sizeof(bytes));
+    return static_cast<bool>(f);
+}
+
+// Flip one payload byte (after the 32-byte header) to break the CRC.
+bool SaveTestFlipPayloadByte(const std::string& path) {
+    std::fstream f(path, std::ios::in | std::ios::out | std::ios::binary);
+    if (!f) {
+        return false;
+    }
+    const std::streamoff at = static_cast<std::streamoff>(sizeof(rsbs::RsbsSaveHeader)) + 4;
+    f.seekg(at, std::ios::beg);
+    char b = 0;
+    f.read(&b, 1);
+    if (!f) {
+        return false;
+    }
+    b = static_cast<char>(b ^ 0xFF);
+    f.seekp(at, std::ios::beg);
+    f.write(&b, 1);
+    return static_cast<bool>(f);
+}
+
+bool SaveTestOoTShadowMatchesPattern() {
+    const uint8_t* p = static_cast<const uint8_t*>(Context_GetOoTSaveContext());
+    if (p == nullptr) {
+        return false;
+    }
+    for (size_t i = 0; i < OOT_SAVE_CONTEXT_SIZE; i++) {
+        if (p[i] != SaveTestOoTByte(i)) {
+            return false;
+        }
+    }
+    return true;
+}
+
+bool SaveTestMMShadowMatchesPattern() {
+    const uint8_t* p = static_cast<const uint8_t*>(Context_GetMMSaveContext());
+    if (p == nullptr) {
+        return false;
+    }
+    for (size_t i = 0; i < MM_SAVE_CONTEXT_SIZE; i++) {
+        if (p[i] != SaveTestMMByte(i)) {
+            return false;
+        }
+    }
+    return true;
+}
+
+}  // namespace
+
+TestResult Test_SaveRoundtripTiers(void) {
+    printf("[TEST] save-roundtrip-tiers: .redsave preserves ComboContext + both SaveContexts (#35)\n");
+
+    rsbs::SaveManager& mgr = rsbs::SaveManager::Instance();
+    mgr.SetSaveDirectory(kSaveTestDir);
+
+    const uint32_t tag = 0x1234ABCDu;
+    SaveTestSeed(tag);
+    mgr.DeleteSave(0);
+
+    SAVE_ASSERT(mgr.Save(0), "Save(0) failed");
+
+    // Wipe live state so a no-op Load could not pass by accident.
+    ComboContext_Init();
+    Context_ClearAllFrozenStates();
+    gComboCtx.saveSlot = 0x7FFFFFFF;
+
+    SAVE_ASSERT(mgr.Load(0), "Load(0) failed");
+
+    SAVE_ASSERT(gComboCtx.saveSlot == static_cast<int32_t>(tag), "ComboContext.saveSlot not restored");
+    SAVE_ASSERT(gComboCtx.sharedFlags[5] == tag, "ComboContext.sharedFlags not restored");
+    SAVE_ASSERT(gComboCtx.sharedRandoSeed == (tag ^ 0xA5A5A5A5u), "ComboContext.sharedRandoSeed not restored");
+    SAVE_ASSERT(gComboCtx.sourceIsRando, "ComboContext.sourceIsRando not restored");
+    SAVE_ASSERT(gComboCtx.sourceGame == GAME_OOT, "ComboContext.sourceGame not restored");
+    SAVE_ASSERT(SaveTestOoTShadowMatchesPattern(), "OoT SaveContext blob not byte-identical after round-trip");
+    SAVE_ASSERT(SaveTestMMShadowMatchesPattern(), "MM SaveContext blob not byte-identical after round-trip");
+
+    mgr.DeleteSave(0);
+    printf("[TEST] PASS: three-tier round-trip is byte-exact\n");
+    return TEST_PASS;
+}
+
+TestResult Test_SaveHeader(void) {
+    printf("[TEST] save-header: .redsave header fields + CRC are well-formed (#35)\n");
+
+    rsbs::SaveManager& mgr = rsbs::SaveManager::Instance();
+    mgr.SetSaveDirectory(kSaveTestDir);
+    SaveTestSeed(0x55AA1234u);
+    mgr.DeleteSave(0);
+    SAVE_ASSERT(mgr.Save(0), "Save(0) failed");
+
+    std::ifstream in(mgr.SlotPath(0), std::ios::binary);
+    SAVE_ASSERT(static_cast<bool>(in), "could not reopen written slot");
+
+    rsbs::RsbsSaveHeader h;
+    in.read(reinterpret_cast<char*>(&h), sizeof(h));
+    SAVE_ASSERT(in.gcount() == static_cast<std::streamsize>(sizeof(h)), "short header read");
+
+    SAVE_ASSERT(std::memcmp(h.magic, RSBS_SAVE_MAGIC, sizeof(h.magic)) == 0, "bad magic");
+    SAVE_ASSERT(h.version == RSBS_SAVE_VERSION, "bad version");
+    SAVE_ASSERT(h.endian == RSBS_SAVE_ENDIAN_LE, "bad endian");
+    SAVE_ASSERT(h.slot == 0, "bad slot");
+    SAVE_ASSERT(h.headerSize == sizeof(rsbs::RsbsSaveHeader), "bad headerSize");
+    SAVE_ASSERT(h.comboSize == sizeof(ComboContext), "bad comboSize");
+    SAVE_ASSERT(h.ootSize == OOT_SAVE_CONTEXT_SIZE, "bad ootSize");
+    SAVE_ASSERT(h.mmSize == MM_SAVE_CONTEXT_SIZE, "bad mmSize");
+
+    // Read the payload and confirm the stored CRC actually verifies.
+    std::vector<uint8_t> payload(h.comboSize + h.ootSize + h.mmSize);
+    in.read(reinterpret_cast<char*>(payload.data()), static_cast<std::streamsize>(payload.size()));
+    SAVE_ASSERT(in.gcount() == static_cast<std::streamsize>(payload.size()), "short payload read");
+    SAVE_ASSERT(h.crc32 != 0u, "CRC unexpectedly zero");
+    SAVE_ASSERT(rsbs::SaveManager::Crc32(payload.data(), payload.size()) == h.crc32, "CRC does not verify");
+
+    mgr.DeleteSave(0);
+    printf("[TEST] PASS: header well-formed and CRC verifies\n");
+    return TEST_PASS;
+}
+
+TestResult Test_SaveHasDelete(void) {
+    printf("[TEST] save-has-delete: HasSave/DeleteSave lifecycle (#35)\n");
+
+    rsbs::SaveManager& mgr = rsbs::SaveManager::Instance();
+    mgr.SetSaveDirectory(kSaveTestDir);
+    SaveTestSeed(0x00C0FFEEu);
+
+    mgr.DeleteSave(0);
+    SAVE_ASSERT(!mgr.HasSave(0), "HasSave true before any Save");
+
+    SAVE_ASSERT(mgr.Save(0), "Save(0) failed");
+    SAVE_ASSERT(mgr.HasSave(0), "HasSave false after Save");
+    SAVE_ASSERT(!std::filesystem::exists(mgr.SlotPath(0) + ".tmp"), "temp file left behind after Save");
+
+    mgr.DeleteSave(0);
+    SAVE_ASSERT(!mgr.HasSave(0), "HasSave true after DeleteSave");
+
+    printf("[TEST] PASS: HasSave/DeleteSave behave correctly\n");
+    return TEST_PASS;
+}
+
+TestResult Test_SaveVersionReject(void) {
+    printf("[TEST] save-version-reject: Load refuses an unknown version without clobbering state (#35)\n");
+
+    rsbs::SaveManager& mgr = rsbs::SaveManager::Instance();
+    mgr.SetSaveDirectory(kSaveTestDir);
+    SaveTestSeed(0x11112222u);
+    mgr.DeleteSave(0);
+    SAVE_ASSERT(mgr.Save(0), "Save(0) failed");
+
+    // Corrupt only the version field (CRC covers the payload, not the header,
+    // so this isolates the version check).
+    SAVE_ASSERT(SaveTestPatchU32(mgr.SlotPath(0), offsetof(rsbs::RsbsSaveHeader, version), 0xFFFFu),
+                "could not patch version");
+
+    // Install distinct live state and prove Load leaves it untouched.
+    SaveTestSeed(0x33334444u);
+    gComboCtx.saveSlot = 0x0BADF00D;
+
+    SAVE_ASSERT(!mgr.Load(0), "Load accepted an unknown version");
+    SAVE_ASSERT(gComboCtx.saveSlot == 0x0BADF00D, "rejected Load clobbered ComboContext");
+    SAVE_ASSERT(SaveTestOoTShadowMatchesPattern(), "rejected Load clobbered OoT shadow");
+
+    mgr.DeleteSave(0);
+    printf("[TEST] PASS: unknown version rejected, live state intact\n");
+    return TEST_PASS;
+}
+
+TestResult Test_SaveSizeMismatch(void) {
+    printf("[TEST] save-size-mismatch: Load refuses a mismatched tier size without clobbering state (#35)\n");
+
+    rsbs::SaveManager& mgr = rsbs::SaveManager::Instance();
+    mgr.SetSaveDirectory(kSaveTestDir);
+    SaveTestSeed(0xAAAA5555u);
+    mgr.DeleteSave(0);
+    SAVE_ASSERT(mgr.Save(0), "Save(0) failed");
+
+    // Claim a different OoT tier size than this build expects.
+    SAVE_ASSERT(SaveTestPatchU32(mgr.SlotPath(0), offsetof(rsbs::RsbsSaveHeader, ootSize),
+                                 static_cast<uint32_t>(OOT_SAVE_CONTEXT_SIZE) + 4u),
+                "could not patch ootSize");
+
+    SaveTestSeed(0x66667777u);
+    gComboCtx.saveSlot = 0x0BADF00D;
+
+    SAVE_ASSERT(!mgr.Load(0), "Load accepted a mismatched tier size");
+    SAVE_ASSERT(gComboCtx.saveSlot == 0x0BADF00D, "rejected Load clobbered ComboContext");
+    SAVE_ASSERT(SaveTestOoTShadowMatchesPattern(), "rejected Load clobbered OoT shadow");
+
+    mgr.DeleteSave(0);
+    printf("[TEST] PASS: tier-size mismatch rejected, live state intact\n");
+    return TEST_PASS;
+}
+
+TestResult Test_SaveCrcCorrupt(void) {
+    printf("[TEST] save-crc-corrupt: Load refuses a corrupt payload without clobbering state (#35)\n");
+
+    rsbs::SaveManager& mgr = rsbs::SaveManager::Instance();
+    mgr.SetSaveDirectory(kSaveTestDir);
+    SaveTestSeed(0x0F0F0F0Fu);
+    mgr.DeleteSave(0);
+    SAVE_ASSERT(mgr.Save(0), "Save(0) failed");
+
+    SAVE_ASSERT(SaveTestFlipPayloadByte(mgr.SlotPath(0)), "could not flip payload byte");
+
+    SaveTestSeed(0xF0F0F0F0u);
+    gComboCtx.saveSlot = 0x0BADF00D;
+
+    SAVE_ASSERT(!mgr.Load(0), "Load accepted a corrupt payload");
+    SAVE_ASSERT(gComboCtx.saveSlot == 0x0BADF00D, "rejected Load clobbered ComboContext");
+    SAVE_ASSERT(SaveTestOoTShadowMatchesPattern(), "rejected Load clobbered OoT shadow");
+
+    mgr.DeleteSave(0);
+    printf("[TEST] PASS: corrupt payload rejected, live state intact\n");
+    return TEST_PASS;
+}


### PR DESCRIPTION
## What

Adds the **headless core** of Phase 2 T6 (#35): the unified cross-game save file (`.redsave`) and its `SaveManager`, with full headless unit coverage. The OoT/MM save-flow hooks (`OnSaveFile`/`OnLoadFile`) and the unified file-select panel are a deliberate **follow-up**, so this PR is fully CI-gated without ROMs (same strategy as the T3/T5/T4-headless work).

Part of Phase 2 (#259); unblocks T10 (#265, `combo/` removal) together with T8/T9.

## Format

`.redsave`, one file per slot, little-endian / host-native:

| Tier | Contents |
|---|---|
| 0 | `RsbsSaveHeader` â€” fixed 32 B: `REDSHIP1` magic, version, slot, per-tier sizes, CRC32 over the payload |
| 1 | `ComboContext` â€” cross-game flags / shared items / last game |
| 2 | OoT `SaveContext` (`OOT_SAVE_CONTEXT_SIZE` bytes) |
| 3 | MM `SaveContext` (`MM_SAVE_CONTEXT_SIZE` bytes) |

## SaveManager (`src/common/save.{h,cpp}`)

- `Save` / `Load` / `HasSave` / `DeleteSave`, a function-local-static singleton, and a `RsbsSave_*` C shim for the deferred game-side hooks.
- Serializes the **cross-game shadow copies the context layer already maintains** (`Context_GetOoTSaveContext` / `Context_GetMMSaveContext` / `gComboCtx`) and restores them via `Context_UpdateShadowCopy` â€” so it depends only on `src/common` and never on either game's `z64save.h`.
- **Atomic write** (temp file + `rename`) so a crash mid-write never leaves a half-written slot.
- **Fail-safe Load**: validates magic, version, endian, header size, each tier's byte length, the CRC32 over the payload, and the inner `ComboContext` magic â€” reading into locals first and committing to live state only after every check passes. A bad/old/corrupt file is refused without clobbering live state.

## Tests (headless, no ROMs / no display, label `redship`)

`src/common/tests/test_save_roundtrip.c`, `#included` into `test_runner.cpp` like the other C++ test files, registered as `redship --test` + CTest targets:

- `save-roundtrip-tiers` â€” byte-exact round-trip of all three tiers
- `save-header` â€” header fields well-formed + CRC verifies
- `save-has-delete` â€” `HasSave`/`DeleteSave` lifecycle, no temp left behind
- `save-version-reject` â€” unknown version refused, live state intact
- `save-size-mismatch` â€” mismatched tier size refused, live state intact
- `save-crc-corrupt` â€” corrupt payload refused, live state intact

## Scope / residual (out of this PR, tracked for the T6 follow-up)

- **No change to the shared `game.h` / `unified_save.c` / `context.cpp`.** The headless core round-trips the context-layer shadow buffers, sized at `game.h`'s `OOT_SAVE_CONTEXT_SIZE` (`0x1428`) / `MM_SAVE_CONTEXT_SIZE` â€” self-consistent with the existing freeze/restore contract (T3 #262).
- The pre-existing discrepancy between `game.h`'s `0x1428` and `unified_save.c`'s `0x22000` live OoT `gSaveContext` storage (existing freeze/restore already clamps OoT to `0x1428`) is **not** addressed here. The game-integration follow-up that wires real save hooks must decide how the full live OoT `SaveContext` maps through the shadow. Flagged so it is not lost.
- `SaveManager::SetSaveDirectory` defaults to `Save` relative to CWD for the headless tests; the follow-up injects the real per-app save directory.

## Verification

Fully exercised by the 6 new headless CTest targets under the `redship` label (the `integration-tests` job runs `ctest --label-regex ^redship$`). No ROMs required.

ðŸ¤– Generated with [Claude Code](https://claude.com/claude-code)


<!--- section:artifacts:start -->
### Build Artifacts
  - [rsbs-windows.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/7313625792.zip)
  - [rsbs-linux.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/7313582089.zip)
<!--- section:artifacts:end -->