### PR TITLE
CI: build Linux jobs in the prebuilt dependency container

### DIFF
--- a/.github/docker/build-base.Dockerfile
+++ b/.github/docker/build-base.Dockerfile
@@ -45,6 +45,11 @@ RUN apt-get update && apt-get install -y \
     # Tools (not in apt-deps.txt)
     ccache \
     curl \
+    # Needed at CMake configure time to generate the appimage icon (sohIcon.png)
+    imagemagick \
+    # Needed by OTRExporter/extract_assets.py (don't rely on the transitive
+    # dependency via lsb-release)
+    python3 \
     # Install packages from apt-deps.txt
     && tr ' ' '\n' < /tmp/apt-deps.txt | xargs apt-get install -y \
     && rm -rf /var/lib/apt/lists/* /tmp/apt-deps.txt

--- a/.github/docker/build-base.Dockerfile
+++ b/.github/docker/build-base.Dockerfile
@@ -47,8 +47,10 @@ RUN apt-get update && apt-get install -y \
     curl \
     # Needed at CMake configure time to generate the appimage icon (sohIcon.png)
     imagemagick \
-    # Hard requirement of appimagetool during cpack packaging
+    # Hard requirements of appimagetool during cpack packaging (it die()s
+    # without `file` and `desktop-file-validate`)
     file \
+    desktop-file-utils \
     # Needed by OTRExporter/extract_assets.py (don't rely on the transitive
     # dependency via lsb-release)
     python3 \

--- a/.github/docker/build-base.Dockerfile
+++ b/.github/docker/build-base.Dockerfile
@@ -47,6 +47,8 @@ RUN apt-get update && apt-get install -y \
     curl \
     # Needed at CMake configure time to generate the appimage icon (sohIcon.png)
     imagemagick \
+    # Hard requirement of appimagetool during cpack packaging
+    file \
     # Needed by OTRExporter/extract_assets.py (don't rely on the transitive
     # dependency via lsb-release)
     python3 \

--- a/.github/workflows/generate-builds.yml
+++ b/.github/workflows/generate-builds.yml
@@ -178,14 +178,16 @@ jobs:
     #  - imagemagick: consumed at CMake configure time (find_package(ImageMagick))
     #    to produce build-cmake/sohIcon.png; without it configure silently skips
     #    the icon and linuxdeploy fails with "No such file: sohIcon.png".
-    #  - file: hard requirement of appimagetool ("file command is missing but
-    #    required").
+    #  - file, desktop-file-utils: hard requirements of appimagetool — its
+    #    dependency check die()s on missing `file` and `desktop-file-validate`
+    #    (verified against the binary's check strings; zsyncmake/appstreamcli/
+    #    gpg are warnings only and mksquashfs is bundled in the plugin).
     # Drop this step once the image (build-base.Dockerfile) has been
     # republished with these baked in.
     - name: Install packaging tools
       run: |
         apt-get update
-        apt-get install -y imagemagick file
+        apt-get install -y imagemagick file desktop-file-utils
     - name: Configure ccache
       uses: hendrikmuhs/ccache-action@v1.2
       with:

--- a/.github/workflows/generate-builds.yml
+++ b/.github/workflows/generate-builds.yml
@@ -21,12 +21,22 @@ jobs:
 
   generate-rsbs-otr:
     runs-on: ubuntu-22.04
+    # Prebuilt CI image with cmake 3.26+, gcc-11, ccache, and SDL2/SDL2_net/
+    # tinyxml2/libzip already compiled in (.github/docker/build-base.Dockerfile),
+    # replacing the per-run apt install + deps-folder cache + from-source builds
+    # that used to live in this job. static-analysis.yml uses the same image.
+    container:
+      image: ghcr.io/spencerduncan/redshipblueship-build:latest
     steps:
     - name: Git Checkout
       uses: actions/checkout@v4
       with:
         fetch-depth: 1
         fetch-tags: true
+    # Required for the git commands run by the otr-cache-key action and the
+    # build: inside the container the workspace is owned by a different uid.
+    - name: Configure git safe directory
+      run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
     - name: Compute soh.o2r cache key
       id: otr-key
       uses: ./.github/actions/otr-cache-key
@@ -51,56 +61,6 @@ jobs:
           ${{ runner.os }}-otr-ccache-${{ github.ref }}
           ${{ runner.os }}-otr-ccache-refs/heads/main
           ${{ runner.os }}-otr-ccache
-    - name: Install dependencies
-      if: steps.rsbs-otr-cache.outputs.cache-hit != 'true'
-      run: |
-        sudo apt-get update
-        sudo apt-get install -y $(cat .github/workflows/apt-deps.txt) libzip-dev zipcmp zipmerge ziptool
-    - name: Restore Cached deps folder
-      if: steps.rsbs-otr-cache.outputs.cache-hit != 'true'
-      uses: actions/cache/restore@v4
-      with:
-        key: ${{ runner.os }}-deps-v1-${{ hashFiles('.github/workflows/apt-deps.txt') }}
-        restore-keys: |
-          ${{ runner.os }}-deps-v1-
-        path: deps
-    - name: Create deps folder
-      if: steps.rsbs-otr-cache.outputs.cache-hit != 'true'
-      run: mkdir -p deps
-    - name: Install latest SDL
-      if: steps.rsbs-otr-cache.outputs.cache-hit != 'true'
-      run: |
-        export PATH="/usr/lib/ccache:/usr/local/opt/ccache/libexec:$PATH"
-        if [ ! -d "deps/SDL2-2.30.3" ]; then
-          wget https://github.com/libsdl-org/SDL/releases/download/release-2.30.3/SDL2-2.30.3.tar.gz
-          tar -xzf SDL2-2.30.3.tar.gz -C deps
-        fi
-        cd deps/SDL2-2.30.3
-        # Skip configure if already done (Makefile exists) — parity with build-linux
-        if [ ! -f "Makefile" ]; then
-          ./configure --enable-hidapi-libusb
-        fi
-        make -j 10
-        sudo make install
-        sudo cp -av /usr/local/lib/libSDL* /lib/x86_64-linux-gnu/
-    - name: Install latest tinyxml2
-      if: steps.rsbs-otr-cache.outputs.cache-hit != 'true'
-      run: |
-        sudo apt-get remove libtinyxml2-dev
-        export PATH="/usr/lib/ccache:/usr/local/opt/ccache/libexec:$PATH"
-        if [ ! -d "deps/tinyxml2-10.0.0" ]; then
-          wget https://github.com/leethomason/tinyxml2/archive/refs/tags/10.0.0.tar.gz
-          tar -xzf 10.0.0.tar.gz -C deps
-        fi
-        cd deps/tinyxml2-10.0.0
-        mkdir -p build
-        cd build
-        # Skip cmake configure if already done AND configured with PIC — parity with build-linux
-        if [ ! -f "CMakeCache.txt" ] || ! grep -q "CMAKE_POSITION_INDEPENDENT_CODE:BOOL=ON" CMakeCache.txt; then
-          cmake .. -DCMAKE_POSITION_INDEPENDENT_CODE=ON
-        fi
-        make
-        sudo make install
     - name: Generate soh.o2r
       if: steps.rsbs-otr-cache.outputs.cache-hit != 'true'
       run: |
@@ -113,8 +73,6 @@ jobs:
         name: soh.o2r
         path: soh.o2r
         retention-days: 3
-    # No "Save Cache deps folder" here: build-linux saves the identical key on
-    # main pushes; a second save of the same key only produces a warning.
 
   build-macos:
     # DISABLED: macOS build is currently broken - see GitHub issue for tracking
@@ -201,6 +159,11 @@ jobs:
   build-linux:
     needs: generate-rsbs-otr
     runs-on: ubuntu-22.04
+    # Prebuilt CI image (see generate-rsbs-otr above) — replaces the per-run
+    # apt install + deps-folder cache + SDL/SDL_net/tinyxml2/libzip source
+    # builds that used to live in this job.
+    container:
+      image: ghcr.io/spencerduncan/redshipblueship-build:latest
     steps:
     - name: Git Checkout
       uses: actions/checkout@v4
@@ -208,10 +171,8 @@ jobs:
         submodules: true
         fetch-depth: 1
         fetch-tags: true
-    - name: Install dependencies
-      run: |
-        sudo apt-get update
-        sudo apt-get install -y $(cat .github/workflows/apt-deps.txt)
+    - name: Configure git safe directory
+      run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
     - name: Configure ccache
       uses: hendrikmuhs/ccache-action@v1.2
       with:
@@ -225,82 +186,6 @@ jobs:
           ${{ runner.os }}-ccache-${{ github.ref }}
           ${{ runner.os }}-ccache-refs/heads/main
           ${{ runner.os }}-ccache
-    - name: Restore Cached deps folder
-      id: restore-cache-deps
-      uses: actions/cache/restore@v4
-      with:
-        key: ${{ runner.os }}-deps-v1-${{ hashFiles('.github/workflows/apt-deps.txt') }}
-        restore-keys: |
-          ${{ runner.os }}-deps-v1-
-        path: deps
-    - name: Create deps folder
-      run: mkdir -p deps
-    - name: Install latest SDL
-      run: |
-        export PATH="/usr/lib/ccache:/usr/local/opt/ccache/libexec:$PATH"
-        if [ ! -d "deps/SDL2-2.30.3" ]; then
-          wget https://github.com/libsdl-org/SDL/releases/download/release-2.30.3/SDL2-2.30.3.tar.gz
-          tar -xzf SDL2-2.30.3.tar.gz -C deps
-        fi
-        cd deps/SDL2-2.30.3
-        # Skip configure if already done (Makefile exists)
-        if [ ! -f "Makefile" ]; then
-          ./configure --enable-hidapi-libusb
-        fi
-        make -j 10
-        sudo make install
-        sudo cp -av /usr/local/lib/libSDL* /lib/x86_64-linux-gnu/
-    - name: Install latest SDL_net
-      run: |
-        export PATH="/usr/lib/ccache:/usr/local/opt/ccache/libexec:$PATH"
-        if [ ! -d "deps/SDL2_net-2.2.0" ]; then
-          wget https://www.libsdl.org/projects/SDL_net/release/SDL2_net-2.2.0.tar.gz
-          tar -xzf SDL2_net-2.2.0.tar.gz -C deps
-        fi
-        cd deps/SDL2_net-2.2.0
-        # Skip configure if already done
-        if [ ! -f "Makefile" ]; then
-          ./configure
-        fi
-        make -j 10
-        sudo make install
-        sudo cp -av /usr/local/lib/libSDL* /lib/x86_64-linux-gnu/
-    - name: Install latest tinyxml2
-      run: |
-        sudo apt-get remove libtinyxml2-dev
-        export PATH="/usr/lib/ccache:/usr/local/opt/ccache/libexec:$PATH"
-        if [ ! -d "deps/tinyxml2-10.0.0" ]; then
-          wget https://github.com/leethomason/tinyxml2/archive/refs/tags/10.0.0.tar.gz
-          tar -xzf 10.0.0.tar.gz -C deps
-        fi
-        cd deps/tinyxml2-10.0.0
-        mkdir -p build
-        cd build
-        # Skip cmake configure if already done AND configured with PIC
-        # (stale cache without PIC causes linking errors with shared libs)
-        if [ ! -f "CMakeCache.txt" ] || ! grep -q "CMAKE_POSITION_INDEPENDENT_CODE:BOOL=ON" CMakeCache.txt; then
-          cmake .. -DCMAKE_POSITION_INDEPENDENT_CODE=ON
-        fi
-        make
-        sudo make install
-    - name: Install libzip without crypto
-      run: |
-        export PATH="/usr/lib/ccache:/usr/local/opt/ccache/libexec:$PATH"
-        if [ ! -d "deps/libzip-1.10.1" ]; then
-          wget https://github.com/nih-at/libzip/releases/download/v1.10.1/libzip-1.10.1.tar.gz
-          tar -xzf libzip-1.10.1.tar.gz -C deps
-        fi
-        cd deps/libzip-1.10.1
-        mkdir -p build
-        cd build
-        # Skip cmake configure if already done AND configured with crypto disabled
-        # (stale cache with different options could cause build issues)
-        if [ ! -f "CMakeCache.txt" ] || ! grep -q "ENABLE_OPENSSL:BOOL=OFF" CMakeCache.txt; then
-          cmake .. -DENABLE_COMMONCRYPTO=OFF -DENABLE_GNUTLS=OFF -DENABLE_MBEDTLS=OFF -DENABLE_OPENSSL=OFF
-        fi
-        make
-        sudo make install
-        sudo cp -av /usr/local/lib/libzip* /lib/x86_64-linux-gnu/
     - name: Download soh.o2r
       uses: actions/download-artifact@v4
       with:
@@ -330,12 +215,6 @@ jobs:
         path: |
           rsbs.appimage
           readme.txt
-    - name: Save Cache deps folder
-      if: ${{ github.ref_name == github.event.repository.default_branch }}
-      uses: actions/cache/save@v4
-      with:
-        key: ${{ runner.os }}-deps-v1-${{ hashFiles('.github/workflows/apt-deps.txt') }}
-        path: deps
 
   build-windows:
     # Issue #177 — investigation results (2026-06-01, runs 26731031162 / 26731511201 / 26731832242):

--- a/.github/workflows/generate-builds.yml
+++ b/.github/workflows/generate-builds.yml
@@ -173,6 +173,16 @@ jobs:
         fetch-tags: true
     - name: Configure git safe directory
       run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
+    # ImageMagick is consumed at CMake configure time (CMakeLists.txt
+    # find_package(ImageMagick)) to produce build-cmake/sohIcon.png; without it
+    # configure silently skips the icon and linuxdeploy later fails the
+    # appimage with "No such file or directory: sohIcon.png". GitHub's hosted
+    # runners ship it; the container does not yet. Drop this step once the
+    # image (build-base.Dockerfile) has been republished with imagemagick.
+    - name: Install packaging tools
+      run: |
+        apt-get update
+        apt-get install -y imagemagick
     - name: Configure ccache
       uses: hendrikmuhs/ccache-action@v1.2
       with:
@@ -199,6 +209,10 @@ jobs:
       env:
         CC: gcc-11
         CXX: g++-11
+        # Key the cache on the compiler's content hash instead of the default
+        # mtime+size, so caches survive container image rebuilds (which reset
+        # mtimes and otherwise force a full ~20 min recompile).
+        CCACHE_COMPILERCHECK: content
     - name: Run tests
       # --no-tests=error: if the "redship" test label ever regresses, fail loudly
       # instead of ctest exiting 0 with "No tests were found".

--- a/.github/workflows/generate-builds.yml
+++ b/.github/workflows/generate-builds.yml
@@ -173,16 +173,19 @@ jobs:
         fetch-tags: true
     - name: Configure git safe directory
       run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
-    # ImageMagick is consumed at CMake configure time (CMakeLists.txt
-    # find_package(ImageMagick)) to produce build-cmake/sohIcon.png; without it
-    # configure silently skips the icon and linuxdeploy later fails the
-    # appimage with "No such file or directory: sohIcon.png". GitHub's hosted
-    # runners ship it; the container does not yet. Drop this step once the
-    # image (build-base.Dockerfile) has been republished with imagemagick.
+    # Tools the appimage packaging needs that GitHub's hosted runners ship but
+    # the container does not yet:
+    #  - imagemagick: consumed at CMake configure time (find_package(ImageMagick))
+    #    to produce build-cmake/sohIcon.png; without it configure silently skips
+    #    the icon and linuxdeploy fails with "No such file: sohIcon.png".
+    #  - file: hard requirement of appimagetool ("file command is missing but
+    #    required").
+    # Drop this step once the image (build-base.Dockerfile) has been
+    # republished with these baked in.
     - name: Install packaging tools
       run: |
         apt-get update
-        apt-get install -y imagemagick
+        apt-get install -y imagemagick file
     - name: Configure ccache
       uses: hendrikmuhs/ccache-action@v1.2
       with:


### PR DESCRIPTION
## Summary

Phase 2 of the CI speedup (follow-up to #316): run `generate-rsbs-otr` and `build-linux` inside the prebuilt dependency image `ghcr.io/spencerduncan/redshipblueship-build:latest` — the same image `static-analysis` already uses — instead of apt-installing and source-building dependencies on every run.

Deletes from both jobs (−138 lines): the apt install step, the deps-folder cache restore/save, and the SDL2 / SDL2_net / tinyxml2 / libzip from-source build steps. The image has all of these pre-compiled (`.github/docker/build-base.Dockerfile`), plus cmake 3.26+, gcc-11, ccache, git, and the libzip CLI tools.

Wins:
- ~1.6 min per Linux job on the warm path; removes 15–25 min of exposure when the deps cache missed.
- The `Linux-deps-v1-*` cache no longer competes for the repo's 10 GB Actions-cache quota (less eviction pressure on the compiler caches #316 fixed).
- One source of truth for the Linux build environment.

Pre-verified risks:
- **AppImage in container**: `Packaging.cmake:77` invokes linuxdeploy with `--appimage-extract-and-run`, so no FUSE is required.
- **safe.directory**: added explicitly after checkout (container uid ≠ workspace owner) — required by the `git rev-parse` in the otr-cache-key action and version stamping.
- **python3** (needed by `extract_assets.py`): present in the image transitively via `lsb-release`. Optional hardening follow-up: add `python3` explicitly to the Dockerfile.

## Verification
This PR's own CI run executes the modified workflow end-to-end: the otr job computes the cache key in-container, build-linux compiles with the image's gcc-11/ccache, runs the `redship` ctest suite, and packages `rsbs.appimage` via cpack External. Confirm the `rsbs-linux` artifact contains a working AppImage (`./rsbs.appimage --appimage-extract` as smoke test).

https://claude.ai/code/session_01DmDHmuHJravA6jCuksnPSE

---
_Generated by [Claude Code](https://claude.ai/code/session_01DmDHmuHJravA6jCuksnPSE)_

<!--- section:artifacts:start -->
### Build Artifacts
  - [rsbs-linux.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/7574556709.zip)
  - [rsbs-windows.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/7573795727.zip)
<!--- section:artifacts:end -->