### PR TITLE
Absorb SOH 9.2.x checks/trackers/world batch (#235)

### DIFF
--- a/games/oot/soh/Enhancements/randomizer/3drando/fill.cpp
+++ b/games/oot/soh/Enhancements/randomizer/3drando/fill.cpp
@@ -83,30 +83,30 @@ static void PropagateTimeTravel(GetAccessibleLocationsStruct& gals, RandomizerGe
 static bool UpdateToDAccess(Entrance* entrance, Region* connection) {
     StartPerformanceTimer(PT_TOD_ACCESS);
 
-    bool ageTimePropogated = false;
+    bool ageTimePropagated = false;
     Region* parent = entrance->GetParentRegion();
 
     if (!connection->childDay && parent->childDay && entrance->CheckConditionAtAgeTime(logic->IsChild, logic->AtDay)) {
         connection->childDay = true;
-        ageTimePropogated = true;
+        ageTimePropagated = true;
     }
     if (!connection->childNight && parent->childNight &&
         entrance->CheckConditionAtAgeTime(logic->IsChild, logic->AtNight)) {
         connection->childNight = true;
-        ageTimePropogated = true;
+        ageTimePropagated = true;
     }
     if (!connection->adultDay && parent->adultDay && entrance->CheckConditionAtAgeTime(logic->IsAdult, logic->AtDay)) {
         connection->adultDay = true;
-        ageTimePropogated = true;
+        ageTimePropagated = true;
     }
     if (!connection->adultNight && parent->adultNight &&
         entrance->CheckConditionAtAgeTime(logic->IsAdult, logic->AtNight)) {
         connection->adultNight = true;
-        ageTimePropogated = true;
+        ageTimePropagated = true;
     }
 
     StopPerformanceTimer(PT_TOD_ACCESS);
-    return ageTimePropogated;
+    return ageTimePropagated;
 }
 
 // Check if key locations in the overworld are accessable
@@ -568,10 +568,12 @@ void GeneratePlaythrough() {
     do {
         gals.InitLoop();
         for (size_t i = 0; i < gals.regionPool.size(); i++) {
+        resetSphere:
             ProcessRegion(RegionTable(gals.regionPool[i]), gals, RG_NONE, false, true);
             if (gals.resetSphere) {
                 gals.resetSphere = false;
-                i = -1;
+                i = 0;
+                goto resetSphere;
             }
         }
         if (gals.itemSphere.size() > 0) {
@@ -896,7 +898,6 @@ static void AssumedFill(const std::vector<RandomizerGet>& items, const std::vect
 
             // retry if there are no more locations to place items
             if (accessibleLocations.empty()) {
-
                 SPDLOG_DEBUG("\nCANNOT PLACE ");
                 SPDLOG_DEBUG(Rando::StaticData::RetrieveItem(item).GetName().GetEnglish());
                 SPDLOG_DEBUG(". TRYING AGAIN...\n");
@@ -904,7 +905,6 @@ static void AssumedFill(const std::vector<RandomizerGet>& items, const std::vect
                 // reset any locations that got an item
                 for (RandomizerCheck loc : attemptedLocations) {
                     ctx->GetItemLocation(loc)->SetPlacedItem(RG_NONE);
-                    // itemsPlaced--;
                 }
                 attemptedLocations.clear();
 
@@ -1409,7 +1409,6 @@ int Fill() {
         StopPerformanceTimer(PT_PLAYTHROUGH_GENERATION);
         // Successful placement, produced beatable result
         if (ctx->playthroughBeatable && !placementFailure) {
-
             SPDLOG_INFO("Calculating Playthrough...");
             StartPerformanceTimer(PT_PARE_DOWN_PLAYTHROUGH);
             PareDownPlaythrough();

--- a/games/oot/soh/Enhancements/randomizer/3drando/item_pool.cpp
+++ b/games/oot/soh/Enhancements/randomizer/3drando/item_pool.cpp
@@ -592,7 +592,7 @@ void GenerateItemPool() {
         ctx->PlaceItemInLocation(RC_TH_DEAD_END_CARPENTER, RG_RECOVERY_HEART, false, true);
         ctx->PlaceItemInLocation(RC_TH_DOUBLE_CELL_CARPENTER, RG_RECOVERY_HEART, false, true);
         ctx->PlaceItemInLocation(RC_TH_STEEP_SLOPE_CARPENTER, RG_RECOVERY_HEART, false, true);
-
+        ctx->PlaceItemInLocation(RC_TH_FREED_CARPENTERS, RG_BLUE_RUPEE, false, true);
     } else if (ctx->GetOption(RSK_GERUDO_KEYS).IsNot(RO_GERUDO_KEYS_VANILLA)) {
         if (ctx->GetOption(RSK_GERUDO_FORTRESS).Is(RO_GF_CARPENTERS_FAST)) {
             AddItemToPool(RG_GERUDO_FORTRESS_SMALL_KEY, 2, 1, 1, 1);
@@ -607,7 +607,6 @@ void GenerateItemPool() {
                 AddItemToPool(RG_GERUDO_FORTRESS_SMALL_KEY, 5, 4, 4, 4);
             }
         }
-
     } else {
         if (ctx->GetOption(RSK_GERUDO_FORTRESS).Is(RO_GF_CARPENTERS_FAST)) {
             ctx->PlaceItemInLocation(RC_TH_1_TORCH_CARPENTER, RG_GERUDO_FORTRESS_SMALL_KEY, false, true);
@@ -625,9 +624,6 @@ void GenerateItemPool() {
     // Gerudo Membership Card
     if (ctx->GetOption(RSK_SHUFFLE_GERUDO_MEMBERSHIP_CARD)) {
         AddItemToPool(RG_GERUDO_MEMBERSHIP_CARD, 2, 1, 1, 1);
-        if (ctx->GetOption(RSK_GERUDO_FORTRESS).IsNot(RO_GF_CARPENTERS_FREE)) {
-            ctx->PlaceItemInLocation(RC_TH_FREED_CARPENTERS, RG_BLUE_RUPEE, false, true);
-        }
     } else {
         ctx->PlaceItemInLocation(RC_TH_FREED_CARPENTERS, RG_GERUDO_MEMBERSHIP_CARD, false, true);
     }

--- a/games/oot/soh/Enhancements/randomizer/location_access/overworld/kokiri_forest.cpp
+++ b/games/oot/soh/Enhancements/randomizer/location_access/overworld/kokiri_forest.cpp
@@ -12,7 +12,7 @@ void RegionTable_Init_KokiriForest() {
     }, {
         //Locations
         //Technically bad logic, because we can move Mido out of logic, but then we already have KSword...
-        LOCATION(RC_MIDO_HINT,                  !ctx->GetOption(RSK_FOREST).Is(RO_CLOSED_FOREST_OFF) && logic->IsChild && logic->CanUse(RG_SPEAK_KOKIRI)),
+        LOCATION(RC_MIDO_HINT,                  !ctx->GetOption(RSK_FOREST).Is(RO_CLOSED_FOREST_OFF) && logic->IsChild && logic->HasItem(RG_SPEAK_KOKIRI)),
         LOCATION(RC_KF_GS_KNOW_IT_ALL_HOUSE,    logic->IsChild && logic->CanKillEnemy(RE_GOLD_SKULLTULA, ED_CLOSE) && logic->CanGetNightTimeGS()),
         LOCATION(RC_KF_GS_BEAN_PATCH,           logic->CanSpawnSoilSkull(RG_KOKIRI_FOREST_BEAN_SOUL) && logic->CanKillEnemy(RE_GOLD_SKULLTULA, ED_CLOSE)),
         LOCATION(RC_KF_GS_HOUSE_OF_TWINS,       logic->IsAdult && logic->CanGetNightTimeGS() && 
@@ -137,7 +137,7 @@ void RegionTable_Init_KokiriForest() {
         LOCATION(RC_KF_MIDOS_TOP_RIGHT_CHEST,    logic->HasItem(RG_OPEN_CHEST)),
         LOCATION(RC_KF_MIDOS_BOTTOM_LEFT_CHEST,  logic->HasItem(RG_OPEN_CHEST)),
         LOCATION(RC_KF_MIDOS_BOTTOM_RIGHT_CHEST, logic->HasItem(RG_OPEN_CHEST)),
-        LOCATION(RC_MIDO_HINT,                         logic->Get(LOGIC_SHOWED_MIDO_SWORD_AND_SHIELD) && logic->IsChild && logic->CanUse(RG_SPEAK_KOKIRI)),
+        LOCATION(RC_MIDO_HINT,                         logic->Get(LOGIC_SHOWED_MIDO_SWORD_AND_SHIELD) && logic->IsChild && logic->HasItem(RG_SPEAK_KOKIRI)),
     }, {
         //Exits
         Entrance(RR_KOKIRI_FOREST, []{return true;}),

--- a/games/oot/soh/Enhancements/randomizer/randomizer_check_tracker.cpp
+++ b/games/oot/soh/Enhancements/randomizer/randomizer_check_tracker.cpp
@@ -15,6 +15,8 @@
 #include "3drando/fill.hpp"
 #include "soh/Enhancements/debugger/performanceTimer.h"
 #include "soh/Enhancements/randomizer/randomizer.h"
+#include "soh/ObjectExtension/ObjectExtension.h"
+#include "overlays/actors/ovl_En_GirlA/z_en_girla.h"
 
 #include <string>
 #include <sstream>
@@ -863,6 +865,32 @@ void CheckTrackerFlagSet(int16_t flagType, int32_t flag) {
     }
 }
 
+void CheckTrackerDialogMessage() {
+    auto identifyCheck = [](RandomizerCheck rc) {
+        auto loc = OTRGlobals::Instance->gRandoContext->GetItemLocation(rc);
+        if (loc->GetCheckStatus() == RCSHOW_UNCHECKED) {
+            loc->SetCheckStatus(RCSHOW_IDENTIFIED);
+            RecalculateAvailableChecks();
+        }
+    };
+
+    if (OoT_gPlayState->msgCtx.textId == TEXT_BEAN_SALESMAN_BUY_FOR_10) {
+        identifyCheck(RC_ZR_MAGIC_BEAN_SALESMAN);
+    } else if (OoT_gPlayState->msgCtx.textId == TEXT_MEDIGORON) {
+        identifyCheck(RC_GC_MEDIGORON);
+    } else if (OoT_gPlayState->msgCtx.textId == TEXT_GRANNYS_SHOP) {
+        identifyCheck(RC_KAK_GRANNYS_SHOP);
+    } else if (OoT_gPlayState->msgCtx.textId == TEXT_CARPET_SALESMAN_1) {
+        identifyCheck(RC_WASTELAND_BOMBCHU_SALESMAN);
+    } else if (OoT_gPlayState->msgCtx.textId == TEXT_SCRUB_RANDOM) {
+        if (auto* actor = OoT_gPlayState->msgCtx.talkActor) {
+            if (auto* checkIdentity = ObjectExtension::GetInstance().Get<ScrubIdentity>(actor)) {
+                identifyCheck(checkIdentity->identity.randomizerCheck);
+            }
+        }
+    }
+}
+
 void InitTrackerData(bool isDebug) {
     TrySetAreas();
     areasSpoiled = 0;
@@ -1566,7 +1594,8 @@ bool IsCheckShuffled(RandomizerCheck rc) {
                (loc->GetRCType() != RCTYPE_SCRUB || showScrubs ||
                 (showMajorScrubs && (rc == RC_LW_DEKU_SCRUB_NEAR_BRIDGE || // The 3 scrubs that are always randomized
                                      rc == RC_HF_DEKU_SCRUB_GROTTO || rc == RC_LW_DEKU_SCRUB_GROTTO_FRONT))) &&
-               (loc->GetRCType() != RCTYPE_MERCHANT || showMerchants) &&
+               ((loc->GetRCType() != RCTYPE_MERCHANT || showMerchants) ||
+                (rc == RC_ZR_MAGIC_BEAN_SALESMAN && showBeans)) &&
                (loc->GetRCType() != RCTYPE_SONG_LOCATION || showSongs) &&
                (loc->GetRCType() != RCTYPE_BEEHIVE || showBeehives) &&
                (loc->GetRCType() != RCTYPE_OCARINA || showOcarinas) &&
@@ -1604,8 +1633,7 @@ bool IsCheckShuffled(RandomizerCheck rc) {
                 rc == RC_DMT_TRADE_CLAIM_CHECK // even when shuffle adult trade is off
                 ) &&
                (rc != RC_KF_KOKIRI_SWORD_CHEST || showKokiriSword) && (rc != RC_TOT_MASTER_SWORD || showMasterSword) &&
-               (rc != RC_LH_HYRULE_LOACH || showHyruleLoach) && (rc != RC_ZR_MAGIC_BEAN_SALESMAN || showBeans) &&
-               (rc != RC_HC_MALON_EGG || showWeirdEgg) &&
+               (rc != RC_LH_HYRULE_LOACH || showHyruleLoach) && (rc != RC_HC_MALON_EGG || showWeirdEgg) &&
                (loc->GetRCType() != RCTYPE_FROG_SONG || showFrogSongRupees) &&
                ((loc->GetRCType() != RCTYPE_MAP && loc->GetRCType() != RCTYPE_COMPASS) || showStartingMapsCompasses) &&
                (loc->GetRCType() != RCTYPE_FOUNTAIN_FAIRY || showFountainFairies) &&
@@ -1731,6 +1759,42 @@ bool CompareChecks(RandomizerCheck i, RandomizerCheck j) {
 
 bool IsHeartPiece(GetItemID giid) {
     return giid == GI_HEART_PIECE || giid == GI_HEART_PIECE_WIN;
+}
+
+bool IsMysteryShopItem(RandomizerCheck rc) {
+    s32 sceneNum = 0;
+    u8 slotIndex = 0;
+
+    if (rc >= RC_KF_SHOP_ITEM_1 && rc <= RC_KF_SHOP_ITEM_8) {
+        sceneNum = SCENE_KOKIRI_SHOP;
+        slotIndex = rc - RC_KF_SHOP_ITEM_1;
+    } else if (rc >= RC_MARKET_BAZAAR_ITEM_1 && rc <= RC_MARKET_BAZAAR_ITEM_8) {
+        sceneNum = SCENE_BAZAAR;
+        slotIndex = rc - RC_MARKET_BAZAAR_ITEM_1;
+    } else if (rc >= RC_MARKET_POTION_SHOP_ITEM_1 && rc <= RC_MARKET_POTION_SHOP_ITEM_8) {
+        sceneNum = SCENE_POTION_SHOP_MARKET;
+        slotIndex = rc - RC_MARKET_POTION_SHOP_ITEM_1;
+    } else if (rc >= RC_MARKET_BOMBCHU_SHOP_ITEM_1 && rc <= RC_MARKET_BOMBCHU_SHOP_ITEM_8) {
+        sceneNum = SCENE_BOMBCHU_SHOP;
+        slotIndex = rc - RC_MARKET_BOMBCHU_SHOP_ITEM_1;
+    } else if (rc >= RC_KAK_BAZAAR_ITEM_1 && rc <= RC_KAK_BAZAAR_ITEM_8) {
+        sceneNum = SCENE_TEST01;
+        slotIndex = rc - RC_KAK_BAZAAR_ITEM_1;
+    } else if (rc >= RC_KAK_POTION_SHOP_ITEM_1 && rc <= RC_KAK_POTION_SHOP_ITEM_8) {
+        sceneNum = SCENE_POTION_SHOP_KAKARIKO;
+        slotIndex = rc - RC_KAK_POTION_SHOP_ITEM_1;
+    } else if (rc >= RC_GC_SHOP_ITEM_1 && rc <= RC_GC_SHOP_ITEM_8) {
+        sceneNum = SCENE_GORON_SHOP;
+        slotIndex = rc - RC_GC_SHOP_ITEM_1;
+    } else if (rc >= RC_ZD_SHOP_ITEM_1 && rc <= RC_ZD_SHOP_ITEM_8) {
+        sceneNum = SCENE_ZORA_SHOP;
+        slotIndex = rc - RC_ZD_SHOP_ITEM_1;
+    } else {
+        return false;
+    }
+
+    ShopItemIdentity shopItemIdentity = OTRGlobals::Instance->gRandomizer->IdentifyShopItem(sceneNum, slotIndex + 1);
+    return shopItemIdentity.enGirlAShopItem == SI_RANDOMIZED_ITEM;
 }
 
 void DrawLocation(RandomizerCheck rc) {
@@ -1890,7 +1954,17 @@ void DrawLocation(RandomizerCheck rc) {
             case RCSHOW_IDENTIFIED:
             case RCSHOW_SEEN:
                 if (IS_RANDO) {
-                    if (itemLoc->GetPlacedRandomizerGet() == RG_ICE_TRAP && !mystery) {
+                    const auto checkType = loc->GetRCType();
+                    const bool hideMerchantName =
+                        checkType == RCTYPE_MERCHANT &&
+                        (!OTRGlobals::Instance->gRandomizer->GetRandoSettingValue(RSK_MERCHANT_TEXT_HINT) || mystery);
+                    const bool hideScrubName =
+                        checkType == RCTYPE_SCRUB &&
+                        (!OTRGlobals::Instance->gRandomizer->GetRandoSettingValue(RSK_SCRUB_TEXT_HINT) || mystery);
+                    const bool hideShopName = checkType == RCTYPE_SHOP && mystery && IsMysteryShopItem(rc);
+                    const bool revealItemName = !(hideMerchantName || hideScrubName || hideShopName);
+
+                    if (itemLoc->GetPlacedRandomizerGet() == RG_ICE_TRAP && revealItemName) {
                         if (status == RCSHOW_IDENTIFIED) {
                             txt = OTRGlobals::Instance->gRandoContext->overrides[rc].GetTrickName().GetForLanguage(
                                 gSaveContext.language);
@@ -1900,14 +1974,12 @@ void DrawLocation(RandomizerCheck rc) {
                                       .GetName()
                                       .GetForLanguage(gSaveContext.language);
                         }
-                    } else if (!mystery) {
+                    } else if (revealItemName) {
                         txt = itemLoc->GetPlacedItem().GetName().GetForLanguage(gSaveContext.language);
                     }
-                    if (IsVisibleInCheckTracker(rc) && status == RCSHOW_IDENTIFIED && !mystery) {
+                    if (IsVisibleInCheckTracker(rc) && status == RCSHOW_IDENTIFIED) {
                         auto price = OTRGlobals::Instance->gRandoContext->GetItemLocation(rc)->GetPrice();
-                        if (price) {
-                            txt += fmt::format(" - {}", price);
-                        }
+                        txt = !txt.empty() ? fmt::format("{} - {}", txt, price) : fmt::format("{}", price);
                     }
                 } else {
                     if (IsHeartPiece((GetItemID)Rando::StaticData::RetrieveItem(loc->GetVanillaItem()).GetItemID())) {
@@ -2231,6 +2303,7 @@ void CheckTrackerWindow::InitElement() {
     GameInteractor::Instance->RegisterGameHook<GameInteractor::OnShopSlotChange>(CheckTrackerShopSlotChange);
     GameInteractor::Instance->RegisterGameHook<GameInteractor::OnSceneFlagSet>(CheckTrackerSceneFlagSet);
     GameInteractor::Instance->RegisterGameHook<GameInteractor::OnFlagSet>(CheckTrackerFlagSet);
+    GameInteractor::Instance->RegisterGameHook<GameInteractor::OnDialogMessage>(CheckTrackerDialogMessage);
 }
 
 void CheckTrackerWindow::UpdateElement() {

--- a/games/oot/soh/Enhancements/randomizer/randomizer_entrance.c
+++ b/games/oot/soh/Enhancements/randomizer/randomizer_entrance.c
@@ -722,17 +722,20 @@ void Entrance_OverrideSpawnScene(s32 sceneNum, s32 spawn) {
             modifiedLinkActorEntry.pos.z = 0xFF22;
             OoT_gPlayState->linkActorEntry = &modifiedLinkActorEntry;
         }
+    }
 
-        // Move Ganon's Castle exit spawn to be on the small ledge near the castle and not over the void
-        // to prevent Link from falling if the bridge isn't spawned
-        if (sceneNum == SCENE_OUTSIDE_GANONS_CASTLE && spawn == 1) {
-            modifiedLinkActorEntry.pos.x = 0xFEA8;
-            modifiedLinkActorEntry.pos.y = 0x065C;
-            modifiedLinkActorEntry.pos.z = 0x0290;
-            modifiedLinkActorEntry.rot.y = 0x0700;
-            modifiedLinkActorEntry.params = 0x0DFF; // stationary spawn
-            OoT_gPlayState->linkActorEntry = &modifiedLinkActorEntry;
-        }
+    // Move Ganon's Castle exit spawn to be on the small ledge near the castle and not over the void
+    // to prevent Link from falling if the bridge isn't spawned
+    if (sceneNum == SCENE_OUTSIDE_GANONS_CASTLE && spawn == 1 &&
+        (Randomizer_GetSettingValue(RSK_SHUFFLE_DUNGEON_ENTRANCES) == RO_DUNGEON_ENTRANCE_SHUFFLE_ON_PLUS_GANON ||
+         Randomizer_GetSettingValue(RSK_SHUFFLE_BOSS_ENTRANCES) != RO_BOSS_ROOM_ENTRANCE_SHUFFLE_OFF ||
+         Randomizer_GetSettingValue(RSK_SHUFFLE_GANONS_TOWER_ENTRANCE))) {
+        modifiedLinkActorEntry.pos.x = 0xFEA8;
+        modifiedLinkActorEntry.pos.y = 0x065C;
+        modifiedLinkActorEntry.pos.z = 0x0290;
+        modifiedLinkActorEntry.rot.y = 0x0700;
+        modifiedLinkActorEntry.params = 0x0DFF; // stationary spawn
+        OoT_gPlayState->linkActorEntry = &modifiedLinkActorEntry;
     }
 
     if (Randomizer_GetSettingValue(RSK_SHUFFLE_BOSS_ENTRANCES) != RO_BOSS_ROOM_ENTRANCE_SHUFFLE_OFF) {

--- a/games/oot/soh/Enhancements/randomizer/randomizer_item_tracker.cpp
+++ b/games/oot/soh/Enhancements/randomizer/randomizer_item_tracker.cpp
@@ -144,6 +144,26 @@ std::vector<ItemTrackerItem> rocsFeather = {
     ITEM_TRACKER_ITEM(RG_ROCS_FEATHER, 0, DrawItem),
 };
 
+std::vector<ItemTrackerItem> swimItems = {
+    ITEM_TRACKER_ITEM_CUSTOM(RG_BRONZE_SCALE, ITEM_SCALE_SILVER, ITEM_SCALE_SILVER, 0, DrawItem),
+};
+
+std::vector<ItemTrackerItem> crawlItems = {
+    ITEM_TRACKER_ITEM(RG_CRAWL, 0, DrawItem),
+};
+
+std::vector<ItemTrackerItem> climbItems = {
+    ITEM_TRACKER_ITEM(RG_CLIMB, 0, DrawItem),
+};
+
+std::vector<ItemTrackerItem> grabItems = {
+    ITEM_TRACKER_ITEM(RG_POWER_BRACELET, 0, DrawItem),
+};
+
+std::vector<ItemTrackerItem> openChestItems = {
+    ITEM_TRACKER_ITEM(RG_OPEN_CHEST, 0, DrawItem),
+};
+
 std::vector<ItemTrackerItem> beanSoulItems = {
     ITEM_TRACKER_ITEM_CUSTOM(RG_DEATH_MOUNTAIN_CRATER_BEAN_SOUL, ITEM_BEAN, ITEM_BEAN, 0, DrawItem),
     ITEM_TRACKER_ITEM_CUSTOM(RG_DEATH_MOUNTAIN_TRAIL_BEAN_SOUL, ITEM_BEAN, ITEM_BEAN, 0, DrawItem),
@@ -1147,6 +1167,31 @@ void DrawItem(ItemTrackerItem item) {
             hasItem = Flags_GetRandomizerInf(RAND_INF_FISHING_HOLE_KEY_OBTAINED);
             itemName = "Fishing Hole Key";
             break;
+        case RG_BRONZE_SCALE:
+            actualItemId = item.id;
+            hasItem = Flags_GetRandomizerInf(RAND_INF_CAN_SWIM);
+            itemName = "Swim";
+            break;
+        case RG_CRAWL:
+            actualItemId = item.id;
+            hasItem = Flags_GetRandomizerInf(RAND_INF_CAN_CRAWL);
+            itemName = "Crawl";
+            break;
+        case RG_CLIMB:
+            actualItemId = item.id;
+            hasItem = Flags_GetRandomizerInf(RAND_INF_CAN_CLIMB);
+            itemName = "Climb";
+            break;
+        case RG_POWER_BRACELET:
+            actualItemId = item.id;
+            hasItem = Flags_GetRandomizerInf(RAND_INF_CAN_GRAB);
+            itemName = "Grab";
+            break;
+        case RG_OPEN_CHEST:
+            actualItemId = item.id;
+            hasItem = Flags_GetRandomizerInf(RAND_INF_CAN_OPEN_CHEST);
+            itemName = "Open";
+            break;
     }
 
     if (GameInteractor::IsSaveLoaded() &&
@@ -1210,6 +1255,15 @@ void DrawItem(ItemTrackerItem item) {
                                          p.y - (iconSize + 13)));
         ImGui::PushStyleColor(ImGuiCol_Text, IM_COL_WHITE);
         ImGui::Text("%s", overworldKeyName.c_str());
+        ImGui::PopStyleColor();
+    }
+
+    if (item.id >= RG_BRONZE_SCALE && item.id <= RG_OPEN_CHEST) {
+        ImVec2 p = ImGui::GetCursorScreenPos();
+        ImGui::SetCursorScreenPos(
+            ImVec2(p.x + (iconSize / 2) - (ImGui::CalcTextSize(itemName.c_str()).x / 2), p.y - (iconSize + 2)));
+        ImGui::PushStyleColor(ImGuiCol_Text, IM_COL_WHITE);
+        ImGui::Text("%s", itemName.c_str());
         ImGui::PopStyleColor();
     }
 
@@ -1564,6 +1618,21 @@ void UpdateVectors() {
     }
     if (IS_RANDO && RAND_GET_OPTION(RSK_ROCS_FEATHER)) {
         mainWindowItems.insert(mainWindowItems.end(), rocsFeather.begin(), rocsFeather.end());
+    }
+    if (IS_RANDO && RAND_GET_OPTION(RSK_SHUFFLE_SWIM)) {
+        mainWindowItems.insert(mainWindowItems.end(), swimItems.begin(), swimItems.end());
+    }
+    if (IS_RANDO && RAND_GET_OPTION(RSK_SHUFFLE_GRAB)) {
+        mainWindowItems.insert(mainWindowItems.end(), grabItems.begin(), grabItems.end());
+    }
+    if (IS_RANDO && RAND_GET_OPTION(RSK_SHUFFLE_CLIMB)) {
+        mainWindowItems.insert(mainWindowItems.end(), climbItems.begin(), climbItems.end());
+    }
+    if (IS_RANDO && RAND_GET_OPTION(RSK_SHUFFLE_CRAWL)) {
+        mainWindowItems.insert(mainWindowItems.end(), crawlItems.begin(), crawlItems.end());
+    }
+    if (IS_RANDO && RAND_GET_OPTION(RSK_SHUFFLE_OPEN_CHEST)) {
+        mainWindowItems.insert(mainWindowItems.end(), openChestItems.begin(), openChestItems.end());
     }
 
     // if we're adding greg to the misc window,

--- a/games/oot/soh/Enhancements/randomizer/savefile.cpp
+++ b/games/oot/soh/Enhancements/randomizer/savefile.cpp
@@ -481,6 +481,7 @@ extern "C" void Randomizer_InitSaveFile() {
         gSaveContext.sceneFlags[SCENE_THIEVES_HIDEOUT].swch |= (1 << 0x11);
         gSaveContext.sceneFlags[SCENE_THIEVES_HIDEOUT].collect |= (1 << 0x0C); // picked up key
 
+        Flags_SetRandomizerInf(RAND_INF_TH_ITEM_FROM_LEADER_OF_FORTRESS);
         if (!Randomizer_GetSettingValue(RSK_SHUFFLE_GERUDO_MEMBERSHIP_CARD)) {
             OoT_Item_Give(NULL, ITEM_GERUDO_CARD);
         }

--- a/games/oot/soh/SohGui/ImGuiUtils.cpp
+++ b/games/oot/soh/SohGui/ImGuiUtils.cpp
@@ -3,6 +3,7 @@
 #include <ship/window/Window.h>
 #include "assets/soh_assets.h"
 #include "soh/Enhancements/randomizer/rando_hash.h"
+#include "soh/Enhancements/randomizer/randomizerTypes.h"
 
 std::map<uint32_t, ItemMapEntry> itemMapping = {
     ITEM_MAP_ENTRY(ITEM_STICK),
@@ -147,6 +148,13 @@ std::map<uint32_t, ItemMapEntry> customItemsMapping = {
     { RG_BONGO_BONGO_SOUL, { RG_BONGO_BONGO_SOUL, "RG_BONGO_BONGO_SOUL", "RG_BONGO_BONGO_SOUL_Faded", gBossSoulTex } },
     { RG_TWINROVA_SOUL, { RG_TWINROVA_SOUL, "RG_TWINROVA_SOUL", "RG_TWINROVA_SOUL_Faded", gBossSoulTex } },
     { RG_GANON_SOUL, { RG_GANON_SOUL, "RG_GANON_SOUL", "RG_GANON_SOUL_Faded", gBossSoulTex } },
+    { RG_OPEN_CHEST, { RG_OPEN_CHEST, "RG_OPEN_CHEST", "RG_OPEN_CHEST_Faded", gMapChestIconTex } }
+};
+
+std::map<uint32_t, ItemMapEntry> actionShuffleMapping = {
+    { RG_CRAWL, { RG_CRAWL, "RG_CRAWL", "RG_CRAWL_Faded", gButtonBackgroundTex } },
+    { RG_CLIMB, { RG_CLIMB, "RG_CLIMB", "RG_CLIMB_Faded", gButtonBackgroundTex } },
+    { RG_POWER_BRACELET, { RG_POWER_BRACELET, "RG_POWER_BRACELET", "RG_POWER_BRACELET_Faded", gButtonBackgroundTex } },
 };
 
 std::map<uint32_t, ItemMapEntry> jabbernutMapping = {
@@ -221,6 +229,16 @@ void RegisterImGuiItemIcons() {
                                                                             gregGreen);
         Ship::Context::GetInstance()->GetWindow()->GetGui()->LoadGuiTexture(entry.second.nameFaded,
                                                                             entry.second.texturePath, gregFadedGreen);
+    }
+
+    for (const auto& entry : actionShuffleMapping) {
+        ImVec4 aButtonBlue = ImVec4(90.f / 255.f, 90.f / 250.f, 255.f / 255.f, 255.f / 255.f);
+        ImVec4 aButtonBlueFaded = aButtonBlue;
+        aButtonBlueFaded.w = 0.3f;
+        Ship::Context::GetInstance()->GetWindow()->GetGui()->LoadGuiTexture(entry.second.name, entry.second.texturePath,
+                                                                            aButtonBlue);
+        Ship::Context::GetInstance()->GetWindow()->GetGui()->LoadGuiTexture(entry.second.nameFaded,
+                                                                            entry.second.texturePath, aButtonBlueFaded);
     }
 
     for (const auto& entry : customItemsMapping) {


### PR DESCRIPTION
Part of epic #235 (Lane 5) — 9.2.x absorption, batch 2 of 2: **checks, trackers, world**.

Absorbs five upstream SOH commits in merge order:

1. **[`2af265db`](https://github.com/HarbourMasters/Shipwright/commit/2af265db4ec105241bcbd751db1ce1cdb22e2bd1) (SOH #6190):** action-shuffle icons (swim, grab, climb, crawl, open chest, bronze scale) in the item tracker + ImGui icon mappings. Not one of the eight originally-listed batch PRs — included as the exact source of the Open Chest tracker/ImGui residue documented on #235 (per-file `RG_OPEN_CHEST` counts now match upstream's final tree).
2. **[`2845baad`](https://github.com/HarbourMasters/Shipwright/commit/2845baad0d8c904f0f425a572fd1cd6b6b4dc8be) (SOH #6641):** merchant/scrub checks identified in the check tracker via message text IDs and talk actor (all `TEXT_*` constants verified present in our CustomMessageTypes.h).
3. **[`5bccc8a3`](https://github.com/HarbourMasters/Shipwright/commit/5bccc8a3e0014c281e0ec57b9b6cbbb5773fbadc) (SOH #6647):** Ganon's Castle exit spawn moved to the safe ledge when boss-entrance or Ganon's-Tower-entrance shuffles are on, not only dungeon-entrances+Ganon. The RSBS-only Hyrule Castle courtyard spawn block (absent upstream) kept under its original condition.
4. **[`31cbeb92`](https://github.com/HarbourMasters/Shipwright/commit/31cbeb92cf3edaf368b6020a692a3d8efcacefac) (SOH #6557):** bean merchant check listed in the check tracker when bean-merchant-only shuffled.
5. **[`80d3114f`](https://github.com/HarbourMasters/Shipwright/commit/80d3114f7985c9f6ca254475bcdfc8f42630748d) (SOH #6661):** carpenters-start-free logic fix (savefile rand-inf flag + unconditional fill placement in item_pool), playthrough `resetSphere` goto fix, `ageTimePropagated` typo, Mido hint `CanUse`→`HasItem`. The fill.cpp `RandomizeDungeonRewards` divergence (upstream's intermediate Link's-Pocket restructure we don't have) left as ours; only this commit's own deltas applied.

### Dropped as inapplicable
**`e5ad4e6f` (SOH #6608, "Fix ending audio shuffle")** — it patches the `SEQ_ENDING` sequence category belonging to the ending-audio-shuffle feature, which is **not in our tree** (our End Credits sequences are still categorized `SEQ_BGM_EVENT`). The first CI run failed on exactly this (`SEQ_ENDING was not declared`); the hunks are reverted. To be ported together with the parent feature in a future sync.

### Port notes
- Touches `item_pool.cpp` (a lane contention file) — permitted, as this is the lane's own single in-flight PR and no other PRs are open
- Single-exe renames applied: `OoT_gPlayState` ×6 in the check tracker
- Rebased onto post-#314 main so the Mido-hint delta from #6661 lands on the #6565-added lines

### Verification
- Zero conflict markers; all referenced symbols verified present; tracker `RG_OPEN_CHEST` parity with upstream final restored
- CI is the acceptance gate: seeds generate cleanly, trackers list the new checks, logic stays solvable

https://claude.ai/code/session_01Px2yG38AB4cBaWUaN9uYEn

<!--- section:artifacts:start -->
### Build Artifacts
  - [rsbs-windows.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/7571507262.zip)
  - [rsbs-linux.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/7571317052.zip)
<!--- section:artifacts:end -->