### PR TITLE
Build/toolchain: GCC 16 distro coverage (#287) + Windows CI investigation (#177)

### DIFF
--- a/.github/workflows/generate-builds.yml
+++ b/.github/workflows/generate-builds.yml
@@ -325,6 +325,18 @@ jobs:
         path: deps
 
   build-windows:
+    # Issue #177 — investigation results (2026-06-01, runs 26731031162 / 26731511201 / 26731832242):
+    #   * sccache hit rate: 99.82% (2848 hits / 2853 executed / 5 misses) — the cache works.
+    #   * CMake configure: 73-114s (vcpkg bootstrap + install, mostly binary-cache hits).
+    #   * CMake build: ~474s wall-clock with 2860 ninja steps → ~165ms per step.
+    #     With 99.8% cache hits, those 165ms are NOT compilation — they are sccache+cl.exe
+    #     process spawn overhead per cache lookup on a 4-vCPU windows-latest runner.
+    #   * vcpkg folder cache hits; x-gha vcpkg binary cache hits; lld-link engaged.
+    # Conclusion: every safe lever (sccache, vcpkg binary cache, vcpkg folder cache, lld-link,
+    # split steps for diagnostics) is already pulled. Further wins would require either
+    # CMAKE_UNITY_BUILD (high blast radius across game CMakeLists), moving off MSVC,
+    # or a larger runner. None fit a low-risk CI tuning change. The Linux/Windows gap is
+    # the fundamental Windows MSVC + ninja per-step process-spawn cost, not a config bug.
     needs: generate-rsbs-otr
     runs-on: windows-latest
     env:
@@ -390,6 +402,12 @@ jobs:
       run: |
         $env:PATH="$env:USERPROFILE/.cargo/bin;$env:PATH"
         cmake -S . -B bw -G Ninja -DCMAKE_MAKE_PROGRAM=ninja -DCMAKE_BUILD_TYPE:STRING=Release -DCMAKE_C_COMPILER_LAUNCHER=sccache -DCMAKE_CXX_COMPILER_LAUNCHER=sccache -DBUILD_REMOTE_CONTROL=1 -DREDSHIP_BUILD_SHARED=ON -DUSE_LLD_LINKER=ON
+    # Zero sccache stats before the build so the post-build "show-stats" reflects
+    # ONLY this run's cache deltas (without it, hendrikmuhs/ccache-action reports
+    # lifetime stats including the previous run that warmed the cache, which can
+    # mislead diagnosis of issue #177-style questions about *this* run's hit rate).
+    - name: Zero sccache stats
+      run: sccache --zero-stats
     - name: CMake build (Windows)
       env:
         VCPKG_ROOT: ${{github.workspace}}/vcpkg

--- a/.github/workflows/test-builds-on-distros.yml
+++ b/.github/workflows/test-builds-on-distros.yml
@@ -7,9 +7,14 @@ concurrency:
 jobs:
   build:
     strategy:
+      # fedora:rawhide and archlinux:base/opensuse:tumbleweed are rolling — they pick up the
+      # newest GCC (GCC 16+ as of 2026-Q2). Issue #287 / upstream SOH #6601: ensures the
+      # redship single-exe target is actually exercised under GCC 16, which the fixed-version
+      # distros below (fedora:39, ubuntu:mantic, debian:bookworm) still cannot do.
+      fail-fast: false
       matrix:
-        image: ["archlinux:base", "opensuse/tumbleweed:latest", "ubuntu:mantic", "debian:bookworm", "fedora:39"]
-        cc: ["gcc", "clang"] 
+        image: ["archlinux:base", "opensuse/tumbleweed:latest", "ubuntu:mantic", "debian:bookworm", "fedora:39", "fedora:rawhide"]
+        cc: ["gcc", "clang"]
         include:
         - cxx: g++
           cc: gcc
@@ -27,12 +32,12 @@ jobs:
         pacman -Syu --noconfirm
         pacman -S --noconfirm ${{ matrix.cc }} git cmake ninja lsb-release sdl2 libpng libzip nlohmann-json tinyxml2 spdlog sdl2_net
     - name: Install dependencies (dnf)
-      if: ${{ matrix.image == 'fedora:39' }}
+      if: ${{ matrix.image == 'fedora:39' || matrix.image == 'fedora:rawhide' }}
       run: |
         echo fedora
-        echo dnf install ${{ matrix.cc }} ${{ (matrix.cxx == 'g++' && 'gcc-c++') || '' }} wget git cmake ninja-build lsb_release SDL2-devel libpng-devel libzip-devel libzip-tools tinyxml2-devel spdlog-devel
+        echo dnf install ${{ matrix.cc }} ${{ (matrix.cxx == 'g++' && 'gcc-c++') || '' }} wget git cmake ninja-build lsb_release SDL2-devel libpng-devel libzip-devel libzip-tools tinyxml2-devel spdlog-devel nlohmann-json-devel
         dnf -y upgrade
-        dnf -y install ${{ matrix.cc }} ${{ (matrix.cxx == 'g++' && 'gcc-c++') || '' }} wget git cmake ninja-build lsb_release SDL2-devel libpng-devel libzip-devel libzip-tools tinyxml2-devel spdlog-devel
+        dnf -y install ${{ matrix.cc }} ${{ (matrix.cxx == 'g++' && 'gcc-c++') || '' }} wget git cmake ninja-build lsb_release SDL2-devel libpng-devel libzip-devel libzip-tools tinyxml2-devel spdlog-devel nlohmann-json-devel
     - name: Install dependencies (apt)
       if: ${{ matrix.image == 'ubuntu:mantic' || matrix.image == 'debian:bookworm' }}
       run: |
@@ -62,6 +67,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
+    - name: Print compiler version
+      run: |
+        ${{ matrix.cc }} --version
+        ${{ matrix.cxx }} --version
     - name: Build SoH
       run: |
         export PATH="/usr/lib/ccache:/usr/local/opt/ccache/libexec:$PATH"


### PR DESCRIPTION
Two issues addressed on one branch.

### Issue #287 — Port SOH #6601 GCC 16 build fixes

**Submodule:** kept at `d11cc8c4` deliberately. SOH #6601 bumped libultraship to `f30fe0ed`, which is on a *divergent* branch (not an ancestor of `d11cc8c4`). The three GCC-16 fixes (`ce717512` ODR, `d93b9e0f` heap singleton, `43b24444` MSVC release debug-info) are already in `d11cc8c4`, plus the `allowOverwrite` commit and shared-graphics changes the repo depends on. Bumping would have rewound those.

**CMake:** already `CXX_STANDARD 20` + `C_STANDARD 23`. No flag changes needed for GCC 16.

**Distro matrix:** added `fedora:rawhide` to `test-builds-on-distros.yml` (rolling distro picks up GCC 16+), added `fail-fast: false`, extended the dnf install step to cover rawhide with `nlohmann-json-devel`, and moved "Print compiler version" to after install so it works for every matrix entry.

The consumer-side soh/ patches in SOH #6601 (e.g. missing `<functional>` / `<set>` includes, Fast3dGui API churn) live in `games/oot/soh/...` — outside this stream's touch-ONLY list. Filed as `claude/6601-consumer-includes` follow-up.

### Issue #177 — Windows CI build time investigation

**Conclusion: no safe win left.** Across 3 recent runs:

| step | T6 push | T10 PR | T10 push |
|---|---|---|---|
| CMake configure | 73s | 77s | 114s |
| CMake build | 501s | 474s | 474s |
| Total Windows job | 12m37s | 11m9s | 13m |

sccache stats (T10 push): 99.82% hit (2848/2853 compile requests). Only 5 actual MSVC compilations ran. The 7m54s build time is process-spawn overhead on 2860 ninja steps × ~165ms each on a 4-vCPU `windows-latest` runner. lld-link engaged on the final link.

Every CI/CMake-side lever (sccache, x-gha vcpkg binary cache, vcpkg folder cache, lld-link, split steps for diagnostics) is already pulled. Pushing below ~7–8 min would need `CMAKE_UNITY_BUILD` (large blast radius across game CMakeLists), moving off MSVC, or a larger runner — none are minimal/measurable.

**Applied:** documented the finding as a top-of-job comment block on `build-windows` so future investigations don't repeat the dig, and added a `sccache --zero-stats` step before the build so post-build show-stats reports this run's deltas rather than cumulative.

Closes #287, #177.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>


<!--- section:artifacts:start -->
### Build Artifacts
  - [rsbs-windows.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/7334747754.zip)
  - [rsbs-linux.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/7334510176.zip)
<!--- section:artifacts:end -->