### PR TITLE
Ignore .claude/tmp/ scratch directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -461,3 +461,6 @@ soh/properties.h
 *.o2r
 Randomizer/
 .venv/
+
+.claude/tmp/*
+


### PR DESCRIPTION
@
Adds `.claude/tmp/*` to `.gitignore` so agent scratch/working files under `.claude/tmp/` aren't accidentally committed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@