### PR TITLE
Port 2S2H Config Updaters + timer display mode persistence (#288)

### DIFF
--- a/games/mm/2s2h/BenGui/BenGui.cpp
+++ b/games/mm/2s2h/BenGui/BenGui.cpp
@@ -222,4 +222,17 @@ void RegisterPopup(std::string title, std::string message, std::string button1, 
     mModalWindow->RegisterPopup(title, message, button1, button2, button1callback, button2callback);
 }
 
+void SetDisplayOverlayVisibility(bool visible) {
+    if (mDisplayOverlayWindow != nullptr) {
+        if (visible) {
+            mDisplayOverlayWindow->Show();
+        } else {
+            mDisplayOverlayWindow->Hide();
+        }
+    } else {
+        CVarSetInteger("gWindows.DisplayOverlay", visible ? 1 : 0);
+    }
+    Ship::Context::GetInstance()->GetWindow()->GetGui()->SaveConsoleVariablesNextFrame();
+}
+
 } // namespace BenGui

--- a/games/mm/2s2h/BenGui/BenGui.hpp
+++ b/games/mm/2s2h/BenGui/BenGui.hpp
@@ -11,6 +11,7 @@ namespace BenGui {
     void Draw();
     void Destroy();
     UIWidgets::Colors GetMenuThemeColor();
+    void SetDisplayOverlayVisibility(bool visible);
 }
 
 #define THEME_COLOR BenGui::GetMenuThemeColor()

--- a/games/mm/2s2h/BenGui/BenMenu.cpp
+++ b/games/mm/2s2h/BenGui/BenMenu.cpp
@@ -1,4 +1,5 @@
 #include "BenMenu.h"
+#include "BenGui.hpp"
 #include "UIWidgets.hpp"
 #include "BenPort.h"
 #include "BenInputEditorWindow.h"
@@ -8,6 +9,7 @@
 #include "2s2h/PresetManager/PresetManager.h"
 #include "HudEditor.h"
 #include "Notification.h"
+#include "2s2h/Enhancements/Trackers/DisplayOverlay.h"
 #include <variant>
 #include <ship/utils/StringHelper.h>
 #include <spdlog/fmt/fmt.h>
@@ -603,8 +605,12 @@ void BenMenu::AddSettings() {
     path.column = SECTION_COLUMN_2;
     AddWidget(path, "In-Game Timer", WIDGET_SEPARATOR_TEXT);
     AddWidget(path, "Display", WIDGET_CVAR_COMBOBOX)
-        .CVar("gWindows.DisplayOverlay")
+        .CVar(CVAR_DISPLAY_OVERLAY_MODE)
         .WindowName("Display Overlay")
+        .Callback([](WidgetInfo& info) {
+            int mode = CVarGetInteger(CVAR_DISPLAY_OVERLAY_MODE, TIMER_DISPLAY_NONE);
+            SetDisplayOverlayVisibility(mode != TIMER_DISPLAY_NONE);
+        })
         .Options(
             ComboboxOptions()
                 .Tooltip(

--- a/games/mm/2s2h/BenPort.cpp
+++ b/games/mm/2s2h/BenPort.cpp
@@ -64,6 +64,7 @@ CrowdControl* CrowdControl::Instance;
 #include "2s2h/ShipUtils.h"
 #include "2s2h/ShipInit.hpp"
 #include "2s2h/PresetManager/PresetManager.h"
+#include "2s2h/config/ConfigUpdaters.h"
 
 // Resource Types/Factories
 #include <ship/resource/type/Blob.h>
@@ -832,6 +833,11 @@ extern "C" void InitOTR() {
     fprintf(stderr, "[MM InitOTR DEBUG] OTRGlobals created\n");
     fflush(stderr);
 
+    std::shared_ptr<Ship::Config> conf = OTRGlobals::Instance->context->GetConfig();
+    conf->RegisterVersionUpdater(std::make_shared<Ben::ConfigVersion1Updater>());
+    conf->RunVersionUpdates();
+    Ship::Context::GetInstance()->GetConsoleVariables()->Save();
+
     fprintf(stderr, "[MM InitOTR DEBUG] Creating GameInteractor...\n");
     fflush(stderr);
     GameInteractor::Instance = new GameInteractor();
@@ -889,7 +895,6 @@ extern "C" void InitOTR() {
     }
 #endif
 
-    std::shared_ptr<Ship::Config> conf = OTRGlobals::Instance->context->GetConfig();
     Ship::Context::GetInstance()->GetFileDropMgr()->RegisterDropHandler(BinarySaveConverter_HandleFileDropped);
     Ship::Context::GetInstance()->GetFileDropMgr()->RegisterDropHandler(SaveManager_HandleFileDropped);
 }

--- a/games/mm/2s2h/Enhancements/Trackers/DisplayOverlay.cpp
+++ b/games/mm/2s2h/Enhancements/Trackers/DisplayOverlay.cpp
@@ -43,10 +43,10 @@ void DrawInGameTimer(uint32_t timer, ImVec4 color = ImVec4(1, 1, 1, 1)) {
 }
 
 void DisplayOverlayWindow::Draw() {
-    if (!MM_gPlayState) {
+    if (!IsVisible() || !MM_gPlayState) {
         return;
     }
-    int displayOverlay = CVarGetInteger("gWindows.DisplayOverlay", 0);
+    int displayOverlay = CVarGetInteger(CVAR_DISPLAY_OVERLAY_MODE, 0);
     if (displayOverlay == TIMER_DISPLAY_NONE) {
         return;
     }

--- a/games/mm/2s2h/Enhancements/Trackers/DisplayOverlay.h
+++ b/games/mm/2s2h/Enhancements/Trackers/DisplayOverlay.h
@@ -2,6 +2,8 @@
 
 #include <ship/window/gui/GuiWindow.h>
 
+#define CVAR_DISPLAY_OVERLAY_MODE "gDisplayOverlay.Mode"
+
 void DisplayOverlayInitSettings();
 
 class DisplayOverlayWindow : public Ship::GuiWindow {

--- a/games/mm/2s2h/config/ConfigUpdaters.cpp
+++ b/games/mm/2s2h/config/ConfigUpdaters.cpp
@@ -1,0 +1,61 @@
+#include "2s2h/config/ConfigUpdaters.h"
+
+#include "2s2h/Enhancements/Enhancements.h"
+#include "2s2h/Enhancements/Trackers/DisplayOverlay.h"
+
+namespace Ben {
+
+struct Migration {
+    const char* from;
+    const char* to;
+};
+
+static void ApplyMigrationActions(const Migration* migrations) {
+    while (migrations->from != nullptr) {
+        if (migrations->to != nullptr) {
+            CVarCopy(migrations->from, migrations->to);
+        }
+        CVarClear(migrations->from);
+        migrations++;
+    }
+}
+
+static const Migration version1Migrations[] = {
+    { "gFixes.FixAmmoCountEnvColor", "gFixes.FixButtonEnvColor" },
+    { nullptr, nullptr },
+};
+
+static bool HasDisplayOverlayModeInConfig(Ship::Config* conf) {
+    if (!conf->GetNestedJson().contains("CVars")) {
+        return false;
+    }
+
+    const auto& cvars = conf->GetNestedJson()["CVars"];
+    return cvars.contains("gDisplayOverlay") && cvars["gDisplayOverlay"].is_object() &&
+           cvars["gDisplayOverlay"].contains("Mode");
+}
+
+static void MigrateDisplayOverlayTimerMode(Ship::Config* conf) {
+    if (HasDisplayOverlayModeInConfig(conf)) {
+        return;
+    }
+
+    int oldVal = CVarGetInteger("gWindows.DisplayOverlay", 0);
+    if (oldVal == TIMER_DISPLAY_RTA || oldVal == TIMER_DISPLAY_IGT) {
+        CVarSetInteger(CVAR_DISPLAY_OVERLAY_MODE, oldVal);
+        CVarSetInteger("gWindows.DisplayOverlay", 1);
+    } else {
+        CVarSetInteger(CVAR_DISPLAY_OVERLAY_MODE, TIMER_DISPLAY_NONE);
+        CVarSetInteger("gWindows.DisplayOverlay", 0);
+    }
+}
+
+ConfigVersion1Updater::ConfigVersion1Updater() : ConfigVersionUpdater(1) {
+}
+
+void ConfigVersion1Updater::Update(Ship::Config* conf) {
+    ApplyMigrationActions(version1Migrations);
+    MigrateDisplayOverlayTimerMode(conf);
+}
+
+} // namespace Ben

--- a/games/mm/2s2h/config/ConfigUpdaters.h
+++ b/games/mm/2s2h/config/ConfigUpdaters.h
@@ -1,0 +1,11 @@
+#include <libultraship/libultraship.h>
+
+namespace Ben {
+
+class ConfigVersion1Updater final : public Ship::ConfigVersionUpdater {
+  public:
+    ConfigVersion1Updater();
+    void Update(Ship::Config* conf) override;
+};
+
+} // namespace Ben


### PR DESCRIPTION
Closes #288.

Ports 2S2H Config Updaters ([HarbourMasters/2ship2harkinian#1703](https://github.com/HarbourMasters/2ship2harkinian/pull/1703), commit [`e1bb65214`](https://github.com/HarbourMasters/2ship2harkinian/commit/e1bb65214)) plus its small functional prerequisite, in two commits:

1. **2S2H #1678 ([`263d0adca`](https://github.com/HarbourMasters/2ship2harkinian/commit/263d0adca), +25/−3):** splits display-overlay window visibility (`gWindows.DisplayOverlay`) from the timer mode (new `gDisplayOverlay.Mode` cvar) so the selected timer mode survives restarts. **Why included:** #1703's version-1 migration exists specifically to move configs onto this scheme — porting the migration without the scheme would rewrite `gWindows.DisplayOverlay` values our pre-#1678 code still interprets as the timer mode, regressing IGT→RTA. Our MM tree (post-#299 sync) predates #1678.
2. **2S2H #1703 (+78/−1):** new `games/mm/2s2h/config/ConfigUpdaters.{cpp,h}` with `Ben::ConfigVersion1Updater` (migrates `gFixes.FixAmmoCountEnvColor` → `gFixes.FixButtonEnvColor`; `gWindows.DisplayOverlay` tri-state → mode/visibility split), registered in MM's `InitOTR` right after `OTRGlobals` construction — mirroring the in-repo OoT pattern (`games/oot/soh/config/ConfigUpdaters.{cpp,h}`, PR #243).

### Single-exe analysis (verified against LUS at our submodule pin `d11cc8c4`)
- `Config::RunVersionUpdates` only ratchets `ConfigVersion` **up** — no downgrade risk against OoT's v1–v6 updaters on the shared config.
- The shared `Ship::Config` instance's updater map is keyed by version: OoT registers `SOH::ConfigVersion1Updater` at key 1 first, so MM's `emplace(1, …)` is a silent no-op in single-exe — zero cross-game migration interference. The port stays upstream-faithful for a future standalone/namespaced-config world.
- `CVarCopy` early-returns on missing source cvars (fresh CI configs are safe); `MM_gPlayState` single-exe symbol prefix preserved in `DisplayOverlay.cpp`.
- Per the issue body's "reconcile with #34" note: the gCore/gOoT/gMM config-namespace migration is explicitly **deferred to #34** — under the shared context this updater currently targets `shipofharkinian.json` (pinned at `rsbs/src/main.cpp`).

MM CMake collects `2s2h/**` sources via `GLOB_RECURSE`, so the new `config/` directory needs no build-system change.

Lane 6 (epic #202): #233 ✅ #231 ✅ #232 ✅ → **#288** → #211 → #286 → #212.

https://claude.ai/code/session_01Uf2rVASuZtYqYjGSyqYLJS

---
_Generated by [Claude Code](https://claude.ai/code/session_01Uf2rVASuZtYqYjGSyqYLJS)_

<!--- section:artifacts:start -->
### Build Artifacts
  - [rsbs-windows.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/7547278075.zip)
  - [rsbs-linux.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/7546947718.zip)
<!--- section:artifacts:end -->