### PR TITLE
Eradicate rand() outside the RNG helpers (#286)

### DIFF
--- a/games/mm/2s2h/BenGui/CosmeticEditor.cpp
+++ b/games/mm/2s2h/BenGui/CosmeticEditor.cpp
@@ -1,4 +1,5 @@
 #include "2s2h/BenGui/UIWidgets.hpp"
+#include "2s2h/ShipUtils.h"
 #include "CosmeticEditor.h"
 #include "2s2h/ShipInit.hpp"
 
@@ -343,9 +344,9 @@ extern "C" Gfx* Gfx_DrawTexRectIA8_DropShadowOffsetOverride(Gfx* pkt, TexturePtr
 
 void CosmeticEditorRandomizeElement(CosmeticEditorElement element) {
     Color_RGBA8 colorSelected;
-    colorSelected.r = static_cast<uint8_t>((rand() % 256) * 255.0f);
-    colorSelected.g = static_cast<uint8_t>((rand() % 256) * 255.0f);
-    colorSelected.b = static_cast<uint8_t>((rand() % 256) * 255.0f);
+    colorSelected.r = static_cast<uint8_t>(Ship_Random(0, 256) * 255.0f);
+    colorSelected.g = static_cast<uint8_t>(Ship_Random(0, 256) * 255.0f);
+    colorSelected.b = static_cast<uint8_t>(Ship_Random(0, 256) * 255.0f);
     colorSelected.a = static_cast<uint8_t>(255);
 
     CVarSetColor(element.colorCvar, colorSelected);

--- a/games/mm/2s2h/BenGui/UIWidgets.cpp
+++ b/games/mm/2s2h/BenGui/UIWidgets.cpp
@@ -1321,7 +1321,7 @@ ImVec4 GetRandomValue() {
     std::random_device rd;
     std::mt19937 rng(rd());
 #else
-    size_t seed = std::hash<std::string>{}(std::to_string(rand()));
+    size_t seed = std::hash<std::string>{}(std::to_string(Ship_Random(0, INT32_MAX)));
     std::mt19937_64 rng(seed);
 #endif
     std::uniform_int_distribution<int> dist(0, 255 - 1);

--- a/games/mm/2s2h/Enhancements/Audio/AudioEditor.cpp
+++ b/games/mm/2s2h/Enhancements/Audio/AudioEditor.cpp
@@ -1,4 +1,5 @@
 #include "AudioEditor.h"
+#include "2s2h/ShipUtils.h"
 
 #include <map>
 #include <set>
@@ -342,7 +343,7 @@ void Draw_SfxTab(const std::string& tabId, SeqType type) {
 
             if (validSequences.size()) {
                 auto it = validSequences.begin();
-                const auto& seqData = *std::next(it, rand() % validSequences.size());
+                const auto& seqData = *std::next(it, Ship_Random(0, validSequences.size()));
                 CVarSetInteger(cvarKey.c_str(), seqData->sequenceId);
                 if (locked) {
                     CVarClear(cvarLockKey.c_str());

--- a/games/mm/2s2h/Enhancements/Equipment/ChuDrops.cpp
+++ b/games/mm/2s2h/Enhancements/Equipment/ChuDrops.cpp
@@ -1,5 +1,6 @@
 #include <libultraship/bridge/consolevariablebridge.h>
 #include "2s2h/GameInteractor/GameInteractor.h"
+#include "2s2h/ShipUtils.h"
 #include "2s2h/ShipInit.hpp"
 #include "2s2h/CustomItem/CustomItem.h"
 #include "2s2h/Enhancements/FrameInterpolation/FrameInterpolation.h"
@@ -75,7 +76,7 @@ static void ChuDrop_Draw(Actor* actor, PlayState* play) {
 void RegisterChuDrops() {
     COND_ID_HOOK(ShouldActorInit, ACTOR_EN_ITEM00, CVAR, [](Actor* actor, bool* should) {
         if (actor->params == ITEM00_BOMBS_0 || actor->params == ITEM00_BOMBS_A || actor->params == ITEM00_BOMBS_B) {
-            if (rand() % 100 < 50) {
+            if (Ship_Random(0, 100) < 50) {
                 *should = false;
                 EnItem00* newItem =
                     CustomItem::Spawn(actor->world.pos.x, actor->world.pos.y, actor->world.pos.z, 0,

--- a/games/mm/2s2h/Rando/ActorBehavior/EnGirlA.cpp
+++ b/games/mm/2s2h/Rando/ActorBehavior/EnGirlA.cpp
@@ -1,4 +1,5 @@
 #include "ActorBehavior.h"
+#include "2s2h/ShipUtils.h"
 #include <libultraship/bridge/consolevariablebridge.h>
 #include "2s2h/CustomMessage/CustomMessage.h"
 #include "2s2h/Rando/MiscBehavior/Traps.h"
@@ -298,7 +299,7 @@ void Rando::ActorBehavior::InitEnGirlABehavior() {
         if (!Rando::IsItemObtainable(randoSaveCheck.randoItemId, randoCheckId) && randoSaveCheck.obtained) {
             entry.msg += "Out of Stock";
         } else {
-            entry.msg += flavorTexts[rand() % flavorTexts.size()];
+            entry.msg += flavorTexts[Ship_Random(0, flavorTexts.size())];
         }
         entry.msg += "\x1A\xBF";
 

--- a/games/mm/2s2h/Rando/ConvertItem.cpp
+++ b/games/mm/2s2h/Rando/ConvertItem.cpp
@@ -88,7 +88,7 @@ RandoItemId Rando::CurrentJunkItem() {
     }
 
     while (lastJunkItem == RI_UNKNOWN) {
-        RandoItemId randJunkItem = junkItems[rand() % junkItems.size()];
+        RandoItemId randJunkItem = junkItems[Ship_Random(0, junkItems.size())];
         if (Rando::IsItemObtainable(randJunkItem)) {
             lastJunkItem = randJunkItem;
         }

--- a/games/mm/2s2h/Rando/MiscBehavior/Traps.cpp
+++ b/games/mm/2s2h/Rando/MiscBehavior/Traps.cpp
@@ -41,7 +41,7 @@ std::vector<TrapTypes> getEnabledTrapTypes() {
 
 int RollTrapType() {
     auto enabledTraps = getEnabledTrapTypes();
-    roll = enabledTraps[rand() % enabledTraps.size()];
+    roll = enabledTraps[Ship_Random(0, enabledTraps.size())];
     return roll;
 }
 
@@ -133,9 +133,9 @@ std::string GetTrapMessage() {
     RollTrapType();
     auto findIt = trapMessageList.find((TrapTypes)roll);
     if (findIt == trapMessageList.end()) {
-        return defaultTrapMessages[rand() % defaultTrapMessages.size()];
+        return defaultTrapMessages[Ship_Random(0, defaultTrapMessages.size())];
     } else {
-        return findIt->second[rand() % findIt->second.size()];
+        return findIt->second[Ship_Random(0, findIt->second.size())];
     }
 }
 

--- a/games/oot/soh/Enhancements/audio/AudioEditor.cpp
+++ b/games/oot/soh/Enhancements/audio/AudioEditor.cpp
@@ -14,6 +14,7 @@
 #include "soh/SohGui/SohGui.hpp"
 #include "AudioCollection.h"
 #include "soh/Enhancements/enhancementTypes.h"
+#include "soh/ShipUtils.h"
 #include "soh/Enhancements/game-interactor/GameInteractor.h"
 #include "soh/Enhancements/randomizer/SeedContext.h"
 
@@ -403,7 +404,7 @@ void Draw_SfxTab(const std::string& tabId, SeqType type, const std::string& tabN
 
             if (validSequences.size()) {
                 auto it = validSequences.begin();
-                const auto& seqData = *std::next(it, rand() % validSequences.size());
+                const auto& seqData = *std::next(it, ShipUtils::Random(0, validSequences.size()));
                 CVarSetInteger(cvarKey.c_str(), seqData->sequenceId);
                 if (locked) {
                     CVarClear(cvarLockKey.c_str());

--- a/games/oot/soh/Enhancements/game-interactor/GameInteractor_RawAction.cpp
+++ b/games/oot/soh/Enhancements/game-interactor/GameInteractor_RawAction.cpp
@@ -4,6 +4,7 @@
 #include <math.h>
 #include "soh/Enhancements/debugger/colViewer.h"
 #include "soh/Enhancements/nametag.h"
+#include "soh/ShipUtils.h"
 
 extern "C" {
 #include "variables.h"
@@ -410,15 +411,11 @@ void GameInteractor::RawAction::EmulateButtonPress(int32_t button) {
 }
 
 void GameInteractor::RawAction::EmulateRandomButtonPress(uint32_t chancePercentage) {
-    uint32_t emulatedButton;
-    uint32_t randomNumber = rand();
+    uint32_t randomNumber = ShipUtils::Random(0, 1400);
     uint32_t possibleButtons[14] = { BTN_CRIGHT, BTN_CLEFT, BTN_CDOWN, BTN_CUP,   BTN_R, BTN_L, BTN_DRIGHT,
                                      BTN_DLEFT,  BTN_DDOWN, BTN_DUP,   BTN_START, BTN_Z, BTN_B, BTN_A };
-
-    emulatedButton = possibleButtons[randomNumber % 14];
-
     if (randomNumber % 100 < chancePercentage) {
-        GameInteractor::State::EmulatedButtons |= emulatedButton;
+        GameInteractor::State::EmulatedButtons |= possibleButtons[randomNumber / 100];
     }
 }
 
@@ -431,7 +428,7 @@ void GameInteractor::RawAction::SetRandomWind(bool active) {
     if (active) {
         GameInteractor::State::RandomWindActive = 1;
         if (GameInteractor::State::RandomWindSecondsSinceLastDirectionChange == 0) {
-            player->pushedYaw = (rand() % 49152) - 32767;
+            player->pushedYaw = ShipUtils::Random(0, 0xc000) - 0x8000;
             GameInteractor::State::RandomWindSecondsSinceLastDirectionChange = 5;
         } else {
             GameInteractor::State::RandomWindSecondsSinceLastDirectionChange--;

--- a/games/oot/soh/Enhancements/mods.cpp
+++ b/games/oot/soh/Enhancements/mods.cpp
@@ -2,6 +2,7 @@
 #include <libultraship/bridge.h>
 #include "game-interactor/GameInteractor.h"
 #include "soh/ResourceManagerHelpers.h"
+#include "soh/ShipUtils.h"
 #include "soh/Enhancements/boss-rush/BossRush.h"
 #include "soh/Enhancements/enhancementTypes.h"
 #include <soh/Enhancements/item-tables/ItemTableManager.h>
@@ -409,16 +410,16 @@ void RegisterRandomizedEnemySizes() {
         float randomNumber;
         float randomScale;
 
-        uint8_t bigActor = rand() % 2;
+        uint8_t bigActor = ShipUtils::Random(0, 2);
 
         // Big actor
         if (bigActor && !smallOnlyEnemy) {
-            randomNumber = rand() % 200;
+            randomNumber = ShipUtils::Random(0, 200);
             // Between 100% and 300% size.
             randomScale = 1.0f + (randomNumber / 100);
         } else {
             // Small actor
-            randomNumber = rand() % 90;
+            randomNumber = ShipUtils::Random(0, 90);
             // Between 10% and 100% size.
             randomScale = 0.1f + (randomNumber / 100);
         }

--- a/games/oot/soh/Enhancements/randomizer/3drando/menu.cpp
+++ b/games/oot/soh/Enhancements/randomizer/3drando/menu.cpp
@@ -10,6 +10,7 @@
 #include "spoiler_log.hpp"
 #include "../location_access.h"
 #include "soh/Enhancements/debugger/performanceTimer.h"
+#include "soh/ShipUtils.h"
 #include <spdlog/spdlog.h>
 #include "../../randomizer/randomizerTypes.h"
 
@@ -26,10 +27,14 @@ bool GenerateRandomizer(std::set<RandomizerCheck> excludedLocations, std::set<Ra
     ResetPerformanceTimers();
     StartPerformanceTimer(PT_WHOLE_SEED);
 
-    srand(static_cast<uint32_t>(time(NULL)));
     // if a blank seed was entered, make a random one
     if (seedInput.empty()) {
-        seedInput = std::to_string(rand());
+        char seedString[11];
+        for (size_t i = 0; i < 10; i++) {
+            seedString[i] = '0' + ShipUtils::Random(0, 10);
+        }
+        seedString[10] = '\0';
+        seedInput = std::string(seedString);
     } else if (seedInput.rfind("seed_testing_count", 0) == 0 && seedInput.length() > 18) {
         int count;
         try {

--- a/games/oot/soh/Enhancements/randomizer/3drando/playthrough.cpp
+++ b/games/oot/soh/Enhancements/randomizer/3drando/playthrough.cpp
@@ -6,6 +6,7 @@
 #include "random.hpp"
 #include "spoiler_log.hpp"
 #include "soh/Enhancements/randomizer/randomizerTypes.h"
+#include "soh/ShipUtils.h"
 #include "soh/Enhancements/randomizer/SeedContext.h"
 #include "soh/Enhancements/randomizer/settings.h"
 #include "variables.h"
@@ -101,7 +102,12 @@ int Playthrough_Repeat(std::set<RandomizerCheck> excludedLocations, std::set<Ran
     auto ctx = Rando::Context::GetInstance();
     uint32_t repeatedSeed = 0;
     for (int i = 0; i < count; i++) {
-        ctx->SetSeedString(std::to_string(rand()));
+        char seedString[11];
+        for (size_t i = 0; i < 10; i++) {
+            seedString[i] = '0' + ShipUtils::Random(0, 10);
+        }
+        seedString[10] = '\0';
+        ctx->SetSeedString(std::string(seedString));
         repeatedSeed = SohUtils::Hash(ctx->GetSeedString());
         ctx->SetSeed(repeatedSeed);
         SPDLOG_DEBUG("testing seed: %d", repeatedSeed);

--- a/games/oot/soh/Network/Sail/Sail.cpp
+++ b/games/oot/soh/Network/Sail/Sail.cpp
@@ -4,6 +4,7 @@
 #include <nlohmann/json.hpp>
 #include "soh/OTRGlobals.h"
 #include "soh/util.h"
+#include "soh/ShipUtils.h"
 
 template <class DstType, class SrcType> bool IsType(const SrcType* src) {
     return dynamic_cast<const DstType*>(src) != nullptr;
@@ -339,7 +340,7 @@ void Sail::RegisterHooks() {
             return;
 
         nlohmann::json payload;
-        payload["id"] = std::rand();
+        payload["id"] = ShipUtils::Random(0, UINT32_MAX);
         payload["type"] = "hook";
         payload["hook"]["type"] = "OnTransitionEnd";
         payload["hook"]["sceneNum"] = sceneNum;
@@ -352,7 +353,7 @@ void Sail::RegisterHooks() {
             return;
 
         nlohmann::json payload;
-        payload["id"] = std::rand();
+        payload["id"] = ShipUtils::Random(0, UINT32_MAX);
         payload["type"] = "hook";
         payload["hook"]["type"] = "OnLoadGame";
         payload["hook"]["fileNum"] = fileNum;
@@ -365,7 +366,7 @@ void Sail::RegisterHooks() {
             return;
 
         nlohmann::json payload;
-        payload["id"] = std::rand();
+        payload["id"] = ShipUtils::Random(0, UINT32_MAX);
         payload["type"] = "hook";
         payload["hook"]["type"] = "OnExitGame";
         payload["hook"]["fileNum"] = fileNum;
@@ -377,7 +378,7 @@ void Sail::RegisterHooks() {
         if (!isConnected || !GameInteractor::IsSaveLoaded())
             return;
         nlohmann::json payload;
-        payload["id"] = std::rand();
+        payload["id"] = ShipUtils::Random(0, UINT32_MAX);
         payload["type"] = "hook";
         payload["hook"]["type"] = "OnItemReceive";
         payload["hook"]["tableId"] = itemEntry.tableId;
@@ -392,7 +393,7 @@ void Sail::RegisterHooks() {
 
         Actor* actor = (Actor*)refActor;
         nlohmann::json payload;
-        payload["id"] = std::rand();
+        payload["id"] = ShipUtils::Random(0, UINT32_MAX);
         payload["type"] = "hook";
         payload["hook"]["type"] = "OnEnemyDefeat";
         payload["hook"]["actorId"] = actor->id;
@@ -407,7 +408,7 @@ void Sail::RegisterHooks() {
 
         Actor* actor = (Actor*)refActor;
         nlohmann::json payload;
-        payload["id"] = std::rand();
+        payload["id"] = ShipUtils::Random(0, UINT32_MAX);
         payload["type"] = "hook";
         payload["hook"]["type"] = "OnActorInit";
         payload["hook"]["actorId"] = actor->id;
@@ -420,7 +421,7 @@ void Sail::RegisterHooks() {
         if (!isConnected || !GameInteractor::IsSaveLoaded())
             return;
         nlohmann::json payload;
-        payload["id"] = std::rand();
+        payload["id"] = ShipUtils::Random(0, UINT32_MAX);
         payload["type"] = "hook";
         payload["hook"]["type"] = "OnFlagSet";
         payload["hook"]["flagType"] = flagType;
@@ -433,7 +434,7 @@ void Sail::RegisterHooks() {
         if (!isConnected || !GameInteractor::IsSaveLoaded())
             return;
         nlohmann::json payload;
-        payload["id"] = std::rand();
+        payload["id"] = ShipUtils::Random(0, UINT32_MAX);
         payload["type"] = "hook";
         payload["hook"]["type"] = "OnFlagUnset";
         payload["hook"]["flagType"] = flagType;
@@ -446,7 +447,7 @@ void Sail::RegisterHooks() {
         if (!isConnected || !GameInteractor::IsSaveLoaded())
             return;
         nlohmann::json payload;
-        payload["id"] = std::rand();
+        payload["id"] = ShipUtils::Random(0, UINT32_MAX);
         payload["type"] = "hook";
         payload["hook"]["type"] = "OnSceneFlagSet";
         payload["hook"]["flagType"] = flagType;
@@ -460,7 +461,7 @@ void Sail::RegisterHooks() {
         if (!isConnected || !GameInteractor::IsSaveLoaded())
             return;
         nlohmann::json payload;
-        payload["id"] = std::rand();
+        payload["id"] = ShipUtils::Random(0, UINT32_MAX);
         payload["type"] = "hook";
         payload["hook"]["type"] = "OnSceneFlagUnset";
         payload["hook"]["flagType"] = flagType;

--- a/games/oot/soh/SohGui/SohMenuRandomizer.cpp
+++ b/games/oot/soh/SohGui/SohMenuRandomizer.cpp
@@ -4,6 +4,7 @@
 #include "soh/Enhancements/randomizer/randomizerTypes.h"
 #include "soh/Enhancements/randomizer/settings.h"
 #include "soh/OTRGlobals.h"
+#include "soh/ShipUtils.h"
 #include "soh/SohGui/SohGui.hpp"
 
 extern "C" {
@@ -575,7 +576,12 @@ void SohMenu::AddMenuRandomizer() {
                         .Color(THEME_COLOR)
                         .Padding(ImVec2(10.f, 6.f))
                         .Tooltip("Creates a new random seed value to be used when generating a randomizer"))) {
-                SohUtils::CopyStringToCharArray(seedString, std::to_string(rand() & 0xFFFFFFFF), MAX_SEED_STRING_SIZE);
+                char newSeed[11];
+                for (size_t i = 0; i < 10; i++) {
+                    newSeed[i] = '0' + ShipUtils::Random(0, 10);
+                }
+                newSeed[10] = '\0';
+                SohUtils::CopyStringToCharArray(seedString, newSeed, MAX_SEED_STRING_SIZE);
             }
             ImGui::SameLine();
             if (UIWidgets::Button(ICON_FA_ERASER, UIWidgets::ButtonOptions()

--- a/games/oot/src/overlays/actors/ovl_En_Bom/z_en_bom.c
+++ b/games/oot/src/overlays/actors/ovl_En_Bom/z_en_bom.c
@@ -8,7 +8,6 @@
 #include "overlays/effects/ovl_Effect_Ss_Dead_Sound/z_eff_ss_dead_sound.h"
 #include "objects/gameplay_keep/gameplay_keep.h"
 #include "soh/Enhancements/game-interactor/GameInteractor.h"
-#include <stdlib.h>
 
 #define FLAGS (ACTOR_FLAG_UPDATE_CULLING_DISABLED | ACTOR_FLAG_DRAW_CULLING_DISABLED)
 
@@ -104,14 +103,13 @@ void OoT_EnBom_Init(Actor* thisx, PlayState* play) {
     } else {
         // Set random fuse timer with a minimum of 10. Do the sound and scale immediately,
         // otherwise the bomb is invisible until the timer hits the "normal" amount.
-        uint32_t randomTimer = (rand() % 150) + 10;
-        this->timer = randomTimer;
+        this->timer = 10 + (s16)(OoT_Rand_ZeroOne() * 150.0f);
         Audio_PlayActorSound2(thisx, NA_SE_PL_TAKE_OUT_SHIELD);
         OoT_Actor_SetScale(thisx, 0.01f);
     }
 
     if (CVarGetFloat(CVAR_CHEAT("BombTimerMultiplier"), 1.0f) != 1.0f) {
-        this->timer = (s32)(70 * CVarGetFloat(CVAR_CHEAT("BombTimerMultiplier"), 1.0f));
+        this->timer *= CVarGetFloat(CVAR_CHEAT("BombTimerMultiplier"), 1.0f);
         // Do the sound and scale immediately if GameInteractor hasn't already.
         if (!GameInteractor_GetRandomBombFuseTimerActive()) {
             Audio_PlayActorSound2(thisx, NA_SE_PL_TAKE_OUT_SHIELD);

--- a/games/oot/src/overlays/actors/ovl_En_Vali/z_en_vali.c
+++ b/games/oot/src/overlays/actors/ovl_En_Vali/z_en_vali.c
@@ -7,7 +7,6 @@
 #include "z_en_vali.h"
 #include "objects/object_vali/object_vali.h"
 #include "soh/Enhancements/game-interactor/GameInteractor_Hooks.h"
-#include <stdlib.h>
 #include "soh/ResourceManagerHelpers.h"
 
 #define FLAGS \
@@ -249,7 +248,7 @@ void EnVali_SetupDivideAndDie(EnVali* this, PlayState* play) {
         // Offset small jellyfish with Enemy Randomizer, otherwise it gets
         // stuck in a loop spawning more big jellyfish with seeded spawns.
         if (CVarGetInteger(CVAR_ENHANCEMENT("RandomizedEnemies"), 0)) {
-            this->actor.world.rot.y += rand() % 50;
+            this->actor.world.rot.y += (s16)(OoT_Rand_ZeroOne() * 50.0f);
         }
 
         OoT_Actor_Spawn(&play->actorCtx, play, ACTOR_EN_BILI, this->actor.world.pos.x, this->actor.world.pos.y,


### PR DESCRIPTION
Closes #286.

Converts all 32 convertible `rand()` call sites across 16 files (full pre-change inventory: 33 sites / 17 files), porting upstream SOH [`a3ab0e2bd`](https://github.com/HarbourMasters/Shipwright/commit/a3ab0e2bd) (#6553) where applicable and using each tree's own deterministic RNG helper:

**OoT C++ → `ShipUtils::Random` / seed-string generation**
- `Network/Sail/Sail.cpp` ×10 payload ids — upstream-exact
- `GameInteractor_RawAction.cpp` ×2 — upstream-exact (button-press roll, random wind yaw)
- `audio/AudioEditor.cpp` — upstream-exact
- `mods.cpp` ×3 — our pre-split copy of upstream's RandomizedEnemySizes logic; minimal swaps preserving our structure
- `3drando/menu.cpp` (+ `srand` removal), `3drando/playthrough.cpp`, `SohGui/SohMenuRandomizer.cpp` — 10-digit random seed strings per upstream, adopting the corrected `seedString[10]` terminator from current upstream develop instead of the original commit's off-by-one

**OoT C → `OoT_Rand_ZeroOne`** (C files can't use the C++-only `ShipUtils::Random`)
- `z_en_bom.c` — upstream hunk, incl. the bundled `BombTimerMultiplier` `*=` fix; unused `<stdlib.h>` dropped
- `z_en_vali.c` — RSBS-divergent site (upstream's equivalent lives in EnemyRandomizer.cpp), same pattern

**MM → `Ship_Random`** (MM's own PCG helper with C linkage; MM files cannot include the OoT helper)
- `CosmeticEditor.cpp` ×3, `UIWidgets.cpp`, `Audio/AudioEditor.cpp`, `ChuDrops.cpp`, `EnGirlA.cpp`, `ConvertItem.cpp`, `Traps.cpp` ×3

**Deliberately left:**
- `games/oot/soh/ShipUtils.cpp:122` — the `__SWITCH__`/`__WIIU__` seeding fallback *inside* the RNG helper itself (converting it is circular; identical line on Shipwright develop, untouched by #6553)
- `srand(now)` in `OTRGlobals.cpp` and `BenPort.cpp` — both still present at the same spots on current Shipwright/2S2H develop; upstream parity (and no remaining `rand()` consumers)
- Upstream's `EnemyRandomizer.cpp`/`RandomizedEnemySizes.cpp` hunks (no counterpart files here) and its tangential `randomizer.h` include-cleanup hunk (out of scope)

`src/common` has zero `rand()` sites (issue's extra-vs-upstream scope). Post-change `git grep '\brand()' -- games/ src/common` returns exactly the one exempt line. Zero new clang-format violations vs main baseline.

Lane 6 (epic #202): #233 ✅ #231 ✅ #232 ✅ #288 ✅ #211 ✅ → **#286** → #212.

https://claude.ai/code/session_01Uf2rVASuZtYqYjGSyqYLJS

---
_Generated by [Claude Code](https://claude.ai/code/session_01Uf2rVASuZtYqYjGSyqYLJS)_

<!--- section:artifacts:start -->
### Build Artifacts
  - [rsbs-windows.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/7550418732.zip)
  - [rsbs-linux.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/7550223041.zip)
<!--- section:artifacts:end -->