### PR TITLE
Allow release/v* branch creation to trigger release publishing

### DIFF
--- a/.github/workflows/generate-builds.yml
+++ b/.github/workflows/generate-builds.yml
@@ -3,6 +3,12 @@ on:
   push:
     branches:
       - main
+      # Creating a release/vX.Y.Z branch is an alternative release trigger for
+      # credentials that can create branches but not tags or workflow
+      # dispatches (e.g. the GitHub MCP integration used by remote agents).
+      # create-release derives the tag from the branch name and deletes the
+      # branch once the release exists.
+      - 'release/v*'
     # Path filters are not evaluated for tag pushes, so paths-ignore below
     # only applies to branch pushes.
     tags:
@@ -375,18 +381,24 @@ jobs:
     # Also runs on workflow_dispatch, where it creates the tag itself at the
     # dispatched commit (see the trigger comment at the top of this file).
     # macOS is intentionally absent — its CI build is disabled (see build-macos).
-    if: startsWith(github.ref, 'refs/tags/v') || github.event_name == 'workflow_dispatch'
+    if: startsWith(github.ref, 'refs/tags/v') || startsWith(github.ref, 'refs/heads/release/v') || github.event_name == 'workflow_dispatch'
     needs: [build-linux, build-windows]
     runs-on: ubuntu-latest
     permissions:
       contents: write
-    env:
-      RELEASE_TAG: ${{ github.event_name == 'workflow_dispatch' && inputs.release_tag || github.ref_name }}
     steps:
     - name: Git Checkout
       uses: actions/checkout@v4
       with:
         fetch-depth: 1
+    # Tag name precedence: dispatch input, else the ref name with any
+    # release/ branch prefix stripped (a no-op for tag-push refs).
+    - name: Resolve release tag
+      env:
+        INPUT_TAG: ${{ inputs.release_tag }}
+      run: |
+        TAG="${INPUT_TAG:-${GITHUB_REF_NAME#release/}}"
+        echo "RELEASE_TAG=${TAG}" >> "$GITHUB_ENV"
     - name: Download Linux build
       uses: actions/download-artifact@v4
       with:
@@ -426,3 +438,10 @@ jobs:
             --notes-file release-notes.md \
             --prerelease
         fi
+    # The branch was only a trigger vehicle; the tag now records the release
+    # commit, so drop the branch to keep the ref namespace tidy.
+    - name: Delete release trigger branch
+      if: startsWith(github.ref, 'refs/heads/release/')
+      env:
+        GH_TOKEN: ${{ github.token }}
+      run: gh api -X DELETE "repos/${GITHUB_REPOSITORY}/git/${GITHUB_REF}"


### PR DESCRIPTION
Follow-up to #332. The `workflow_dispatch` path merged there turns out to be unusable by the GitHub MCP integration that remote agents run on: the token lacks `actions: write` (`403 Resource not accessible by integration` on the dispatch API). The one release-shaped write that token does have is **branch creation**, so this adds a third trigger:

- Creating a `release/vX.Y.Z` branch runs the same build jobs; `create-release` strips the `release/` prefix to get the tag name, creates the tag at the branch tip (`gh release create --target`), and deletes the trigger branch once the release exists.
- Tag resolution moved from a job-level `env` expression to a small step, because workflow expressions have no prefix-strip function.
- Tag-push and dispatch paths are unchanged.

After merge, creating `release/v0.1.0-prealpha` from main cuts the v0.1.0-prealpha release.

https://claude.ai/code/session_01GWc9bWibT2n4LRFbbpyDtK

---
_Generated by [Claude Code](https://claude.ai/code/session_01GWc9bWibT2n4LRFbbpyDtK)_

<!--- section:artifacts:start -->
### Build Artifacts
  - [rsbs-windows.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/7599513461.zip)
  - [rsbs-linux.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/7599318821.zip)
<!--- section:artifacts:end -->