### PR TITLE
Fix stock-settings rando seed generation + add RandoGen regression test

### DIFF
--- a/.github/workflows/generate-builds.yml
+++ b/.github/workflows/generate-builds.yml
@@ -202,11 +202,12 @@ jobs:
     #    (verified against the binary's check strings; zsyncmake/appstreamcli/
     #    gpg are warnings only and mksquashfs is bundled in the plugin).
     # Drop this step once the image (build-base.Dockerfile) has been
-    # republished with these baked in.
+    # republished with these baked in. xvfb + llvmpipe are for the RandoGen
+    # seed-generation test, which needs a display but no game archives.
     - name: Install packaging tools
       run: |
         apt-get update
-        apt-get install -y imagemagick file desktop-file-utils
+        apt-get install -y imagemagick file desktop-file-utils xvfb libgl1-mesa-dri
     - name: Configure ccache
       uses: hendrikmuhs/ccache-action@v1.2
       with:
@@ -241,6 +242,11 @@ jobs:
       # --no-tests=error: if the "redship" test label ever regresses, fail loudly
       # instead of ctest exiting 0 with "No tests were found".
       run: ctest --test-dir build-cmake --output-on-failure --label-regex "^redship$" --no-tests=error
+    - name: Run rando seed generation test
+      # Generates a real seed with default settings (issue #337). Needs a
+      # display for the Fast3dWindow bring-up (hence xvfb-run) but NO game
+      # archives, so unlike the int-* tier it can run on hosted runners.
+      run: xvfb-run -a ctest --test-dir build-cmake --output-on-failure --label-regex "^rando$" --no-tests=error
     - name: Package
       run: |
         (cd build-cmake && cpack -G External)

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -136,6 +136,12 @@ jobs:
     - name: Run unit tests
       run: ctest --test-dir build-cmake --output-on-failure --label-regex "^redship$"
 
+    # Seed generation needs the windowed bring-up (hence xvfb-run) but no game
+    # archives, so it runs unconditionally — unlike the archive-gated int-*
+    # tier below. Guards against #337-style silent rando regressions.
+    - name: Run rando seed generation test
+      run: xvfb-run -a ctest --test-dir build-cmake --output-on-failure --label-regex "^rando$" --no-tests=error
+
     - name: Check for game archives
       id: check-archives
       run: |

--- a/CMake/SingleExecutable.cmake
+++ b/CMake/SingleExecutable.cmake
@@ -220,6 +220,20 @@ if(BUILD_TESTING)
     )
 
     # ========================================================================
+    # Rando seed-generation test (requires a display for the Fast3dWindow
+    # bring-up but NO game archives — CI runs it under xvfb-run; issue #337).
+    # Not in the "redship" label because that tier runs display-free.
+    # ========================================================================
+    add_test(NAME RandoGen COMMAND redship --test rando-gen)
+    set_tests_properties(
+        RandoGen
+        PROPERTIES
+        TIMEOUT 180
+        LABELS "rando"
+        ENVIRONMENT "SDL_AUDIODRIVER=dummy;RSBS_DISABLE_OTR_INIT=1"
+    )
+
+    # ========================================================================
     # Integration tests (requires display - use Xvfb in CI)
     # These tests actually boot the games and verify boot completion
     # ========================================================================

--- a/games/oot/soh/Enhancements/randomizer/3drando/fill.cpp
+++ b/games/oot/soh/Enhancements/randomizer/3drando/fill.cpp
@@ -836,29 +836,16 @@ static void AssumedFill(const std::vector<RandomizerGet>& items, const std::vect
                         bool setLocationsAsHintable = false) {
     auto ctx = Rando::Context::GetInstance();
     if (items.size() > allowedLocations.size()) {
-        SPDLOG_ERROR("ERROR: MORE ITEMS THAN LOCATIONS IN GIVEN LISTS");
-        fprintf(stderr, "[rando-diag] AssumedFill overflow: %zu items > %zu locations\n", items.size(),
-                allowedLocations.size());
+        // Log the offending lists at error level: this state is fatal to seed
+        // generation, and the old SPDLOG_DEBUG dumps compile out of Release
+        // builds — which left issue #337's reports undiagnosable from logs.
+        SPDLOG_ERROR("ERROR: MORE ITEMS THAN LOCATIONS IN GIVEN LISTS ({} items > {} locations)", items.size(),
+                     allowedLocations.size());
         for (const RandomizerGet item : items) {
-            fprintf(stderr, "[rando-diag] item: %s\n",
-                    Rando::StaticData::RetrieveItem(item).GetName().GetEnglish().c_str());
+            SPDLOG_ERROR("overflow item: {}", Rando::StaticData::RetrieveItem(item).GetName().GetEnglish());
         }
         for (const RandomizerCheck loc : allowedLocations) {
-            fprintf(stderr, "[rando-diag] loc: %s\n", Rando::StaticData::GetLocation(loc)->GetName().c_str());
-        }
-        SPDLOG_DEBUG("Items:\n");
-        // NOLINTNEXTLINE(clang-diagnostic-unused-variable)
-        for (const RandomizerGet item : items) {
-            SPDLOG_DEBUG("\t");
-            SPDLOG_DEBUG(Rando::StaticData::RetrieveItem(item).GetName().GetEnglish());
-            SPDLOG_DEBUG("\n");
-        }
-        SPDLOG_DEBUG("\nAllowed Locations:\n");
-        // NOLINTNEXTLINE(clang-diagnostic-unused-variable)
-        for (const RandomizerCheck loc : allowedLocations) {
-            SPDLOG_DEBUG("\t");
-            SPDLOG_DEBUG(Rando::StaticData::GetLocation(loc)->GetName());
-            SPDLOG_DEBUG("\n");
+            SPDLOG_ERROR("overflow location: {}", Rando::StaticData::GetLocation(loc)->GetName());
         }
         placementFailure = true;
         return;

--- a/games/oot/soh/Enhancements/randomizer/3drando/fill.cpp
+++ b/games/oot/soh/Enhancements/randomizer/3drando/fill.cpp
@@ -837,6 +837,15 @@ static void AssumedFill(const std::vector<RandomizerGet>& items, const std::vect
     auto ctx = Rando::Context::GetInstance();
     if (items.size() > allowedLocations.size()) {
         SPDLOG_ERROR("ERROR: MORE ITEMS THAN LOCATIONS IN GIVEN LISTS");
+        fprintf(stderr, "[rando-diag] AssumedFill overflow: %zu items > %zu locations\n", items.size(),
+                allowedLocations.size());
+        for (const RandomizerGet item : items) {
+            fprintf(stderr, "[rando-diag] item: %s\n",
+                    Rando::StaticData::RetrieveItem(item).GetName().GetEnglish().c_str());
+        }
+        for (const RandomizerCheck loc : allowedLocations) {
+            fprintf(stderr, "[rando-diag] loc: %s\n", Rando::StaticData::GetLocation(loc)->GetName().c_str());
+        }
         SPDLOG_DEBUG("Items:\n");
         // NOLINTNEXTLINE(clang-diagnostic-unused-variable)
         for (const RandomizerGet item : items) {

--- a/games/oot/soh/Enhancements/randomizer/3drando/menu.cpp
+++ b/games/oot/soh/Enhancements/randomizer/3drando/menu.cpp
@@ -13,6 +13,9 @@
 #include "soh/ShipUtils.h"
 #include <spdlog/spdlog.h>
 #include "../../randomizer/randomizerTypes.h"
+#include "../static_data.h"
+#include "../SeedContext.h"
+#include "../settings.h"
 
 namespace {
 bool seedChanged;
@@ -20,6 +23,26 @@ uint16_t pastSeedLength;
 std::vector<std::string> presetEntries;
 Rando::Option* currentSetting;
 } // namespace
+
+// Local diagnostic bridge: drive seed generation with default settings from
+// the display-free test harness (no ImGui interaction). The real bring-up
+// (InitOTRForMMFirstBoot) normally created the rando context/settings/
+// randomizer already; fall back to manual init only if it didn't (mirrors
+// OTRGlobals.cpp init order — InitItemTable depends on the context's Logic).
+extern "C" int Rando_HeadlessSeedTest(const char* seedStr) {
+    auto ctx = Rando::Context::GetInstance();
+    if (!ctx) {
+        ctx = Rando::Context::CreateInstance();
+        ctx->InitStaticData();
+        Rando::Settings::GetInstance()->AssignContext(ctx);
+        Rando::StaticData::InitItemTable();
+        Rando::StaticData::InitLocationTable();
+    }
+    Rando::Settings::GetInstance()->SetAllToContext();
+    bool ok = GenerateRandomizer({}, {}, seedStr ? seedStr : "");
+    fprintf(stderr, "[rando-diag] GenerateRandomizer returned %s\n", ok ? "true" : "false");
+    return ok ? 0 : 1;
+}
 
 bool GenerateRandomizer(std::set<RandomizerCheck> excludedLocations, std::set<RandomizerTrick> enabledTricks,
                         std::string seedInput) {

--- a/games/oot/soh/Enhancements/randomizer/3drando/menu.cpp
+++ b/games/oot/soh/Enhancements/randomizer/3drando/menu.cpp
@@ -12,6 +12,7 @@
 #include "soh/Enhancements/debugger/performanceTimer.h"
 #include "soh/ShipUtils.h"
 #include <spdlog/spdlog.h>
+#include <libultraship/bridge.h>
 #include "../../randomizer/randomizerTypes.h"
 #include "../static_data.h"
 #include "../SeedContext.h"
@@ -24,8 +25,8 @@ std::vector<std::string> presetEntries;
 Rando::Option* currentSetting;
 } // namespace
 
-// Local diagnostic bridge: drive seed generation with default settings from
-// the display-free test harness (no ImGui interaction). The real bring-up
+// Test bridge for the RandoGen regression test (issue #337): drive seed
+// generation without ImGui interaction. The real bring-up
 // (InitOTRForMMFirstBoot) normally created the rando context/settings/
 // randomizer already; fall back to manual init only if it didn't (mirrors
 // OTRGlobals.cpp init order — InitItemTable depends on the context's Logic).
@@ -37,6 +38,20 @@ extern "C" int Rando_HeadlessSeedTest(const char* seedStr) {
         Rando::Settings::GetInstance()->AssignContext(ctx);
         Rando::StaticData::InitItemTable();
         Rando::StaticData::InitLocationTable();
+    }
+    // Optional non-default settings, e.g.
+    // RSBS_DIAG_CVARS="gRandoSettings.ShuffleSongs=2,gRandoSettings.ShuffleSpeak=1"
+    if (const char* cvars = std::getenv("RSBS_DIAG_CVARS")) {
+        std::stringstream ss(cvars);
+        std::string pair;
+        while (std::getline(ss, pair, ',')) {
+            auto eq = pair.find('=');
+            if (eq == std::string::npos) {
+                continue;
+            }
+            CVarSetInteger(pair.substr(0, eq).c_str(), std::stoi(pair.substr(eq + 1)));
+            fprintf(stderr, "[rando-diag] cvar %s\n", pair.c_str());
+        }
     }
     Rando::Settings::GetInstance()->SetAllToContext();
     bool ok = GenerateRandomizer({}, {}, seedStr ? seedStr : "");

--- a/games/oot/soh/Enhancements/randomizer/logic.cpp
+++ b/games/oot/soh/Enhancements/randomizer/logic.cpp
@@ -2302,11 +2302,7 @@ void Logic::InitSaveContext() {
     mSaveContext->ship.pendingIceTrapCount = 0;
 
     // Init with normal quest unless only an MQ rom is provided
-    // [rando-diag] null-guard for the headless test harness, which has no
-    // OTRGlobals instance; a null instance means "assume original quest",
-    // matching an environment where oot.o2r is present.
-    mSaveContext->ship.quest.id =
-        (OTRGlobals::Instance == nullptr || OTRGlobals::Instance->HasOriginal()) ? QUEST_NORMAL : QUEST_MASTER;
+    mSaveContext->ship.quest.id = OTRGlobals::Instance->HasOriginal() ? QUEST_NORMAL : QUEST_MASTER;
 
     // RANDOTODO (ADD ITEMLOCATIONS TO GSAVECONTEXT)
 }
@@ -2381,6 +2377,14 @@ const std::vector<uint8_t>& GetDungeonSmallKeyDoors(SceneID sceneId) {
         return foundEntry->second;
     }
     dungeonSmallKeyDoors[key] = {};
+
+    // With no game archive loaded, ResourceManager::LoadResource below never
+    // resolves (the async load waits forever on a file that cannot exist).
+    // Bail to the empty list instead — reachable in archive-less states like
+    // the headless RandoGen test and MM-first boots without oot.o2r (#330).
+    if (!Ship::Context::GetInstance()->GetResourceManager()->GetArchiveManager()->IsLoaded()) {
+        return emptyVector;
+    }
 
     // Get the scene path
     SceneTableEntry* sceneTableEntry = &OoT_gSceneTable[sceneId];
@@ -2683,6 +2687,16 @@ void Logic::Reset(bool resetSaveContext /*= true*/) {
         // If we're not shuffling open chest, we start with it
         if (ctx->GetOption(RSK_SHUFFLE_OPEN_CHEST).Is(false)) {
             SetRandoInf(RAND_INF_CAN_OPEN_CHEST, true);
+        }
+
+        // If we're not shuffling speak, we start with all dialogue
+        if (ctx->GetOption(RSK_SHUFFLE_SPEAK).Is(false)) {
+            SetRandoInf(RAND_INF_CAN_SPEAK_DEKU, true);
+            SetRandoInf(RAND_INF_CAN_SPEAK_GERUDO, true);
+            SetRandoInf(RAND_INF_CAN_SPEAK_GORON, true);
+            SetRandoInf(RAND_INF_CAN_SPEAK_HYLIAN, true);
+            SetRandoInf(RAND_INF_CAN_SPEAK_KOKIRI, true);
+            SetRandoInf(RAND_INF_CAN_SPEAK_ZORA, true);
         }
 
         // If we're not shuffling child's wallet, we start with it

--- a/games/oot/soh/Enhancements/randomizer/logic.cpp
+++ b/games/oot/soh/Enhancements/randomizer/logic.cpp
@@ -2302,7 +2302,11 @@ void Logic::InitSaveContext() {
     mSaveContext->ship.pendingIceTrapCount = 0;
 
     // Init with normal quest unless only an MQ rom is provided
-    mSaveContext->ship.quest.id = OTRGlobals::Instance->HasOriginal() ? QUEST_NORMAL : QUEST_MASTER;
+    // [rando-diag] null-guard for the headless test harness, which has no
+    // OTRGlobals instance; a null instance means "assume original quest",
+    // matching an environment where oot.o2r is present.
+    mSaveContext->ship.quest.id =
+        (OTRGlobals::Instance == nullptr || OTRGlobals::Instance->HasOriginal()) ? QUEST_NORMAL : QUEST_MASTER;
 
     // RANDOTODO (ADD ITEMLOCATIONS TO GSAVECONTEXT)
 }

--- a/games/oot/soh/Enhancements/randomizer/settings.cpp
+++ b/games/oot/soh/Enhancements/randomizer/settings.cpp
@@ -1280,9 +1280,7 @@ void Settings::CreateOptions() {
     OPT_BOOL(RSK_SKULLS_SUNS_SONG, "Night Skulltula's Expect Sun's Song", CVAR_RANDOMIZER_SETTING("GsExpectSunsSong"), mOptionDescriptions[RSK_SKULLS_SUNS_SONG]);
     OPT_U8(RSK_DAMAGE_MULTIPLIER, "Damage Multiplier", {"x1/2", "x1", "x2", "x4", "x8", "x16", "OHKO"}, OptionCategory::Setting, "", "", WIDGET_CVAR_SLIDER_INT, RO_DAMAGE_MULTIPLIER_DEFAULT);
     // Don't show any MQ options if both quests aren't available
-    // [rando-diag] null instance (headless harness) = original quest only
-    if (OTRGlobals::Instance == nullptr ||
-        !(OTRGlobals::Instance->HasMasterQuest() && OTRGlobals::Instance->HasOriginal())) {
+    if (!(OTRGlobals::Instance->HasMasterQuest() && OTRGlobals::Instance->HasOriginal())) {
         mOptions[RSK_MQ_DUNGEON_RANDOM].Disable("This option has been disabled because only one type of O2R has been loaded");
         mOptions[RSK_MQ_DUNGEON_COUNT].Disable("This option has been disabled because only one type of O2R has been loaded");
         mOptions[RSK_MQ_DUNGEON_SET].Disable("This option has been disabled because only one type of O2R has been loaded");
@@ -2947,18 +2945,14 @@ void Context::FinalizeSettings(const std::set<RandomizerCheck>& excludedLocation
     }
 
     // If we only have MQ, set all dungeons to MQ
-    // [rando-diag] null instance (headless harness) = original quest only
-    if (OTRGlobals::Instance != nullptr && OTRGlobals::Instance->HasMasterQuest() &&
-        !OTRGlobals::Instance->HasOriginal()) {
+    if (OTRGlobals::Instance->HasMasterQuest() && !OTRGlobals::Instance->HasOriginal()) {
         mOptions[RSK_MQ_DUNGEON_RANDOM].Set(RO_MQ_DUNGEONS_SET_NUMBER);
         mOptions[RSK_MQ_DUNGEON_COUNT].Set(12);
         mOptions[RSK_MQ_DUNGEON_SET].Set(RO_GENERIC_OFF);
     }
 
     // If we don't have MQ, set all dungeons to Vanilla
-    // [rando-diag] null instance (headless harness) = original quest only
-    if (OTRGlobals::Instance == nullptr ||
-        (OTRGlobals::Instance->HasOriginal() && !OTRGlobals::Instance->HasMasterQuest())) {
+    if (OTRGlobals::Instance->HasOriginal() && !OTRGlobals::Instance->HasMasterQuest()) {
         mOptions[RSK_MQ_DUNGEON_RANDOM].Set(RO_MQ_DUNGEONS_NONE);
     }
 

--- a/games/oot/soh/Enhancements/randomizer/settings.cpp
+++ b/games/oot/soh/Enhancements/randomizer/settings.cpp
@@ -1280,7 +1280,9 @@ void Settings::CreateOptions() {
     OPT_BOOL(RSK_SKULLS_SUNS_SONG, "Night Skulltula's Expect Sun's Song", CVAR_RANDOMIZER_SETTING("GsExpectSunsSong"), mOptionDescriptions[RSK_SKULLS_SUNS_SONG]);
     OPT_U8(RSK_DAMAGE_MULTIPLIER, "Damage Multiplier", {"x1/2", "x1", "x2", "x4", "x8", "x16", "OHKO"}, OptionCategory::Setting, "", "", WIDGET_CVAR_SLIDER_INT, RO_DAMAGE_MULTIPLIER_DEFAULT);
     // Don't show any MQ options if both quests aren't available
-    if (!(OTRGlobals::Instance->HasMasterQuest() && OTRGlobals::Instance->HasOriginal())) {
+    // [rando-diag] null instance (headless harness) = original quest only
+    if (OTRGlobals::Instance == nullptr ||
+        !(OTRGlobals::Instance->HasMasterQuest() && OTRGlobals::Instance->HasOriginal())) {
         mOptions[RSK_MQ_DUNGEON_RANDOM].Disable("This option has been disabled because only one type of O2R has been loaded");
         mOptions[RSK_MQ_DUNGEON_COUNT].Disable("This option has been disabled because only one type of O2R has been loaded");
         mOptions[RSK_MQ_DUNGEON_SET].Disable("This option has been disabled because only one type of O2R has been loaded");
@@ -2945,14 +2947,18 @@ void Context::FinalizeSettings(const std::set<RandomizerCheck>& excludedLocation
     }
 
     // If we only have MQ, set all dungeons to MQ
-    if (OTRGlobals::Instance->HasMasterQuest() && !OTRGlobals::Instance->HasOriginal()) {
+    // [rando-diag] null instance (headless harness) = original quest only
+    if (OTRGlobals::Instance != nullptr && OTRGlobals::Instance->HasMasterQuest() &&
+        !OTRGlobals::Instance->HasOriginal()) {
         mOptions[RSK_MQ_DUNGEON_RANDOM].Set(RO_MQ_DUNGEONS_SET_NUMBER);
         mOptions[RSK_MQ_DUNGEON_COUNT].Set(12);
         mOptions[RSK_MQ_DUNGEON_SET].Set(RO_GENERIC_OFF);
     }
 
     // If we don't have MQ, set all dungeons to Vanilla
-    if (OTRGlobals::Instance->HasOriginal() && !OTRGlobals::Instance->HasMasterQuest()) {
+    // [rando-diag] null instance (headless harness) = original quest only
+    if (OTRGlobals::Instance == nullptr ||
+        (OTRGlobals::Instance->HasOriginal() && !OTRGlobals::Instance->HasMasterQuest())) {
         mOptions[RSK_MQ_DUNGEON_RANDOM].Set(RO_MQ_DUNGEONS_NONE);
     }
 

--- a/src/common/test_runner.cpp
+++ b/src/common/test_runner.cpp
@@ -150,7 +150,7 @@ extern "C" int Rando_HeadlessSeedTest(const char* seedStr);
 extern "C" void InitOTRForMMFirstBoot(int argc, char* argv[]);
 
 TestResult Test_RandoGen(void) {
-    printf("[TEST] rando-gen: headless seed generation with default settings (diagnostic)\n");
+    printf("[TEST] rando-gen: seed generation succeeds with default settings (#337)\n");
 
     auto ctx = CreateHarnessStyleContext();
     if (!ctx) {
@@ -497,7 +497,7 @@ TestResult Test_Context(void) {
 // ============================================================================
 
 const TestDescriptor gTests[] = {
-    {"rando-gen", "Headless seed generation with default settings (diagnostic)", Test_RandoGen},
+    {"rando-gen", "Seed generation succeeds with default settings (#337)", Test_RandoGen},
     {"boot-oot", "Shared-context bring-up leaves no null subsystems (#329)", Test_BootOoT},
     {"boot-mm", "MM-first bring-up prerequisites on the shared context (#330)", Test_BootMM},
     {"switch-oot-mm", "Test game switch OoT -> MM", Test_SwitchOoTMM},
@@ -579,6 +579,14 @@ int TestRunner_Run(const char* testName) {
         int total = 0;
 
         for (int i = 0; gTests[i].name != nullptr; i++) {
+            // rando-gen needs a display (Fast3dWindow bring-up) and the
+            // RSBS_DISABLE_OTR_INIT environment; it runs as its own CTest
+            // ("rando" label, under xvfb-run) rather than in this
+            // display-free suite, where it would hang the 60s timeout.
+            if (strcmp(gTests[i].name, "rando-gen") == 0) {
+                printf("\n--- Skipping: %s (needs display; runs as the RandoGen CTest) ---\n", gTests[i].name);
+                continue;
+            }
             printf("\n--- Running: %s ---\n", gTests[i].name);
             TestResult result = gTests[i].runFunc();
             total++;

--- a/src/common/test_runner.cpp
+++ b/src/common/test_runner.cpp
@@ -146,6 +146,31 @@ TestResult Test_BootOoT(void) {
     return TEST_PASS;
 }
 
+extern "C" int Rando_HeadlessSeedTest(const char* seedStr);
+extern "C" void InitOTRForMMFirstBoot(int argc, char* argv[]);
+
+TestResult Test_RandoGen(void) {
+    printf("[TEST] rando-gen: headless seed generation with default settings (diagnostic)\n");
+
+    auto ctx = CreateHarnessStyleContext();
+    if (!ctx) {
+        printf("[TEST] FAIL: could not create Ship::Context singleton\n");
+        return TEST_FAIL;
+    }
+
+    // Full OoT bring-up minus the extraction prompt (the MM-first path):
+    // tolerant of a missing oot.o2r, constructs OTRGlobals::Instance,
+    // gRandomizer and gRandoContext, which the fill logic dereferences all
+    // over. Needs a display (Fast3dWindow) — run under Xvfb.
+    static char arg0[] = "redship";
+    static char* fakeArgv[] = { arg0, nullptr };
+    InitOTRForMMFirstBoot(1, fakeArgv);
+
+    int rc = Rando_HeadlessSeedTest("RSBSDIAG1");
+    printf("[TEST] %s: seed generation rc=%d\n", rc == 0 ? "PASS" : "FAIL", rc);
+    return rc == 0 ? TEST_PASS : TEST_FAIL;
+}
+
 TestResult Test_BootMM(void) {
     printf("[TEST] boot-mm: MM-first bring-up prerequisites (#330)\n");
     sTargetGame = GAME_MM;
@@ -472,6 +497,7 @@ TestResult Test_Context(void) {
 // ============================================================================
 
 const TestDescriptor gTests[] = {
+    {"rando-gen", "Headless seed generation with default settings (diagnostic)", Test_RandoGen},
     {"boot-oot", "Shared-context bring-up leaves no null subsystems (#329)", Test_BootOoT},
     {"boot-mm", "MM-first bring-up prerequisites on the shared context (#330)", Test_BootMM},
     {"switch-oot-mm", "Test game switch OoT -> MM", Test_SwitchOoTMM},


### PR DESCRIPTION
Fixes #337 — randomizer seed generation has failed at **stock settings** since June 10, invisibly (nothing could boot until #336, and nothing in CI generates a seed).

## Root cause

The Shuffle Speak port (#303) took only half of upstream SoH #6206: `savefile.cpp:330-335` grants the six `RAND_INF_CAN_SPEAK_*` flags **in-game** when the shuffle is off, but `Logic::Reset()` — which seeds the fill logic's state — never did, unlike the equivalent grants for swim/grab/climb/crawl/open-chest/wallet/fishing-pole that sit right next to the new block. With Speak off (the default), every speak-gated check (King Zora, all scrub purchases, the Zora shop, …) is permanently unreachable during fill, so every generation attempt exhausts its 5 retries.

Root cause was isolated by a 12-agent audit of the June batch (all six fill passes statically cleared at stock settings; the Speak gap confirmed by two independent agents) and then reproduced + fix-verified empirically with the new headless harness.

## Changes

- **`Logic::Reset()`**: grant the six speak flags when `RSK_SHUFFLE_SPEAK` is off (the missing half of upstream #6206).
- **RandoGen regression test** (`--test rando-gen`, CTest label `rando`): archive-tolerant full bring-up (`InitOTRForMMFirstBoot`) + real seed generation with default settings. Needs a display but **no ROMs**, so `integration-tests.yml` runs it unconditionally under `xvfb-run` — unlike the archive-gated int-* tier. Seed generation can no longer regress silently (#337's acceptance ask). Skipped inside `--test all` (display-free suite). Supports `RSBS_DIAG_CVARS=name=int,...` to reproduce user setting combos.
- **`AssumedFill` overflow dump at error level**: the "MORE ITEMS THAN LOCATIONS" branch now logs the offending item/location lists to the release log — the old `SPDLOG_DEBUG` dumps compile out of Release, which is exactly why #337's report couldn't be diagnosed from the user's log.
- **`GetDungeonSmallKeyDoors`**: bail out before `LoadResource` when no archive is loaded — the async load never resolves and hangs generation forever in archive-less states (headless test, MM-first boots without `oot.o2r`).

## Verification (local, Xvfb, no ROMs)

- `rando-gen` **fails** at stock settings without the `Logic::Reset` change and **passes** with it.
- 9-config matrix all generate successfully: each of Speak/Climb/Grab/OpenChest/Swim enabled individually, all together, and every Songs mode (Off / Song Locations / Dungeon Rewards / Anywhere).
- Full `redship` ctest tier: 16/16 (including `AllTests`, which skips the display-needing test).
- `ctest --label-regex "^rando$"` under `xvfb-run`: 1/1, ~1s.

## Notes

- The reporter's exact "MORE ITEMS THAN LOCATIONS" signature did **not** reproduce in any swept configuration — it likely depends on the specific settings in their `shipofharkinian.json`. With this PR the error-level dump will identify the exact overflowing pass if it recurs; follow-up tracked on #337 if so.
- Side-finding from the same audit filed as #338 (Fire Temple registers the Forest boss-key hint).

https://claude.ai/code/session_01GWc9bWibT2n4LRFbbpyDtK

---
_Generated by [Claude Code](https://claude.ai/code/session_01GWc9bWibT2n4LRFbbpyDtK)_

<!--- section:artifacts:start -->
### Build Artifacts
  - [rsbs-windows.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/8291237315.zip)
  - [rsbs-linux.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/8291043433.zip)
<!--- section:artifacts:end -->