### PR TITLE
Ship soh.o2r in the Windows single-exe package

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -319,6 +319,12 @@ install(DIRECTORY "${CMAKE_SOURCE_DIR}/games/mm/assets/xml/" DESTINATION ./asset
 # Linux AppImage (see the usr/bin/assets/extractor rules above).
 install(TARGETS ZAPD_OoT RUNTIME DESTINATION ./assets/extractor COMPONENT ship)
 install(TARGETS ZAPD_MM RUNTIME DESTINATION ./assets/extractor COMPONENT ship)
+# soh.o2r (the port's custom assets — fonts, GUI, shaders) cannot be produced
+# by the shipped extractor, so the zip must bundle it. The upstream-parity
+# rule in games/oot/CMakeLists.txt only fires when NOT SINGLE_EXECUTABLE_BUILD,
+# and the rule above at line ~300 is Linux-only — without this line the
+# Windows package has no .o2r at all (issue #334).
+install(FILES "${CMAKE_BINARY_DIR}/soh/soh.o2r" DESTINATION . COMPONENT ship)
 endif()
 
 find_package(Python3 COMPONENTS Interpreter)


### PR DESCRIPTION
Fixes #334 — the published v0.1.0-prealpha Windows zip contains no `.o2r` at all (verified against the actual release asset), so a fresh Windows install has no path to a working game: `soh.o2r` is the port's custom-asset archive and cannot be regenerated by the shipped extractor.

## Why it was missing

Both existing install rules are unreachable for the Windows single-exe build:
- `games/oot/CMakeLists.txt:807-810` is gated `if (Windows AND NOT SINGLE_EXECUTABLE_BUILD)` — the upstream-parity block that also ships the 210 MB `soh.pdb` (incidentally the answer to why upstream SoH's Win64 zip is 68.5 MB to our 25 MB).
- Root `CMakeLists.txt:300` is inside the `if(Linux)` block, which is why the AppImage bundles it correctly.

CI already builds `soh.o2r` and stages it at `bw/soh/soh.o2r`; cpack just never installed it on Windows.

## Fix

One `install(FILES ...)` line in the Windows install block that #328 added for the ZAPD executables (`CMakeLists.txt:312`), with a comment explaining the two unreachable sibling rules.

## Verification

The `rsbs-windows` CI artifact from this PR should now contain `soh.o2r` at the package root next to `redship.exe` — that artifact is the deliverable for manual testing. Note the binary still has the #329 boot crash (being fixed on `claude/single-exe-first-boot-329-330`); release-asset refresh is deliberately deferred until that lands so the release gets both fixes at once.

https://claude.ai/code/session_01GWc9bWibT2n4LRFbbpyDtK

---
_Generated by [Claude Code](https://claude.ai/code/session_01GWc9bWibT2n4LRFbbpyDtK)_

<!--- section:artifacts:start -->
### Build Artifacts
  - [rsbs-windows.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/7602101407.zip)
  - [rsbs-linux.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/7601918231.zip)
<!--- section:artifacts:end -->