### PR TITLE
Fix soh.o2r version detection: pass bare filename to DetectOTRVersion (#231)

### DIFF
--- a/games/oot/soh/OTRGlobals.cpp
+++ b/games/oot/soh/OTRGlobals.cpp
@@ -342,7 +342,7 @@ OTRGlobals::OTRGlobals() {
     context = Ship::Context::CreateUninitializedInstance("Ship of Harkinian", appShortName, "shipofharkinian.json");
 
     portArchivePath = Ship::Context::LocateFileAcrossAppDirs("soh.o2r");
-    OTRVersion portArchiveVersion = DetectOTRVersion(portArchivePath, false);
+    OTRVersion portArchiveVersion = DetectOTRVersion("soh.o2r", false);
     sohArchiveVersionMatch = portArchiveVersion.major == OoT_gBuildVersionMajor &&
                              portArchiveVersion.minor == OoT_gBuildVersionMinor &&
                              portArchiveVersion.patch == OoT_gBuildVersionPatch;


### PR DESCRIPTION
Closes #231.

Ports upstream SOH commit [`35039565d`](https://github.com/HarbourMasters/Shipwright/commit/35039565d) (SOH PR HarbourMasters/Shipwright#6168): `OTRGlobals.cpp:345` passed the already-resolved `portArchivePath` into `DetectOTRVersion()`, but `DetectOTRVersion()` (line 1477) calls `Ship::Context::LocateFileAcrossAppDirs(fileName, appShortName)` on its argument itself — so it needs the bare `"soh.o2r"` filename, not a full path. Double-resolving made the version probe miss the archive.

One-line change, identical to the upstream diff.

Issue criteria mapping:
- **Version match passes** — `sohArchiveVersionMatch` now compares against the correctly located archive's version record.
- **Mismatch → "soh.o2r is outdated"** — `RunExtract`'s `ES_PORT_ARCHIVE` popup logic unchanged and reachable: title selects `"soh.o2r is outdated"` when the file exists but versions differ.
- **Missing file graceful** — `DetectOTRVersion` returns the `{INT16_MAX, INT16_MAX, INT16_MAX}` sentinel when the archive doesn't exist; the popup path selects `"Missing soh.o2r"`.

Note: the 2026-06-01 triage comment on #231 suggested this was verify-and-close; it is not — main still had the pre-fix call (verified at `b4b218f4`).

Lane 6 (epic #202), OTRGlobals chain PR 2 of 4 (#233 ✅ → **#231** → #232 → #211).

https://claude.ai/code/session_01Uf2rVASuZtYqYjGSyqYLJS

---
_Generated by [Claude Code](https://claude.ai/code/session_01Uf2rVASuZtYqYjGSyqYLJS)_

<!--- section:artifacts:start -->
### Build Artifacts
  - [rsbs-windows.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/7546257506.zip)
  - [rsbs-linux.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/7546031203.zip)
<!--- section:artifacts:end -->