### PR TITLE
Fix song-shuffle seed generation: linker dropped self-registering rando TUs

### DIFF
--- a/CMake/SingleExecutable.cmake
+++ b/CMake/SingleExecutable.cmake
@@ -233,6 +233,27 @@ if(BUILD_TESTING)
         ENVIRONMENT "SDL_AUDIODRIVER=dummy;RSBS_DISABLE_OTR_INIT=1"
     )
 
+    # Song shuffle modes. Stock (RandoGen above) already covers mode 1 — "Song
+    # Locations" is the default — which is the mode that regressed when the
+    # linker dropped ShuffleSongs.cpp.o from the static soh_rando archive and
+    # left the fill with 12 songs and 0 song locations.
+    add_test(NAME RandoGenSongsDungeonRewards COMMAND redship --test rando-gen)
+    add_test(NAME RandoGenSongsAnywhere COMMAND redship --test rando-gen)
+    set_tests_properties(
+        RandoGenSongsDungeonRewards
+        PROPERTIES
+        TIMEOUT 180
+        LABELS "rando"
+        ENVIRONMENT "SDL_AUDIODRIVER=dummy;RSBS_DISABLE_OTR_INIT=1;RSBS_DIAG_CVARS=gRandoSettings.ShuffleSongs=2"
+    )
+    set_tests_properties(
+        RandoGenSongsAnywhere
+        PROPERTIES
+        TIMEOUT 180
+        LABELS "rando"
+        ENVIRONMENT "SDL_AUDIODRIVER=dummy;RSBS_DISABLE_OTR_INIT=1;RSBS_DIAG_CVARS=gRandoSettings.ShuffleSongs=3"
+    )
+
     # ========================================================================
     # Integration tests (requires display - use Xvfb in CI)
     # These tests actually boot the games and verify boot completion

--- a/games/oot/CMakeLists.txt
+++ b/games/oot/CMakeLists.txt
@@ -263,8 +263,17 @@ if(SINGLE_EXECUTABLE_BUILD)
         target_link_libraries(${_t} PRIVATE redship_common rsbs libultraship ZAPDLib)
     endforeach()
 
-    # Export static targets for root CMakeLists to link into redship
-    set(SOH_STATIC_TARGETS soh_src soh_port soh_enh soh_rando PARENT_SCOPE)
+    # Export static targets for root CMakeLists to link into redship.
+    #
+    # soh_rando links with WHOLE_ARCHIVE: many randomizer translation units
+    # (ShuffleSongs.cpp, Messages/ItemMessages.cpp, Messages/StaticHints.cpp, ...)
+    # register themselves purely through RegisterShipInitFunc static initializers
+    # and export no symbol anything references. With plain archive semantics the
+    # linker drops those members, silently losing song locations, rando item
+    # messages, and static hints from the shipped binaries on every platform.
+    # Upstream SoH links all of these objects directly into its executable;
+    # WHOLE_ARCHIVE restores that behavior for the randomizer split.
+    set(SOH_STATIC_TARGETS soh_src soh_port soh_enh "$<LINK_LIBRARY:WHOLE_ARCHIVE,soh_rando>" PARENT_SCOPE)
 else()
     # Build as SHARED library for dynamic loading
     add_library(${PROJECT_NAME} SHARED ${ALL_FILES})

--- a/games/oot/soh/Enhancements/randomizer/3drando/menu.cpp
+++ b/games/oot/soh/Enhancements/randomizer/3drando/menu.cpp
@@ -39,6 +39,13 @@ extern "C" int Rando_HeadlessSeedTest(const char* seedStr) {
         Rando::StaticData::InitItemTable();
         Rando::StaticData::InitLocationTable();
     }
+    // Normally SohMenuRandomizer's menu setup creates the Settings options; in
+    // archive-less harness runs the GUI layer is skipped, which used to leave
+    // every Option blank (empty CVar name, default 0). SetAllToContext then fed
+    // all-zero settings into generation, so this test silently ran with every
+    // shuffle Off instead of the real stock defaults, and RSBS_DIAG_CVARS had
+    // no effect. Create the real options so the test exercises what users get.
+    Rando::Settings::GetInstance()->CreateOptions();
     // Optional non-default settings, e.g.
     // RSBS_DIAG_CVARS="gRandoSettings.ShuffleSongs=2,gRandoSettings.ShuffleSpeak=1"
     if (const char* cvars = std::getenv("RSBS_DIAG_CVARS")) {

--- a/games/oot/soh/Enhancements/randomizer/location_list.cpp
+++ b/games/oot/soh/Enhancements/randomizer/location_list.cpp
@@ -1007,6 +1007,26 @@ void Rando::StaticData::InitLocationTable() {
     // Init locationNameToEnum
     locationNameToEnum["Invalid Location"] = RC_UNKNOWN_CHECK;
     locationNameToEnum["Link's Pocket"] = RC_LINKS_POCKET;
+
+    // The per-shuffle location entries live in self-registering translation units
+    // (ShuffleSongs.cpp etc.) that hook ShipInit via static initializers. In
+    // single-exe builds those TUs sit in the static soh_rando archive, and the
+    // linker drops any member nothing references — ShuffleSongs.cpp exports no
+    // other symbol, so both shipped platforms lost RCTYPE_SONG_LOCATION entirely
+    // and every song-shuffle seed died with "MORE ITEMS THAN LOCATIONS".
+    // Calling the registrars here gives each TU a strong reference so the linker
+    // must keep it, and guarantees the table is complete for every init path
+    // (including headless harnesses that never run ShipInit::InitAll).
+    RegisterSongLocations();
+    RegisterBeehiveLocations();
+    RegisterCowLocations();
+    RegisterFishLocations();
+    RegisterFairyLocations();
+    RegisterPotLocations();
+    RegisterFreestandingLocations();
+    RegisterGrassLocations();
+    RegisterCrateLocations();
+    RegisterTreeLocations();
 }
 
 void Rando::StaticData::InitHashMaps() {

--- a/games/oot/soh/Enhancements/randomizer/settings.cpp
+++ b/games/oot/soh/Enhancements/randomizer/settings.cpp
@@ -149,6 +149,10 @@ void Settings::HandleStartingAgeUI() {
 }
 
 void Settings::CreateOptions() {
+    if (mOptionsCreated) {
+        return;
+    }
+    mOptionsCreated = true;
     CreateOptionDescriptions();
     // clang-format off
     OPT_U8(RSK_FOREST, "Closed Forest", {"On", "Deku Only", "Off"}, OptionCategory::Setting, CVAR_RANDOMIZER_SETTING("ClosedForest"), mOptionDescriptions[RSK_FOREST], WIDGET_CVAR_COMBOBOX, RO_CLOSED_FOREST_ON);

--- a/games/oot/soh/Enhancements/randomizer/settings.h
+++ b/games/oot/soh/Enhancements/randomizer/settings.h
@@ -33,6 +33,7 @@ class Settings {
     /**
      * @brief Creates the `Option` and `OptionGroup` objects. This happens after construction because certain
      * other events in the codebase need to happen before all of the `Option`s can be created.
+     * Idempotent: repeat calls are no-ops (mTricksByArea and friends would otherwise accumulate duplicates).
      */
     void CreateOptions();
 
@@ -150,5 +151,6 @@ class Settings {
     std::array<TrickOption, RT_MAX> mTrickOptions = {};
     std::vector<std::vector<Option*>> mExcludeLocationsOptionsAreas = {};
     std::unordered_map<std::string, RandomizerTrick> mTrickNameToEnum;
+    bool mOptionsCreated = false;
 };
 } // namespace Rando


### PR DESCRIPTION
# Summary

Seeds with **Shuffle Songs** on any location-restricted mode — including the **stock default, "Song Locations"** — failed with:

```
[fill.cpp:843] [error] ERROR: MORE ITEMS THAN LOCATIONS IN GIVEN LISTS (12 items > 0 locations)
[fill.cpp:845] [error] overflow item: Zelda's Lullaby
... (all 12 songs)
```

## Root cause: static-archive member elision

`ShuffleSongs.cpp` populates the 12 `RCTYPE_SONG_LOCATION` entries of the location table purely through a `RegisterShipInitFunc` static initializer and **exports no symbol anything references**. In single-exe builds the randomizer sources are the static `soh_rando` archive, and linkers only pull archive members that resolve a needed symbol — so `ShuffleSongs.cpp.o` was silently dropped, the registrar never ran, and the song fill saw 12 songs and 0 locations. Verified with `nm` on a HEAD build: `RegisterSongLocations` absent from the binary while present in `libsoh_rando.a`.

The same elision drops **all seven `Messages/*.cpp` TUs** (rando item-get texts, static hints, merchant/entrance/Navi/rupee messages) — confirmed absent from a plain-archive-semantics build via `nm`. Every other `Shuffle*.cpp` survives only by luck: they happen to define actor-hook functions (`ObjTsubo_RandomizerSpawnCollectible`, …) that game code references, and the location registrars ride along.

## Why CI stayed green (#339's RandoGen test)

`Settings::CreateOptions()` only runs from GUI menu setup (`SohMenuRandomizer.cpp`), which archive-less harness runs skip. The RandoGen test therefore generated with **all-zero blank Options** — every shuffle Off, ShuffleSongs included — instead of real stock defaults, and `RSBS_DIAG_CVARS` was a silent no-op (blank Options have empty CVar names, so the 9-config matrix in #339 actually tested the same all-zeros config every time). With songs Off, the fill takes the vanilla-placement branch and never touches song locations.

## Fixes (layered)

- **`location_list.cpp`**: `InitLocationTable()` now calls every `Register*Locations()` registrar directly. Strong references force the linker to keep those TUs on every platform, and the table is complete for every init path (including harnesses that never run `ShipInit::InitAll()`). All registrars are idempotent (`static bool registered` guards; `RegisterTreeLocations` is pure re-assignment).
- **`games/oot/CMakeLists.txt`**: link `soh_rando` with `$<LINK_LIBRARY:WHOLE_ARCHIVE,…>` so *every* randomizer TU is kept — matching upstream SoH, which links all these objects directly into its executable. This also restores the seven dropped Messages TUs. GNU ld: `--whole-archive`; MSVC: `/WHOLEARCHIVE`. Verified on Linux: no duplicate-symbol errors, binary +1.2 MB.
- **`menu.cpp` (harness)**: `Rando_HeadlessSeedTest` now calls `CreateOptions()` so generation runs with real stock settings and diag CVars actually apply.
- **`settings.cpp/.h`**: idempotence guard on `CreateOptions()` (repeat calls previously duplicated `mTricksByArea` entries).
- **`CMake/SingleExecutable.cmake`**: new CTest entries `RandoGenSongsDungeonRewards` / `RandoGenSongsAnywhere` (label `rando`, picked up by the existing CI step). Stock `RandoGen` covers "Song Locations" since it is the default.

## Verification (Linux, Xvfb, no ROMs)

- **Negative control**: with the harness fix but *without* the two linker fixes, `RandoGen` reproduces the exact reported failure — `12 items > 0 locations`, identical 12-song overflow list — and the test correctly exits 1. The old harness passed this same configuration, confirming the CI blind spot.
- **With the full fix**: `RandoGen`, `RandoGenSongsDungeonRewards`, `RandoGenSongsAnywhere` and the full 16-test `redship` unit tier all pass; `nm` shows `RegisterSongLocations`, `RegisterItemMessages`, `RegisterStaticHints`, and every other previously dropped registrar linked as defined symbols.

## Follow-up (not in this PR)

`soh_enh` and the MM `2ship_*` static archives have the same theoretical hazard for self-registering enhancement TUs; the ones sampled survive via real references today. Worth a separate audit/issue rather than widening the blast radius here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013FeUjqnLXVKZ1DiR6F4BKd

---
_Generated by [Claude Code](https://claude.ai/code/session_013FeUjqnLXVKZ1DiR6F4BKd)_

<!--- section:artifacts:start -->
### Build Artifacts
  - [rsbs-windows.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/8295026589.zip)
  - [rsbs-linux.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/8294821678.zip)
<!--- section:artifacts:end -->