### PR TITLE
Fix segfault on quit: reset sohFast3dWindow in DeinitOTR (#233)

### DIFF
--- a/games/oot/soh/OTRGlobals.cpp
+++ b/games/oot/soh/OTRGlobals.cpp
@@ -1622,6 +1622,7 @@ extern "C" void DeinitOTR() {
     // Destroying gui here because we have shared ptrs to LUS objects which output to SPDLOG which is destroyed before
     // these shared ptrs.
     SohGui::Destroy();
+    sohFast3dWindow = nullptr;
 
     OTRGlobals::Instance->context = nullptr;
 }


### PR DESCRIPTION
Closes #233.

Ports upstream SOH commit [`79d6f54be`](https://github.com/HarbourMasters/Shipwright/commit/79d6f54be) (SOH PR HarbourMasters/Shipwright#6212): adds `sohFast3dWindow = nullptr;` immediately after `SohGui::Destroy();` inside `DeinitOTR()` so the file-scope `Fast::Fast3dWindow` shared_ptr is released during the controlled teardown sequence rather than at static destruction time, fixing the segfault on quit.

One-line change to `games/oot/soh/OTRGlobals.cpp`, identical to the upstream diff (the `sohFast3dWindow` variable landed here via PR #250 / SOH #5892).

Per the lane plan, this PR closes on CI green + code-port evidence; the manual test-criteria items on #233 (Valgrind, window-close button, cross-game-switch-then-quit feel) roll into the #212 verification carve-out.

Lane 6 (epic #202), OTRGlobals chain PR 1 of 4 (#233 → #231 → #232 → #211).

https://claude.ai/code/session_01Uf2rVASuZtYqYjGSyqYLJS

---
_Generated by [Claude Code](https://claude.ai/code/session_01Uf2rVASuZtYqYjGSyqYLJS)_

<!--- section:artifacts:start -->
### Build Artifacts
  - [rsbs-windows.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/7545798978.zip)
  - [rsbs-linux.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/7545569352.zip)
<!--- section:artifacts:end -->