### PR TITLE
CI: stop redundant per-PR work and fix compiler-cache eviction

### DIFF
--- a/.github/actions/otr-cache-key/action.yml
+++ b/.github/actions/otr-cache-key/action.yml
@@ -1,0 +1,32 @@
+name: Compute soh.o2r cache key
+description: >
+  Computes the cache key for the generated soh.o2r archive from the actual
+  inputs of the GenerateSohOtr (--norom) target: the games/oot/assets tree
+  (custom assets + xml), the OTRExporter/ZAPDTR/libultraship gitlink SHAs
+  (tool sources and the LUS shaders copied into assets/custom — readable
+  WITHOUT submodule init), copy-existing-otrs.cmake, and the project version
+  (passed as --port-ver and baked into the archive). Replaces the old
+  hashFiles('games/**/*.c', ...) key, which (a) forced a ~25 min regen on
+  every decomp .c/.h change even though GenerateSohOtr never reads those
+  files, and (b) hashed empty submodule directories before `git submodule
+  update --init` ran, so tool bumps never invalidated the cache.
+outputs:
+  key:
+    description: soh.o2r cache key
+    value: ${{ steps.compute.outputs.key }}
+runs:
+  using: composite
+  steps:
+    - id: compute
+      shell: bash
+      run: |
+        HASH=$(git rev-parse \
+          HEAD:games/oot/assets \
+          HEAD:OTRExporter \
+          HEAD:ZAPDTR \
+          HEAD:libultraship \
+          HEAD:copy-existing-otrs.cmake \
+          | sha256sum | cut -c1-16)
+        VER=$(sed -n 's/^project(Ship VERSION \([0-9][0-9.]*\).*/\1/p' CMakeLists.txt)
+        echo "key=rsbs-otr-v2-${VER}-${HASH}" >> "$GITHUB_OUTPUT"
+        echo "Computed soh.o2r cache key: rsbs-otr-v2-${VER}-${HASH}"

--- a/.github/workflows/generate-builds.yml
+++ b/.github/workflows/generate-builds.yml
@@ -27,11 +27,16 @@ jobs:
       with:
         fetch-depth: 1
         fetch-tags: true
+    - name: Compute soh.o2r cache key
+      id: otr-key
+      uses: ./.github/actions/otr-cache-key
+    # Exact-match only (no restore-keys): this caches a final artifact, not an
+    # incremental cache — a stale partial restore would be silently wrong.
     - name: Restore soh.o2r Cache
       id: rsbs-otr-cache
       uses: actions/cache@v4
       with:
-        key: rsbs-otr-v1-${{ hashFiles('games/**/*.c', 'games/**/*.h', 'games/**/*.xml', 'OTRExporter/**/*.cpp', 'OTRExporter/**/*.h', 'ZAPDTR/**/*.cpp', 'ZAPDTR/**/*.h') }}
+        key: ${{ steps.otr-key.outputs.key }}
         path: soh.o2r
     - name: Checkout submodules
       if: steps.rsbs-otr-cache.outputs.cache-hit != 'true'
@@ -71,7 +76,10 @@ jobs:
           tar -xzf SDL2-2.30.3.tar.gz -C deps
         fi
         cd deps/SDL2-2.30.3
-        ./configure --enable-hidapi-libusb
+        # Skip configure if already done (Makefile exists) — parity with build-linux
+        if [ ! -f "Makefile" ]; then
+          ./configure --enable-hidapi-libusb
+        fi
         make -j 10
         sudo make install
         sudo cp -av /usr/local/lib/libSDL* /lib/x86_64-linux-gnu/
@@ -87,7 +95,10 @@ jobs:
         cd deps/tinyxml2-10.0.0
         mkdir -p build
         cd build
-        cmake .. -DCMAKE_POSITION_INDEPENDENT_CODE=ON
+        # Skip cmake configure if already done AND configured with PIC — parity with build-linux
+        if [ ! -f "CMakeCache.txt" ] || ! grep -q "CMAKE_POSITION_INDEPENDENT_CODE:BOOL=ON" CMakeCache.txt; then
+          cmake .. -DCMAKE_POSITION_INDEPENDENT_CODE=ON
+        fi
         make
         sudo make install
     - name: Generate soh.o2r

--- a/.github/workflows/generate-builds.yml
+++ b/.github/workflows/generate-builds.yml
@@ -102,12 +102,8 @@ jobs:
         name: soh.o2r
         path: soh.o2r
         retention-days: 3
-    - name: Save Cache deps folder
-      if: ${{ github.ref_name == github.event.repository.default_branch }}
-      uses: actions/cache/save@v4
-      with:
-        key: ${{ runner.os }}-deps-v1-${{ hashFiles('.github/workflows/apt-deps.txt') }}
-        path: deps
+    # No "Save Cache deps folder" here: build-linux saves the identical key on
+    # main pushes; a second save of the same key only produces a warning.
 
   build-macos:
     # DISABLED: macOS build is currently broken - see GitHub issue for tracking
@@ -209,6 +205,10 @@ jobs:
       uses: hendrikmuhs/ccache-action@v1.2
       with:
         save: ${{ github.ref_name == github.event.repository.default_branch }}
+        # The action's default 500M cap is too small for the full OoT+MM build
+        # (~8180 objects): measured 2026-06-11 at 89.66% full with 15 cleanups
+        # and a 73.24% hit rate. The working set is ~1.0-1.2G compressed.
+        max-size: "1.5G"
         key: ${{ runner.os }}-ccache-${{ github.ref }}
         restore-keys: |
           ${{ runner.os }}-ccache-${{ github.ref }}
@@ -304,7 +304,9 @@ jobs:
         CC: gcc-11
         CXX: g++-11
     - name: Run tests
-      run: ctest --test-dir build-cmake --output-on-failure --label-regex "^redship$"
+      # --no-tests=error: if the "redship" test label ever regresses, fail loudly
+      # instead of ctest exiting 0 with "No tests were found".
+      run: ctest --test-dir build-cmake --output-on-failure --label-regex "^redship$" --no-tests=error
     - name: Package
       run: |
         (cd build-cmake && cpack -G External)
@@ -337,6 +339,10 @@ jobs:
     # CMAKE_UNITY_BUILD (high blast radius across game CMakeLists), moving off MSVC,
     # or a larger runner. None fit a low-risk CI tuning change. The Linux/Windows gap is
     # the fundamental Windows MSVC + ninja per-step process-spawn cost, not a config bug.
+    # Update 2026-06-11: the warm-cache conclusion above still holds; the later
+    # degradation to ~26 min builds (65.89% hit rate) was 10GB cache-quota LRU
+    # eviction caused by per-PR ~2.3GB sccache saves — fixed by the main-only
+    # save policy on the "Configure sccache" step below.
     needs: generate-rsbs-otr
     runs-on: windows-latest
     env:
@@ -353,7 +359,7 @@ jobs:
           core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env.ACTIONS_RUNTIME_TOKEN || '');
     - name: Install dependencies
       run: |
-        choco install ninja llvm -y
+        choco install ninja llvm -y --no-progress
         Remove-Item -Path "C:\ProgramData\Chocolatey\bin\ccache.exe" -Force -ErrorAction SilentlyContinue
     - name: Git Checkout
       uses: actions/checkout@v4
@@ -366,10 +372,15 @@ jobs:
       with:
         variant: sccache
         max-size: "5G"
-        # Save on every branch (default), not just main, so subsequent pushes to
-        # the same PR pick up the previous push's cache instead of cold-restoring
-        # from main. Issue #177 — Phase 2 iteration on Windows-only integration
-        # tests will rebuild many times per PR.
+        # Save on main only. The previous per-branch save policy (issue #177)
+        # wrote a fresh ~2.3GB cache on every PR push; at the current PR rate
+        # that blew the repo's 10GB Actions-cache quota and LRU-evicted main's
+        # linux-ccache/deps/vcpkg/soh.o2r caches (measured 2026-06-11: 65.89%
+        # sccache hit rate and ~26 min builds, vs 99.82% and ~8 min on
+        # 2026-06-01). Main merges several times a day, so the main-keyed
+        # cache restored via restore-keys is nearly fresh for every PR; a PR's
+        # repeated pushes only re-compile files the PR itself touched.
+        save: ${{ github.ref_name == github.event.repository.default_branch }}
         key: ${{ runner.os }}-sccache-${{ github.ref }}
         restore-keys: |
           ${{ runner.os }}-sccache-${{ github.ref }}

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -1,19 +1,15 @@
 name: integration-tests
+# Manual-only (workflow_dispatch). Every integration test below requires the
+# ROM-derived archives oot.o2r/mm.o2r, which cannot be distributed and can
+# therefore never exist on GitHub-hosted runners. When this ran on every PR,
+# all test steps were skipped while still spending ~25 min of compute per PR
+# (a duplicate generate-rsbs-otr job + a full from-scratch rebuild + the same
+# `ctest --label-regex "^redship$"` that generate-builds' build-linux already
+# runs). Re-enable pull_request/push triggers together with
+# `runs-on: [self-hosted, ...]` once a ROM-equipped runner exists
+# (see docs/BUILDING.md).
 on:
-  push:
-    branches:
-      - main
-    paths-ignore:
-      - '**.md'
-      - 'docs/**'
-      - 'LICENSE*'
-      - '.gitignore'
-  pull_request:
-    paths-ignore:
-      - '**.md'
-      - 'docs/**'
-      - 'LICENSE*'
-      - '.gitignore'
+  workflow_dispatch:
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -261,11 +261,16 @@ jobs:
       uses: actions/checkout@v4
       with:
         fetch-depth: 1
+    - name: Compute soh.o2r cache key
+      id: otr-key
+      uses: ./.github/actions/otr-cache-key
+    # Exact-match only (no restore-keys): this caches a final artifact, not an
+    # incremental cache — a stale partial restore would be silently wrong.
     - name: Restore soh.o2r Cache
       id: rsbs-otr-cache
       uses: actions/cache@v4
       with:
-        key: rsbs-otr-v1-${{ hashFiles('games/**/*.c', 'games/**/*.h', 'games/**/*.xml', 'OTRExporter/**/*.cpp', 'OTRExporter/**/*.h', 'ZAPDTR/**/*.cpp', 'ZAPDTR/**/*.h') }}
+        key: ${{ steps.otr-key.outputs.key }}
         path: soh.o2r
     - name: Checkout submodules
       if: steps.rsbs-otr-cache.outputs.cache-hit != 'true'


### PR DESCRIPTION
## Summary

Three CI fixes driven by measured run data (runs 27318838740 / 27318838736, 2026-06-11). Expected effect once caches re-warm: PR wall-clock ~31–36 min → ~12–15 min; per-PR compute ~70 min → ~25–30 min.

### 1. integration-tests → workflow_dispatch only
Every integration test requires the ROM-derived `oot.o2r`/`mm.o2r` archives, which cannot exist on GitHub-hosted runners — so on PRs all test steps were skipped while the workflow still spent ~25 compute-min per PR (a duplicate `generate-rsbs-otr` job, a full from-scratch rebuild under its own ccache namespace, and a ctest invocation identical to build-linux's). Not a required check. Kept manually runnable for a future ROM-equipped self-hosted runner.

### 2. Compiler-cache eviction fixes
- **Windows sccache: save on main only.** The per-branch policy wrote a fresh ~2.3 GB cache on every PR push, blowing the repo's 10 GB Actions-cache quota and LRU-evicting the main-branch caches everything restores from. Measured: hit rate fell from 99.82% (2026-06-01, issue #177) to 65.89%, the build step from ~8 min to ~26 min.
- **Linux ccache: max-size 500M → 1.5G.** The full build (~8180 objects) overflowed the default cap (89.66% full, 15 cleanups, 73.24% hits).
- Extras: `ctest --no-tests=error`, drop a duplicate deps-cache save, `choco --no-progress`.

### 3. soh.o2r cache key v2
The old key (a) hashed `games/**/*.c`/`*.h`, which `GenerateSohOtr --norom` never reads — any decomp change paid a needless ~25-min serial asset regen gating both builds; and (b) ran `hashFiles()` on the OTRExporter/ZAPDTR patterns *before* submodule init, hashing empty directories — tool bumps never invalidated the cache. The new key is computed by a shared composite action (`.github/actions/otr-cache-key`) from git object SHAs readable at fetch-depth 1: the `games/oot/assets` tree, the OTRExporter/ZAPDTR/libultraship gitlinks, `copy-existing-otrs.cmake`, and the project version (verified against `extract_assets.py`'s `--norom` path).

## Verification
- This PR's own run exercises all changes: no integration-tests run is triggered; ccache post-step shows the 1.5G cap; Windows sccache logs "Not saving cache"; the otr job computes the v2 key (expected one-time ~25-min regen since v2 has never been cached).
- After merge, the first main push saves the v2 soh.o2r cache to main scope; subsequent PRs hit in ~22 s. A decomp-only change should hit; a submodule bump should miss.
- Cache hit rates should recover toward ~99% over the next day as main-keyed caches stop being evicted.

Follow-up (separate PR): run the Linux jobs in the prebuilt `ghcr.io/spencerduncan/redshipblueship-build` container to drop the apt/SDL/tinyxml2/libzip steps entirely.

https://claude.ai/code/session_01DmDHmuHJravA6jCuksnPSE

---
_Generated by [Claude Code](https://claude.ai/code/session_01DmDHmuHJravA6jCuksnPSE)_

<!--- section:artifacts:start -->
### Build Artifacts
  - [rsbs-windows.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/7570649881.zip)
  - [rsbs-linux.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/7570450383.zip)
<!--- section:artifacts:end -->