### PR TITLE
Fix Windows boot stack overflow (0xc00000fd): de-nest randomizer table-builder frames, set /STACK on redship

### DIFF
--- a/CMake/SingleExecutable.cmake
+++ b/CMake/SingleExecutable.cmake
@@ -179,6 +179,17 @@ if(MSVC)
     set_target_properties(redship PROPERTIES
         MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>"
     )
+    # 8 MB stack reserve (upstream SoH's value), all configs. The randomizer
+    # table-builder functions (InitLocationTable, RegisterPotLocations, ...)
+    # are too large for MSVC to optimize (C4883), so every Location temporary
+    # gets its own stack slot and each function carries a several-hundred-KB
+    # frame. With the MSVC default 1 MB reserve the boot-time rando init
+    # overflows the stack (0xc00000fd). The game targets' own /STACK flags
+    # never reach this link: they sit on STATIC libraries, whose link options
+    # do not propagate to the final executable. Reserve is virtual address
+    # space, not committed memory, and applies to every thread created with
+    # a default stack size.
+    target_link_options(redship PRIVATE /STACK:8777216)
 endif()
 
 if(UNIX AND NOT APPLE)

--- a/games/oot/soh/Enhancements/randomizer/location_list.cpp
+++ b/games/oot/soh/Enhancements/randomizer/location_list.cpp
@@ -144,7 +144,20 @@ std::vector<RandomizerCheck> Rando::StaticData::GetSongFairyLocations() {
     return fairyLocations;
 }
 
-void Rando::StaticData::InitLocationTable() {
+// Keep the giant table-builder frames out of each other's stacks: MSVC gives
+// up optimizing functions this large (C4883) and assigns each Location
+// temporary its own stack slot, so this function and the bigger
+// Register*Locations functions each carry a several-hundred-KB frame. They
+// must run sequentially, never nested, or the 1 MB default Windows stack
+// overflows (0xc00000fd) during boot. noinline stops the compiler from
+// merging them back into their single caller.
+#ifdef _MSC_VER
+#define RANDO_TABLE_NOINLINE __declspec(noinline)
+#else
+#define RANDO_TABLE_NOINLINE __attribute__((noinline))
+#endif
+
+RANDO_TABLE_NOINLINE void Rando::StaticData::InitMainLocationTable() {
     // clang-format off
     //                                                                                                Randomizer Check                                                 Quest            Type                                Area                                 Actor ID              Scene ID                            Params                        Flags Short Name                                     Hint Text Key                                                    Vanilla Item                                                        Spoiler Collection Check                                                                                                      Vanilla Progression  Price
     locationTable[RC_UNKNOWN_CHECK] =                                                  Location::Base(RC_UNKNOWN_CHECK,                                                RCQUEST_BOTH,    RCTYPE_STANDARD,                    RCAREA_INVALID,                      ACTOR_ID_MAX,         SCENE_ID_MAX,                       0x00,                               "Invalid Location", "Invalid Location",        RHT_NONE,                                                        RG_NONE);
@@ -1007,6 +1020,14 @@ void Rando::StaticData::InitLocationTable() {
     // Init locationNameToEnum
     locationNameToEnum["Invalid Location"] = RC_UNKNOWN_CHECK;
     locationNameToEnum["Link's Pocket"] = RC_LINKS_POCKET;
+}
+
+void Rando::StaticData::InitLocationTable() {
+    // Build the base table first, then the per-shuffle entries — as sibling
+    // calls, so only one giant table-builder frame is live at a time (see
+    // InitMainLocationTable in static_data.h; nesting them overflowed the
+    // 1 MB default Windows stack at boot).
+    InitMainLocationTable();
 
     // The per-shuffle location entries live in self-registering translation units
     // (ShuffleSongs.cpp etc.) that hook ShipInit via static initializers. In

--- a/games/oot/soh/Enhancements/randomizer/static_data.h
+++ b/games/oot/soh/Enhancements/randomizer/static_data.h
@@ -19,6 +19,13 @@ class StaticData {
   private:
     static std::array<Item, RG_MAX> itemTable;
     static std::array<Location, RC_MAX> locationTable;
+    // Builds the base (non-shuffle) location table entries. Split out of
+    // InitLocationTable so that its stack frame is never live at the same
+    // time as the Register*Locations frames: MSVC declines to optimize
+    // functions this large (C4883) and gives every Location temporary its
+    // own stack slot, producing frames of several hundred KB. Nesting two
+    // of them overflows the 1 MB default Windows stack during boot.
+    static void InitMainLocationTable();
 
   public:
     static void InitItemTable();


### PR DESCRIPTION
# Summary

Windows builds since #340 crash instantly at boot with exception `0xc00000fd` (stack overflow), ~30 ms after the "Starting Ship of Harkinian version" banner. This PR fixes the crash two independent ways.

## Root cause

The crash register state is a `__chkstk` stack probe of **RAX = 0x78428 = 492,584 bytes** — the fingerprint of a single function with a ~492 KB stack frame. MSVC refuses to optimize the randomizer table-builder functions (warning C4883: "function size suppresses optimizations") and gives every `Location` temporary its own stack slot; `sizeof(Location)` is **840 bytes** on MSVC x64, dominated by the by-value `Option excludedOption` member (720 B, embedding four 64-B `std::function`s).

- `RegisterPotLocations()`: 540 `locationTable[...] = Location::Pot(...)` statements → 540 × 912 B/stmt + prologue = **492,584 bytes. Byte-exact match with the crash.**
- `InitLocationTable()` base body: 741 statements → **~650 KB frame**.

#340 appended direct calls to the ten `Register*Locations()` registrars **inside** `InitLocationTable()`, so both giant frames became live simultaneously on the boot path (`OTRGlobals` ctor → `InitStaticData()` → `InitLocationTable()` → `RegisterPotLocations()`): ~650 KB + ~492 KB > the 1 MB default Windows stack reserve. Linux CI never sees it because Linux main threads get 8 MB. Upstream SoH ships x64 Release on the same 1 MB default and boots — because upstream never nests these frames (its registrars only run as shallow siblings via `ShipInit::InitAll`).

The crashing binary (embedded commit `4d586fc`) is the **PR #342 CI artifact**, built from GitHub's ephemeral `refs/pull/342/merge` commit — which is based on #340's squash commit `c5c0fc2`. A full review of #342's diff found no mechanism: none of its code runs in the crash window (its OoT extractor changes run after the crashing constructor, and only when `oot.o2r` is missing). #342 was the delivery vehicle; #340's nesting is the cause. PR #340's own CI artifact crashes identically; release v0.1.1-prealpha (pre-#340) is unaffected.

## Fix

1. **De-nest the giant frames** (`location_list.cpp`, `static_data.h`): the 741-entry base-table body moves into a `noinline` private helper `InitMainLocationTable()`; `InitLocationTable()` becomes a thin dispatcher that runs it and the ten registrars as **sequential siblings**, so only one giant frame is ever live — the same peak-stack shape upstream boots with. All three `InitLocationTable` call sites (`InitStaticData`, `Randomizer::Randomizer`, the headless harness fallback) keep identical behavior, and #340's strong linker references stay in place. `noinline` prevents the compiler from merging the frames back into one caller.

2. **Set the stack reserve on the actual executable** (`CMake/SingleExecutable.cmake`): `target_link_options(redship PRIVATE /STACK:8777216)` — upstream SoH's value, all configs. The `/STACK` flag inherited from upstream in `games/oot/CMakeLists.txt` is stranded on STATIC library targets (Win32 + Debug only, besides), and link options on static libraries never propagate to the final executable, so the shipped `redship.exe` ran on the MSVC 1 MB default. Stack reserve is virtual address space committed page-by-page, and applies to all threads created with default stack size — same behavior upstream ships.

Either change alone stops this crash; both land together so the nesting land-mine is disarmed and future table growth (~880 B per added location) or compiler codegen drift has 8× headroom.

## Verification

- Frame math cross-checked against the crash dump: 540 pot entries × 912 B + 104 B prologue = 492,584 = RAX exactly; two independent crash logs show the identical probe.
- Brace balance, single definitions, and clang-format cleanliness verified on the edited files.
- Behavior preserved: registrars are idempotent and still also run via `ShipInit::InitAll`; no call-site semantics change.
- Windows CI on this PR is the real regression gate for the build; the crash itself only reproduces on a Windows host with a ROM-derived `oot.o2r`, which hosted CI can't exercise — a hands-on boot check on the Windows artifact from this PR is the final confirmation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CbdrV7vV7RzjDYSJdcba8G

---
_Generated by [Claude Code](https://claude.ai/code/session_01CbdrV7vV7RzjDYSJdcba8G)_

<!--- section:artifacts:start -->
### Build Artifacts
  - [rsbs-windows.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/8317248962.zip)
  - [rsbs-linux.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/8316914942.zip)
<!--- section:artifacts:end -->