### PR TITLE
Add in-app mm.o2r generation to the start prompt (#317)

### DIFF
--- a/CMake/SingleExecutable.cmake
+++ b/CMake/SingleExecutable.cmake
@@ -18,6 +18,8 @@ message(STATUS "=== Single Executable Architecture Enabled ===")
 set(REDSHIP_COMMON_SOURCES
     ${CMAKE_SOURCE_DIR}/src/common/game.c
     ${CMAKE_SOURCE_DIR}/src/common/archive_check.cpp
+    # Bundled ZAPD subprocess driver shared by both games' in-app extraction (#325)
+    ${CMAKE_SOURCE_DIR}/src/common/zapd_subprocess.cpp
     ${CMAKE_SOURCE_DIR}/src/common/context.cpp
     ${CMAKE_SOURCE_DIR}/src/common/switch.cpp
     ${CMAKE_SOURCE_DIR}/src/common/entrance.cpp
@@ -49,6 +51,7 @@ endif()
 set(REDSHIP_COMMON_HEADERS
     ${CMAKE_SOURCE_DIR}/src/common/game.h
     ${CMAKE_SOURCE_DIR}/src/common/archive_check.h
+    ${CMAKE_SOURCE_DIR}/src/common/zapd_subprocess.h
     ${CMAKE_SOURCE_DIR}/src/common/context.h
     ${CMAKE_SOURCE_DIR}/src/common/entrance.h
     ${CMAKE_SOURCE_DIR}/src/common/test_runner.h

--- a/docs/mm-archive-setup.md
+++ b/docs/mm-archive-setup.md
@@ -5,12 +5,26 @@ RedShipBlueShip needs a game archive for each game it runs:
 | Game | Archive | Generated from | First-run extraction in-app? |
 |------|---------|----------------|------------------------------|
 | Ocarina of Time | `oot.o2r` (or `oot-mq.o2r`) | Your OoT ROM | Yes — launch with `--game oot` and the built-in extractor walks you through it |
-| Majora's Mask | `mm.o2r` (also accepts `mm.zip` / `mm.otr`) | Your MM ROM | **Not yet** ([#317](https://github.com/spencerduncan/redshipblueship/issues/317)) — bring your own, see below |
+| Majora's Mask | `mm.o2r` (also accepts `mm.zip` / `mm.otr`) | Your MM ROM | Yes — select Majora's Mask at the start prompt (or launch with `--game mm`) and accept the generation offer ([#317](https://github.com/spencerduncan/redshipblueship/issues/317)) |
 
-Until in-app MM extraction lands, you must generate `mm.o2r` yourself and
-place it where RedShipBlueShip can find it. If it is missing, the app shows
-an explanatory message instead of starting MM (and refuses cross-game
-switches into MM rather than crashing).
+## In-app generation (recommended)
+
+Select Majora's Mask at the start prompt (or launch with `--game mm`). When
+no MM archive exists, RedShipBlueShip offers to generate one: it looks for
+`.z64`/`.n64`/`.v64` ROMs next to the executable (next to the `.AppImage`
+file on AppImage runs), lets you browse for one otherwise, validates it, and
+runs the bundled `ZAPD_MM` extractor. The resulting `mm.o2r` is written to
+the MM app data directory — the working directory for portable builds (see
+[Where RedShipBlueShip looks](#where-redshipblueship-looks)) — and the game
+then boots normally.
+
+This needs the packaged `assets/` folder next to the executable (present in
+release packages; a plain `cmake --build` tree does not have one — use
+Option B below there). If `mm.o2r` is missing and generation is declined or
+fails, the app shows an explanatory message instead of starting MM (and
+refuses cross-game switches into MM rather than crashing).
+
+You can also provide the archive yourself:
 
 ## Supported ROMs
 

--- a/games/mm/2s2h/BenPort.cpp
+++ b/games/mm/2s2h/BenPort.cpp
@@ -607,7 +607,7 @@ void Check2ShipArchiveVersion(std::string archivePath) {
 
     if (!std::filesystem::exists(archivePath)) {
 #if not defined(__SWITCH__) && not defined(__WIIU__)
-        Extractor::ShowErrorBox("2ship.o2r file is missing", msg.c_str());
+        MMExtractor::ShowErrorBox("2ship.o2r file is missing", msg.c_str());
         exit(1);
 #elif defined(__SWITCH__)
         Ship::Switch::PrintErrorMessageToScreen(("\x1b[2;2HYou are missing the 2ship.o2r file." + msg).c_str());
@@ -621,7 +621,7 @@ void Check2ShipArchiveVersion(std::string archivePath) {
     if (archiveVer.major != MM_gBuildVersionMajor || archiveVer.minor != MM_gBuildVersionMinor ||
         archiveVer.patch != MM_gBuildVersionPatch) {
 #if not defined(__SWITCH__) && not defined(__WIIU__)
-        Extractor::ShowErrorBox("2ship.o2r file version does not match", msg.c_str());
+        MMExtractor::ShowErrorBox("2ship.o2r file version does not match", msg.c_str());
         exit(1);
 #elif defined(__SWITCH__)
         Ship::Switch::PrintErrorMessageToScreen(("\x1b[2;2HYou have an old 2ship.o2r file." + msg).c_str());
@@ -667,18 +667,18 @@ void DetectArchiveVersion(std::string fileName, bool isO2rType) {
                  "Would you like to regenerate it now?",
                  fileName.c_str(), version);
 
-        if (Extractor::ShowYesNoBox("Old O2R File Found", msgBuf) == IDYES) {
+        if (MMExtractor::ShowYesNoBox("Old O2R File Found", msgBuf) == IDYES) {
             std::string installPath = Ship::Context::GetAppBundlePath();
             if (!std::filesystem::exists(installPath + "/assets")) {
-                Extractor::ShowErrorBox(
+                MMExtractor::ShowErrorBox(
                     "Extractor assets not found",
                     "Unable to regenerate. Missing assets folder needed to generate O2R file.\n\nExiting...");
                 exit(1);
             }
 
-            Extractor extract;
+            MMExtractor extract;
             if (!extract.Run(Ship::Context::GetAppDirectoryPath(appShortName))) {
-                Extractor::ShowErrorBox("Error", "An error occurred, no O2R file was generated.\n\nExiting...");
+                MMExtractor::ShowErrorBox("Error", "An error occurred, no O2R file was generated.\n\nExiting...");
                 exit(1);
             }
 
@@ -687,7 +687,10 @@ void DetectArchiveVersion(std::string fileName, bool isO2rType) {
                 std::filesystem::remove(archivePath);
             }
 
-            extract.CallZapd(installPath, Ship::Context::GetAppDirectoryPath(appShortName));
+            if (!extract.CallZapd(installPath, Ship::Context::GetAppDirectoryPath(appShortName))) {
+                MMExtractor::ShowErrorBox("Error", "An error occurred, no O2R file was generated.\n\nExiting...");
+                exit(1);
+            }
 
             // Rename the new O2R with the previously used extension
             if (isO2rType) {
@@ -804,19 +807,22 @@ extern "C" void InitOTR() {
         if (!std::filesystem::exists(installPath + "/assets")) {
             fprintf(stderr, "[MM InitOTR DEBUG] No assets folder, showing error and exiting\n");
             fflush(stderr);
-            Extractor::ShowErrorBox(
+            MMExtractor::ShowErrorBox(
                 "Extractor assets not found",
                 "No game O2R file found. Missing assets folder needed to generate O2R file. Exiting...");
             exit(1);
         }
 
-        if (Extractor::ShowYesNoBox("No O2R File", "No O2R files found. Generate one now?") == IDYES) {
-            Extractor extract;
+        if (MMExtractor::ShowYesNoBox("No O2R File", "No O2R files found. Generate one now?") == IDYES) {
+            MMExtractor extract;
             if (!extract.Run(Ship::Context::GetAppDirectoryPath(appShortName))) {
-                Extractor::ShowErrorBox("Error", "An error occurred, no O2R file was generated. Exiting...");
+                MMExtractor::ShowErrorBox("Error", "An error occurred, no O2R file was generated. Exiting...");
                 exit(1);
             }
-            extract.CallZapd(installPath, Ship::Context::GetAppDirectoryPath(appShortName));
+            if (!extract.CallZapd(installPath, Ship::Context::GetAppDirectoryPath(appShortName))) {
+                MMExtractor::ShowErrorBox("Error", "An error occurred, no O2R file was generated. Exiting...");
+                exit(1);
+            }
         } else {
             fprintf(stderr, "[MM InitOTR DEBUG] User declined extraction, exiting\n");
             fflush(stderr);
@@ -2094,7 +2100,7 @@ extern "C" int Controller_ShouldRumble(size_t slot) {
 }
 
 extern "C" void Messagebox_ShowErrorBox(char* title, char* body) {
-    Extractor::ShowErrorBox(title, body);
+    MMExtractor::ShowErrorBox(title, body);
 }
 
 // Helper to redirect the user to the boot screen in place of known console crash scenarios, and emits a notification

--- a/games/mm/2s2h/Extractor/Extract.cpp
+++ b/games/mm/2s2h/Extractor/Extract.cpp
@@ -16,6 +16,10 @@
 #include <unistd.h>
 #endif
 
+#ifdef RSBS_SINGLE_EXECUTABLE
+#include "zapd_subprocess.h"
+#endif
+
 #ifdef _MSC_VER
 #define BSWAP32 _byteswap_ulong
 #define BSWAP16 _byteswap_ushort
@@ -45,6 +49,7 @@
 #include <array>
 #include <fstream>
 #include <filesystem>
+#include <thread>
 #include <unordered_map>
 #include <random>
 #include <string>
@@ -71,7 +76,7 @@ enum class ButtonId : int {
     FIND,
 };
 
-void Extractor::ShowErrorBox(const char* title, const char* text) {
+void MMExtractor::ShowErrorBox(const char* title, const char* text) {
 #ifdef _WIN32
     MessageBoxA(nullptr, text, title, MB_OK | MB_ICONERROR);
 #else
@@ -79,7 +84,7 @@ void Extractor::ShowErrorBox(const char* title, const char* text) {
 #endif
 }
 
-void Extractor::ShowSizeErrorBox() const {
+void MMExtractor::ShowSizeErrorBox() const {
     std::unique_ptr<char[]> boxBuffer = std::make_unique<char[]>(mCurrentRomPath.size() + 100);
     snprintf(boxBuffer.get(), mCurrentRomPath.size() + 100,
              "The Majora's Mask ROM file %s was not a valid size. Was %zu MB, expecting 32, 54, or 64MB.",
@@ -87,23 +92,26 @@ void Extractor::ShowSizeErrorBox() const {
     ShowErrorBox("Majora's Mask - Invalid Rom Size", boxBuffer.get());
 }
 
-void Extractor::ShowCrcErrorBox() const {
+void MMExtractor::ShowCrcErrorBox() const {
     ShowErrorBox("Majora's Mask - Rom CRC invalid",
                  "The selected Majora's Mask ROM CRC did not match the list of known compatible roms. "
                  "Please find another.\n\n"
                  "Visit https://2ship.equipment/ to validate your ROM and see a list of compatible versions");
 }
 
-void Extractor::ShowCompressedErrorBox() const {
+void MMExtractor::ShowCompressedErrorBox() const {
     ShowErrorBox("Majora's Mask - File is Compressed",
                  "The selected file appears to be compressed. Please extract before using.");
 }
 
-int Extractor::ShowRomPickBox(uint32_t verCrc) const {
+int MMExtractor::ShowRomPickBox(uint32_t verCrc) const {
     std::unique_ptr<char[]> boxBuffer = std::make_unique<char[]>(mCurrentRomPath.size() + 100);
     SDL_MessageBoxData boxData = { 0 };
     SDL_MessageBoxButtonData buttons[3] = { { 0 } };
-    int ret;
+    // Default to "No" so a failed SDL_ShowMessageBox (e.g. headless systems,
+    // where boxes fail silently) reads as declining instead of leaving ret
+    // uninitialized.
+    int ret = (int)ButtonId::NO;
 
     buttons[0].buttonid = 0;
     buttons[0].text = "Yes";
@@ -129,8 +137,9 @@ int Extractor::ShowRomPickBox(uint32_t verCrc) const {
     return ret;
 }
 
-int Extractor::ShowYesNoBox(const char* title, const char* box) {
-    int ret;
+int MMExtractor::ShowYesNoBox(const char* title, const char* box) {
+    // Default to "No" on a failed SDL_ShowMessageBox — see ShowRomPickBox.
+    int ret = IDNO;
 #ifdef _WIN32
     ret = MessageBoxA(nullptr, box, title, MB_YESNO | MB_ICONQUESTION);
 #else
@@ -153,12 +162,12 @@ int Extractor::ShowYesNoBox(const char* title, const char* box) {
     return ret;
 }
 
-void Extractor::SetRomInfo(const std::string& path) {
+void MMExtractor::SetRomInfo(const std::string& path) {
     mCurrentRomPath = path;
     mCurRomSize = GetCurRomSize();
 }
 
-void Extractor::FilterRoms(std::vector<std::string>& roms, RomSearchMode searchMode) {
+void MMExtractor::FilterRoms(std::vector<std::string>& roms, RomSearchMode searchMode) {
     std::ifstream inFile;
     std::vector<std::string>::iterator it = roms.begin();
 
@@ -191,23 +200,28 @@ void Extractor::FilterRoms(std::vector<std::string>& roms, RomSearchMode searchM
     }
 }
 
-void Extractor::GetRoms(std::vector<std::string>& roms) {
+void MMExtractor::GetRoms(std::vector<std::string>& roms) {
 #ifdef _WIN32
     WIN32_FIND_DATAA ffd;
-    HANDLE h = FindFirstFileA(".\\*", &ffd);
+    // Search mSearchPath like the other platforms (upstream scanned the
+    // process working directory, which breaks when cwd differs from the
+    // requested search dir), and guard the handle: a failed FindFirstFileA
+    // must not feed uninitialized ffd data into the loop.
+    std::string searchPattern = mSearchPath + "\\*";
+    HANDLE h = FindFirstFileA(searchPattern.c_str(), &ffd);
 
-    do {
-        if (!(ffd.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY)) {
-            char* ext = PathFindExtensionA(ffd.cFileName);
+    if (h != INVALID_HANDLE_VALUE) {
+        do {
+            if (!(ffd.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY)) {
+                char* ext = PathFindExtensionA(ffd.cFileName);
 
-            // Check for any standard N64 rom file extensions.
-            if ((strcmp(ext, ".z64") == 0) || (strcmp(ext, ".n64") == 0) || (strcmp(ext, ".v64") == 0))
-                roms.push_back(ffd.cFileName);
-        }
-    } while (FindNextFileA(h, &ffd) != 0);
-    // if (h != nullptr) {
-    //    CloseHandle(h);
-    //}
+                // Check for any standard N64 rom file extensions.
+                if ((strcmp(ext, ".z64") == 0) || (strcmp(ext, ".n64") == 0) || (strcmp(ext, ".v64") == 0))
+                    roms.push_back(mSearchPath + "\\" + ffd.cFileName);
+            }
+        } while (FindNextFileA(h, &ffd) != 0);
+        FindClose(h);
+    }
 #elif unix
     // Open the directory of the app.
     DIR* d = opendir(mSearchPath.c_str());
@@ -247,7 +261,7 @@ void Extractor::GetRoms(std::vector<std::string>& roms) {
 #endif
 }
 
-bool Extractor::GetRomPathFromBox() {
+bool MMExtractor::GetRomPathFromBox() {
 #ifdef _WIN32
     OPENFILENAMEA box = { 0 };
     char nameBuffer[512];
@@ -276,7 +290,8 @@ bool Extractor::GetRomPathFromBox() {
                     errStr = "Failed to open a filebox because there is not enough RAM to do so.";
                     break;
             }
-            MessageBoxA(nullptr, "Box Error", errStr, MB_OK | MB_ICONERROR);
+            MessageBoxA(nullptr, errStr != nullptr ? errStr : "Unknown file dialog error.", "Box Error",
+                        MB_OK | MB_ICONERROR);
             return false;
         }
     }
@@ -299,15 +314,15 @@ bool Extractor::GetRomPathFromBox() {
     return true;
 }
 
-uint32_t Extractor::GetRomVerCrc() const {
+uint32_t MMExtractor::GetRomVerCrc() const {
     return BSWAP32(((uint32_t*)mRomData.get())[4]);
 }
 
-size_t Extractor::GetCurRomSize() const {
+size_t MMExtractor::GetCurRomSize() const {
     return std::filesystem::file_size(mCurrentRomPath);
 }
 
-bool Extractor::ValidateAndFixRom() {
+bool MMExtractor::ValidateAndFixRom() {
     const uint32_t actualCrc = CRC32C(mRomData.get(), mCurRomSize);
 
     for (const uint32_t crc : goodCrcs) {
@@ -319,7 +334,7 @@ bool Extractor::ValidateAndFixRom() {
 }
 
 // The file box will only allow selecting an n64 rom but typing in the file name will allow selecting anything.
-bool Extractor::ValidateNotCompressed() const {
+bool MMExtractor::ValidateNotCompressed() const {
     // ZIP file header
     if (mRomData[0] == 'P' && mRomData[1] == 'K' && mRomData[2] == 0x03 && mRomData[3] == 0x04) {
         return false;
@@ -337,14 +352,14 @@ bool Extractor::ValidateNotCompressed() const {
     return true;
 }
 
-bool Extractor::ValidateRomSize() const {
+bool MMExtractor::ValidateRomSize() const {
     if (mCurRomSize != MB32 && mCurRomSize != MB54 && mCurRomSize != MB64) {
         return false;
     }
     return true;
 }
 
-bool Extractor::ValidateRom(bool skipCrcTextBox) {
+bool MMExtractor::ValidateRom(bool skipCrcTextBox) {
     if (!ValidateNotCompressed()) {
         ShowCompressedErrorBox();
         return false;
@@ -362,7 +377,7 @@ bool Extractor::ValidateRom(bool skipCrcTextBox) {
     return true;
 }
 
-bool Extractor::ManuallySearchForRom() {
+bool MMExtractor::ManuallySearchForRom() {
     std::ifstream inFile;
 
     if (!GetRomPathFromBox()) {
@@ -376,6 +391,13 @@ bool Extractor::ManuallySearchForRom() {
         return false; // TODO Handle error
     }
 
+    // Validate the size BEFORE reading: mRomData is a fixed 64MB buffer and
+    // the file dialog can hand back arbitrarily large files.
+    if (!ValidateRomSize()) {
+        ShowSizeErrorBox();
+        return false;
+    }
+
     inFile.read((char*)mRomData.get(), mCurRomSize);
     inFile.close();
     BitConverter::RomToBigEndian(mRomData.get(), mCurRomSize);
@@ -387,7 +409,7 @@ bool Extractor::ManuallySearchForRom() {
     return true;
 }
 
-bool Extractor::ManuallySearchForRomMatchingType(RomSearchMode searchMode) {
+bool MMExtractor::ManuallySearchForRomMatchingType(RomSearchMode searchMode) {
     if (!ManuallySearchForRom()) {
         return false;
     }
@@ -408,19 +430,22 @@ bool Extractor::ManuallySearchForRomMatchingType(RomSearchMode searchMode) {
                 }
                 continue;
             case IDNO:
-                return false;
             default:
-                UNREACHABLE;
-                break;
+                // A failed or closed message box counts as "No".
+                return false;
         }
     }
 
     return true;
 }
 
-bool Extractor::Run(std::string searchPath, RomSearchMode searchMode) {
+bool MMExtractor::Run(std::string searchPath, RomSearchMode searchMode) {
     std::vector<std::string> roms;
     std::ifstream inFile;
+    // Only report success once a ROM has actually passed validation — the
+    // selection loop below can fall through without one (every candidate
+    // rejected), and the caller must not hand an empty mRomData to CallZapd.
+    bool haveValidRom = false;
 
     mSearchPath = searchPath;
 
@@ -436,13 +461,13 @@ bool Extractor::Run(std::string searchPath, RomSearchMode searchMode) {
                 if (!ManuallySearchForRomMatchingType(searchMode)) {
                     return false;
                 }
+                haveValidRom = true;
                 break;
             case IDNO:
+            default:
+                // A failed or closed message box counts as "No".
                 ShowErrorBox("Majora's Mask - No rom selected", "No Majora's Mask ROM selected. Exiting");
                 return false;
-            default:
-                UNREACHABLE;
-                break;
         }
     }
 
@@ -487,29 +512,31 @@ bool Extractor::Run(std::string searchPath, RomSearchMode searchMode) {
                 }
                 continue;
             }
+            haveValidRom = true;
             break;
         } else if (option == (int)ButtonId::FIND) {
             if (!ManuallySearchForRomMatchingType(searchMode)) {
                 return false;
             }
+            haveValidRom = true;
             break;
-        } else if (option == (int)ButtonId::NO) {
+        } else {
+            // ButtonId::NO, or a failed/closed message box — skip this ROM.
             if (rom == roms.back()) {
                 ShowErrorBox("Majora's Mask - No rom provided", "No Majora's Mask ROM provided. Exiting");
                 return false;
             }
             continue;
         }
-        break;
     }
-    return true;
+    return haveValidRom;
 }
 
-bool Extractor::IsMasterQuest() const {
+bool MMExtractor::IsMasterQuest() const {
     return false;
 }
 
-const char* Extractor::GetZapdVerStr() const {
+const char* MMExtractor::GetZapdVerStr() const {
     switch (GetRomVerCrc()) {
         case MM_US_10:
             return "N64_US";
@@ -522,14 +549,15 @@ const char* Extractor::GetZapdVerStr() const {
     }
 }
 
-std::string Extractor::Mkdtemp() {
+std::string MMExtractor::Mkdtemp() {
     std::string temp_dir = std::filesystem::temp_directory_path().string();
 
-    // create 6 random alphanumeric characters
+    // create 6 random alphanumeric characters (sizeof includes the NUL
+    // terminator, so the last valid index is sizeof - 2)
     static const char charset[] = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";
     std::random_device rd;
     std::mt19937 gen(rd());
-    std::uniform_int_distribution<> dist(0, sizeof(charset) - 1);
+    std::uniform_int_distribution<> dist(0, sizeof(charset) - 2);
 
     char randchr[7];
     for (int i = 0; i < 6; i++) {
@@ -542,10 +570,12 @@ std::string Extractor::Mkdtemp() {
     return tmppath;
 }
 
+#ifndef RSBS_SINGLE_EXECUTABLE
 extern "C" int zapd_main(int argc, char** argv);
+#endif
 static void MessageboxWorker();
 
-bool Extractor::CallZapd(std::string installPath, std::string exportdir) {
+bool MMExtractor::CallZapd(std::string installPath, std::string exportdir) {
     constexpr int argc = 22;
     char xmlPath[1024];
     char confPath[1024];
@@ -568,114 +598,160 @@ bool Extractor::CallZapd(std::string installPath, std::string exportdir) {
         return false;
     }
 
-    // Work this out in the temporary folder
-    std::string tempdir = Mkdtemp();
-    std::string curdir = std::filesystem::current_path().string();
-#ifdef _WIN32
-    std::filesystem::copy(assetsPath, tempdir + "/assets",
-                          std::filesystem::copy_options::recursive | std::filesystem::copy_options::update_existing);
-#else
-    std::filesystem::create_symlink(assetsPath, tempdir + "/assets");
-#endif
-
-    std::filesystem::current_path(tempdir);
-
-    snprintf(xmlPath, 1024, "assets/xml/%s", version);
-    snprintf(confPath, 1024, "assets/Config_%s.xml", version);
-    snprintf(portVersion, 18, "%d.%d.%d", MM_gBuildVersionMajor, MM_gBuildVersionMinor, MM_gBuildVersionPatch);
-
-    argv[0] = "ZAPD";
-    argv[1] = "ed";
-    argv[2] = "-i";
-    argv[3] = xmlPath;
-    argv[4] = "-b";
-    argv[5] = romPath.c_str();
-    argv[6] = "-fl";
-    argv[7] = "assets/filelists";
-    argv[8] = "-gsf";
-    argv[9] = "0";
-    argv[10] = "-rconf";
-    argv[11] = confPath;
-    argv[12] = "-se";
-    argv[13] = "OTR";
-    argv[14] = "--otrfile";
-    argv[15] = otrFile;
-    argv[16] = "--portVer";
-    argv[17] = portVersion;
-    argv[18] = "-o";
-    argv[19] = "placeholder";
-    argv[20] = "-osf";
-    argv[21] = "placeholder";
-
-    // Validate config XML exists before calling zapd_main
-    if (!std::filesystem::exists(confPath)) {
-        std::string errMsg = "Extractor config not found: " + std::string(confPath) +
-                             "\n\nThis may indicate an incomplete installation.";
-        fprintf(stderr, "Extractor config not found: %s. This may indicate an incomplete installation.\n", confPath);
-        ShowErrorBox("Extraction Failed", errMsg.c_str());
-        std::filesystem::current_path(curdir);
-        std::filesystem::remove_all(tempdir);
-        return false;
-    }
-
-#ifdef _WIN32
-    // Grab a handle to the command window.
-    HWND cmdWindow = GetConsoleWindow();
-
-    // Normally the command window is hidden. We want the window to be shown here so the user can see the progess of the
-    // extraction.
-    ShowWindow(cmdWindow, SW_SHOW);
-    SetWindowPos(cmdWindow, HWND_NOTOPMOST, 0, 0, 0, 0, SWP_NOSIZE | SWP_NOMOVE);
-#else
-    std::thread mbThread(MessageboxWorker);
-    mbThread.detach();
-#endif
-
+    // Work this out in a temporary folder. Everything below drives throwing
+    // std::filesystem overloads; an escaped exception would propagate out of
+    // the pre-window extraction flow and terminate the app, so wrap the body
+    // and guarantee cwd + tempdir cleanup on every exit path (mirrors the
+    // hardening in OoT's CallZapd, games/oot/soh/Extractor/Extract.cpp).
+    std::string tempdir;
+    std::string curdir;
+    bool success = false;
     try {
-        zapd_main(argc, (char**)argv.data());
+        curdir = std::filesystem::current_path().string();
+        tempdir = Mkdtemp();
+#ifdef _WIN32
+        // Copy the assets tree except extractor/ — the bundled ZAPD
+        // executables are spawned from the install dir, not the temp copy.
+        std::filesystem::create_directories(tempdir + "/assets");
+        for (const auto& entry : std::filesystem::directory_iterator(assetsPath)) {
+            if (entry.path().filename() == "extractor") {
+                continue;
+            }
+            std::filesystem::copy(entry.path(), tempdir + "/assets/" + entry.path().filename().string(),
+                                  std::filesystem::copy_options::recursive |
+                                      std::filesystem::copy_options::update_existing);
+        }
+#else
+        std::filesystem::create_symlink(assetsPath, tempdir + "/assets");
+#endif
+
+        std::filesystem::current_path(tempdir);
+
+        snprintf(xmlPath, 1024, "assets/xml/%s", version);
+        snprintf(confPath, 1024, "assets/Config_%s.xml", version);
+        snprintf(portVersion, 18, "%d.%d.%d", MM_gBuildVersionMajor, MM_gBuildVersionMinor, MM_gBuildVersionPatch);
+
+        argv[0] = "ZAPD";
+        argv[1] = "ed";
+        argv[2] = "-i";
+        argv[3] = xmlPath;
+        argv[4] = "-b";
+        argv[5] = romPath.c_str();
+        argv[6] = "-fl";
+        argv[7] = "assets/filelists";
+        argv[8] = "-gsf";
+        argv[9] = "0";
+        argv[10] = "-rconf";
+        argv[11] = confPath;
+        argv[12] = "-se";
+        argv[13] = "OTR";
+        argv[14] = "--otrfile";
+        argv[15] = otrFile;
+        argv[16] = "--portVer";
+        argv[17] = portVersion;
+        argv[18] = "-o";
+        argv[19] = "placeholder";
+        argv[20] = "-osf";
+        argv[21] = "placeholder";
+
+        // Validate config XML exists before invoking ZAPD
+        if (!std::filesystem::exists(confPath)) {
+            std::string errMsg = "Extractor config not found: " + std::string(confPath) +
+                                 "\n\nThis may indicate an incomplete installation.";
+            fprintf(stderr, "Extractor config not found: %s. This may indicate an incomplete installation.\n",
+                    confPath);
+            ShowErrorBox("Extraction Failed", errMsg.c_str());
+        } else {
+#ifdef _WIN32
+            // Grab a handle to the command window.
+            HWND cmdWindow = GetConsoleWindow();
+
+            // Normally the command window is hidden. We want the window to be shown here so the user can see the
+            // progess of the extraction.
+            ShowWindow(cmdWindow, SW_SHOW);
+            SetWindowPos(cmdWindow, HWND_NOTOPMOST, 0, 0, 0, 0, SWP_NOSIZE | SWP_NOMOVE);
+#else
+            std::thread mbThread(MessageboxWorker);
+            mbThread.detach();
+#endif
+
+            bool zapdRan = false;
+#ifdef RSBS_SINGLE_EXECUTABLE
+            // Issue #325: in the single exe zapd_main cannot be called in-process
+            // — both ZAPDLib_OoT and ZAPDLib_MM define it, and MM's assets need
+            // the GAME_MM exporter set. Spawn the bundled standalone ZAPD_MM
+            // instead (shared driver in src/common/zapd_subprocess.cpp).
+            std::string zapdPath = ZapdSubprocess_Locate(assetsPath, "ZAPD_MM");
+            if (zapdPath.empty()) {
+                std::string errMsg = "ZAPD extractor executable not found under: " + assetsPath +
+                                     "/extractor\n\nThis may indicate an incomplete installation.";
+                fprintf(stderr, "%s\n", errMsg.c_str());
+                ShowErrorBox("Extraction Failed", errMsg.c_str());
+            } else {
+                int zapdRet = ZapdSubprocess_Run(zapdPath, argv.data(), argc);
+                if (zapdRet != 0) {
+                    fprintf(stderr, "ZAPD exited with code %d\n", zapdRet);
+                    std::string errMsg = "ZAPD extraction failed (exit code " + std::to_string(zapdRet) +
+                                         ").\n\nCheck that the ROM file is valid and the assets directory is "
+                                         "complete.";
+                    ShowErrorBox("Extraction Failed", errMsg.c_str());
+                } else {
+                    zapdRan = true;
+                }
+            }
+#else
+            try {
+                zapd_main(argc, (char**)argv.data());
+                zapdRan = true;
+            } catch (const std::exception& e) {
+                fprintf(stderr, "Extraction failed: %s\n", e.what());
+                std::string errMsg = "ZAPD extraction failed with error: " + std::string(e.what());
+                ShowErrorBox("Extraction Failed", errMsg.c_str());
+            } catch (...) {
+                fprintf(stderr, "Extraction failed with unknown error\n");
+                ShowErrorBox("Extraction Failed", "ZAPD extraction failed with an unknown error.");
+            }
+#endif
+
+#ifdef _WIN32
+            // Hide the command window again.
+            ShowWindow(cmdWindow, SW_HIDE);
+#endif
+
+            if (zapdRan) {
+                // Verify the output file was created before attempting to copy
+                if (!std::filesystem::exists(otrFile)) {
+                    std::string errMsg =
+                        "ZAPD extraction failed - output file was not created: " + std::string(otrFile) +
+                        "\n\nCheck that the ROM file is valid and the assets directory is complete.";
+                    ShowErrorBox("Extraction Failed", errMsg.c_str());
+                } else {
+                    std::filesystem::copy(otrFile, exportdir + "/" + otrFile,
+                                          std::filesystem::copy_options::overwrite_existing);
+                    success = true;
+                }
+            }
+        }
     } catch (const std::exception& e) {
-        fprintf(stderr, "Extraction failed: %s\n", e.what());
-        std::string errMsg = "ZAPD extraction failed with error: " + std::string(e.what());
+        fprintf(stderr, "Extraction failed during file setup/copy: %s\n", e.what());
+        std::string errMsg = "Extraction failed during file setup/copy: " + std::string(e.what());
         ShowErrorBox("Extraction Failed", errMsg.c_str());
-#ifdef _WIN32
-        ShowWindow(cmdWindow, SW_HIDE);
-#endif
-        std::filesystem::current_path(curdir);
-        std::filesystem::remove_all(tempdir);
-        return false;
     } catch (...) {
-        fprintf(stderr, "Extraction failed with unknown error\n");
-        ShowErrorBox("Extraction Failed", "ZAPD extraction failed with an unknown error.");
-#ifdef _WIN32
-        ShowWindow(cmdWindow, SW_HIDE);
-#endif
-        std::filesystem::current_path(curdir);
-        std::filesystem::remove_all(tempdir);
-        return false;
+        fprintf(stderr, "Extraction failed during file setup/copy with unknown error\n");
+        ShowErrorBox("Extraction Failed", "Extraction failed during file setup/copy with an unknown error.");
     }
 
-#ifdef _WIN32
-    // Hide the command window again.
-    ShowWindow(cmdWindow, SW_HIDE);
-#endif
-
-    // Verify the output file was created before attempting to copy
-    if (!std::filesystem::exists(otrFile)) {
-        std::string errMsg = "ZAPD extraction failed - output file was not created: " + std::string(otrFile) +
-                             "\n\nCheck that the ROM file is valid and the assets directory is complete.";
-        ShowErrorBox("Extraction Failed", errMsg.c_str());
-        std::filesystem::current_path(curdir);
-        std::filesystem::remove_all(tempdir);
-        return false;
+    // Cleanup on all paths, including exception unwind. Use the non-throwing
+    // overloads so a failing cleanup cannot escape either.
+    std::error_code ec;
+    if (!curdir.empty()) {
+        std::filesystem::current_path(curdir, ec);
+    }
+    if (!tempdir.empty()) {
+        std::filesystem::remove_all(tempdir, ec);
     }
 
-    std::filesystem::copy(otrFile, exportdir + "/" + otrFile, std::filesystem::copy_options::overwrite_existing);
-
-    // Go back to where this game was executed from
-    std::filesystem::current_path(curdir);
-    std::filesystem::remove_all(tempdir);
-
-    return true;
+    return success;
 }
 
 static void MessageboxWorker() {

--- a/games/mm/2s2h/Extractor/Extract.h
+++ b/games/mm/2s2h/Extractor/Extract.h
@@ -1,5 +1,5 @@
-#ifndef EXTRACT_H
-#define EXTRACT_H
+#ifndef MM_EXTRACT_H
+#define MM_EXTRACT_H
 
 #include <stdint.h>
 #include <string>
@@ -25,7 +25,10 @@ enum class RomSearchMode {
     MQ = 2,
 };
 
-class Extractor {
+// Named MMExtractor (not Extractor like upstream 2S2H) because single-exe
+// builds also compile OoT's identically-named Extractor class
+// (games/oot/soh/Extractor/Extract.h) and the two would collide at link time.
+class MMExtractor {
     std::unique_ptr<unsigned char[]> mRomData = std::make_unique<unsigned char[]>(MB64);
     std::string mCurrentRomPath;
     std::string mSearchPath;

--- a/games/mm/2s2h/GameExports_SingleExe.cpp
+++ b/games/mm/2s2h/GameExports_SingleExe.cpp
@@ -20,6 +20,7 @@
 #ifdef RSBS_SINGLE_EXECUTABLE
 
 #include <cstdio>
+#include <cstdlib>
 #include <cstring>
 #include <cassert>
 #include <filesystem>
@@ -43,6 +44,7 @@
 #include "2s2h/resource/importer/TextMMFactory.h"
 #include "2s2h/resource/importer/TextureAnimationFactory.h"
 #include "2s2h/resource/importer/KeyFrameFactory.h"
+#include "Extractor/Extract.h"
 
 // From main.c headers
 extern "C" {
@@ -112,6 +114,12 @@ extern "C" {
 // an OoT-first boot gets, minus the OoT ROM-extraction prompt. No-op if the
 // bring-up already happened.
 extern "C" void InitOTRForMMFirstBoot(int argc, char* argv[]);
+
+// LUS app-directory key for MM. Must match the appName in
+// src/common/archive_check.cpp's MM spec: the extraction flow exports
+// mm.o2r to this app directory, which is the first location the archive
+// availability checks probe.
+static const char kMmAppName[] = "2s2h";
 
 // Track if MM has been initialized (for re-entry after game switch)
 static bool sMMInitialized = false;
@@ -356,12 +364,11 @@ static int LoadMMArchives() {
     }
     auto archiveMgr = ctx->GetResourceManager()->GetArchiveManager();
 
-    const std::string mmAppName = "2s2h";
     int loaded = 0;
 
     // Try mm.o2r (primary), then .zip/.otr fallbacks
     for (const char* ext : {"mm.o2r", "mm.zip", "mm.otr"}) {
-        std::string path = Ship::Context::LocateFileAcrossAppDirs(ext, mmAppName);
+        std::string path = Ship::Context::LocateFileAcrossAppDirs(ext, kMmAppName);
         if (!path.empty() && std::filesystem::exists(path)) {
             if (archiveMgr->AddArchive(path)) {
                 fprintf(stderr, "[MM] Loaded archive: %s\n", path.c_str());
@@ -676,6 +683,89 @@ const char* MM_Game_GetId(void) {
 }
 
 } // extern "C"
+
+// ============================================================================
+// In-app mm.o2r generation for the start prompt (issue #317)
+// ============================================================================
+
+/**
+ * Offer to generate mm.o2r from the user's own Majora's Mask ROM.
+ *
+ * Called by the harness (rsbs/src/main.cpp) when Majora's Mask is selected at
+ * the start prompt but no MM game archive exists. Runs before any game init or
+ * window creation, so the UI is parentless SDL message boxes plus a native
+ * file dialog — the same pre-window flow standalone 2Ship drives from InitOTR
+ * (2s2h/BenPort.cpp). ROMs are searched for next to the executable (next to
+ * the .AppImage file on AppImage runs); the archive is exported to MM's app
+ * directory, the first location the archive checks probe
+ * (src/common/archive_check.cpp). The harness re-checks archive presence
+ * after this returns — success is "mm.o2r now exists", not a return value.
+ */
+extern "C" void MM_Extract_OfferAndRun(void) {
+#if defined(__SWITCH__) || defined(__WIIU__)
+    // No extractor on console platforms (games/mm/CMakeLists.txt globs the
+    // Extractor sources out there) — consoles bring their own archives.
+    return;
+#else
+    const std::string installPath = Ship::Context::GetAppBundlePath();
+    const std::string exportDir = Ship::Context::GetAppDirectoryPath(kMmAppName);
+
+    if (!std::filesystem::exists(installPath + "/assets")) {
+        MMExtractor::ShowErrorBox(
+            "Extractor assets not found",
+            "No Majora's Mask O2R file found, and the assets folder needed to generate one is missing.\n\n"
+            "In-app generation needs a packaged RedShipBlueShip install (an assets/ folder next to the executable).");
+        return;
+    }
+
+    if (MMExtractor::ShowYesNoBox("No Majora's Mask O2R file",
+                                  "No Majora's Mask game archive (mm.o2r) was found.\n\n"
+                                  "Generate one from your Majora's Mask ROM now?") != IDYES) {
+        return;
+    }
+
+    // ROMs are searched for next to the executable — except on AppImage runs,
+    // where the bundle path is a transient read-only mount: there the user's
+    // ROM sits next to the .AppImage file itself.
+    std::string romSearchDir = installPath;
+    const char* appImagePath = getenv("APPIMAGE");
+    if (appImagePath != nullptr && appImagePath[0] != '\0') {
+        std::filesystem::path appImageDir = std::filesystem::path(appImagePath).parent_path();
+        std::error_code aec;
+        if (!appImageDir.empty() && std::filesystem::is_directory(appImageDir, aec)) {
+            romSearchDir = appImageDir.string();
+        }
+    }
+
+    // GetAppDirectoryPath can name a directory that does not exist yet (e.g.
+    // ~/.local/share/2s2h on a first boot); CallZapd's final copy needs it.
+    std::error_code ec;
+    std::filesystem::create_directories(exportDir, ec);
+
+    // The extractor drives throwing std::filesystem overloads (file probes,
+    // reads); nothing above this frame catches, so keep exceptions from
+    // escaping the pre-window flow.
+    try {
+        MMExtractor extract;
+        if (!extract.Run(romSearchDir)) {
+            MMExtractor::ShowErrorBox("Error", "An error occurred, no O2R file was generated.");
+            return;
+        }
+        if (!extract.CallZapd(installPath, exportDir)) {
+            // CallZapd reports its own errors via message boxes.
+            return;
+        }
+    } catch (const std::exception& e) {
+        fprintf(stderr, "[MM] Extraction failed: %s\n", e.what());
+        fflush(stderr);
+        MMExtractor::ShowErrorBox("Extraction Failed", e.what());
+        return;
+    }
+
+    fprintf(stderr, "[MM] mm.o2r generated into %s\n", exportDir.c_str());
+    fflush(stderr);
+#endif
+}
 
 // ============================================================================
 // GameOps registration

--- a/games/mm/CMakeLists.txt
+++ b/games/mm/CMakeLists.txt
@@ -270,8 +270,12 @@ if(SINGLE_EXECUTABLE_BUILD)
     list(FILTER ship__ EXCLUDE REGEX "2s2h/resource/type/SkeletonLimb\\.cpp$")
     list(FILTER ship__ EXCLUDE REGEX "2s2h/resource/type/scenecommand/.*\\.cpp$")
 
-    # Extractor
-    list(FILTER ship__Extractor EXCLUDE REGEX "2s2h/Extractor/.*\\.cpp$")
+    # Extractor: Extract.cpp is compiled (in-app mm.o2r generation, #317) —
+    # its class is named MMExtractor so it can coexist with OoT's Extractor,
+    # and in single-exe mode its CallZapd spawns the bundled ZAPD_MM
+    # subprocess instead of the in-process zapd_main (#325). FastCrc32C.c
+    # stays excluded: it defines the unprefixed CRC32C symbol, which OoT's
+    # identical soh/Extractor/FastCrc32C.c already provides.
     list(FILTER ship__Extractor EXCLUDE REGEX "2s2h/Extractor/.*\\.c$")
 
     # OTR-specific scene/play files

--- a/games/oot/soh/Extractor/Extract.cpp
+++ b/games/oot/soh/Extractor/Extract.cpp
@@ -17,9 +17,8 @@
 #include <unistd.h>
 #endif
 
-#if defined(RSBS_SINGLE_EXECUTABLE) && !defined(_WIN32)
-#include <sys/wait.h>
-#include <unistd.h>
+#ifdef RSBS_SINGLE_EXECUTABLE
+#include "zapd_subprocess.h"
 #endif
 
 #ifdef _MSC_VER
@@ -147,7 +146,10 @@ int Extractor::ShowRomPickBox(uint32_t verCrc) const {
     std::unique_ptr<char[]> boxBuffer = std::make_unique<char[]>(mCurrentRomPath.size() + 100);
     SDL_MessageBoxData boxData = { 0 };
     SDL_MessageBoxButtonData buttons[3] = { { 0 } };
-    int ret;
+    // Default to "No" so a failed SDL_ShowMessageBox (e.g. headless systems,
+    // where boxes fail silently) reads as declining instead of leaving ret
+    // uninitialized.
+    int ret = 1;
 
     buttons[0].buttonid = 0;
     buttons[0].text = "Yes";
@@ -174,7 +176,8 @@ int Extractor::ShowRomPickBox(uint32_t verCrc) const {
 }
 
 int Extractor::ShowYesNoBox(const char* title, const char* box) {
-    int ret;
+    // Default to "No" on a failed SDL_ShowMessageBox — see ShowRomPickBox.
+    int ret = IDNO;
 #ifdef _WIN32
     ret = MessageBoxA(nullptr, box, title, MB_YESNO | MB_ICONQUESTION);
 #else
@@ -657,74 +660,7 @@ std::string Extractor::Mkdtemp() {
     return tmppath;
 }
 
-#ifdef RSBS_SINGLE_EXECUTABLE
-// Issue #325: in the single exe zapd_main cannot be called in-process. Both
-// ZAPDLib_OoT and ZAPDLib_MM define it (same sources, different GAME_*
-// defines), and the link resolves the reference to the no-op stub that used
-// to live in mm_stubs.c rather than either real library member. Instead,
-// spawn the bundled standalone ZAPD executable as a subprocess — the same
-// way CI's extract_assets.py drives it. The child inherits the process
-// working directory, which CallZapd has already set to the temp extraction
-// dir, so ZAPD's relative paths (assets/..., output o2r) resolve unchanged.
-//
-// Returns the child's exit code, or -1 if the process could not be spawned
-// or terminated abnormally. argv[0] is replaced with exePath.
-static int RunZapdSubprocess(const std::string& exePath, const char* const* argv, int argc) {
-#ifdef _WIN32
-    // CreateProcess takes a single command line; quote each argument. Naive
-    // quoting is sufficient here: the only variable arguments are filesystem
-    // paths (quotes are illegal in Windows paths, and these paths do not end
-    // in a backslash) and a x.y.z version string.
-    std::string cmdLine = "\"" + exePath + "\"";
-    for (int i = 1; i < argc; i++) {
-        cmdLine += " \"";
-        cmdLine += argv[i];
-        cmdLine += "\"";
-    }
-    std::vector<char> mutableCmd(cmdLine.begin(), cmdLine.end());
-    mutableCmd.push_back('\0');
-
-    STARTUPINFOA si = { 0 };
-    si.cb = sizeof(si);
-    PROCESS_INFORMATION pi = { 0 };
-    if (!CreateProcessA(exePath.c_str(), mutableCmd.data(), nullptr, nullptr, FALSE, 0, nullptr, nullptr, &si, &pi)) {
-        fprintf(stderr, "Failed to spawn ZAPD (%s): error %lu\n", exePath.c_str(), GetLastError());
-        return -1;
-    }
-    WaitForSingleObject(pi.hProcess, INFINITE);
-    DWORD exitCode = (DWORD)-1;
-    GetExitCodeProcess(pi.hProcess, &exitCode);
-    CloseHandle(pi.hProcess);
-    CloseHandle(pi.hThread);
-    return (int)exitCode;
-#else
-    pid_t pid = fork();
-    if (pid < 0) {
-        fprintf(stderr, "Failed to fork for ZAPD (%s)\n", exePath.c_str());
-        return -1;
-    }
-    if (pid == 0) {
-        // Child: only async-signal-safe calls between fork and exec.
-        std::vector<char*> childArgv;
-        childArgv.push_back(const_cast<char*>(exePath.c_str()));
-        for (int i = 1; i < argc; i++) {
-            childArgv.push_back(const_cast<char*>(argv[i]));
-        }
-        childArgv.push_back(nullptr);
-        execv(exePath.c_str(), childArgv.data());
-        _exit(127);
-    }
-    int status = 0;
-    if (waitpid(pid, &status, 0) < 0) {
-        return -1;
-    }
-    if (WIFEXITED(status)) {
-        return WEXITSTATUS(status);
-    }
-    return -1;
-#endif
-}
-#else
+#ifndef RSBS_SINGLE_EXECUTABLE
 extern "C" int zapd_main(int argc, char** argv);
 #endif
 
@@ -813,17 +749,18 @@ bool Extractor::CallZapd(std::string installPath, std::string exportdir, std::at
             // until ZAPD is uplifted.
             bool zapdRan = false;
 #ifdef RSBS_SINGLE_EXECUTABLE
-            std::string zapdPath = assetsPath + "/extractor/ZAPD_OoT";
-#ifdef _WIN32
-            zapdPath += ".exe";
-#endif
-            if (!std::filesystem::exists(zapdPath)) {
-                std::string errMsg = "ZAPD extractor executable not found: " + zapdPath +
-                                     "\n\nThis may indicate an incomplete installation.";
+            // Issue #325: in the single exe zapd_main cannot be called
+            // in-process — spawn the bundled standalone ZAPD_OoT instead
+            // (shared driver in src/common/zapd_subprocess.cpp, which also
+            // handles ZAPDTR's ZAPD_OoT.out output name on Linux/macOS).
+            std::string zapdPath = ZapdSubprocess_Locate(assetsPath, "ZAPD_OoT");
+            if (zapdPath.empty()) {
+                std::string errMsg = "ZAPD extractor executable not found under: " + assetsPath +
+                                     "/extractor\n\nThis may indicate an incomplete installation.";
                 fprintf(stderr, "%s\n", errMsg.c_str());
                 ShowErrorBox("Extraction Failed", errMsg.c_str());
             } else {
-                int zapdRet = RunZapdSubprocess(zapdPath, argv.data(), argc);
+                int zapdRet = ZapdSubprocess_Run(zapdPath, argv.data(), argc);
                 if (zapdRet != 0) {
                     fprintf(stderr, "ZAPD exited with code %d\n", zapdRet);
                     std::string errMsg = "ZAPD extraction failed (exit code " + std::to_string(zapdRet) +

--- a/rsbs/src/main.cpp
+++ b/rsbs/src/main.cpp
@@ -88,6 +88,11 @@ extern "C" {
     // Whether the shared bring-up found an OoT game archive and ran OoT's
     // asset-dependent init (games/oot/soh/OTRGlobals.cpp, #330).
     int OoT_GameAssetsInitialized(void);
+    // In-app mm.o2r generation, offered at the start prompt when MM is
+    // selected without a game archive (#317). Defined in
+    // games/mm/2s2h/GameExports_SingleExe.cpp. Success is observed by
+    // re-checking archive availability, not via a return value.
+    void MM_Extract_OfferAndRun(void);
     // Build-version strings baked into each game library
     // (games/*/src/boot/build.c); declarations match each game's own header.
     extern const char OoT_gBuildVersion[];
@@ -363,15 +368,27 @@ int main(int argc, char** argv) {
 
     // ========================================================================
     // Pre-flight archive check (#317): verify the selected game's ROM-derived
-    // archives exist before any init. OoT can self-heal on a cold boot — its
-    // in-app extractor (RunExtract) generates oot.o2r from a ROM — so only MM,
-    // which has no in-app extraction path yet, is gated here. Without this,
-    // a missing mm.o2r surfaces as a bare "Failed to initialize game" on the
-    // console, which a GUI-launched user never sees.
+    // archives exist before any init. OoT can self-heal during its own init —
+    // its in-app extractor (RunExtract) generates oot.o2r from a ROM. MM's
+    // init has no equivalent, so the harness offers MM's extractor here
+    // instead: it runs before any window exists (parentless SDL dialogs plus
+    // a native file picker), generates mm.o2r from the user's ROM via the
+    // bundled ZAPD_MM, and lets the boot continue. Integration tests stay
+    // non-interactive: there a missing archive remains a hard failure.
+    // Without this gate, a missing mm.o2r surfaces as a bare "Failed to
+    // initialize game" on the console, which a GUI-launched user never sees.
     // ========================================================================
     if (selectedGame == GAME_MM && !ArchiveCheck_GameAvailable(GAME_MM)) {
-        ArchiveCheck_ReportMissing(GAME_MM, /*showDialog=*/!TestRunner_IsIntegrationTestMode());
-        return 1;
+        bool interactive = !TestRunner_IsIntegrationTestMode();
+        bool available = false;
+        if (interactive) {
+            MM_Extract_OfferAndRun();
+            available = ArchiveCheck_GameAvailable(GAME_MM);
+        }
+        if (!available) {
+            ArchiveCheck_ReportMissing(GAME_MM, /*showDialog=*/interactive);
+            return 1;
+        }
     }
 
     // Build filtered argv (remove our flags before passing to game)

--- a/src/common/archive_check.cpp
+++ b/src/common/archive_check.cpp
@@ -41,12 +41,14 @@ const GameArchiveSpec* SpecFor(GameId game) {
         "2s2h",
         { "mm.o2r", "mm.zip", "mm.otr" },
         "mm.o2r is generated from your own Majora's Mask ROM\n"
-        "(US N64 1.0 or US GameCube version). To set it up:\n"
-        "  1. Generate mm.o2r with standalone 2Ship2Harkinian (run it once\n"
-        "     and point it at your ROM), or build it from this repository —\n"
-        "     see docs/mm-archive-setup.md for both walkthroughs.\n"
-        "  2. Copy mm.o2r next to the redship executable.\n"
-        "  3. Relaunch.\n",
+        "(US N64 1.0 or US GameCube version). To set it up, either:\n"
+        "  - Relaunch RedShipBlueShip, select Majora's Mask, and accept the\n"
+        "    generation prompt — the built-in extractor creates mm.o2r from\n"
+        "    your ROM (needs the packaged assets folder next to the\n"
+        "    executable), or\n"
+        "  - Generate mm.o2r elsewhere (standalone 2Ship2Harkinian, or a\n"
+        "    build of this repository — see docs/mm-archive-setup.md) and\n"
+        "    copy it next to the redship executable, then relaunch.\n",
     };
 
     switch (game) {

--- a/src/common/archive_check.h
+++ b/src/common/archive_check.h
@@ -3,10 +3,11 @@
  * @brief ROM-archive availability checks for the single executable (issue #317)
  *
  * The single exe can only run a game whose ROM-derived archive is present
- * (oot.o2r / oot-mq.o2r for OoT, mm.o2r / mm.zip / mm.otr for MM). OoT can
- * regenerate its archive through the bundled in-app extractor on a cold boot,
- * but MM has no in-app extraction path yet — its archive must be brought by
- * the user (see docs/mm-archive-setup.md).
+ * (oot.o2r / oot-mq.o2r for OoT, mm.o2r / mm.zip / mm.otr for MM). Either
+ * game can regenerate its archive through a bundled in-app extractor on a
+ * cold boot: OoT during its own init (RunExtract), MM through the start-
+ * prompt offer the harness drives via MM_Extract_OfferAndRun (see
+ * rsbs/src/main.cpp and docs/mm-archive-setup.md).
  *
  * These helpers let the harness (rsbs/src/main.cpp) verify availability
  * up front and show an instructive message instead of failing mid-init or

--- a/src/common/zapd_subprocess.cpp
+++ b/src/common/zapd_subprocess.cpp
@@ -1,0 +1,103 @@
+/**
+ * @file zapd_subprocess.cpp
+ * @brief Bundled standalone ZAPD subprocess driver for in-app extraction (issue #325)
+ *
+ * See zapd_subprocess.h for the rationale.
+ */
+
+#include "zapd_subprocess.h"
+
+#include <cerrno>
+#include <cstdio>
+#include <filesystem>
+#include <vector>
+
+#ifdef _WIN32
+#include <windows.h>
+#else
+#include <sys/wait.h>
+#include <unistd.h>
+#endif
+
+std::string ZapdSubprocess_Locate(const std::string& assetsPath, const char* variant) {
+    const std::string base = assetsPath + "/extractor/" + variant;
+#ifdef _WIN32
+    const std::string candidates[] = { base + ".exe" };
+#else
+    // ZAPDTR names the Linux/macOS executables "<variant>.out" (OUTPUT_NAME,
+    // ZAPDTR/ZAPD/CMakeLists.txt); accept the bare name too in case a
+    // packaging step strips the suffix.
+    const std::string candidates[] = { base + ".out", base };
+#endif
+    for (const auto& path : candidates) {
+        std::error_code ec;
+        if (std::filesystem::exists(path, ec)) {
+            return path;
+        }
+    }
+    return "";
+}
+
+int ZapdSubprocess_Run(const std::string& exePath, const char* const* argv, int argc) {
+#ifdef _WIN32
+    // CreateProcess takes a single command line; quote each argument. Naive
+    // quoting is sufficient here: the only variable arguments are filesystem
+    // paths (quotes are illegal in Windows paths, and these paths do not end
+    // in a backslash) and a x.y.z version string.
+    std::string cmdLine = "\"" + exePath + "\"";
+    for (int i = 1; i < argc; i++) {
+        cmdLine += " \"";
+        cmdLine += argv[i];
+        cmdLine += "\"";
+    }
+    std::vector<char> mutableCmd(cmdLine.begin(), cmdLine.end());
+    mutableCmd.push_back('\0');
+
+    STARTUPINFOA si = { 0 };
+    si.cb = sizeof(si);
+    PROCESS_INFORMATION pi = { 0 };
+    if (!CreateProcessA(exePath.c_str(), mutableCmd.data(), nullptr, nullptr, FALSE, 0, nullptr, nullptr, &si, &pi)) {
+        fprintf(stderr, "Failed to spawn ZAPD (%s): error %lu\n", exePath.c_str(), GetLastError());
+        return -1;
+    }
+    WaitForSingleObject(pi.hProcess, INFINITE);
+    DWORD exitCode = (DWORD)-1;
+    GetExitCodeProcess(pi.hProcess, &exitCode);
+    CloseHandle(pi.hProcess);
+    CloseHandle(pi.hThread);
+    return (int)exitCode;
+#else
+    // Build the child argv BEFORE forking: the process is multithreaded here
+    // (SDL dialog threads, logger threads), so the child may only make
+    // async-signal-safe calls between fork and exec — no heap allocation.
+    std::vector<char*> childArgv;
+    childArgv.reserve(argc + 1);
+    childArgv.push_back(const_cast<char*>(exePath.c_str()));
+    for (int i = 1; i < argc; i++) {
+        childArgv.push_back(const_cast<char*>(argv[i]));
+    }
+    childArgv.push_back(nullptr);
+
+    pid_t pid = fork();
+    if (pid < 0) {
+        fprintf(stderr, "Failed to fork for ZAPD (%s)\n", exePath.c_str());
+        return -1;
+    }
+    if (pid == 0) {
+        execv(exePath.c_str(), childArgv.data());
+        _exit(127);
+    }
+    int status = 0;
+    pid_t waited;
+    do {
+        waited = waitpid(pid, &status, 0);
+    } while (waited < 0 && errno == EINTR);
+    if (waited < 0) {
+        return -1;
+    }
+    if (WIFEXITED(status)) {
+        return WEXITSTATUS(status);
+    }
+    return -1;
+#endif
+}

--- a/src/common/zapd_subprocess.h
+++ b/src/common/zapd_subprocess.h
@@ -1,0 +1,41 @@
+/**
+ * @file zapd_subprocess.h
+ * @brief Bundled standalone ZAPD subprocess driver for in-app extraction (issue #325)
+ *
+ * In the single executable zapd_main cannot be called in-process: both
+ * ZAPDLib_OoT and ZAPDLib_MM define it (same sources, different GAME_*
+ * defines), so the link can only ever resolve the symbol to one variant.
+ * In-app extraction instead spawns the bundled standalone ZAPD executable
+ * (ZAPD_OoT / ZAPD_MM, packaged under <exe dir>/assets/extractor) as a
+ * subprocess — the same way CI's extract_assets.py drives it. Both games'
+ * extractors share this driver.
+ */
+
+#ifndef RSBS_COMMON_ZAPD_SUBPROCESS_H
+#define RSBS_COMMON_ZAPD_SUBPROCESS_H
+
+#include <string>
+
+/**
+ * Locate the bundled standalone ZAPD executable `variant` ("ZAPD_OoT" or
+ * "ZAPD_MM") under assetsPath + "/extractor". Probes the platform name
+ * variants: "<variant>.exe" on Windows; "<variant>.out" (ZAPDTR's
+ * OUTPUT_NAME for Linux/macOS) and the bare "<variant>" elsewhere.
+ *
+ * @return the path of the executable that exists, or "" when none does
+ */
+std::string ZapdSubprocess_Locate(const std::string& assetsPath, const char* variant);
+
+/**
+ * Run a ZAPD executable as a subprocess and wait for it to finish. The child
+ * inherits the process working directory, which the extraction flow has
+ * already set to the temp extraction dir, so ZAPD's relative paths
+ * (assets/..., the output o2r) resolve unchanged. argv[0] is replaced with
+ * exePath.
+ *
+ * @return the child's exit code, or -1 if the process could not be spawned
+ *         or terminated abnormally
+ */
+int ZapdSubprocess_Run(const std::string& exePath, const char* const* argv, int argc);
+
+#endif // RSBS_COMMON_ZAPD_SUBPROCESS_H


### PR DESCRIPTION
Closes #317.

Selecting Majora's Mask at the start prompt (or launching with `--game mm`) with no MM game archive now offers to generate `mm.o2r` from the user's own ROM instead of hard-exiting with setup instructions. The flow runs before any window exists — parentless SDL dialogs plus a native file picker, the same pre-window flow standalone 2Ship drives from `InitOTR` — searches for ROMs next to the executable (next to the `.AppImage` file on AppImage runs), validates them, and drives the bundled `ZAPD_MM` extractor. The generated archive lands in the MM app directory, the first location the archive checks probe, and boot continues normally. Integration tests stay non-interactive: a missing archive there is still a hard failure.

## Mechanics

- `2s2h/Extractor/Extract.cpp` is now compiled in single-exe builds; its class is renamed `MMExtractor` because OoT's identically-named `Extractor` is also linked. `FastCrc32C.c` stays excluded (OoT's identical `CRC32C` is already linked).
- New shared driver `src/common/zapd_subprocess.{h,cpp}` locates the bundled `ZAPD_OoT`/`ZAPD_MM` — including ZAPDTR's `.out` output name on Linux/macOS, which OoT's extraction previously missed (it probed the bare `ZAPD_OoT` name no Linux package ships) — and spawns it, building the child argv before `fork` and retrying `waitpid` on `EINTR`. Replaces the per-game byte-identical copies.
- New `MM_Extract_OfferAndRun()` in `2s2h/GameExports_SingleExe.cpp` drives the offer; the pre-flight gate in `rsbs/src/main.cpp` calls it and re-checks archive availability instead of trusting a return value.

## Hardening of the newly reachable extractor paths

- `MMExtractor::CallZapd` wraps its throwing `std::filesystem` work in try/catch with guaranteed cwd + tempdir cleanup (mirrors OoT's `CallZapd` hardening); the Windows temp assets copy skips the bundled extractor executables.
- `MMExtractor::Run` only reports success once a ROM actually validated, and closed/failed message boxes count as "No" instead of hitting `default: UNREACHABLE` (undefined behavior). Both games' dialog helpers no longer return uninitialized ints when `SDL_ShowMessageBox` fails (headless systems).
- `ManuallySearchForRom` validates ROM size before reading into the fixed 64MB buffer — oversized picker selections used to overflow the heap.
- Windows `GetRoms` searches `mSearchPath` (not cwd), guards the find handle against `INVALID_HANDLE_VALUE`, and calls `FindClose`; `Mkdtemp` can no longer draw the NUL terminator into the temp-dir suffix; legacy BenPort flows check `CallZapd`'s result instead of falling through or throwing on a missing output file.

## Docs

`docs/mm-archive-setup.md` documents the in-app path as the recommended option; the missing-archive message leads with it.

## Verification

- Full single-exe build on Linux; all 19 unit tests pass (`ctest`, integration tests skipped — no ROM archives on this runner, same as CI).
- End-to-end under Xvfb with auto-confirmed dialogs and a CRC-forged 32MB test file: offer → ROM discovery → validation → temp-dir setup → `ZAPD_MM` subprocess spawn (verified argv) → `mm.o2r` exported → gate re-check passes → MM boot proceeds. Also verified: the `APPIMAGE` env override finds a ROM next to the AppImage path; a real `ZAPD_MM` failing on a bad ROM surfaces the error dialog and falls back to the explanatory report (exit 1); headless runs decline gracefully; integration-test mode remains non-interactive.
- Real-ROM extraction needs manual testing on a packaged build (assets/ next to the executable).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DS29hijroLiSL4WFUxNnst

---
_Generated by [Claude Code](https://claude.ai/code/session_01DS29hijroLiSL4WFUxNnst)_

<!--- section:artifacts:start -->
### Build Artifacts
  - [rsbs-windows.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/8302887293.zip)
  - [rsbs-linux.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/8302677687.zip)
<!--- section:artifacts:end -->