### PR TITLE
Port SOH OTRGlobals cleanup batch: #6636 decoupling, #6656 stdint.h, #6385 include hygiene (#211)

### DIFF
--- a/games/oot/soh/Enhancements/Cheats/Infinite/Ammo.cpp
+++ b/games/oot/soh/Enhancements/Cheats/Infinite/Ammo.cpp
@@ -1,5 +1,7 @@
 #include <libultraship/bridge.h>
 #include "soh/Enhancements/game-interactor/GameInteractor_Hooks.h"
+#include "soh/Enhancements/randomizer/SeedContext.h"
+#include "soh/OTRGlobals.h"
 #include "soh/ShipInit.hpp"
 #include "z64save.h"
 

--- a/games/oot/soh/Enhancements/Difficulty/PermanentLosses.cpp
+++ b/games/oot/soh/Enhancements/Difficulty/PermanentLosses.cpp
@@ -1,4 +1,5 @@
 #include "soh/Enhancements/game-interactor/GameInteractor_Hooks.h"
+#include "soh/Enhancements/randomizer/randomizer.h"
 #include "soh/OTRGlobals.h"
 #include "soh/SaveManager.h"
 #include "soh/ShipInit.hpp"

--- a/games/oot/soh/Enhancements/ExtraTraps.cpp
+++ b/games/oot/soh/Enhancements/ExtraTraps.cpp
@@ -3,6 +3,7 @@
 #include "soh/Enhancements/randomizer/3drando/random.hpp"
 #include "soh/Notification/Notification.h"
 #include "soh/OTRGlobals.h"
+#include "soh/Enhancements/randomizer/SeedContext.h"
 
 extern "C" {
 #include "variables.h"

--- a/games/oot/soh/Enhancements/InjectItemCounts.cpp
+++ b/games/oot/soh/Enhancements/InjectItemCounts.cpp
@@ -1,4 +1,5 @@
 #include <soh/OTRGlobals.h>
+#include "soh/Enhancements/randomizer/randomizer.h"
 
 extern "C" {
 #include "variables.h"

--- a/games/oot/soh/Enhancements/Items/BetterBombchuShopping.cpp
+++ b/games/oot/soh/Enhancements/Items/BetterBombchuShopping.cpp
@@ -1,4 +1,5 @@
 #include <soh/OTRGlobals.h>
+#include "soh/Enhancements/randomizer/randomizer.h"
 
 extern "C" {
 #include <variables.h>

--- a/games/oot/soh/Enhancements/NoSkulltulaFreeze.cpp
+++ b/games/oot/soh/Enhancements/NoSkulltulaFreeze.cpp
@@ -1,4 +1,5 @@
 #include <soh/OTRGlobals.h>
+#include "soh/Enhancements/randomizer/randomizer.h"
 
 extern "C" {
 #include "variables.h"

--- a/games/oot/soh/Enhancements/Presets/Presets.cpp
+++ b/games/oot/soh/Enhancements/Presets/Presets.cpp
@@ -7,12 +7,15 @@
 #include <libultraship/libultraship.h>
 #include <ship/resource/type/Json.h>
 #include "soh/OTRGlobals.h"
+#include "soh/util.h"
 #include "soh/SohGui/MenuTypes.h"
 #include "soh/SohGui/SohMenu.h"
 #include "soh/SohGui/SohGui.hpp"
 #include "soh/Enhancements/randomizer/randomizer_check_tracker.h"
 #include "soh/Enhancements/randomizer/randomizer_entrance_tracker.h"
 #include "soh/Enhancements/randomizer/randomizer_item_tracker.h"
+#include "soh/Enhancements/randomizer/SeedContext.h"
+#include "soh/Enhancements/randomizer/settings.h"
 
 namespace fs = std::filesystem;
 

--- a/games/oot/soh/Enhancements/QoL/OpenAllHours.cpp
+++ b/games/oot/soh/Enhancements/QoL/OpenAllHours.cpp
@@ -1,4 +1,5 @@
 #include "soh/Enhancements/game-interactor/GameInteractor_Hooks.h"
+#include "soh/Enhancements/randomizer/randomizer.h"
 #include "soh/OTRGlobals.h"
 #include "soh/ShipInit.hpp"
 

--- a/games/oot/soh/Enhancements/TimeSavers/MarketSneak.cpp
+++ b/games/oot/soh/Enhancements/TimeSavers/MarketSneak.cpp
@@ -1,4 +1,5 @@
 #include <soh/OTRGlobals.h>
+#include "soh/Enhancements/randomizer/randomizer.h"
 
 extern "C" {
 #include <variables.h>

--- a/games/oot/soh/Enhancements/TimeSavers/QuitFishingAtDoor.cpp
+++ b/games/oot/soh/Enhancements/TimeSavers/QuitFishingAtDoor.cpp
@@ -1,4 +1,5 @@
 #include <soh/OTRGlobals.h>
+#include "soh/Enhancements/randomizer/randomizer.h"
 
 extern "C" {
 #include <variables.h>

--- a/games/oot/soh/Enhancements/audio/AudioCollection.h
+++ b/games/oot/soh/Enhancements/audio/AudioCollection.h
@@ -3,7 +3,7 @@
 #include <map>
 #include <string>
 #include <set>
-#include <cstdint>
+#include <stdint.h>
 
 enum SeqType {
     SEQ_NOSHUFFLE = 0,

--- a/games/oot/soh/Enhancements/audio/AudioEditor.cpp
+++ b/games/oot/soh/Enhancements/audio/AudioEditor.cpp
@@ -15,6 +15,7 @@
 #include "AudioCollection.h"
 #include "soh/Enhancements/enhancementTypes.h"
 #include "soh/Enhancements/game-interactor/GameInteractor.h"
+#include "soh/Enhancements/randomizer/SeedContext.h"
 
 extern "C" {
 #include "z64save.h"

--- a/games/oot/soh/Enhancements/audio/AudioEditor.h
+++ b/games/oot/soh/Enhancements/audio/AudioEditor.h
@@ -1,5 +1,5 @@
 #pragma once
-#include "stdint.h"
+#include <stdint.h>
 
 #ifdef __cplusplus
 

--- a/games/oot/soh/Enhancements/boss-rush/BossRush.cpp
+++ b/games/oot/soh/Enhancements/boss-rush/BossRush.cpp
@@ -1,5 +1,5 @@
 #include "BossRush.h"
-#include "soh/OTRGlobals.h"
+#include "soh/ShipInit.hpp"
 #include "soh/Enhancements/game-interactor/GameInteractor.h"
 #include "soh/Enhancements/game-interactor/GameInteractor_Hooks.h"
 #include "soh_assets.h"

--- a/games/oot/soh/Enhancements/controls/InputViewer.cpp
+++ b/games/oot/soh/Enhancements/controls/InputViewer.cpp
@@ -11,7 +11,6 @@
 #include <cmath>
 
 #include "soh/SohGui/UIWidgets.hpp"
-#include "soh/SohGui/UIWidgets.hpp"
 #include "soh/SohGui/SohGui.hpp"
 
 using namespace UIWidgets;

--- a/games/oot/soh/Enhancements/controls/SohInputEditorWindow.h
+++ b/games/oot/soh/Enhancements/controls/SohInputEditorWindow.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "stdint.h"
+#include <stdint.h>
 #include <libultraship/libultraship.h>
 #include <imgui.h>
 #include <unordered_map>

--- a/games/oot/soh/Enhancements/cosmetics/CosmeticsEditor.cpp
+++ b/games/oot/soh/Enhancements/cosmetics/CosmeticsEditor.cpp
@@ -14,6 +14,7 @@
 #include "soh/OTRGlobals.h"
 #include "soh/ResourceManagerHelpers.h"
 #include "soh/Enhancements/enhancementTypes.h"
+#include "soh/Enhancements/randomizer/SeedContext.h"
 
 extern "C" {
 #include "z64.h"

--- a/games/oot/soh/Enhancements/cosmetics/NoMasterSword.cpp
+++ b/games/oot/soh/Enhancements/cosmetics/NoMasterSword.cpp
@@ -1,4 +1,5 @@
 #include "soh/Enhancements/game-interactor/GameInteractor_Hooks.h"
+#include "soh/Enhancements/randomizer/randomizer.h"
 #include "soh/ShipInit.hpp"
 #include "soh/OTRGlobals.h"
 #include "soh/ResourceManagerHelpers.h"

--- a/games/oot/soh/Enhancements/custom-message/CustomMessageManager.h
+++ b/games/oot/soh/Enhancements/custom-message/CustomMessageManager.h
@@ -1,6 +1,6 @@
 #pragma once
 #include <unordered_map>
-#include <cstdint>
+#include <stdint.h>
 #include <exception>
 #include <vector>
 #include <string>

--- a/games/oot/soh/Enhancements/debugconsole.cpp
+++ b/games/oot/soh/Enhancements/debugconsole.cpp
@@ -12,6 +12,7 @@
 #include "soh/Enhancements/cosmetics/CosmeticsEditor.h"
 #include "soh/Enhancements/audio/AudioEditor.h"
 #include "soh/Enhancements/randomizer/logic.h"
+#include "soh/Enhancements/randomizer/randomizer.h"
 
 #define Path _Path
 #define PATH_HACK

--- a/games/oot/soh/Enhancements/debugconsole.h
+++ b/games/oot/soh/Enhancements/debugconsole.h
@@ -1,5 +1,5 @@
 #pragma once
 
-#include "stdint.h"
+#include <stdint.h>
 
 void DebugConsole_Init(void);

--- a/games/oot/soh/Enhancements/debugger/SohGfxDebuggerWindow.cpp
+++ b/games/oot/soh/Enhancements/debugger/SohGfxDebuggerWindow.cpp
@@ -1,5 +1,7 @@
 #include "SohGfxDebuggerWindow.h"
 #include "soh/OTRGlobals.h"
+#include <libultraship/bridge/consolevariablebridge.h>
+#include "soh/cvar_prefixes.h"
 
 void SohGfxDebuggerWindow::InitElement() {
     GfxDebuggerWindow::InitElement();

--- a/games/oot/soh/Enhancements/debugger/debugSaveEditor.cpp
+++ b/games/oot/soh/Enhancements/debugger/debugSaveEditor.cpp
@@ -1,4 +1,6 @@
 #include "debugSaveEditor.h"
+#include "soh/Enhancements/randomizer/randomizerTypes.h"
+#include "soh/Enhancements/randomizer/randomizer.h"
 #include "soh/util.h"
 #include "soh/SohGui/ImGuiUtils.h"
 #include "soh/OTRGlobals.h"

--- a/games/oot/soh/Enhancements/debugger/debugSaveEditor.h
+++ b/games/oot/soh/Enhancements/debugger/debugSaveEditor.h
@@ -4,7 +4,7 @@
 #include <map>
 #include <string>
 #include <vector>
-#include <cstdint>
+#include <stdint.h>
 #include "soh/Enhancements/randomizer/randomizerTypes.h"
 #include <libultraship/libultraship.h>
 

--- a/games/oot/soh/Enhancements/debugger/valueViewer.cpp
+++ b/games/oot/soh/Enhancements/debugger/valueViewer.cpp
@@ -3,6 +3,7 @@
 #include "soh/SohGui/SohGui.hpp"
 #include "soh/OTRGlobals.h"
 #include "soh/ShipInit.hpp"
+#include "soh/Enhancements/game-interactor/GameInteractor.h"
 
 extern "C" {
 #include <z64.h>

--- a/games/oot/soh/Enhancements/kaleido.cpp
+++ b/games/oot/soh/Enhancements/kaleido.cpp
@@ -2,6 +2,7 @@
 
 #include "objects/gameplay_keep/gameplay_keep.h"
 #include "soh/Enhancements/randomizer/randomizerTypes.h"
+#include "soh/Enhancements/randomizer/SeedContext.h"
 #include "soh/ShipInit.hpp"
 #include "soh/ShipUtils.h"
 #include <ship/utils/StringHelper.h>

--- a/games/oot/soh/Enhancements/randomizer/3drando/playthrough.cpp
+++ b/games/oot/soh/Enhancements/randomizer/3drando/playthrough.cpp
@@ -6,6 +6,8 @@
 #include "random.hpp"
 #include "spoiler_log.hpp"
 #include "soh/Enhancements/randomizer/randomizerTypes.h"
+#include "soh/Enhancements/randomizer/SeedContext.h"
+#include "soh/Enhancements/randomizer/settings.h"
 #include "variables.h"
 #include "soh/OTRGlobals.h"
 #include "soh/cvar_prefixes.h"

--- a/games/oot/soh/Enhancements/randomizer/3drando/random.hpp
+++ b/games/oot/soh/Enhancements/randomizer/3drando/random.hpp
@@ -3,7 +3,7 @@
 #include "soh/ShipUtils.h"
 #include <array>
 #include <cstddef>
-#include <cstdint>
+#include <stdint.h>
 #include <utility>
 #include <vector>
 #include <set>

--- a/games/oot/soh/Enhancements/randomizer/BigPoes.cpp
+++ b/games/oot/soh/Enhancements/randomizer/BigPoes.cpp
@@ -1,4 +1,5 @@
 #include <soh/OTRGlobals.h>
+#include "soh/Enhancements/randomizer/randomizer.h"
 
 extern "C" {
 #include "variables.h"

--- a/games/oot/soh/Enhancements/randomizer/Bombchus.cpp
+++ b/games/oot/soh/Enhancements/randomizer/Bombchus.cpp
@@ -2,6 +2,7 @@
 #include "soh/Enhancements/game-interactor/GameInteractor_Hooks.h"
 #include "soh/ShipInit.hpp"
 #include "src/overlays/actors/ovl_En_GirlA/z_en_girla.h"
+#include "soh/Enhancements/randomizer/SeedContext.h"
 
 extern "C" {
 #include "z64save.h"

--- a/games/oot/soh/Enhancements/randomizer/ColoredMapsAndCompasses.cpp
+++ b/games/oot/soh/Enhancements/randomizer/ColoredMapsAndCompasses.cpp
@@ -6,6 +6,7 @@
 #include "objects/object_gi_compass/object_gi_compass.h"
 #include "objects/object_gi_map/object_gi_map.h"
 #include "soh/OTRGlobals.h"
+#include "soh/Enhancements/randomizer/SeedContext.h"
 
 extern "C" {
 extern SaveContext gSaveContext;

--- a/games/oot/soh/Enhancements/randomizer/LockOverworldDoors.cpp
+++ b/games/oot/soh/Enhancements/randomizer/LockOverworldDoors.cpp
@@ -1,6 +1,7 @@
 #include <libultraship/libultraship.h>
 #include "soh/OTRGlobals.h"
 #include "soh/Enhancements/game-interactor/GameInteractor_Hooks.h"
+#include "soh/Enhancements/randomizer/SeedContext.h"
 #include "soh/ShipInit.hpp"
 
 extern "C" {

--- a/games/oot/soh/Enhancements/randomizer/MedallionLockedTrials.cpp
+++ b/games/oot/soh/Enhancements/randomizer/MedallionLockedTrials.cpp
@@ -1,5 +1,6 @@
 #include "soh/OTRGlobals.h"
 #include "soh/ShipInit.hpp"
+#include "soh/Enhancements/randomizer/SeedContext.h"
 
 extern "C" {
 extern PlayState* OoT_gPlayState;

--- a/games/oot/soh/Enhancements/randomizer/Messages/EntranceHints.cpp
+++ b/games/oot/soh/Enhancements/randomizer/Messages/EntranceHints.cpp
@@ -1,5 +1,6 @@
 #include "soh/Enhancements/randomizer/entrance.h"
 #include "soh/Enhancements/randomizer/randomizer_entrance_tracker.h"
+#include "soh/Enhancements/randomizer/randomizer.h"
 #include <soh/OTRGlobals.h>
 
 extern "C" {

--- a/games/oot/soh/Enhancements/randomizer/Messages/Goron.cpp
+++ b/games/oot/soh/Enhancements/randomizer/Messages/Goron.cpp
@@ -3,6 +3,7 @@
  * trapped Gorons have when you free them.
  */
 #include <soh/OTRGlobals.h>
+#include "soh/Enhancements/randomizer/randomizer.h"
 
 extern "C" {
 #include <variables.h>

--- a/games/oot/soh/Enhancements/randomizer/Messages/GossipStoneHints.cpp
+++ b/games/oot/soh/Enhancements/randomizer/Messages/GossipStoneHints.cpp
@@ -3,6 +3,7 @@
  * hints.
  */
 #include <soh/OTRGlobals.h>
+#include "soh/Enhancements/randomizer/randomizer.h"
 
 extern "C" {
 extern PlayState* OoT_gPlayState;

--- a/games/oot/soh/Enhancements/randomizer/Messages/ItemMessages.cpp
+++ b/games/oot/soh/Enhancements/randomizer/Messages/ItemMessages.cpp
@@ -8,6 +8,9 @@
 #include <soh/OTRGlobals.h>
 #include "soh/Enhancements/game-interactor/GameInteractor_Hooks.h"
 #include "soh/Enhancements/custom-message/CustomMessageTypes.h"
+#include "soh/Enhancements/randomizer/Traps.h"
+#include "soh/Enhancements/randomizer/item.h"
+#include "soh/Enhancements/randomizer/randomizer.h"
 #include "soh/ShipInit.hpp"
 #include <soh/ResourceManagerHelpers.h>
 

--- a/games/oot/soh/Enhancements/randomizer/Messages/ItemMessages.cpp
+++ b/games/oot/soh/Enhancements/randomizer/Messages/ItemMessages.cpp
@@ -8,7 +8,6 @@
 #include <soh/OTRGlobals.h>
 #include "soh/Enhancements/game-interactor/GameInteractor_Hooks.h"
 #include "soh/Enhancements/custom-message/CustomMessageTypes.h"
-#include "soh/Enhancements/randomizer/Traps.h"
 #include "soh/Enhancements/randomizer/item.h"
 #include "soh/Enhancements/randomizer/randomizer.h"
 #include "soh/ShipInit.hpp"

--- a/games/oot/soh/Enhancements/randomizer/Messages/MerchantMessages.cpp
+++ b/games/oot/soh/Enhancements/randomizer/Messages/MerchantMessages.cpp
@@ -8,6 +8,7 @@
  */
 #include <soh/OTRGlobals.h>
 #include "soh/ObjectExtension/ObjectExtension.h"
+#include "soh/Enhancements/randomizer/randomizer.h"
 
 extern "C" {
 extern PlayState* OoT_gPlayState;

--- a/games/oot/soh/Enhancements/randomizer/Messages/Miscellaneous.cpp
+++ b/games/oot/soh/Enhancements/randomizer/Messages/Miscellaneous.cpp
@@ -6,6 +6,7 @@
  */
 
 #include <soh/OTRGlobals.h>
+#include "soh/Enhancements/randomizer/randomizer.h"
 
 extern "C" {
 #include <variables.h>

--- a/games/oot/soh/Enhancements/randomizer/Messages/Navi.cpp
+++ b/games/oot/soh/Enhancements/randomizer/Messages/Navi.cpp
@@ -3,6 +3,7 @@
  * for the Rando-Relevant Navi Hints enhancement.
  */
 #include <soh/OTRGlobals.h>
+#include "soh/Enhancements/randomizer/randomizer.h"
 
 extern "C" {
 #include <variables.h>

--- a/games/oot/soh/Enhancements/randomizer/Messages/Rupees.cpp
+++ b/games/oot/soh/Enhancements/randomizer/Messages/Rupees.cpp
@@ -3,6 +3,7 @@
  * enhancement
  */
 #include <soh/OTRGlobals.h>
+#include "soh/Enhancements/randomizer/randomizer.h"
 
 extern "C" {
 #include "variables.h"

--- a/games/oot/soh/Enhancements/randomizer/Messages/StaticHints.cpp
+++ b/games/oot/soh/Enhancements/randomizer/Messages/StaticHints.cpp
@@ -6,6 +6,7 @@
  * are always given by a specific NPC and/or for a specific item.
  */
 #include <soh/OTRGlobals.h>
+#include "soh/Enhancements/randomizer/randomizer.h"
 
 extern "C" {
 extern PlayState* OoT_gPlayState;

--- a/games/oot/soh/Enhancements/randomizer/RocsFeather.cpp
+++ b/games/oot/soh/Enhancements/randomizer/RocsFeather.cpp
@@ -1,5 +1,6 @@
 #include <soh/OTRGlobals.h>
 #include "soh/Enhancements/game-interactor/GameInteractor_Hooks.h"
+#include "soh/Enhancements/randomizer/SeedContext.h"
 #include "soh/ShipInit.hpp"
 #include <soh_assets.h>
 

--- a/games/oot/soh/Enhancements/randomizer/SeedContext.cpp
+++ b/games/oot/soh/Enhancements/randomizer/SeedContext.cpp
@@ -13,7 +13,6 @@
 #include "3drando/hints.hpp"
 #include "soh/util.h"
 #include "../kaleido.h"
-#include "soh/Enhancements/randomizer/Traps.h"
 #include "soh/Enhancements/randomizer/randomizer.h"
 
 #include <fstream>

--- a/games/oot/soh/Enhancements/randomizer/SeedContext.cpp
+++ b/games/oot/soh/Enhancements/randomizer/SeedContext.cpp
@@ -13,6 +13,8 @@
 #include "3drando/hints.hpp"
 #include "soh/util.h"
 #include "../kaleido.h"
+#include "soh/Enhancements/randomizer/Traps.h"
+#include "soh/Enhancements/randomizer/randomizer.h"
 
 #include <fstream>
 #include <spdlog/spdlog.h>

--- a/games/oot/soh/Enhancements/randomizer/ShuffleBeehives.cpp
+++ b/games/oot/soh/Enhancements/randomizer/ShuffleBeehives.cpp
@@ -1,6 +1,7 @@
 #include <soh/OTRGlobals.h>
 #include "static_data.h"
 #include "soh/ObjectExtension/ObjectExtension.h"
+#include "soh/Enhancements/randomizer/randomizer.h"
 
 extern "C" {
 #include "src/overlays/actors/ovl_Obj_Comb/z_obj_comb.h"

--- a/games/oot/soh/Enhancements/randomizer/ShuffleCows.cpp
+++ b/games/oot/soh/Enhancements/randomizer/ShuffleCows.cpp
@@ -1,5 +1,6 @@
 #include <soh/OTRGlobals.h>
 #include "static_data.h"
+#include "soh/Enhancements/randomizer/randomizer.h"
 
 extern "C" {
 #include "src/overlays/actors/ovl_En_Cow/z_en_cow.h"

--- a/games/oot/soh/Enhancements/randomizer/ShuffleCrates.cpp
+++ b/games/oot/soh/Enhancements/randomizer/ShuffleCrates.cpp
@@ -5,6 +5,8 @@
 #include "global.h"
 #include "soh/ResourceManagerHelpers.h"
 #include "soh/ObjectExtension/ObjectExtension.h"
+#include "item_category_adj.h"
+#include "soh/Enhancements/randomizer/randomizer.h"
 
 extern "C" {
 #include "variables.h"

--- a/games/oot/soh/Enhancements/randomizer/ShuffleCrates.cpp
+++ b/games/oot/soh/Enhancements/randomizer/ShuffleCrates.cpp
@@ -5,7 +5,6 @@
 #include "global.h"
 #include "soh/ResourceManagerHelpers.h"
 #include "soh/ObjectExtension/ObjectExtension.h"
-#include "item_category_adj.h"
 #include "soh/Enhancements/randomizer/randomizer.h"
 
 extern "C" {

--- a/games/oot/soh/Enhancements/randomizer/ShuffleFairies.cpp
+++ b/games/oot/soh/Enhancements/randomizer/ShuffleFairies.cpp
@@ -5,6 +5,7 @@
 #include "static_data.h"
 #include "soh/Enhancements/item-tables/ItemTableTypes.h"
 #include "soh/ObjectExtension/ObjectExtension.h"
+#include "soh/Enhancements/randomizer/randomizer.h"
 
 extern "C" {
 #include "src/overlays/actors/ovl_En_Elf/z_en_elf.h"

--- a/games/oot/soh/Enhancements/randomizer/ShuffleFreestanding.cpp
+++ b/games/oot/soh/Enhancements/randomizer/ShuffleFreestanding.cpp
@@ -1,4 +1,5 @@
 #include <soh/OTRGlobals.h>
+#include "soh/Enhancements/randomizer/randomizer.h"
 
 extern "C" {
 #include "variables.h"

--- a/games/oot/soh/Enhancements/randomizer/ShuffleGrass.cpp
+++ b/games/oot/soh/Enhancements/randomizer/ShuffleGrass.cpp
@@ -3,6 +3,7 @@
 #include "static_data.h"
 #include "soh/ObjectExtension/ObjectExtension.h"
 #include "soh/Enhancements/enhancementTypes.h"
+#include "soh/Enhancements/randomizer/randomizer.h"
 
 extern "C" {
 #include "variables.h"

--- a/games/oot/soh/Enhancements/randomizer/ShufflePots.cpp
+++ b/games/oot/soh/Enhancements/randomizer/ShufflePots.cpp
@@ -2,6 +2,7 @@
 #include "soh_assets.h"
 #include "static_data.h"
 #include "soh/ObjectExtension/ObjectExtension.h"
+#include "soh/Enhancements/randomizer/randomizer.h"
 
 extern "C" {
 #include "variables.h"

--- a/games/oot/soh/Enhancements/randomizer/ShuffleTrees.cpp
+++ b/games/oot/soh/Enhancements/randomizer/ShuffleTrees.cpp
@@ -2,6 +2,8 @@
 #include "soh_assets.h"
 #include "static_data.h"
 #include "soh/ObjectExtension/ObjectExtension.h"
+#include "item_category_adj.h"
+#include "soh/Enhancements/randomizer/randomizer.h"
 
 extern "C" {
 #include "variables.h"

--- a/games/oot/soh/Enhancements/randomizer/ShuffleTrees.cpp
+++ b/games/oot/soh/Enhancements/randomizer/ShuffleTrees.cpp
@@ -2,7 +2,6 @@
 #include "soh_assets.h"
 #include "static_data.h"
 #include "soh/ObjectExtension/ObjectExtension.h"
-#include "item_category_adj.h"
 #include "soh/Enhancements/randomizer/randomizer.h"
 
 extern "C" {

--- a/games/oot/soh/Enhancements/randomizer/draw.cpp
+++ b/games/oot/soh/Enhancements/randomizer/draw.cpp
@@ -4,6 +4,7 @@
 #include "randomizerTypes.h"
 #include "soh_assets.h"
 #include "soh/Enhancements/cosmetics/cosmeticsTypes.h"
+#include "soh/Enhancements/randomizer/randomizer.h"
 
 extern "C" {
 #include "z64.h"

--- a/games/oot/soh/Enhancements/randomizer/fishsanity.cpp
+++ b/games/oot/soh/Enhancements/randomizer/fishsanity.cpp
@@ -6,6 +6,8 @@
 #include "functions.h"
 #include "macros.h"
 #include <libultraship/bridge/consolevariablebridge.h>
+#include "soh/Enhancements/randomizer/randomizer.h"
+#include "soh/Enhancements/randomizer/randomizerTypes.h"
 
 extern "C" {
 #include "src/overlays/actors/ovl_Fishing/z_fishing.h"

--- a/games/oot/soh/Enhancements/randomizer/fishsanity.h
+++ b/games/oot/soh/Enhancements/randomizer/fishsanity.h
@@ -25,6 +25,8 @@ typedef enum {
 } FishsanityCheckType;
 
 #ifdef __cplusplus
+#include "soh/Enhancements/randomizer/location.h"
+
 namespace Rando {
 
 /**

--- a/games/oot/soh/Enhancements/randomizer/hook_handlers.cpp
+++ b/games/oot/soh/Enhancements/randomizer/hook_handlers.cpp
@@ -14,6 +14,8 @@
 #include "soh/SaveManager.h"
 #include "soh/ShipInit.hpp"
 #include "soh/ObjectExtension/ObjectExtension.h"
+#include "item_category_adj.h"
+#include "soh/Enhancements/randomizer/randomizer.h"
 
 extern "C" {
 #include "macros.h"

--- a/games/oot/soh/Enhancements/randomizer/hook_handlers.cpp
+++ b/games/oot/soh/Enhancements/randomizer/hook_handlers.cpp
@@ -59,7 +59,6 @@ extern "C" {
 #include "src/overlays/actors/ovl_Door_Gerudo/z_door_gerudo.h"
 #include "src/overlays/actors/ovl_En_Xc/z_en_xc.h"
 #include "src/overlays/actors/ovl_Fishing/z_fishing.h"
-#include "src/overlays/actors/ovl_En_Mk/z_en_mk.h"
 #include "src/overlays/actors/ovl_Obj_Bean/z_obj_bean.h"
 #include "src/overlays/actors/ovl_En_Heishi2/z_en_heishi2.h"
 #include "draw.h"

--- a/games/oot/soh/Enhancements/randomizer/hook_handlers.cpp
+++ b/games/oot/soh/Enhancements/randomizer/hook_handlers.cpp
@@ -14,7 +14,6 @@
 #include "soh/SaveManager.h"
 #include "soh/ShipInit.hpp"
 #include "soh/ObjectExtension/ObjectExtension.h"
-#include "item_category_adj.h"
 #include "soh/Enhancements/randomizer/randomizer.h"
 
 extern "C" {

--- a/games/oot/soh/Enhancements/randomizer/item.cpp
+++ b/games/oot/soh/Enhancements/randomizer/item.cpp
@@ -9,6 +9,7 @@
 #include "macros.h"
 #include "functions.h"
 #include "../../OTRGlobals.h"
+#include "soh/Enhancements/randomizer/randomizer.h"
 
 namespace Rando {
 Item::Item()

--- a/games/oot/soh/Enhancements/randomizer/logic.h
+++ b/games/oot/soh/Enhancements/randomizer/logic.h
@@ -2,7 +2,7 @@
 
 #include "randomizerTypes.h"
 #include "SeedContext.h"
-#include <cstdint>
+#include <stdint.h>
 
 namespace Rando {
 

--- a/games/oot/soh/Enhancements/randomizer/option.h
+++ b/games/oot/soh/Enhancements/randomizer/option.h
@@ -3,7 +3,7 @@
 #ifndef RANDOPTION_H
 #define RANDOPTION_H
 
-#include <cstdint>
+#include <stdint.h>
 #include <set>
 #include <string>
 #include <unordered_map>

--- a/games/oot/soh/Enhancements/randomizer/randomizer_check_tracker.cpp
+++ b/games/oot/soh/Enhancements/randomizer/randomizer_check_tracker.cpp
@@ -14,6 +14,7 @@
 #include "location_access.h"
 #include "3drando/fill.hpp"
 #include "soh/Enhancements/debugger/performanceTimer.h"
+#include "soh/Enhancements/randomizer/randomizer.h"
 
 #include <string>
 #include <sstream>

--- a/games/oot/soh/Enhancements/randomizer/randomizer_check_tracker.cpp
+++ b/games/oot/soh/Enhancements/randomizer/randomizer_check_tracker.cpp
@@ -26,7 +26,6 @@
 #include "item_location.h"
 #include "soh/Enhancements/game-interactor/GameInteractor.h"
 #include "z64item.h"
-#include "randomizerTypes.h"
 #include "fishsanity.h"
 
 extern "C" {

--- a/games/oot/soh/Enhancements/randomizer/randomizer_entrance_tracker.cpp
+++ b/games/oot/soh/Enhancements/randomizer/randomizer_entrance_tracker.cpp
@@ -7,6 +7,7 @@
 #include <vector>
 #include <libultraship/controller/controldeck/ControlDeck.h>
 #include <libultraship/libultraship.h>
+#include "soh/Enhancements/randomizer/randomizer.h"
 
 extern "C" {
 #include <z64.h>

--- a/games/oot/soh/Enhancements/randomizer/randomizer_entrance_tracker.h
+++ b/games/oot/soh/Enhancements/randomizer/randomizer_entrance_tracker.h
@@ -3,7 +3,7 @@
 #include <map>
 #include <string>
 #include <vector>
-#include <cstdint>
+#include <stdint.h>
 
 #include <libultraship/libultraship.h>
 #include "randomizerTypes.h"

--- a/games/oot/soh/Enhancements/randomizer/randomizer_item_tracker.cpp
+++ b/games/oot/soh/Enhancements/randomizer/randomizer_item_tracker.cpp
@@ -19,6 +19,7 @@
 #include "soh/SohGui/SohMenu.h"
 #include "soh/SohGui/UIWidgets.hpp"
 #include "soh/util.h"
+#include "soh/Enhancements/randomizer/randomizer.h"
 
 extern "C" {
 #include <z64.h>

--- a/games/oot/soh/Enhancements/randomizer/randomizer_item_tracker.h
+++ b/games/oot/soh/Enhancements/randomizer/randomizer_item_tracker.h
@@ -2,7 +2,7 @@
 
 #include <string>
 #include <vector>
-#include <cstdint>
+#include <stdint.h>
 #include <libultraship/libultraship.h>
 
 void DrawItemAmmo(int itemId);

--- a/games/oot/soh/Enhancements/randomizer/savefile.cpp
+++ b/games/oot/soh/Enhancements/randomizer/savefile.cpp
@@ -3,6 +3,7 @@
 #include "soh/ResourceManagerHelpers.h"
 #include "soh/Enhancements/game-interactor/GameInteractor.h"
 #include "soh/Enhancements/randomizer/logic.h"
+#include "soh/Enhancements/randomizer/randomizer.h"
 
 extern "C" {
 #include <z64.h>

--- a/games/oot/soh/Enhancements/savestates.h
+++ b/games/oot/soh/Enhancements/savestates.h
@@ -1,7 +1,7 @@
 #ifndef SAVE_STATES_H
 #define SAVE_STATES_H
 
-#include <cstdint>
+#include <stdint.h>
 #include <queue>
 #include <unordered_map>
 #include <memory>

--- a/games/oot/soh/Enhancements/timesplits/TimeSplits.cpp
+++ b/games/oot/soh/Enhancements/timesplits/TimeSplits.cpp
@@ -1,23 +1,18 @@
 #include <vector>
 #include <fstream>
-#include <filesystem>
 
 #include <ship/Context.h>
 #include "TimeSplits.h"
 #include "soh/Enhancements/gameplaystats.h"
-#include "soh/SaveManager.h"
-#include "soh/util.h"
 
-#include "soh/OTRGlobals.h"
 #include "soh/Enhancements/game-interactor/GameInteractor.h"
-#include "soh/Enhancements/debugger/debugSaveEditor.h"
 #include "soh_assets.h"
-#include "assets/textures/parameter_static/parameter_static.h"
 #include <soh/SohGui/SohGui.hpp>
 #include "soh/SohGui/UIWidgets.hpp"
 
 extern "C" {
 #include "z64item.h"
+#include "macros.h"
 extern SaveContext gSaveContext;
 extern PlayState* OoT_gPlayState;
 }

--- a/games/oot/soh/GameExports_SingleExe.cpp
+++ b/games/oot/soh/GameExports_SingleExe.cpp
@@ -12,6 +12,8 @@
 #include "OTRGlobals.h"
 #include "soh/CrashHandlerExt.h"
 #include <libultraship/bridge.h>
+#include <ship/Context.h>
+#include "z64save.h"
 
 #include "game_lifecycle.h"
 #include "integration_test_hooks.h"
@@ -34,7 +36,7 @@ extern "C" {
     extern s32 gAudioContextInitalized;
     void Audio_InitMesgQueues(void);
 
-    // OoT's SaveContext (type defined via OTRGlobals.h -> z64save.h).
+    // OoT's SaveContext (type from z64save.h).
     // Declared here so OoT_Game_Resume() can restore it on return from MM (#170).
     extern SaveContext gSaveContext;
 }

--- a/games/oot/soh/Network/Anchor/Anchor.cpp
+++ b/games/oot/soh/Network/Anchor/Anchor.cpp
@@ -4,6 +4,7 @@
 #include "soh/OTRGlobals.h"
 #include "soh/Enhancements/nametag.h"
 #include "soh/ObjectExtension/ObjectExtension.h"
+#include "soh/Enhancements/randomizer/randomizer.h"
 
 extern "C" {
 #include "variables.h"

--- a/games/oot/soh/Network/Anchor/AnchorRoomWindow.cpp
+++ b/games/oot/soh/Network/Anchor/AnchorRoomWindow.cpp
@@ -1,5 +1,7 @@
 #include "Anchor.h"
 #include "soh/OTRGlobals.h"
+#include "soh/util.h"
+#include "soh/Enhancements/randomizer/SeedContext.h"
 
 extern "C" {
 #include "variables.h"

--- a/games/oot/soh/Network/Anchor/DummyPlayer.cpp
+++ b/games/oot/soh/Network/Anchor/DummyPlayer.cpp
@@ -1,6 +1,5 @@
 #include "Anchor.h"
 #include "soh/Enhancements/nametag.h"
-#include "soh/frame_interpolation.h"
 
 extern "C" {
 #include "macros.h"

--- a/games/oot/soh/Network/Anchor/Packets/SetCheckStatus.cpp
+++ b/games/oot/soh/Network/Anchor/Packets/SetCheckStatus.cpp
@@ -3,6 +3,7 @@
 #include <libultraship/libultraship.h>
 #include "soh/Enhancements/game-interactor/GameInteractor.h"
 #include "soh/OTRGlobals.h"
+#include "soh/Enhancements/randomizer/randomizer.h"
 
 static bool isResultOfHandling = false;
 

--- a/games/oot/soh/Network/Anchor/Packets/UpdateClientState.cpp
+++ b/games/oot/soh/Network/Anchor/Packets/UpdateClientState.cpp
@@ -3,6 +3,7 @@
 #include <nlohmann/json.hpp>
 #include <libultraship/libultraship.h>
 #include "soh/OTRGlobals.h"
+#include "soh/Enhancements/randomizer/SeedContext.h"
 
 extern "C" {
 #include "variables.h"

--- a/games/oot/soh/Network/Anchor/Packets/UpdateTeamState.cpp
+++ b/games/oot/soh/Network/Anchor/Packets/UpdateTeamState.cpp
@@ -6,6 +6,7 @@
 #include "soh/Enhancements/randomizer/dungeon.h"
 #include "soh/OTRGlobals.h"
 #include "soh/Notification/Notification.h"
+#include "soh/Enhancements/randomizer/randomizer.h"
 
 extern "C" {
 #include "variables.h"

--- a/games/oot/soh/OTRGlobals.cpp
+++ b/games/oot/soh/OTRGlobals.cpp
@@ -2516,6 +2516,17 @@ bool SoH_HandleConfigDrop(char* filePath) {
     return false;
 }
 
+// Kept vs upstream SOH #6636: our randomizer_entrance.c still calls this C bridge
+extern "C" void CheckTracker_RecalculateAvailableChecks() {
+    CheckTracker::RecalculateAvailableChecks();
+}
+
+// Kept vs upstream SOH #6636: MM's z_kankyo.c calls this OoT-provided symbol in
+// single-exe builds (scrolling-texture-interpolation port, #234)
+extern "C" uint32_t Ship_GetInterpolationFPS() {
+    return OTRGlobals::Instance->GetInterpolationFPS();
+}
+
 // Number of interpolated frames
 extern "C" uint32_t Ship_GetInterpolationFrameCount() {
     return ceil((float)OTRGlobals::Instance->GetInterpolationFPS() / 20.0f);

--- a/games/oot/soh/OTRGlobals.cpp
+++ b/games/oot/soh/OTRGlobals.cpp
@@ -1,6 +1,5 @@
 #include "OTRGlobals.h"
 #include "OTRAudio.h"
-#include <iostream>
 #include <algorithm>
 #include <atomic>
 #include <filesystem>
@@ -14,7 +13,6 @@
 #include <fast/Fast3dWindow.h>
 #include <ship/Context.h>
 #include <ship/resource/File.h>
-#include <fast/resource/type/DisplayList.h>
 #include <ship/window/Window.h>
 #include <soh/GameVersions.h>
 #include <spdlog/sinks/rotating_file_sink.h>
@@ -82,7 +80,6 @@
 #include <functions.h>
 #include "Enhancements/item-tables/ItemTableManager.h"
 #include "Enhancements/Lang/Lang.h"
-#include "soh/SohGui/SohGui.hpp"
 #include "soh/SohGui/ImGuiUtils.h"
 #include "ActorDB.h"
 #include "SaveManager.h"

--- a/games/oot/soh/OTRGlobals.cpp
+++ b/games/oot/soh/OTRGlobals.cpp
@@ -8,9 +8,11 @@
 #include <vector>
 #include <chrono>
 #include <optional>
+#include <imgui.h>
 
 #include "ResourceManagerHelpers.h"
 #include <fast/Fast3dWindow.h>
+#include <ship/Context.h>
 #include <ship/resource/File.h>
 #include <fast/resource/type/DisplayList.h>
 #include <ship/window/Window.h>
@@ -38,8 +40,10 @@
 #include "Enhancements/randomizer/randomizer_check_tracker.h"
 #include "Enhancements/randomizer/3drando/random.hpp"
 #include "Enhancements/randomizer/static_data.h"
+#include "soh/Enhancements/randomizer/settings.h"
 #include "Enhancements/gameplaystats.h"
 #include "ObjectExtension/ObjectExtension.h"
+#include "soh/Enhancements/savestates.h"
 #include "frame_interpolation.h"
 #include "SohGui/SohMenu.h"
 #include "SohGui/SohGui.hpp"
@@ -145,6 +149,14 @@ extern "C" bool RsbsFeatureEnabled(const char* disableEnvVar) {
     }
     return true;
 }
+
+#ifdef __WIIU__
+const uint32_t defaultImGuiScale = 3;
+#else
+const uint32_t defaultImGuiScale = 1;
+#endif
+
+const float imguiScaleOptionToValue[4] = { 0.75f, 1.0f, 1.5f, 2.0f };
 
 bool SoH_HandleConfigDrop(char* filePath);
 
@@ -1006,25 +1018,6 @@ void OTRGlobals::ScaleImGui() {
     previousImGuiScaleIndex = imGuiScaleIndex;
 }
 
-ImFont* OTRGlobals::CreateDefaultFontWithSize(float size) {
-    auto mImGuiIo = &ImGui::GetIO();
-    ImFontConfig fontCfg = ImFontConfig();
-    fontCfg.OversampleH = fontCfg.OversampleV = 1;
-    fontCfg.PixelSnapH = true;
-    fontCfg.SizePixels = size;
-    ImFont* font = mImGuiIo->Fonts->AddFontDefault(&fontCfg);
-    // FontAwesome fonts need to have their sizes reduced by 2.0f/3.0f in order to align correctly
-    float iconFontSize = size * 2.0f / 3.0f;
-    static const ImWchar sIconsRanges[] = { ICON_MIN_FA, ICON_MAX_16_FA, 0 };
-    ImFontConfig iconsConfig;
-    iconsConfig.MergeMode = true;
-    iconsConfig.PixelSnapH = true;
-    iconsConfig.GlyphMinAdvanceX = iconFontSize;
-    mImGuiIo->Fonts->AddFontFromMemoryCompressedBase85TTF(fontawesome_compressed_data_base85, iconFontSize,
-                                                          &iconsConfig, sIconsRanges);
-    return font;
-}
-
 bool OTRGlobals::HasMasterQuest() {
     return hasMasterQuest;
 }
@@ -1047,7 +1040,7 @@ uint32_t OTRGlobals::GetInterpolationFPS() {
 extern "C" void OTRMessage_Init();
 extern "C" void OoT_AudioMgr_CreateNextAudioBuffer(s16* samples, u32 num_samples);
 extern "C" void AudioPlayer_Play(const uint8_t* buf, uint32_t len);
-extern "C" int AudioPlayer_Buffered(void);
+int AudioPlayer_Buffered(void);
 extern "C" int AudioPlayer_GetDesiredBuffered(void);
 std::unordered_map<std::string, ExtensionEntry> ExtensionCache;
 
@@ -1091,8 +1084,7 @@ void OTRAudio_Thread() {
     }
 }
 
-// C->C++ Bridge
-extern "C" void OTRAudio_Init() {
+void OTRAudio_Init() {
     // Precache all our samples, sequences, etc...
     ResourceMgr_LoadDirectory("audio");
 
@@ -1102,6 +1094,7 @@ extern "C" void OTRAudio_Init() {
     }
 }
 
+// C->C++ Bridge
 extern "C" char** sequenceMap;
 extern "C" size_t sequenceMapSize;
 
@@ -1133,7 +1126,7 @@ extern "C" void OTRAudio_Exit() {
 #endif
 }
 
-extern "C" void VanillaItemTable_Init() {
+void VanillaItemTable_Init() {
     static GetItemEntry getItemTable[] = {
         // clang-format off
         GET_ITEM(ITEM_BOMBS_5,          OBJECT_GI_BOMB_1,        GID_BOMB,             0x32, 0x59, CHEST_ANIM_SHORT, ITEM_CATEGORY_JUNK,            MOD_NONE, GI_BOMBS_5),
@@ -1870,8 +1863,6 @@ extern "C" void Graph_ProcessGfxCommands(Gfx* commands) {
          OTRGlobals::Instance->context->lastScancode = -1;*/
 }
 
-float divisor_num = 0.0f;
-
 extern "C" void OTRGetPixelDepthPrepare(float x, float y) {
     auto wnd = std::dynamic_pointer_cast<Fast::Fast3dWindow>(Ship::Context::GetInstance()->GetWindow());
     if (wnd == nullptr) {
@@ -1899,62 +1890,6 @@ extern "C" uint8_t GetSeedIconIndex(uint8_t index) {
 }
 
 std::map<std::string, SoundFontSample*> cachedCustomSFs;
-
-extern "C" SoundFontSample* ReadCustomSample(const char* path) {
-    return nullptr;
-    /*
-    if (!ExtensionCache.contains(path))
-        return nullptr;
-
-    ExtensionEntry entry = ExtensionCache[path];
-
-    auto sampleRaw = Ship::Context::GetInstance()->GetResourceManager()->LoadFile(entry.path);
-    uint32_t* strem = (uint32_t*)sampleRaw->Buffer.get();
-    uint8_t* strem2 = (uint8_t*)strem;
-
-    SoundFontSample* sampleC = new SoundFontSample;
-
-    if (entry.ext == "wav") {
-        drwav_uint32 channels;
-        drwav_uint32 sampleRate;
-        drwav_uint64 totalPcm;
-        drmp3_int16* pcmData =
-            drwav_open_memory_and_read_pcm_frames_s16(strem2, sampleRaw->BufferSize, &channels, &sampleRate, &totalPcm,
-    NULL); sampleC->size = totalPcm; sampleC->sampleAddr = (uint8_t*)pcmData; sampleC->codec = CODEC_S16;
-
-        sampleC->loop = new AdpcmLoop;
-        sampleC->loop->start = 0;
-        sampleC->loop->end = sampleC->size - 1;
-        sampleC->loop->count = 0;
-        sampleC->sampleRateMagicValue = 'RIFF';
-        sampleC->sampleRate = sampleRate;
-
-        cachedCustomSFs[path] = sampleC;
-        return sampleC;
-    } else if (entry.ext == "mp3") {
-        drmp3_config mp3Info;
-        drmp3_uint64 totalPcm;
-        drmp3_int16* pcmData =
-            drmp3_open_memory_and_read_pcm_frames_s16(strem2, sampleRaw->BufferSize, &mp3Info, &totalPcm, NULL);
-
-        sampleC->size = totalPcm * mp3Info.channels * sizeof(short);
-        sampleC->sampleAddr = (uint8_t*)pcmData;
-        sampleC->codec = CODEC_S16;
-
-        sampleC->loop = new AdpcmLoop;
-        sampleC->loop->start = 0;
-        sampleC->loop->end = sampleC->size;
-        sampleC->loop->count = 0;
-        sampleC->sampleRateMagicValue = 'RIFF';
-        sampleC->sampleRate = mp3Info.sampleRate;
-
-        cachedCustomSFs[path] = sampleC;
-        return sampleC;
-    }
-
-    return nullptr;
-    */
-}
 
 ImFont* OTRGlobals::CreateFontWithSize(float size, std::string fontPath, bool isJapaneseFont) {
     auto mImGuiIo = &ImGui::GetIO();
@@ -2006,20 +1941,6 @@ std::filesystem::path GetSaveFile() {
     const std::shared_ptr<Ship::Config> pConf = OTRGlobals::Instance->context->GetConfig();
 
     return GetSaveFile(pConf);
-}
-
-void OTRGlobals::CheckSaveFile(size_t sramSize) const {
-    const std::shared_ptr<Ship::Config> pConf = Instance->context->GetConfig();
-
-    std::filesystem::path savePath = GetSaveFile(pConf);
-    std::fstream saveFile(savePath, std::fstream::in | std::fstream::out | std::fstream::binary);
-    if (saveFile.fail()) {
-        saveFile.open(savePath, std::fstream::in | std::fstream::out | std::fstream::binary | std::fstream::app);
-        for (size_t i = 0; i < sramSize; i++) {
-            saveFile.write("\0", 1);
-        }
-    }
-    saveFile.close();
 }
 
 extern "C" void Ctx_ReadSaveFile(uintptr_t addr, void* dramAddr, size_t size) {
@@ -2146,14 +2067,6 @@ extern "C" void OTRGfxPrint(const char* str, void* printer, void (*printImpl)(vo
             }
         }
     }
-}
-
-extern "C" uint32_t OTRGetCurrentWidth() {
-    return OTRGlobals::Instance->context->GetWindow()->GetWidth();
-}
-
-extern "C" uint32_t OTRGetCurrentHeight() {
-    return OTRGlobals::Instance->context->GetWindow()->GetHeight();
 }
 
 Color_RGB8 GetColorForControllerLED() {
@@ -2327,7 +2240,7 @@ extern "C" int16_t OTRGetRectDimensionFromRightEdge(float v) {
     return ((int)ceilf(OTRGetDimensionFromRightEdge(v)));
 }
 
-extern "C" int AudioPlayer_Buffered(void) {
+int AudioPlayer_Buffered(void) {
     return AudioPlayerBuffered();
 }
 
@@ -2415,10 +2328,6 @@ extern "C" void Randomizer_ParseSpoiler(const char* fileLoc) {
     OTRGlobals::Instance->gRandoContext->ParseSpoiler(fileLoc);
 }
 
-extern "C" bool Randomizer_IsTrialRequired(s32 trialFlag) {
-    return OTRGlobals::Instance->gRandomizer->IsTrialRequired(trialFlag);
-}
-
 extern "C" u32 SpoilerFileExists(const char* spoilerFileName) {
     return OTRGlobals::Instance->gRandomizer->SpoilerFileExists(spoilerFileName);
 }
@@ -2447,15 +2356,6 @@ extern "C" GetItemEntry ItemTable_RetrieveEntry(s16 tableID, s16 getItemID) {
     return ItemTableManager::Instance->RetrieveItemEntry(tableID, getItemID);
 }
 
-extern "C" GetItemEntry Randomizer_GetItemFromActor(s16 actorId, s16 sceneNum, s16 actorParams, GetItemID ogId) {
-    return OTRGlobals::Instance->gRandomizer->GetItemFromActor(actorId, sceneNum, actorParams, ogId);
-}
-
-extern "C" GetItemEntry Randomizer_GetItemFromActorWithoutObtainabilityCheck(s16 actorId, s16 sceneNum, s16 actorParams,
-                                                                             GetItemID ogId) {
-    return OTRGlobals::Instance->gRandomizer->GetItemFromActor(actorId, sceneNum, actorParams, ogId, false);
-}
-
 extern "C" GetItemEntry Randomizer_GetItemFromKnownCheck(RandomizerCheck randomizerCheck, GetItemID ogId) {
     return OTRGlobals::Instance->gRandomizer->GetItemFromKnownCheck(randomizerCheck, ogId);
 }
@@ -2463,10 +2363,6 @@ extern "C" GetItemEntry Randomizer_GetItemFromKnownCheck(RandomizerCheck randomi
 extern "C" GetItemEntry Randomizer_GetItemFromKnownCheckWithoutObtainabilityCheck(RandomizerCheck randomizerCheck,
                                                                                   GetItemID ogId) {
     return OTRGlobals::Instance->gRandomizer->GetItemFromKnownCheck(randomizerCheck, ogId, false);
-}
-
-extern "C" RandomizerInf Randomizer_GetRandomizerInfFromCheck(RandomizerCheck randomizerCheck) {
-    return OTRGlobals::Instance->gRandomizer->GetRandomizerInfFromCheck(randomizerCheck);
 }
 
 extern "C" ItemObtainability Randomizer_GetItemObtainabilityFromRandomizerCheck(RandomizerCheck randomizerCheck) {
@@ -2483,10 +2379,6 @@ extern "C" GetItemEntry GetItemMystery() {
 
 extern "C" uint8_t Randomizer_IsSeedGenerated() {
     return OTRGlobals::Instance->gRandoContext->IsSeedGenerated() ? 1 : 0;
-}
-
-extern "C" void Randomizer_SetSeedGenerated(bool seedGenerated) {
-    OTRGlobals::Instance->gRandoContext->SetSeedGenerated(seedGenerated);
 }
 
 extern "C" uint8_t Randomizer_IsSpoilerLoaded() {
@@ -2627,17 +2519,9 @@ bool SoH_HandleConfigDrop(char* filePath) {
     return false;
 }
 
-extern "C" void CheckTracker_RecalculateAvailableChecks() {
-    CheckTracker::RecalculateAvailableChecks();
-}
-
-extern "C" uint32_t Ship_GetInterpolationFPS() {
-    return OTRGlobals::Instance->GetInterpolationFPS();
-}
-
 // Number of interpolated frames
 extern "C" uint32_t Ship_GetInterpolationFrameCount() {
-    return ceil((float)Ship_GetInterpolationFPS() / 20.0f);
+    return ceil((float)OTRGlobals::Instance->GetInterpolationFPS() / 20.0f);
 }
 
 // ============================================================================

--- a/games/oot/soh/OTRGlobals.h
+++ b/games/oot/soh/OTRGlobals.h
@@ -16,7 +16,8 @@
 #define M_PI_2f 1.57079632679489661923f // pi/2
 
 #ifdef __cplusplus
-#include <memory> // for shared_ptr
+#include <stdint.h>
+#include <memory>
 #include <string>
 #include <unordered_map>
 

--- a/games/oot/soh/OTRGlobals.h
+++ b/games/oot/soh/OTRGlobals.h
@@ -1,6 +1,3 @@
-#ifndef OTR_GLOBALS_H
-#define OTR_GLOBALS_H
-
 #pragma once
 
 #define BTN_CUSTOM_MODIFIER1 0x0040
@@ -17,15 +14,11 @@
 
 #define M_PIf 3.14159265358979323846f
 #define M_PI_2f 1.57079632679489661923f // pi/2
-#define M_SQRT2f 1.41421356237309504880f
-#define M_SQRT1_2f 0.70710678118654752440f /* 1/sqrt(2) */
 
 #ifdef __cplusplus
-#include <ship/Context.h>
-#include "Enhancements/savestates.h"
-#include "Enhancements/randomizer/randomizer.h"
-#include <vector>
+#include <memory> // for shared_ptr
 #include <string>
+#include <unordered_map>
 
 struct ExtensionEntry {
     std::string path;
@@ -33,17 +26,21 @@ struct ExtensionEntry {
 };
 
 extern std::unordered_map<std::string, ExtensionEntry> ExtensionCache;
-#include "Enhancements/randomizer/settings.h"
 
 const std::string appShortName = "soh";
 
-#ifdef __WIIU__
-const uint32_t defaultImGuiScale = 3;
-#else
-const uint32_t defaultImGuiScale = 1;
-#endif
+class Randomizer;
+class SaveStateMgr;
 
-const float imguiScaleOptionToValue[4] = { 0.75f, 1.0f, 1.5f, 2.0f };
+namespace Rando {
+class Context;
+}
+
+namespace Ship {
+class Context;
+}
+
+struct ImFont;
 
 class OTRGlobals {
   public:
@@ -53,10 +50,6 @@ class OTRGlobals {
     std::shared_ptr<SaveStateMgr> gSaveStateMgr;
     std::shared_ptr<Randomizer> gRandomizer;
     std::shared_ptr<Rando::Context> gRandoContext;
-
-    ImFont* defaultFontSmaller;
-    ImFont* defaultFontLarger;
-    ImFont* defaultFontLargest;
 
     ImFont* fontMonoSmall = nullptr;
     ImFont* fontStandard = nullptr;
@@ -76,13 +69,10 @@ class OTRGlobals {
     bool HasMasterQuest();
     bool HasOriginal();
     uint32_t GetInterpolationFPS();
-    std::shared_ptr<std::vector<std::string>> ListFiles(std::string path);
 
   private:
-    void CheckSaveFile(size_t sramSize) const;
     bool hasMasterQuest;
     bool hasOriginal;
-    ImFont* CreateDefaultFontWithSize(float size);
     ImFont* CreateFontWithSize(float size, std::string fontPath, bool isJapaneseFont = false);
 };
 #endif
@@ -90,21 +80,14 @@ class OTRGlobals {
 #ifndef __cplusplus
 void InitOTR(int argc, char* argv[]);
 void DeinitOTR(void);
-void VanillaItemTable_Init();
-void OTRAudio_Init();
 void OTRMessage_Init();
-void InitAudio();
 void Graph_StartFrame();
 void Graph_ProcessGfxCommands(Gfx* commands);
-void Graph_ProcessFrame(void (*run_one_game_iter)(void));
-void OTRLogString(const char* src);
 // Runtime feature flag check - returns false if env var is set to "1"
 bool RsbsFeatureEnabled(const char* disableEnvVar);
 void OTRGfxPrint(const char* str, void* printer, void (*printImpl)(void*, char));
 void OTRGetPixelDepthPrepare(float x, float y);
 uint16_t OTRGetPixelDepth(float x, float y);
-int32_t OTRGetLastScancode();
-char* GetResourceDataByNameHandlingMQ(const char* path);
 
 void Ctx_ReadSaveFile(uintptr_t addr, void* dramAddr, size_t size);
 void Ctx_WriteSaveFile(uintptr_t addr, void* dramAddr, size_t size);
@@ -112,8 +95,6 @@ void Ctx_WriteSaveFile(uintptr_t addr, void* dramAddr, size_t size);
 uint64_t GetPerfCounter();
 uint64_t osGetTime(void);
 uint32_t osGetCount(void);
-uint32_t OTRGetCurrentWidth(void);
-uint32_t OTRGetCurrentHeight(void);
 float OTRGetAspectRatio(void);
 float OTRGetDimensionFromLeftEdge(float v);
 float OTRGetDimensionFromRightEdge(float v);
@@ -121,13 +102,10 @@ int16_t OTRGetRectDimensionFromLeftEdge(float v);
 int16_t OTRGetRectDimensionFromRightEdge(float v);
 uint32_t OTRGetGameRenderWidth();
 uint32_t OTRGetGameRenderHeight();
-int AudioPlayer_Buffered(void);
 int AudioPlayer_GetDesiredBuffered(void);
 void AudioPlayer_Play(const uint8_t* buf, uint32_t len);
 void OoT_AudioMgr_CreateNextAudioBuffer(s16* samples, u32 num_samples);
 int Controller_ShouldRumble(size_t slot);
-void Controller_BlockGameInput();
-void Controller_UnblockGameInput();
 size_t GetEquipNowMessage(char* buffer, char* src, const size_t maxBufferSize);
 u32 SpoilerFileExists(const char* spoilerFileName);
 Sprite* GetSeedTexture(uint8_t index);
@@ -136,18 +114,12 @@ u8 Randomizer_GetSettingValue(RandomizerSettingKey randoSettingKey);
 RandomizerCheck Randomizer_GetCheckFromActor(s16 actorId, s16 sceneNum, s16 actorParams);
 ShopItemIdentity Randomizer_IdentifyShopItem(s32 sceneNum, u8 slotIndex);
 void Randomizer_ParseSpoiler(const char* fileLoc);
-bool Randomizer_IsTrialRequired(s32 trialFlag);
-GetItemEntry Randomizer_GetItemFromActor(s16 actorId, s16 sceneNum, s16 actorParams, GetItemID ogId);
-GetItemEntry Randomizer_GetItemFromActorWithoutObtainabilityCheck(s16 actorId, s16 sceneNum, s16 actorParams,
-                                                                  GetItemID ogId);
 GetItemEntry Randomizer_GetItemFromKnownCheck(RandomizerCheck randomizerCheck, GetItemID ogId);
 GetItemEntry Randomizer_GetItemFromKnownCheckWithoutObtainabilityCheck(RandomizerCheck randomizerCheck, GetItemID ogId);
-RandomizerInf Randomizer_GetRandomizerInfFromCheck(RandomizerCheck randomizerCheck);
 bool Randomizer_IsCheckShuffled(RandomizerCheck check);
 GetItemEntry GetItemMystery();
 ItemObtainability Randomizer_GetItemObtainabilityFromRandomizerCheck(RandomizerCheck randomizerCheck);
 uint8_t Randomizer_IsSeedGenerated();
-void Randomizer_SetSeedGenerated(bool seedGenerated);
 uint8_t Randomizer_IsSpoilerLoaded();
 void Randomizer_SetSpoilerLoaded(bool spoilerLoaded);
 uint8_t Randomizer_GenerateRandomizer();
@@ -160,14 +132,13 @@ void Gfx_RegisterBlendedTexture(const char* name, u8* mask, u8* replacement);
 void Gfx_UnregisterBlendedTexture(const char* name);
 void Gfx_TextureCacheDelete(const uint8_t* addr);
 void SaveManager_ThreadPoolWait();
-void CheckTracker_OnMessageClose();
+// Kept vs upstream SOH #6636: our randomizer_entrance.c still calls this (C23 forbids implicit declarations)
 void CheckTracker_RecalculateAvailableChecks();
 
 GetItemID RetrieveGetItemIDFromItemID(ItemID itemID);
 RandomizerGet RetrieveRandomizerGetFromItemID(ItemID itemID);
 void Messagebox_ShowErrorBox(char* title, char* body);
 
-uint32_t Ship_GetInterpolationFPS();
 uint32_t Ship_GetInterpolationFrameCount();
 #endif
 
@@ -177,6 +148,4 @@ extern "C" {
 uint64_t GetUnixTimestamp();
 #ifdef __cplusplus
 };
-#endif
-
 #endif

--- a/games/oot/soh/ResourceManagerHelpers.cpp
+++ b/games/oot/soh/ResourceManagerHelpers.cpp
@@ -5,6 +5,7 @@
 #include "cvar_prefixes.h"
 #include "Enhancements/enhancementTypes.h"
 #include "Enhancements/randomizer/dungeon.h"
+#include "soh/Enhancements/randomizer/SeedContext.h"
 #include <libultraship/libultraship.h>
 #include <soh/GameVersions.h>
 #include "resource/type/SohResourceType.h"

--- a/games/oot/soh/SaveManager.cpp
+++ b/games/oot/soh/SaveManager.cpp
@@ -8,6 +8,7 @@
 #include "soh/util.h"
 #include "Enhancements/randomizer/hint.h"
 #include "Enhancements/randomizer/item.h"
+#include "soh/Enhancements/randomizer/settings.h"
 #include "ResourceManagerHelpers.h"
 
 #include "z64.h"

--- a/games/oot/soh/SohGui/SohGui.cpp
+++ b/games/oot/soh/SohGui/SohGui.cpp
@@ -25,7 +25,6 @@
 #include "soh/OTRGlobals.h"
 #include "soh/Enhancements/Presets/Presets.h"
 #include "soh/resource/type/Skeleton.h"
-#include "libultraship/libultraship.h"
 
 #include "soh/Enhancements/game-interactor/GameInteractor.h"
 #include "soh/Enhancements/cosmetics/authenticGfxPatches.h"

--- a/games/oot/soh/SohGui/SohMenuEnhancements.cpp
+++ b/games/oot/soh/SohGui/SohMenuEnhancements.cpp
@@ -6,6 +6,7 @@
 #include <soh/Enhancements/cosmetics/authenticGfxPatches.h>
 #include <soh/Enhancements/enemyrandomizer.h>
 #include <soh/Enhancements/TimeDisplay/TimeDisplay.h>
+#include "soh/Enhancements/randomizer/randomizer.h"
 
 extern "C" {
 #include "functions.h"

--- a/games/oot/soh/SohGui/SohMenuNetwork.cpp
+++ b/games/oot/soh/SohGui/SohMenuNetwork.cpp
@@ -3,6 +3,7 @@
 #include <soh/Network/Network.h>
 #include "SohGui.hpp"
 #include "soh/OTRGlobals.h"
+#include "soh/util.h"
 #include <soh/Network/Sail/Sail.h>
 #include <soh/Network/CrowdControl/CrowdControl.h>
 

--- a/games/oot/soh/SohGui/SohMenuRandomizer.cpp
+++ b/games/oot/soh/SohGui/SohMenuRandomizer.cpp
@@ -2,6 +2,7 @@
 #include "soh/Enhancements/enhancementTypes.h"
 #include "soh/Enhancements/randomizer/randomizer.h"
 #include "soh/Enhancements/randomizer/randomizerTypes.h"
+#include "soh/Enhancements/randomizer/settings.h"
 #include "soh/OTRGlobals.h"
 #include "soh/SohGui/SohGui.hpp"
 

--- a/games/oot/soh/resource/importer/PathFactory.cpp
+++ b/games/oot/soh/resource/importer/PathFactory.cpp
@@ -3,6 +3,7 @@
 #include "soh/resource/logging/PathLogger.h"
 #include "spdlog/spdlog.h"
 #include <tinyxml2.h>
+#include <libultraship/bridge/consolevariablebridge.h>
 
 namespace SOH {
 std::shared_ptr<Ship::IResource>

--- a/games/oot/soh/resource/type/AudioSample.h
+++ b/games/oot/soh/resource/type/AudioSample.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <cstdint>
+#include <stdint.h>
 #include <ship/resource/Resource.h>
 #include <libultraship/libultra/types.h>
 

--- a/games/oot/soh/resource/type/AudioSequence.h
+++ b/games/oot/soh/resource/type/AudioSequence.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <cstdint>
+#include <stdint.h>
 #include <ship/resource/Resource.h>
 
 namespace SOH {

--- a/games/oot/soh/resource/type/AudioSoundFont.h
+++ b/games/oot/soh/resource/type/AudioSoundFont.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <cstdint>
+#include <stdint.h>
 #include <vector>
 #include <ship/resource/Resource.h>
 #include "soh/resource/type/AudioSample.h"

--- a/games/oot/soh/resource/type/CollisionHeader.h
+++ b/games/oot/soh/resource/type/CollisionHeader.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <cstdint>
+#include <stdint.h>
 #include <vector>
 #include <ship/resource/Resource.h>
 #include <libultraship/libultra.h>

--- a/games/oot/soh/resource/type/Path.h
+++ b/games/oot/soh/resource/type/Path.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <cstdint>
+#include <stdint.h>
 #include <vector>
 #include <ship/resource/Resource.h>
 #include <libultraship/libultra/types.h>

--- a/games/oot/soh/resource/type/Scene.h
+++ b/games/oot/soh/resource/type/Scene.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <cstdint>
+#include <stdint.h>
 #include <vector>
 #include <memory>
 #include <ship/resource/Resource.h>

--- a/games/oot/soh/resource/type/Skeleton.cpp
+++ b/games/oot/soh/resource/type/Skeleton.cpp
@@ -5,11 +5,11 @@
 #include <soh_assets.h>
 #include <objects/object_link_child/object_link_child.h>
 #include <objects/object_link_boy/object_link_boy.h>
-#include "macros.h"
 
 extern "C" {
 #include "variables.h"
 #include "z64.h"
+#include "macros.h"
 #include "z64player.h"
 extern PlayState* OoT_gPlayState;
 }

--- a/games/oot/soh/resource/type/Skeleton.h
+++ b/games/oot/soh/resource/type/Skeleton.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <cstdint>
+#include <stdint.h>
 #include <ship/resource/Resource.h>
 #include "SkeletonLimb.h"
 #include <z64animation.h>

--- a/games/oot/soh/resource/type/Text.h
+++ b/games/oot/soh/resource/type/Text.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <cstdint>
+#include <stdint.h>
 #include <vector>
 #include <ship/resource/Resource.h>
 #include <libultraship/libultra/types.h>

--- a/games/oot/soh/resource/type/scenecommand/EndMarker.h
+++ b/games/oot/soh/resource/type/scenecommand/EndMarker.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <cstdint>
+#include <stdint.h>
 #include <vector>
 #include <memory>
 #include <ship/resource/Resource.h>

--- a/games/oot/soh/resource/type/scenecommand/RomFile.h
+++ b/games/oot/soh/resource/type/scenecommand/RomFile.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <cstdint>
+#include <stdint.h>
 
 namespace SOH {
 typedef struct {

--- a/games/oot/soh/resource/type/scenecommand/SceneCommand.h
+++ b/games/oot/soh/resource/type/scenecommand/SceneCommand.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <cstdint>
+#include <stdint.h>
 #include <vector>
 #include <memory>
 #include <ship/resource/Resource.h>

--- a/games/oot/soh/resource/type/scenecommand/SetActorList.h
+++ b/games/oot/soh/resource/type/scenecommand/SetActorList.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <cstdint>
+#include <stdint.h>
 #include <vector>
 #include <memory>
 #include <string>

--- a/games/oot/soh/resource/type/scenecommand/SetAlternateHeaders.h
+++ b/games/oot/soh/resource/type/scenecommand/SetAlternateHeaders.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <cstdint>
+#include <stdint.h>
 #include <vector>
 #include <memory>
 #include <string>

--- a/games/oot/soh/resource/type/scenecommand/SetCameraSettings.h
+++ b/games/oot/soh/resource/type/scenecommand/SetCameraSettings.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <cstdint>
+#include <stdint.h>
 #include <vector>
 #include <memory>
 #include <ship/resource/Resource.h>

--- a/games/oot/soh/resource/type/scenecommand/SetCollisionHeader.h
+++ b/games/oot/soh/resource/type/scenecommand/SetCollisionHeader.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <cstdint>
+#include <stdint.h>
 #include <vector>
 #include <memory>
 #include <string>

--- a/games/oot/soh/resource/type/scenecommand/SetCsCamera.h
+++ b/games/oot/soh/resource/type/scenecommand/SetCsCamera.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <cstdint>
+#include <stdint.h>
 #include <vector>
 #include <memory>
 #include <ship/resource/Resource.h>

--- a/games/oot/soh/resource/type/scenecommand/SetCutscenes.h
+++ b/games/oot/soh/resource/type/scenecommand/SetCutscenes.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <cstdint>
+#include <stdint.h>
 #include <vector>
 #include <memory>
 #include <string>

--- a/games/oot/soh/resource/type/scenecommand/SetEchoSettings.h
+++ b/games/oot/soh/resource/type/scenecommand/SetEchoSettings.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <cstdint>
+#include <stdint.h>
 #include <vector>
 #include <memory>
 #include <ship/resource/Resource.h>

--- a/games/oot/soh/resource/type/scenecommand/SetEntranceList.h
+++ b/games/oot/soh/resource/type/scenecommand/SetEntranceList.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <cstdint>
+#include <stdint.h>
 #include <vector>
 #include <memory>
 #include <string>

--- a/games/oot/soh/resource/type/scenecommand/SetExitList.h
+++ b/games/oot/soh/resource/type/scenecommand/SetExitList.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <cstdint>
+#include <stdint.h>
 #include <vector>
 #include <memory>
 #include <ship/resource/Resource.h>

--- a/games/oot/soh/resource/type/scenecommand/SetLightList.h
+++ b/games/oot/soh/resource/type/scenecommand/SetLightList.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <cstdint>
+#include <stdint.h>
 #include <vector>
 #include <memory>
 #include <string>

--- a/games/oot/soh/resource/type/scenecommand/SetLightingSettings.h
+++ b/games/oot/soh/resource/type/scenecommand/SetLightingSettings.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <cstdint>
+#include <stdint.h>
 #include <vector>
 #include <memory>
 #include <ship/resource/Resource.h>

--- a/games/oot/soh/resource/type/scenecommand/SetMesh.h
+++ b/games/oot/soh/resource/type/scenecommand/SetMesh.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <cstdint>
+#include <stdint.h>
 #include <vector>
 #include <memory>
 #include <ship/resource/Resource.h>

--- a/games/oot/soh/resource/type/scenecommand/SetObjectList.h
+++ b/games/oot/soh/resource/type/scenecommand/SetObjectList.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <cstdint>
+#include <stdint.h>
 #include <vector>
 #include <memory>
 #include <string>

--- a/games/oot/soh/resource/type/scenecommand/SetPathways.h
+++ b/games/oot/soh/resource/type/scenecommand/SetPathways.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <cstdint>
+#include <stdint.h>
 #include <vector>
 #include <memory>
 #include <ship/resource/Resource.h>

--- a/games/oot/soh/resource/type/scenecommand/SetRoomBehavior.h
+++ b/games/oot/soh/resource/type/scenecommand/SetRoomBehavior.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <cstdint>
+#include <stdint.h>
 #include <vector>
 #include <memory>
 #include <ship/resource/Resource.h>

--- a/games/oot/soh/resource/type/scenecommand/SetRoomList.h
+++ b/games/oot/soh/resource/type/scenecommand/SetRoomList.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <cstdint>
+#include <stdint.h>
 #include <vector>
 #include <memory>
 #include <string>

--- a/games/oot/soh/resource/type/scenecommand/SetSkyboxModifier.h
+++ b/games/oot/soh/resource/type/scenecommand/SetSkyboxModifier.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <cstdint>
+#include <stdint.h>
 #include <vector>
 #include <memory>
 #include <ship/resource/Resource.h>

--- a/games/oot/soh/resource/type/scenecommand/SetSkyboxSettings.h
+++ b/games/oot/soh/resource/type/scenecommand/SetSkyboxSettings.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <cstdint>
+#include <stdint.h>
 #include <vector>
 #include <memory>
 #include <ship/resource/Resource.h>

--- a/games/oot/soh/resource/type/scenecommand/SetSoundSettings.h
+++ b/games/oot/soh/resource/type/scenecommand/SetSoundSettings.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <cstdint>
+#include <stdint.h>
 #include <vector>
 #include <memory>
 #include <ship/resource/Resource.h>

--- a/games/oot/soh/resource/type/scenecommand/SetSpecialObjects.h
+++ b/games/oot/soh/resource/type/scenecommand/SetSpecialObjects.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <cstdint>
+#include <stdint.h>
 #include <vector>
 #include <memory>
 #include <ship/resource/Resource.h>

--- a/games/oot/soh/resource/type/scenecommand/SetStartPositionList.h
+++ b/games/oot/soh/resource/type/scenecommand/SetStartPositionList.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <cstdint>
+#include <stdint.h>
 #include <vector>
 #include <memory>
 #include <string>

--- a/games/oot/soh/resource/type/scenecommand/SetTimeSettings.h
+++ b/games/oot/soh/resource/type/scenecommand/SetTimeSettings.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <cstdint>
+#include <stdint.h>
 #include <vector>
 #include <memory>
 #include <ship/resource/Resource.h>

--- a/games/oot/soh/resource/type/scenecommand/SetTransitionActorList.h
+++ b/games/oot/soh/resource/type/scenecommand/SetTransitionActorList.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <cstdint>
+#include <stdint.h>
 #include <vector>
 #include <memory>
 #include <string>

--- a/games/oot/soh/resource/type/scenecommand/SetWindSettings.h
+++ b/games/oot/soh/resource/type/scenecommand/SetWindSettings.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <cstdint>
+#include <stdint.h>
 #include <vector>
 #include <memory>
 #include <ship/resource/Resource.h>

--- a/games/oot/soh/z_message_OTR.cpp
+++ b/games/oot/soh/z_message_OTR.cpp
@@ -1,4 +1,3 @@
-#include "OTRGlobals.h"
 #include <libultraship/libultraship.h>
 #include "soh/resource/type/Scene.h"
 #include <ship/utils/StringHelper.h>

--- a/games/oot/soh/z_play_otr.cpp
+++ b/games/oot/soh/z_play_otr.cpp
@@ -1,4 +1,3 @@
-#include "OTRGlobals.h"
 #include "ResourceManagerHelpers.h"
 #include <libultraship/libultraship.h>
 #include "soh/resource/type/Scene.h"

--- a/games/oot/soh/z_scene_otr.cpp
+++ b/games/oot/soh/z_scene_otr.cpp
@@ -1,4 +1,4 @@
-#include "OTRGlobals.h"
+#include "soh/Enhancements/game-interactor/GameInteractor_Hooks.h"
 #include "ResourceManagerHelpers.h"
 #include <libultraship/libultraship.h>
 #include "soh/resource/type/Scene.h"


### PR DESCRIPTION
Closes #211.

Final PR of the Lane 6 OTRGlobals chain (#233 ✅ → #231 ✅ → #232 ✅ → **#211**). Three upstream commits, one commit each, applied in upstream chronological order:

1. **[`b65c1c831`](https://github.com/HarbourMasters/Shipwright/commit/b65c1c831) (SOH #6385, unused includes):** re-assessed file-by-file per the issue plan — every removal survives: each is a duplicate include (`z_en_mk.h` ×2 in hook_handlers, `UIWidgets.hpp` ×2 in InputViewer, `randomizerTypes.h` ×2 in randomizer_check_tracker, `libultraship.h` ×2 in SohGui.cpp, `SohGui.hpp` ×2 and `DisplayList.h` ×2 in OTRGlobals.cpp) or verifiably unused (`<iostream>`, DummyPlayer's `frame_interpolation.h`, the TimeSplits set — our TimeSplits body matches upstream's modulo single-exe renames).
2. **[`1785a70f2`](https://github.com/HarbourMasters/Shipwright/commit/1785a70f2) (SOH #6636, Clean OTRGlobals 2):** decouples `OTRGlobals.h` from all non-std headers (forward declarations; `defaultImGuiScale`/`imguiScaleOptionToValue` moved into the .cpp) with compensating includes in dependents. **64 of 72 upstream files ported**; `ShuffleSpeak.cpp`'s hunk is already satisfied by PR #303's port; the 7 still-absent shuffle files are handed to the #289–#293 lane via [a comment on #235](https://github.com/spencerduncan/redshipblueship/issues/235#issuecomment-4674289411). RSBS adaptations: `CheckTracker_RecalculateAvailableChecks()` declaration kept (our `randomizer_entrance.c` still calls it; C23 forbids implicit declarations), `RsbsFeatureEnabled()` kept, RSBS-only `GameExports_SingleExe.cpp` given direct `ship/Context.h` + `z64save.h` includes it previously got transitively, kaleido's `SeedContext.h` hunk dropped (our post-#303 kaleido has no seed-texture code).
3. **[`1de22d816`](https://github.com/HarbourMasters/Shipwright/commit/1de22d816) (SOH #6656, stdint.h):** standardize on `#include <stdint.h>` across 48 headers + add to the decoupled OTRGlobals.h. Applied cleanly, all 48 files present.

Static verification performed: every declaration upstream removed from OTRGlobals.h was grepped against our C files (one live C caller found and preserved); every `.cpp`/`.h` includer of OTRGlobals.h not covered by #6636's compensations was audited — each either matches upstream's include set (upstream-green) or has no relevant delta; all post-#303 Shuffle Speak files re-audited against the decoupled header. Zero new clang-format violations vs main baseline across all changed files.

SOH #6656's stated goal applies here too: changing `OTRGlobals.h` no longer rebuilds the world.

https://claude.ai/code/session_01Uf2rVASuZtYqYjGSyqYLJS

---
_Generated by [Claude Code](https://claude.ai/code/session_01Uf2rVASuZtYqYjGSyqYLJS)_

<!--- section:artifacts:start -->
### Build Artifacts
  - [rsbs-linux.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/7549179444.zip)
  - [rsbs-windows.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/7549075814.zip)
<!--- section:artifacts:end -->