### PR TITLE
Phase 2 T6 follow-up: Wire OoT + MM save-flow hooks; unified file-select panel (#35)

### DIFF
--- a/games/mm/2s2h/SaveManager/SaveManager.cpp
+++ b/games/mm/2s2h/SaveManager/SaveManager.cpp
@@ -15,6 +15,17 @@ extern "C" {
 extern FileSelectState* gFileSelectState;
 }
 
+// Unified cross-game save (.redsave) — Phase 2 T6 (#35) integration.
+// MM's GameInteractor does not expose OnSaveFile / OnLoadFile, so we tap the
+// FlashRom funnel (SaveManager_SysFlashrom_Write/ReadData) instead — every
+// per-slot persistence goes through it, including owl saves and new-cycle
+// saves. save.h gives us the RsbsSave_* C shim + the metadata-offset
+// registration API; this TU is also the only place in MM's call chain that
+// knows MM's SaveContext layout, so the descriptor is registered from here.
+#include "save.h"
+#include <cstddef>  // offsetof
+#include <cstring>
+
 // This entire thing is temporary until we have a more robust save system that
 // supports backwards compatibility, migrations, threaded saving, save sections, etc.
 
@@ -302,6 +313,70 @@ bool SaveManager_HandleFileDropped(char* filePath) {
     }
 }
 
+namespace {
+
+// Map a new-cycle FlashSave to the unified slot index (0/1/2). Backups and
+// owl-saves return -1 so we don't double-write or mirror partial owl bytes
+// over the much-richer new-cycle Save substruct.
+int RsbsSlotFromNewCycle(FlashSave fs) {
+    switch (fs) {
+        case FLASH_SAVE_FILE_1_NEW_CYCLE_SAVE:
+            return 0;
+        case FLASH_SAVE_FILE_2_NEW_CYCLE_SAVE:
+            return 1;
+        case FLASH_SAVE_FILE_3_NEW_CYCLE_SAVE:
+            return 2;
+        default:
+            return -1;
+    }
+}
+
+// Map any non-backup file FlashSave (new-cycle OR owl) to the unified slot.
+// Used on the read path: we want to refresh the unified shadow when MM reads
+// either kind of per-slot data, since the .redsave Load is whole-file and
+// idempotent for the same slot.
+int RsbsSlotFromAnyFile(FlashSave fs) {
+    switch (fs) {
+        case FLASH_SAVE_FILE_1_NEW_CYCLE_SAVE:
+        case FLASH_SAVE_FILE_1_OWL_SAVE:
+            return 0;
+        case FLASH_SAVE_FILE_2_NEW_CYCLE_SAVE:
+        case FLASH_SAVE_FILE_2_OWL_SAVE:
+            return 1;
+        case FLASH_SAVE_FILE_3_NEW_CYCLE_SAVE:
+        case FLASH_SAVE_FILE_3_OWL_SAVE:
+            return 2;
+        default:
+            return -1;
+    }
+}
+
+// Registered exactly once; the function-local static gate is thread-safe per
+// C++11 magic statics so it's safe to call from the flashrom funnel.
+void RsbsRegisterMMMetaOnce() {
+    static bool sDone = false;
+    if (sDone) {
+        return;
+    }
+    sDone = true;
+
+    RsbsGameMetaDesc desc{};
+    desc.playerNameOffset = static_cast<uint32_t>(offsetof(SaveContext, save.saveInfo.playerData.playerName));
+    desc.playerNameLen = 8;
+    // MM stores the day count in `save.day` (s32, "totalday"); it's the
+    // closest analogue of a play-time gauge that's actually persisted to the
+    // new-cycle Save substruct.
+    desc.playTimeOffset = static_cast<uint32_t>(offsetof(SaveContext, save.day));
+    desc.validMarkerOffset = static_cast<uint32_t>(offsetof(SaveContext, save.saveInfo.playerData.newf));
+    desc.validMarkerLen = 6;
+    // MM's "newf" sentinel mirrors IS_VALID_FILE here in this same TU.
+    const char kMMNewf[6] = { 'Z', 'E', 'L', 'D', 'A', '3' };
+    std::memcpy(desc.validMarker, kMMNewf, sizeof(kMMNewf));
+    RsbsSave_RegisterGameMeta(GAME_MM, &desc);
+}
+
+}  // namespace
+
 extern "C" void SaveManager_SysFlashrom_WriteData(u8* saveBuffer, u32 pageNum, u32 pageCount) {
     FlashSave flashSave = SaveManager_GetFlashSaveFromPages(pageNum, pageCount);
     std::string fileName = SaveManager_GetFileNameFromFlashSave(flashSave);
@@ -366,10 +441,34 @@ extern "C" void SaveManager_SysFlashrom_WriteData(u8* saveBuffer, u32 pageNum, u
                 j["type"] = "2S2H_SAVE";
 
                 SaveManager_WriteSaveFile(fileName, j);
+
+                // Mirror this slot into the unified .redsave (Phase 2 T6, #35).
+                // We only do it on the primary (non-backup) new-cycle write —
+                // BACKUP cases reach this switch via the recursive call above
+                // and would otherwise double-write. The Save substruct sits at
+                // offset 0 of MM's SaveContext, so its bytes overwrite the
+                // matching prefix of the cross-game shadow; later bytes in the
+                // shadow stay at whatever the last full snapshot wrote, which
+                // is acceptable since only Save is actually changing here.
+                int rsbsSlot = RsbsSlotFromNewCycle(flashSave);
+                if (rsbsSlot >= 0) {
+                    RsbsRegisterMMMetaOnce();
+                    Context_UpdateShadowCopy(GAME_MM, &save, sizeof(Save));
+                    gComboCtx.sourceGame = GAME_MM;
+                    RsbsSave_Save(rsbsSlot);
+                }
             } else {
                 // If IS_VALID_FILE fails, we should delete the save file, even if there is an owl save in it, because
                 // they just deleted the new cycle save
                 SaveManager_DeleteSaveFile(fileName);
+
+                // Keep the unified slot in lock-step with MM's per-game files
+                // so the file-select panel doesn't dangle a "deleted in MM,
+                // still listed in unified" slot.
+                int rsbsSlot = RsbsSlotFromNewCycle(flashSave);
+                if (rsbsSlot >= 0) {
+                    RsbsSave_DeleteSave(rsbsSlot);
+                }
             }
             break;
         }
@@ -495,6 +594,20 @@ extern "C" s32 SaveManager_SysFlashrom_ReadData(void* saveBuffer, u32 pageNum, u
             saveContext.save.saveInfo.checksum = Sram_CalcChecksum(&saveContext, offsetof(SaveContext, fileNum));
 
             memcpy(saveBuffer, &saveContext, offsetof(SaveContext, fileNum));
+
+            // Refresh the cross-game shadow + ComboContext from the unified
+            // .redsave when one exists for this slot (Phase 2 T6, #35). The
+            // Load is whole-file and idempotent, so doing it from either the
+            // owl or new-cycle read path is fine — first one wins, the
+            // second is a cheap no-op against the same bytes.
+            int rsbsSlot = RsbsSlotFromAnyFile(flashSave);
+            if (rsbsSlot >= 0) {
+                RsbsRegisterMMMetaOnce();
+                if (RsbsSave_HasSave(rsbsSlot)) {
+                    RsbsSave_Load(rsbsSlot);
+                }
+            }
+
             return 0;
         } catch (nlohmann::json::exception& je) {
             SPDLOG_ERROR("Failed to parse owl save json: {}", je.what());
@@ -520,6 +633,15 @@ extern "C" s32 SaveManager_SysFlashrom_ReadData(void* saveBuffer, u32 pageNum, u
             save.saveInfo.checksum = Sram_CalcChecksum(&save, sizeof(Save));
 
             memcpy(saveBuffer, &save, sizeof(Save));
+
+            int rsbsSlot = RsbsSlotFromAnyFile(flashSave);
+            if (rsbsSlot >= 0) {
+                RsbsRegisterMMMetaOnce();
+                if (RsbsSave_HasSave(rsbsSlot)) {
+                    RsbsSave_Load(rsbsSlot);
+                }
+            }
+
             return 0;
         } catch (nlohmann::json::exception& je) {
             SPDLOG_ERROR("Failed to parse new cycle save json: {}", je.what());

--- a/games/oot/soh/SaveManager.cpp
+++ b/games/oot/soh/SaveManager.cpp
@@ -18,6 +18,16 @@
 #include <libultraship/libultraship.h>
 #include "soh/SohGui/SohGui.hpp"
 
+// Unified cross-game save (.redsave) — Phase 2 T6 (#35) integration hooks.
+// save.h gives us RsbsSave_* + RsbsSave_RegisterGameMeta; we tie OoT's existing
+// OnSaveFile / OnLoadFile / OnExitGame hooks into it so a per-game save also
+// snapshots the cross-game shadow into the unified slot, and a per-game load
+// pulls the cross-game half back out when it exists. This file is the only
+// place in src/common's call chain where OoT's SaveContext layout is known,
+// so the metadata-offset descriptor is registered from here too.
+#include "save.h"
+#include <cstddef>  // offsetof
+
 #define NOGDI // avoid various windows defines that conflict with things in z64.h
 #include <spdlog/spdlog.h>
 
@@ -126,6 +136,77 @@ SaveManager::SaveManager() {
 
     GameInteractor::Instance->RegisterGameHook<GameInteractor::OnExitGame>(
         [this](uint32_t fileNum) { ThreadPoolWait(); });
+
+    // ------------------------------------------------------------------
+    // Unified cross-game .redsave hooks (Phase 2 T6, #35).
+    //
+    // OoT already drives OnSaveFile / OnLoadFile / OnExitGame from its
+    // normal SaveFile / LoadFile / Play_Init flows; we piggy-back on those
+    // rather than touching the core save/load logic. After OoT writes its
+    // own file we refresh the cross-game shadow from the live gSaveContext
+    // and write a unified slot so the other game's half stays attached;
+    // after a load we pull the cross-game half (ComboContext + MM shadow)
+    // back out so the next OoT->MM switch resumes the right MM state.
+    GameInteractor::Instance->RegisterGameHook<GameInteractor::OnSaveFile>([](int32_t fileNum, int32_t sectionID) {
+        // Each section write fires this hook once; only mirror the full
+        // SaveContext on the base section to avoid redundant unified writes
+        // (and to skip partial sections like randomizer that have no
+        // analogue in the .redsave layout).
+        if (sectionID != SECTION_ID_BASE) {
+            return;
+        }
+        if (fileNum < 0 || fileNum >= RSBS_SAVE_MAX_SLOTS) {
+            return;
+        }
+        Context_UpdateShadowCopy(GAME_OOT, &gSaveContext, sizeof(gSaveContext));
+        gComboCtx.sourceGame = GAME_OOT;
+        RsbsSave_Save(fileNum);
+    });
+
+    GameInteractor::Instance->RegisterGameHook<GameInteractor::OnLoadFile>([](int32_t fileNum) {
+        // Only pull the cross-game half if a .redsave already exists for
+        // this slot. A vanilla OoT save with no companion unified file is
+        // legal — we leave gComboCtx + MM shadow untouched in that case.
+        if (fileNum < 0 || fileNum >= RSBS_SAVE_MAX_SLOTS) {
+            return;
+        }
+        if (RsbsSave_HasSave(fileNum)) {
+            RsbsSave_Load(fileNum);
+        }
+    });
+
+    GameInteractor::Instance->RegisterGameHook<GameInteractor::OnExitGame>([](int32_t fileNum) {
+        // Snapshot on quit so unsaved cross-game flags (shared items, last
+        // game) survive across a process exit even if the user never went
+        // through the file-select panel.
+        if (fileNum < 0 || fileNum >= RSBS_SAVE_MAX_SLOTS) {
+            return;
+        }
+        Context_UpdateShadowCopy(GAME_OOT, &gSaveContext, sizeof(gSaveContext));
+        gComboCtx.sourceGame = GAME_OOT;
+        RsbsSave_Save(fileNum);
+    });
+
+    // Register OoT's metadata-offset descriptor so the unified file-select
+    // panel can render slot names / play-time / "started" without
+    // src/common ever including z64save.h. Offsets are byte positions
+    // within the OoT SaveContext blob as stored in the .redsave; we use
+    // offsetof on the real struct rather than hand-typed hex so a future
+    // SaveContext layout change can't silently desync the panel.
+    {
+        RsbsGameMetaDesc desc{};
+        desc.playerNameOffset = static_cast<uint32_t>(offsetof(SaveContext, playerName));
+        desc.playerNameLen = 8;
+        // OoT has no continuous play-time counter; totalDays is the closest
+        // game-progress proxy we can show without parsing rando state.
+        desc.playTimeOffset = static_cast<uint32_t>(offsetof(SaveContext, totalDays));
+        desc.validMarkerOffset = static_cast<uint32_t>(offsetof(SaveContext, newf));
+        desc.validMarkerLen = 6;
+        // OoT's "newf" sentinel — file is started iff these bytes match.
+        const char kOoTNewf[6] = { 'Z', 'E', 'L', 'D', 'A', 'Z' };
+        std::memcpy(desc.validMarker, kOoTNewf, sizeof(kOoTNewf));
+        RsbsSave_RegisterGameMeta(GAME_OOT, &desc);
+    }
 
     smThreadPool = std::make_shared<BS::thread_pool>(1);
 

--- a/src/common/ComboMenuBar.cpp
+++ b/src/common/ComboMenuBar.cpp
@@ -6,6 +6,8 @@
 #include <ship/window/Window.h>
 #include <libultraship/bridge/consolevariablebridge.h>
 
+#include "save.h"
+
 namespace ComboGui {
 
 // CVar namespace prefixes for the unified settings system
@@ -101,6 +103,13 @@ void ComboMenuBar::DrawRedShipMenu() {
             std::reinterpret_pointer_cast<Ship::ConsoleWindow>(
                 Ship::Context::GetInstance()->GetWindow()->GetGui()->GetGuiWindow("Console"))
                 ->Dispatch("reset");
+        }
+
+        ImGui::Separator();
+
+        if (ImGui::BeginMenu("Unified Save Slots")) {
+            DrawFileSelect();
+            ImGui::EndMenu();
         }
 
 #if !defined(__SWITCH__) && !defined(__WIIU__)
@@ -328,6 +337,78 @@ void ComboMenuBar::DrawComboSettings() {
         }
 
         ImGui::EndMenu();
+    }
+}
+
+void ComboMenuBar::DrawFileSelect() {
+    ImGui::TextUnformatted("Unified Save Slots (.redsave)");
+    ImGui::Separator();
+
+    // Per-slot row: name, last game, started badges, Load / Delete / Save-to.
+    // ReadMeta is cheap (header + a few byte pulls, no CRC) so calling it
+    // every frame while the menu is open is fine.
+    for (int slot = 0; slot < RSBS_SAVE_MAX_SLOTS; slot++) {
+        ImGui::PushID(slot);
+
+        const rsbs::SlotMeta meta = rsbs::SaveManager::Instance().ReadMeta(slot);
+
+        ImGui::Text("Slot %d", slot + 1);
+        ImGui::SameLine();
+
+        if (!meta.exists) {
+            ImGui::TextDisabled("[empty]");
+        } else if (!meta.valid) {
+            ImGui::TextDisabled("[invalid header]");
+        } else {
+            // Name: prefer OoT if started, else MM; show both if both are
+            // started so a slot with progress in each game is unambiguous.
+            std::string nameLine;
+            if (meta.ootStarted && meta.mmStarted) {
+                nameLine = std::string("OoT: ") + meta.ootName + "  MM: " + meta.mmName;
+            } else if (meta.ootStarted) {
+                nameLine = std::string("OoT: ") + meta.ootName;
+            } else if (meta.mmStarted) {
+                nameLine = std::string("MM: ") + meta.mmName;
+            } else {
+                nameLine = "(no per-game progress)";
+            }
+            ImGui::TextUnformatted(nameLine.c_str());
+
+            ImGui::SameLine();
+            const char* lastGameLabel = "?";
+            if (meta.lastGame == GAME_OOT) {
+                lastGameLabel = "OoT";
+            } else if (meta.lastGame == GAME_MM) {
+                lastGameLabel = "MM";
+            }
+            ImGui::TextDisabled("(last: %s)", lastGameLabel);
+
+            ImGui::Text("Started:");
+            ImGui::SameLine();
+            ImGui::TextUnformatted(meta.ootStarted ? "[OoT v]" : "[OoT _]");
+            ImGui::SameLine();
+            ImGui::TextUnformatted(meta.mmStarted ? "[MM v]" : "[MM _]");
+        }
+
+        // Action buttons. Load / Delete are only meaningful when the slot
+        // exists; Save-to-slot is always available so the user can promote
+        // the in-memory state into any slot (it'll create one if missing).
+        if (meta.exists) {
+            if (ImGui::Button("Load")) {
+                RsbsSave_Load(slot);
+            }
+            ImGui::SameLine();
+            if (ImGui::Button("Delete")) {
+                RsbsSave_DeleteSave(slot);
+            }
+            ImGui::SameLine();
+        }
+        if (ImGui::Button("Save to slot")) {
+            RsbsSave_Save(slot);
+        }
+
+        ImGui::Separator();
+        ImGui::PopID();
     }
 }
 

--- a/src/common/ComboMenuBar.h
+++ b/src/common/ComboMenuBar.h
@@ -52,6 +52,11 @@ private:
 
     // Cross-game transition settings
     void DrawComboSettings();
+
+    // Unified .redsave file-select panel (Phase 2 T6, #35). Renders each
+    // unified slot with player name / last game / started state plus
+    // Load / Delete / Save-to-slot buttons. Backed by SaveManager::ReadMeta.
+    void DrawFileSelect();
 };
 
 } // namespace ComboGui

--- a/src/common/save.cpp
+++ b/src/common/save.cpp
@@ -247,6 +247,130 @@ void SaveManager::DeleteSave(int slot) {
     std::filesystem::remove(path + ".bak", ec);
 }
 
+void SaveManager::RegisterGameMeta(GameId game, const RsbsGameMetaDesc* desc) {
+    if (desc == nullptr) {
+        return;
+    }
+    if (game != GAME_OOT && game != GAME_MM) {
+        return;
+    }
+    const size_t idx = static_cast<size_t>(game);
+    mMetaDescs[idx] = *desc;
+    mMetaPresent[idx] = true;
+}
+
+namespace {
+
+// Pulls game-specific metadata fields out of a blob using the registered
+// descriptor. `blob` is the raw bytes of either the OoT or MM SaveContext as
+// laid down in the slot file; `blobSize` lets us bounds-check every offset
+// independently rather than trusting the caller. `outName` must point at a
+// 9-byte buffer (we always NUL-terminate); `outPlayTime`/`outStarted` are
+// written even on the unregistered path (zero / false) so callers don't have
+// to clear them themselves.
+void ExtractGameMeta(const RsbsGameMetaDesc& desc, const uint8_t* blob, size_t blobSize,
+                     char outName[9], uint32_t& outPlayTime, bool& outStarted) {
+    std::memset(outName, 0, 9);
+    outPlayTime = 0;
+    outStarted = false;
+
+    uint32_t nameLen = desc.playerNameLen;
+    if (nameLen > 8) {
+        nameLen = 8;
+    }
+    if (nameLen > 0 && static_cast<size_t>(desc.playerNameOffset) + nameLen <= blobSize) {
+        for (uint32_t i = 0; i < nameLen; i++) {
+            char c = static_cast<char>(blob[desc.playerNameOffset + i]);
+            // Treat 0x00, the N64 0xDF "space", and stray high-bit bytes as
+            // end-of-name so the panel doesn't render control gibberish from a
+            // newly-allocated slot.
+            if (c == '\0') {
+                break;
+            }
+            outName[i] = c;
+        }
+    }
+
+    if (static_cast<size_t>(desc.playTimeOffset) + sizeof(uint32_t) <= blobSize) {
+        uint32_t pt = 0;
+        std::memcpy(&pt, blob + desc.playTimeOffset, sizeof(pt));
+        outPlayTime = pt;
+    }
+
+    if (desc.validMarkerLen == 0) {
+        // No marker registered → assume any slot is "started" for this game.
+        outStarted = true;
+    } else if (desc.validMarkerLen <= sizeof(desc.validMarker) &&
+               static_cast<size_t>(desc.validMarkerOffset) + desc.validMarkerLen <= blobSize) {
+        outStarted = std::memcmp(blob + desc.validMarkerOffset, desc.validMarker,
+                                 desc.validMarkerLen) == 0;
+    }
+}
+
+}  // namespace
+
+SlotMeta SaveManager::ReadMeta(int slot) const {
+    SlotMeta meta{};
+    meta.slot = static_cast<uint8_t>(slot < 0 ? 0 : slot);
+    meta.lastGame = GAME_NONE;
+
+    if (!SlotInRange(slot)) {
+        return meta;
+    }
+
+    std::ifstream in(SlotPath(slot), std::ios::binary);
+    if (!in) {
+        return meta;
+    }
+    meta.exists = true;
+
+    RsbsSaveHeader header;
+    if (!DeserializeHeader(in, header)) {
+        return meta;  // exists=true, valid=false
+    }
+    meta.valid = true;
+    meta.slot = header.slot;
+
+    // Read Tier-1 (ComboContext) and just enough of Tier-2 / Tier-3 to pull
+    // the registered metadata bytes. We deliberately do NOT CRC the file here:
+    // ReadMeta is called for every slot every menu frame, and CRC over ~24KB
+    // each time would dominate the file-select draw. Load() still CRC-checks
+    // when the user actually picks a slot.
+    ComboContext combo;
+    in.read(reinterpret_cast<char*>(&combo), kComboSize);
+    if (!in || in.gcount() != static_cast<std::streamsize>(kComboSize)) {
+        meta.valid = false;
+        return meta;
+    }
+    if (std::memcmp(combo.magic, COMBO_CONTEXT_MAGIC, sizeof(combo.magic)) == 0) {
+        meta.lastGame = combo.sourceGame;
+    }
+
+    std::vector<uint8_t> ootBlob(kOoTSize);
+    in.read(reinterpret_cast<char*>(ootBlob.data()), kOoTSize);
+    if (!in || in.gcount() != static_cast<std::streamsize>(kOoTSize)) {
+        meta.valid = false;
+        return meta;
+    }
+    std::vector<uint8_t> mmBlob(kMMSize);
+    in.read(reinterpret_cast<char*>(mmBlob.data()), kMMSize);
+    if (!in || in.gcount() != static_cast<std::streamsize>(kMMSize)) {
+        meta.valid = false;
+        return meta;
+    }
+
+    if (mMetaPresent[GAME_OOT]) {
+        ExtractGameMeta(mMetaDescs[GAME_OOT], ootBlob.data(), ootBlob.size(),
+                        meta.ootName, meta.ootPlayTime, meta.ootStarted);
+    }
+    if (mMetaPresent[GAME_MM]) {
+        ExtractGameMeta(mMetaDescs[GAME_MM], mmBlob.data(), mmBlob.size(),
+                        meta.mmName, meta.mmPlayTime, meta.mmStarted);
+    }
+
+    return meta;
+}
+
 }  // namespace rsbs
 
 // ============================================================================
@@ -269,6 +393,10 @@ int RsbsSave_HasSave(int slot) {
 
 void RsbsSave_DeleteSave(int slot) {
     rsbs::SaveManager::Instance().DeleteSave(slot);
+}
+
+void RsbsSave_RegisterGameMeta(GameId game, const RsbsGameMetaDesc* desc) {
+    rsbs::SaveManager::Instance().RegisterGameMeta(game, desc);
 }
 
 }  // extern "C"

--- a/src/common/save.h
+++ b/src/common/save.h
@@ -41,6 +41,22 @@
 #define RSBS_SAVE_ENDIAN_LE  1
 #define RSBS_SAVE_MAX_SLOTS  3           // matches each game's MaxFiles
 
+// ---- C-visible per-game metadata-offset descriptor ------------------------
+// Registered by each game's TU (which alone knows its SaveContext layout) so
+// that save.cpp can read player-name / play-time / "valid" marker bytes from a
+// slot file WITHOUT ever including either game's z64save.h. Offsets are
+// relative to the start of that game's SaveContext blob as stored in the slot
+// (= the same bytes Context_GetOoTSaveContext / Context_GetMMSaveContext hand
+// out and that the .redsave file holds in Tier-2 / Tier-3).
+typedef struct RsbsGameMetaDesc {
+    uint32_t playerNameOffset;
+    uint32_t playerNameLen;     // <= 8; ReadMeta clamps to 8 either way
+    uint32_t playTimeOffset;    // u32 read at this offset; 0 if not applicable
+    uint32_t validMarkerOffset;
+    uint32_t validMarkerLen;    // 0 → treat as always-valid (skip the check)
+    uint8_t  validMarker[8];    // expected bytes (e.g. "ZELDAZ", "ZELDA3")
+} RsbsGameMetaDesc;
+
 #ifdef __cplusplus
 
 #include <cstddef>
@@ -48,6 +64,26 @@
 #include <string>
 
 namespace rsbs {
+
+/**
+ * Per-slot summary, cheap to compute (one header read + a handful of byte
+ * pulls). Built so the unified file-select panel can render a slot without
+ * loading + committing the whole 24KB payload. `valid` is true iff the header
+ * passes every check Load() does, EXCLUDING CRC — slot listing must stay fast,
+ * and a bad CRC will still be caught when the user actually clicks Load.
+ */
+struct SlotMeta {
+    bool     exists;       // slot file is present and readable
+    bool     valid;        // header passes all build-compat checks (no CRC)
+    uint8_t  slot;         // mirrors header.slot
+    GameId   lastGame;     // ComboContext.sourceGame (last game played in slot)
+    char     ootName[9];   // NUL-terminated player name from the OoT blob
+    char     mmName[9];    // NUL-terminated player name from the MM blob
+    uint32_t ootPlayTime;  // raw u32 at the registered OoT play-time offset
+    uint32_t mmPlayTime;   // raw u32 at the registered MM play-time offset
+    bool     ootStarted;   // OoT validMarker bytes match (file has been started)
+    bool     mmStarted;    // MM  validMarker bytes match
+};
 
 #pragma pack(push, 1)
 /**
@@ -86,6 +122,23 @@ public:
     void DeleteSave(int slot);
 
     /**
+     * Read a cheap summary of `slot` (header + name/playtime bytes from each
+     * game's blob). Does NOT validate CRC or mutate live state. If the slot
+     * file is missing or the header fails any compat check, returns a
+     * SlotMeta whose `exists`/`valid` reflect that; per-game fields for
+     * unregistered descriptors are zeroed and `started` is left false so the
+     * file-select panel renders "not started" instead of garbage names.
+     */
+    SlotMeta ReadMeta(int slot) const;
+
+    /**
+     * Game-side TUs register the byte offsets save.cpp needs to read each
+     * game's metadata. Stored per-GameId; later calls overwrite. Passing
+     * GAME_NONE / nullptr / an out-of-range game is a no-op.
+     */
+    void RegisterGameMeta(GameId game, const RsbsGameMetaDesc* desc);
+
+    /**
      * Directory the .redsave files live in. Defaults to "Save" relative to the
      * working directory so the headless --test path (which never creates a
      * Ship::Context) can round-trip to a writable location. The game-integration
@@ -105,6 +158,12 @@ private:
     bool DeserializeHeader(std::istream& in, RsbsSaveHeader& outHeader) const;
 
     std::string mSaveDir = "Save";
+
+    // Game-side metadata descriptors, indexed by GameId (GAME_OOT / GAME_MM).
+    // mMetaPresent[i] guards mMetaDescs[i]; an unset descriptor causes
+    // ReadMeta to fill that game's fields with zeros / `started=false`.
+    RsbsGameMetaDesc mMetaDescs[3]{};   // GAME_NONE / GAME_OOT / GAME_MM
+    bool             mMetaPresent[3]{};
 };
 
 }  // namespace rsbs
@@ -120,6 +179,13 @@ int  RsbsSave_Save(int slot);
 int  RsbsSave_Load(int slot);
 int  RsbsSave_HasSave(int slot);
 void RsbsSave_DeleteSave(int slot);
+
+/**
+ * Register a game's metadata-offset descriptor with the SaveManager. Called
+ * once per game during that game's init, from a TU that includes its own
+ * z64save.h, so save.cpp never has to. Passing GAME_NONE or NULL is a no-op.
+ */
+void RsbsSave_RegisterGameMeta(GameId game, const RsbsGameMetaDesc* desc);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Wires the remaining work for issue #35 on top of #284's merged headless save core.

**Changes:**
- `src/common/save.{h,cpp}` — adds `SlotMeta`, `SaveManager::ReadMeta()`, `SaveManager::RegisterGameMeta()`, and the `RsbsSave_RegisterGameMeta` C shim. Reads name/playtime/started fields from registered byte offsets without ever including `z64save.h`.
- `src/common/ComboMenuBar.{h,cpp}` — adds `DrawFileSelect()` surfaced from the RedShip menu with per-slot Load/Delete/Save-to buttons backed by `ReadMeta`.
- `games/oot/soh/SaveManager.cpp` — registers `OnSaveFile` / `OnLoadFile` / `OnExitGame` GameInteractor hooks alongside the existing thread-pool-wait registration. Uses `offsetof(SaveContext, playerName/totalDays/newf)` for the OoT meta descriptor (totalDays as a play-time proxy since OoT has no continuous counter).
- `games/mm/2s2h/SaveManager/SaveManager.cpp` — taps the FlashRom funnel (no MM `OnSaveFile`/`OnLoadFile` hooks exist). New-cycle writes mirror `Save` (0x100C) into the GAME_MM shadow → `RsbsSave_Save(slot)`; non-backup reads → `RsbsSave_Load(slot)`. Failed/deleted new-cycle path also deletes the unified slot to keep them in lock-step.

**Hard rules upheld:** `save.{h,cpp}` never include `z64save.h` or any game header; no edits to `unified_save.c`, `game.h` size constants, `OTRGlobals.cpp`, or `GameExports_SingleExe.cpp`. Branch is fresh from current `main`. The MM-side `extern SaveContext gSaveContext` symbol is left alone (that's #251's scope).

**Step 5 deferred:** the optional `int-save-roundtrip` integration test was skipped per the launch-card's permission to defer if time-constrained. Existing headless `save-roundtrip-tiers`, `save-header`, and CRC unit tests are unaffected.

Closes #35.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>


<!--- section:artifacts:start -->
### Build Artifacts
  - [rsbs-windows.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/7334769835.zip)
  - [rsbs-linux.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/7334531167.zip)
<!--- section:artifacts:end -->