### PR TITLE
CI: add tag-triggered release pipeline with persistent artifacts

### DIFF
--- a/.github/release-notes-template.md
+++ b/.github/release-notes-template.md
@@ -1,0 +1,24 @@
+RedShipBlueShip combines Ocarina of Time (Ship of Harkinian) and Majora's Mask (2Ship2Harkinian) into a single executable with cross-game randomization inspired by OoTMM.
+
+**This is a pre-alpha build.** Expect bugs, missing features, and breaking changes between releases. Windows and Linux only.
+
+## Downloads
+
+- **Windows (x64):** `redshipblueship-{{TAG}}-windows.zip`
+- **Linux (x86_64):** `redshipblueship-{{TAG}}-linux.AppImage`
+
+Both builds bundle `soh.o2r` and the asset extraction tools (`assets/extractor/`, `assets/xml/`). You need your own original Ocarina of Time and Majora's Mask ROMs: on first launch the game asks for them and extracts the remaining assets.
+
+## Running
+
+- **Windows:** extract the zip anywhere and run `redship.exe`.
+- **Linux:** `chmod +x redshipblueship-{{TAG}}-linux.AppImage`, then run it.
+
+## Known Issues
+
+- **No macOS build.** The macOS CI build is disabled due to a libultraship linking issue; this pre-alpha supports Windows and Linux only.
+- **Stubbed settings tabs.** Several settings/enhancements tabs in the menu bar are placeholders and have no effect yet.
+- **MM enhancement hooks disabled.** The Majora's Mask C++ enhancement layer is stubbed out in single-executable builds, so MM enhancements are unavailable.
+- **Config file name.** Settings are saved to `shipofharkinian.json` (legacy name inherited from upstream Ship of Harkinian).
+
+Found something else? Report it at https://github.com/spencerduncan/redshipblueship/issues.

--- a/.github/workflows/generate-builds.yml
+++ b/.github/workflows/generate-builds.yml
@@ -3,6 +3,10 @@ on:
   push:
     branches:
       - main
+    # Path filters are not evaluated for tag pushes, so paths-ignore below
+    # only applies to branch pushes.
+    tags:
+      - 'v*'
     paths-ignore:
       - '**.md'
       - 'docs/**'
@@ -456,3 +460,55 @@ jobs:
       with:
         key: ${{ runner.os }}-vcpkg-v2-${{ hashFiles('CMakeLists.txt', 'CMake/automate-vcpkg.cmake') }}
         path: vcpkg
+
+  create-release:
+    # Tag-triggered release publishing (issue #318): attaches the builds from
+    # the jobs above to a GitHub Release so pre-alpha testers get a stable
+    # download URL that outlives the short CI artifact retention window.
+    # macOS is intentionally absent — its CI build is disabled (see build-macos).
+    if: startsWith(github.ref, 'refs/tags/v')
+    needs: [build-linux, build-windows]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+    - name: Git Checkout
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 1
+    - name: Download Linux build
+      uses: actions/download-artifact@v4
+      with:
+        name: rsbs-linux
+        path: rsbs-linux
+    - name: Download Windows build
+      uses: actions/download-artifact@v4
+      with:
+        name: rsbs-windows
+        path: rsbs-windows
+    - name: Prepare release assets
+      run: |
+        mv rsbs-linux/rsbs.appimage "redshipblueship-${GITHUB_REF_NAME}-linux.AppImage"
+        # build-windows uploads the unzipped cpack output (artifacts are stored
+        # extracted so PR testers get a browsable tree); re-zip it for release.
+        (cd rsbs-windows && zip -qr "../redshipblueship-${GITHUB_REF_NAME}-windows.zip" .)
+    - name: Render release notes
+      run: sed "s/{{TAG}}/${GITHUB_REF_NAME}/g" .github/release-notes-template.md > release-notes.md
+    - name: Create GitHub Release
+      env:
+        GH_TOKEN: ${{ github.token }}
+      run: |
+        ASSETS=(
+          "redshipblueship-${GITHUB_REF_NAME}-linux.AppImage"
+          "redshipblueship-${GITHUB_REF_NAME}-windows.zip"
+        )
+        # Idempotent on re-runs: if the release already exists, refresh its assets.
+        if gh release view "${GITHUB_REF_NAME}" --repo "${GITHUB_REPOSITORY}" > /dev/null 2>&1; then
+          gh release upload "${GITHUB_REF_NAME}" "${ASSETS[@]}" --repo "${GITHUB_REPOSITORY}" --clobber
+        else
+          gh release create "${GITHUB_REF_NAME}" "${ASSETS[@]}" \
+            --repo "${GITHUB_REPOSITORY}" \
+            --title "RedShipBlueShip ${GITHUB_REF_NAME} (pre-alpha)" \
+            --notes-file release-notes.md \
+            --prerelease
+        fi


### PR DESCRIPTION
Resolves #318 (pre-alpha blocker: no release distribution channel).

## What

- **Tag trigger**: `generate-builds.yml` now also runs on `v*` tag pushes. GitHub does not evaluate path filters for tag pushes, so the existing `paths-ignore` is unaffected.
- **`create-release` job**: runs only on `v*` tags, after `build-linux` and `build-windows`. It downloads the existing `rsbs-linux` / `rsbs-windows` artifacts, renames the AppImage and re-zips the Windows tree (the Windows artifact is stored extracted for PR testers), and publishes a **prerelease** GitHub Release named `RedShipBlueShip <tag> (pre-alpha)` with both assets attached.
- **Release notes template** (`.github/release-notes-template.md`): download/run instructions plus the Known Issues section from the issue — macOS unsupported (Windows/Linux only), stubbed settings tabs, MM enhancement hooks disabled in single-exe builds, config file named `shipofharkinian.json`.

## Notes

- The job is idempotent on workflow re-runs: if the release already exists it re-uploads assets with `--clobber` instead of failing.
- Cache behavior on tag runs is restore-only: every save step is gated on `ref_name == default branch`, and tag runs can restore main's caches (including the exact-match `soh.o2r` cache), so a tag build is mostly cache-warm.
- `pr-artifacts.yml` is unaffected: it filters on `workflow_run.event == 'pull_request'` and tag runs are `push` events.
- macOS stays out of scope per the issue (`build-macos` remains `if: false`); the release notes declare Windows/Linux-only.
- Releases are marked **prerelease** while the project is pre-alpha.

To cut a release: `git tag v0.x.y && git push origin v0.x.y`.

https://claude.ai/code/session_01GWc9bWibT2n4LRFbbpyDtK

---
_Generated by [Claude Code](https://claude.ai/code/session_01GWc9bWibT2n4LRFbbpyDtK)_

<!--- section:artifacts:start -->
### Build Artifacts
  - [rsbs-windows.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/7572208431.zip)
  - [rsbs-linux.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/7571797956.zip)
<!--- section:artifacts:end -->