### PR TITLE
Port SOH RunExtract follow-up fixes: crash detection, mod folder, args, data-dir ROM search (#232)

### DIFF
--- a/games/oot/soh/OTRGlobals.cpp
+++ b/games/oot/soh/OTRGlobals.cpp
@@ -7,6 +7,7 @@
 #include <fstream>
 #include <vector>
 #include <chrono>
+#include <optional>
 
 #include "ResourceManagerHelpers.h"
 #include <fast/Fast3dWindow.h>
@@ -452,7 +453,6 @@ void OTRGlobals::RunExtract(int argc, char* argv[]) {
     Extractor extract;
     PromptSteps promptStep = PS_FILE_CHECK;
     bool generatedIsMQ = false;
-    std::atomic<bool> extracting = false;
     std::atomic<size_t> extractCount = 0, totalExtract = 0;
 
     std::string installPath = Ship::Context::GetAppBundlePath();
@@ -487,8 +487,9 @@ void OTRGlobals::RunExtract(int argc, char* argv[]) {
     }
 
     std::shared_ptr<BS::thread_pool> threadPool = std::make_shared<BS::thread_pool>(1);
+    std::optional<std::future<void>> extractionTask;
     while (!extractDone) {
-        if (SohGui::PopupsQueued() > 0 || extracting) {
+        if (SohGui::PopupsQueued() > 0 || extractionTask.has_value()) {
             goto render;
         }
         switch (extractStep) {
@@ -626,20 +627,16 @@ void OTRGlobals::RunExtract(int argc, char* argv[]) {
                     if (std::filesystem::exists(Ship::Context::GetAppDirectoryPath(appShortName) + "/" + archive)) {
                         std::string msg = "Archive for current ROM, " + archive + ", already exists.\nExtract again?";
                         SohGui::RegisterPopup("Confirm Re-extract", msg.c_str(), "Yes", "No", [&]() {
-                            extracting = true;
-                            threadPool->detach_task([&]() -> void {
+                            extractionTask = threadPool->submit_task([&]() -> void {
                                 extract.CallZapd(installPath, Ship::Context::GetAppDirectoryPath(appShortName),
                                                  &extractCount, &totalExtract);
-                                extracting = false;
                                 extractCount = totalExtract = 0;
                             });
                         });
                     } else {
-                        extracting = true;
-                        threadPool->detach_task([&]() -> void {
+                        extractionTask = threadPool->submit_task([&]() -> void {
                             extract.CallZapd(installPath, Ship::Context::GetAppDirectoryPath(appShortName),
                                              &extractCount, &totalExtract);
-                            extracting = false;
                             extractCount = totalExtract = 0;
                         });
                     }
@@ -689,12 +686,10 @@ void OTRGlobals::RunExtract(int argc, char* argv[]) {
                             promptStep = PS_FILE_CHECK;
                             continue;
                         }
-                        extracting = true;
-                        threadPool->detach_task([&]() -> void {
+                        extractionTask = threadPool->submit_task([&]() -> void {
                             extract.CallZapd(installPath, Ship::Context::GetAppDirectoryPath(appShortName),
                                              &extractCount, &totalExtract);
                             generatedIsMQ = extract.IsMasterQuest();
-                            extracting = false;
                             promptStep = PS_SECOND;
                             extractCount = 0;
                             totalExtract = 0;
@@ -709,11 +704,9 @@ void OTRGlobals::RunExtract(int argc, char* argv[]) {
                                                                                             : RomSearchMode::MQ)) {
                                     extractStep = ES_VERIFY;
                                 } else {
-                                    extracting = true;
-                                    threadPool->detach_task([&]() -> void {
+                                    extractionTask = threadPool->submit_task([&]() -> void {
                                         extract.CallZapd(installPath, Ship::Context::GetAppDirectoryPath(appShortName),
                                                          &extractCount, &totalExtract);
-                                        extracting = false;
                                         extractStep = ES_VERIFY;
                                         extractCount = 0;
                                         totalExtract = 0;
@@ -763,30 +756,40 @@ void OTRGlobals::RunExtract(int argc, char* argv[]) {
         gui->StartDraw();
         sohFast3dWindow->StartFrame();
         sohFast3dWindow->RunGuiOnly();
-        if (extracting && !ImGui::IsPopupOpen("ROM Extraction")) {
-            ImGui::OpenPopup("ROM Extraction");
-        }
-        if (extracting) {
-            ImGui::PushStyleVar(ImGuiStyleVar_FrameRounding, 3.0f);
-            ImGui::PushStyleVar(ImGuiStyleVar_FramePadding, ImVec2(10.0f, 8.0f));
-            auto color = UIWidgets::ColorValues.at(THEME_COLOR);
-            ImGui::PushStyleColor(ImGuiCol_FrameBg, ImVec4(color.x, color.y, color.z, 0.6f));
-            ImGui::PushStyleColor(ImGuiCol_PlotHistogram, ImVec4(color.x, color.y, color.z, 1.0f));
-            ImGui::PushStyleColor(ImGuiCol_Border, ImVec4(0.0f, 0.0f, 0.0f, 0.3f));
-            if (ImGui::BeginPopupModal("ROM Extraction", NULL,
-                                       ImGuiWindowFlags_AlwaysAutoResize | ImGuiWindowFlags_NoResize |
-                                           ImGuiWindowFlags_NoMove | ImGuiWindowFlags_NoScrollbar |
-                                           ImGuiWindowFlags_NoSavedSettings)) {
-                float progress = (totalExtract > 0.0f ? (float)extractCount / (float)totalExtract : 0) * 100.0f;
-                auto filename = std::filesystem::path(file).filename().string();
-                ImGui::Text("Extracting %s...%s", filename.c_str(),
-                            roundf(progress) == 100.0f ? " Done. Finishing up." : "");
-                std::string overlay = extractCount > 0 ? fmt::format("{:.0f}%", progress) : "Starting Up";
-                ImGui::ProgressBar(progress / 100.0f, ImVec2(600.0f, 50.0f), overlay.c_str());
-                ImGui::EndPopup();
+        if (extractionTask.has_value()) {
+            auto status = extractionTask->wait_for(std::chrono::milliseconds(0));
+            if (status == std::future_status::ready) {
+                try {
+                    extractionTask->get();
+                } catch (const std::exception& e) {
+                    SohGui::RegisterPopup("Extraction Crashed", e.what(), "Close", "", []() { exit(1); });
+                }
+                extractionTask.reset();
+            } else {
+                if (!ImGui::IsPopupOpen("ROM Extraction")) {
+                    ImGui::OpenPopup("ROM Extraction");
+                }
+                ImGui::PushStyleVar(ImGuiStyleVar_FrameRounding, 3.0f);
+                ImGui::PushStyleVar(ImGuiStyleVar_FramePadding, ImVec2(10.0f, 8.0f));
+                auto color = UIWidgets::ColorValues.at(THEME_COLOR);
+                ImGui::PushStyleColor(ImGuiCol_FrameBg, ImVec4(color.x, color.y, color.z, 0.6f));
+                ImGui::PushStyleColor(ImGuiCol_PlotHistogram, ImVec4(color.x, color.y, color.z, 1.0f));
+                ImGui::PushStyleColor(ImGuiCol_Border, ImVec4(0.0f, 0.0f, 0.0f, 0.3f));
+                if (ImGui::BeginPopupModal("ROM Extraction", NULL,
+                                           ImGuiWindowFlags_AlwaysAutoResize | ImGuiWindowFlags_NoResize |
+                                               ImGuiWindowFlags_NoMove | ImGuiWindowFlags_NoScrollbar |
+                                               ImGuiWindowFlags_NoSavedSettings)) {
+                    float progress = (totalExtract > 0.0f ? (float)extractCount / (float)totalExtract : 0) * 100.0f;
+                    auto filename = std::filesystem::path(file).filename().string();
+                    ImGui::Text("Extracting %s...%s", filename.c_str(),
+                                roundf(progress) == 100.0f ? " Done. Finishing up." : "");
+                    std::string overlay = extractCount > 0 ? fmt::format("{:.0f}%", progress) : "Starting Up";
+                    ImGui::ProgressBar(progress / 100.0f, ImVec2(600.0f, 50.0f), overlay.c_str());
+                    ImGui::EndPopup();
+                }
+                ImGui::PopStyleColor(3);
+                ImGui::PopStyleVar(2);
             }
-            ImGui::PopStyleColor(3);
-            ImGui::PopStyleVar(2);
         }
         gui->EndDraw();
         sohFast3dWindow->EndFrame();

--- a/games/oot/soh/OTRGlobals.cpp
+++ b/games/oot/soh/OTRGlobals.cpp
@@ -456,6 +456,7 @@ void OTRGlobals::RunExtract(int argc, char* argv[]) {
     std::atomic<size_t> extractCount = 0, totalExtract = 0;
 
     std::string installPath = Ship::Context::GetAppBundlePath();
+    std::string dataPath = Ship::Context::GetAppDirectoryPath(appShortName);
     std::string file;
 
 #if defined(__SWITCH__)
@@ -670,6 +671,8 @@ void OTRGlobals::RunExtract(int argc, char* argv[]) {
                     case PS_LOCAL: {
                         extract = Extractor();
                         extract.SetSearchPath(installPath);
+                        extract.GetRoms(args);
+                        extract.SetSearchPath(dataPath);
                         extract.GetRoms(args);
                         if (!args.empty()) {
                             promptStep = PS_WAIT;

--- a/games/oot/soh/OTRGlobals.cpp
+++ b/games/oot/soh/OTRGlobals.cpp
@@ -505,7 +505,7 @@ void OTRGlobals::RunExtract(int argc, char* argv[]) {
 #elif (defined(__WIIU__) || defined(__SWITCH__))
                     extractStep = ES_VERIFY;
 #else
-                    extractStep = ES_EXTRACT;
+                    extractStep = args.empty() ? ES_EXTRACT : ES_EXTRACT_ARGS;
 #endif
                 } else {
                     std::string msg;
@@ -592,11 +592,7 @@ void OTRGlobals::RunExtract(int argc, char* argv[]) {
                                                   "OK", "", [&]() { exit(0); });
                         } else {
                             windowsStep = WS_DONE;
-                            if (args.size() > 0) {
-                                extractStep = ES_EXTRACT_ARGS;
-                            } else {
-                                extractStep = ES_EXTRACT;
-                            }
+                            extractStep = args.empty() ? ES_EXTRACT : ES_EXTRACT_ARGS;
                         }
                         continue;
                     }
@@ -607,7 +603,7 @@ void OTRGlobals::RunExtract(int argc, char* argv[]) {
             }
             case ES_EXTRACT_ARGS: {
 #if !defined(__SWITCH__) && !defined(__WIIU__)
-                if (args.size() == 0) {
+                if (args.empty()) {
                     SohGui::RegisterPopup(
                         "Run Ship of Harkinian", "All files have been processed. Run SoH?", "Yes", "No",
                         [&]() {

--- a/games/oot/soh/OTRGlobals.cpp
+++ b/games/oot/soh/OTRGlobals.cpp
@@ -488,6 +488,11 @@ void OTRGlobals::RunExtract(int argc, char* argv[]) {
 
     std::shared_ptr<BS::thread_pool> threadPool = std::make_shared<BS::thread_pool>(1);
     std::optional<std::future<void>> extractionTask;
+
+#if not defined(__SWITCH__) && not defined(__WIIU__)
+    CheckAndCreateModFolder();
+#endif
+
     while (!extractDone) {
         if (SohGui::PopupsQueued() > 0 || extractionTask.has_value()) {
             goto render;
@@ -800,10 +805,6 @@ void OTRGlobals::RunExtract(int argc, char* argv[]) {
     Ship::Switch::Init(Ship::PreInitPhase);
 #elif defined(__WIIU__)
     Ship::WiiU::Init(appShortName);
-#endif
-
-#if not defined(__SWITCH__) && not defined(__WIIU__)
-    CheckAndCreateModFolder();
 #endif
 }
 


### PR DESCRIPTION
Closes #232.

Ports the remaining deltas of all four upstream RunExtract follow-up commits against the post-#250 flow, one commit per upstream commit (all in `games/oot/soh/OTRGlobals.cpp`):

1. **[`96c4fef05`](https://github.com/HarbourMasters/Shipwright/commit/96c4fef05) (SOH #6386 — detect extraction task crash):** replaces the detached extraction task + `std::atomic<bool> extracting` flag with a stored `std::optional<std::future<void>>`; exceptions thrown on the extraction thread now surface as an "Extraction Crashed" popup instead of vanishing. Our pre-state used `detach_task` (PR #250's adaptation) where upstream used fire-and-forget `submit_task`; both converge on the identical post-state. Diffstat matches upstream exactly (+40/−37).
2. **[`99c1f23d5`](https://github.com/HarbourMasters/Shipwright/commit/99c1f23d5) (SOH #6412 — macOS first-install crash):** moves `CheckAndCreateModFolder()` from the end of `RunExtract` to before the extraction loop (+5/−4, upstream-exact).
3. **[`adb1e46ba`](https://github.com/HarbourMasters/Shipwright/commit/adb1e46ba) (SOH #6501 — extractor args handling):** routes `ES_PORT_ARCHIVE` to `ES_EXTRACT_ARGS` when ROMs are passed via argv (previously only the Windows path honored them); `args.empty()` cleanup. **Disposition:** the upstream `argv[i]` indexing hunk is already pre-applied on main and not repeated.
4. **[`cc0941cc9`](https://github.com/HarbourMasters/Shipwright/commit/cc0941cc9) (SOH #6215 — AppImage/ROM search, re-checked per issue):** **Disposition:** the `Extract.cpp` half (Windows ROM search honoring the search path) was already ported via PR #241 (`Extract.cpp:236`). The `OTRGlobals.cpp` half (also search the app **data** directory for ROMs in `PS_LOCAL`) was still missing and is ported here (+3).

Verification: our `RunExtract` now diffs against upstream's post-`adb1e46ba` function with only three intentional RSBS divergences — the `RSBS_SINGLE_EXECUTABLE` early-return guard, a `tfile` null-guard, and two dead locals upstream carries (`doExtract`, `open`) that PR #250's port dropped. No new clang-format violations (checked against main's baseline).

AppImage-hardware test criteria are manual — per the lane plan this PR closes on CI green + port evidence, with manual residue rolled into the #212 verification carve-out.

Lane 6 (epic #202), OTRGlobals chain PR 3 of 4 (#233 ✅ → #231 ✅ → **#232** → #211).

https://claude.ai/code/session_01Uf2rVASuZtYqYjGSyqYLJS

---
_Generated by [Claude Code](https://claude.ai/code/session_01Uf2rVASuZtYqYjGSyqYLJS)_

<!--- section:artifacts:start -->
### Build Artifacts
  - [rsbs-windows.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/7546644635.zip)
  - [rsbs-linux.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/7546433254.zip)
<!--- section:artifacts:end -->