### PR TITLE
Fix MM boot/switch crashes on Windows; ship 2ship.o2r in packages

### DIFF
--- a/.github/actions/otr-cache-key/action.yml
+++ b/.github/actions/otr-cache-key/action.yml
@@ -1,18 +1,19 @@
-name: Compute soh.o2r cache key
+name: Compute port-archive (soh.o2r + 2ship.o2r) cache key
 description: >
-  Computes the cache key for the generated soh.o2r archive from the actual
-  inputs of the GenerateSohOtr (--norom) target: the games/oot/assets tree
+  Computes the cache key for the generated port-asset archives (soh.o2r and
+  2ship.o2r) from the actual inputs of the GenerateSohOtr / Generate2ShipOtr
+  (--norom) targets: the games/oot/assets and games/mm/assets trees
   (custom assets + xml), the OTRExporter/ZAPDTR/libultraship gitlink SHAs
   (tool sources and the LUS shaders copied into assets/custom — readable
   WITHOUT submodule init), copy-existing-otrs.cmake, and the project version
-  (passed as --port-ver and baked into the archive). Replaces the old
+  (passed as --port-ver and baked into the archives). Replaces the old
   hashFiles('games/**/*.c', ...) key, which (a) forced a ~25 min regen on
-  every decomp .c/.h change even though GenerateSohOtr never reads those
+  every decomp .c/.h change even though the generators never read those
   files, and (b) hashed empty submodule directories before `git submodule
   update --init` ran, so tool bumps never invalidated the cache.
 outputs:
   key:
-    description: soh.o2r cache key
+    description: port-archive cache key
     value: ${{ steps.compute.outputs.key }}
 runs:
   using: composite
@@ -22,11 +23,12 @@ runs:
       run: |
         HASH=$(git rev-parse \
           HEAD:games/oot/assets \
+          HEAD:games/mm/assets \
           HEAD:OTRExporter \
           HEAD:ZAPDTR \
           HEAD:libultraship \
           HEAD:copy-existing-otrs.cmake \
           | sha256sum | cut -c1-16)
         VER=$(sed -n 's/^project(Ship VERSION \([0-9][0-9.]*\).*/\1/p' CMakeLists.txt)
-        echo "key=rsbs-otr-v2-${VER}-${HASH}" >> "$GITHUB_OUTPUT"
-        echo "Computed soh.o2r cache key: rsbs-otr-v2-${VER}-${HASH}"
+        echo "key=rsbs-otr-v3-${VER}-${HASH}" >> "$GITHUB_OUTPUT"
+        echo "Computed port-archive cache key: rsbs-otr-v3-${VER}-${HASH}"

--- a/.github/workflows/generate-builds.yml
+++ b/.github/workflows/generate-builds.yml
@@ -56,17 +56,19 @@ jobs:
     # build: inside the container the workspace is owned by a different uid.
     - name: Configure git safe directory
       run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
-    - name: Compute soh.o2r cache key
+    - name: Compute port-archive cache key
       id: otr-key
       uses: ./.github/actions/otr-cache-key
-    # Exact-match only (no restore-keys): this caches a final artifact, not an
+    # Exact-match only (no restore-keys): this caches final artifacts, not an
     # incremental cache — a stale partial restore would be silently wrong.
-    - name: Restore soh.o2r Cache
+    - name: Restore port-archive Cache
       id: rsbs-otr-cache
       uses: actions/cache@v4
       with:
         key: ${{ steps.otr-key.outputs.key }}
-        path: soh.o2r
+        path: |
+          soh.o2r
+          2ship.o2r
     - name: Checkout submodules
       if: steps.rsbs-otr-cache.outputs.cache-hit != 'true'
       run: git submodule update --init --recursive
@@ -80,17 +82,23 @@ jobs:
           ${{ runner.os }}-otr-ccache-${{ github.ref }}
           ${{ runner.os }}-otr-ccache-refs/heads/main
           ${{ runner.os }}-otr-ccache
-    - name: Generate soh.o2r
+    - name: Generate soh.o2r and 2ship.o2r
       if: steps.rsbs-otr-cache.outputs.cache-hit != 'true'
       run: |
         export PATH="/usr/lib/ccache:/usr/local/opt/ccache/libexec:$PATH"
         cmake --no-warn-unused-cli -H. -Bbuild-cmake -GNinja -DCMAKE_BUILD_TYPE:STRING=Release -DREDSHIP_BUILD_SHARED=ON
-        cmake --build build-cmake --config Release --target GenerateSohOtr -j10
+        cmake --build build-cmake --config Release --target GenerateSohOtr Generate2ShipOtr -j10
     - name: Upload soh.o2r
       uses: actions/upload-artifact@v4
       with:
         name: soh.o2r
         path: soh.o2r
+        retention-days: 3
+    - name: Upload 2ship.o2r
+      uses: actions/upload-artifact@v4
+      with:
+        name: 2ship.o2r
+        path: 2ship.o2r
         retention-days: 3
 
   build-macos:
@@ -152,6 +160,11 @@ jobs:
       with:
         name: soh.o2r
         path: build-cmake/soh
+    - name: Download 2ship.o2r
+      uses: actions/download-artifact@v4
+      with:
+        name: 2ship.o2r
+        path: build-cmake/mm
     - name: Build SoH
       run: |
         export PATH="/usr/lib/ccache:/opt/homebrew/opt/ccache/libexec:/usr/local/opt/ccache/libexec:$PATH"
@@ -226,6 +239,11 @@ jobs:
       with:
         name: soh.o2r
         path: build-cmake/soh
+    - name: Download 2ship.o2r
+      uses: actions/download-artifact@v4
+      with:
+        name: 2ship.o2r
+        path: build-cmake/mm
     - name: Build SoH
       run: |
         export PATH="/usr/lib/ccache:/usr/local/opt/ccache/libexec:$PATH"
@@ -336,6 +354,11 @@ jobs:
       with:
         name: soh.o2r
         path: bw/soh
+    - name: Download 2ship.o2r
+      uses: actions/download-artifact@v4
+      with:
+        name: 2ship.o2r
+        path: bw/mm
     # Build is split into Configure / Build / Package so the GitHub Actions UI
     # surfaces per-stage timing. Issue #177 — previously a single ~24 min step,
     # making it impossible to tell whether time was going to vcpkg, compile, link

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -124,6 +124,15 @@ jobs:
         name: soh.o2r
         path: build-cmake/soh
 
+    # Placed at the repo root: the int-* tests run ./build-cmake/redship from
+    # the repo root, and the MM port-archive gate (ArchiveCheck_PortArchive-
+    # Available) probes the app-bundle dir and then ./2ship.o2r in the cwd.
+    - name: Download 2ship.o2r
+      uses: actions/download-artifact@v4
+      with:
+        name: 2ship.o2r
+        path: .
+
     - name: Build SoH
       run: |
         export PATH="/usr/lib/ccache:/usr/local/opt/ccache/libexec:$PATH"
@@ -267,17 +276,19 @@ jobs:
       uses: actions/checkout@v4
       with:
         fetch-depth: 1
-    - name: Compute soh.o2r cache key
+    - name: Compute port-archive cache key
       id: otr-key
       uses: ./.github/actions/otr-cache-key
-    # Exact-match only (no restore-keys): this caches a final artifact, not an
+    # Exact-match only (no restore-keys): this caches final artifacts, not an
     # incremental cache — a stale partial restore would be silently wrong.
-    - name: Restore soh.o2r Cache
+    - name: Restore port-archive Cache
       id: rsbs-otr-cache
       uses: actions/cache@v4
       with:
         key: ${{ steps.otr-key.outputs.key }}
-        path: soh.o2r
+        path: |
+          soh.o2r
+          2ship.o2r
     - name: Checkout submodules
       if: steps.rsbs-otr-cache.outputs.cache-hit != 'true'
       run: git submodule update --init --recursive
@@ -335,17 +346,23 @@ jobs:
         cmake .. -DCMAKE_POSITION_INDEPENDENT_CODE=ON
         make
         sudo make install
-    - name: Generate soh.o2r
+    - name: Generate soh.o2r and 2ship.o2r
       if: steps.rsbs-otr-cache.outputs.cache-hit != 'true'
       run: |
         export PATH="/usr/lib/ccache:/usr/local/opt/ccache/libexec:$PATH"
         cmake --no-warn-unused-cli -H. -Bbuild-cmake -GNinja -DCMAKE_BUILD_TYPE:STRING=Release -DREDSHIP_BUILD_SHARED=ON
-        cmake --build build-cmake --config Release --target GenerateSohOtr -j10
+        cmake --build build-cmake --config Release --target GenerateSohOtr Generate2ShipOtr -j10
     - name: Upload soh.o2r
       uses: actions/upload-artifact@v4
       with:
         name: soh.o2r
         path: soh.o2r
+        retention-days: 3
+    - name: Upload 2ship.o2r
+      uses: actions/upload-artifact@v4
+      with:
+        name: 2ship.o2r
+        path: 2ship.o2r
         retention-days: 3
     - name: Save Cache deps folder
       if: ${{ github.ref_name == github.event.repository.default_branch }}

--- a/.github/workflows/pr-artifacts.yml
+++ b/.github/workflows/pr-artifacts.yml
@@ -53,7 +53,7 @@ jobs:
             });
 
             return allArtifacts.data.artifacts.reduce((acc, item) => {
-              if (item.name === "soh.o2r") return acc;
+              if (item.name === "soh.o2r" || item.name === "2ship.o2r") return acc;
               acc += `
               - [${item.name}.zip](https://nightly.link/${context.repo.owner}/${context.repo.repo}/actions/artifacts/${item.id}.zip)`;
               return acc;

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -298,6 +298,11 @@ if(NOT SINGLE_EXECUTABLE_BUILD)
     install(TARGETS 2ship LIBRARY DESTINATION . COMPONENT ship)
 endif()
 install(FILES "${CMAKE_BINARY_DIR}/soh/soh.o2r" DESTINATION . COMPONENT ship)
+# 2ship.o2r is MM's port-asset archive (fonts, port textures, overlays) —
+# like soh.o2r it cannot be generated from a ROM by the shipped extractor,
+# so the package must bundle it. The upstream-parity rule in
+# games/mm/CMakeLists.txt only fires when NOT SINGLE_EXECUTABLE_BUILD.
+install(FILES "${CMAKE_BINARY_DIR}/mm/2ship.o2r" DESTINATION . COMPONENT ship)
 # Install extractor assets to usr/bin/assets/ so they are relative to the executable.
 # linuxdeploy places the executable at usr/bin/, and GetAppBundlePath() returns that path.
 # The extraction code looks for assets at GetAppBundlePath() + "/assets".
@@ -325,6 +330,11 @@ install(TARGETS ZAPD_MM RUNTIME DESTINATION ./assets/extractor COMPONENT ship)
 # and the rule above at line ~300 is Linux-only — without this line the
 # Windows package has no .o2r at all (issue #334).
 install(FILES "${CMAKE_BINARY_DIR}/soh/soh.o2r" DESTINATION . COMPONENT ship)
+# Same for MM's port-asset archive: without this line the Windows package
+# ships no 2ship.o2r (the games/mm/CMakeLists.txt rule is gated on
+# NOT SINGLE_EXECUTABLE_BUILD and its component is never packaged), and MM
+# boots into null-resource crashes on a user machine.
+install(FILES "${CMAKE_BINARY_DIR}/mm/2ship.o2r" DESTINATION . COMPONENT ship)
 endif()
 
 find_package(Python3 COMPONENTS Interpreter)
@@ -376,6 +386,13 @@ add_custom_target(
     ExtractMMAssets
     COMMAND ${CMAKE_COMMAND} -E rm -f mm.o2r 2ship.o2r
     COMMAND ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/OTRExporter/extract_assets.py -z "$<TARGET_FILE:ZAPD_MM>" --non-interactive --xml-root assets/xml --custom-otr-file 2ship.o2r "--custom-assets-path" ${CMAKE_CURRENT_SOURCE_DIR}/games/mm/assets/custom --port-ver "${CMAKE_PROJECT_VERSION}" "${CMAKE_CURRENT_SOURCE_DIR}/OTRExporter/mm.z64"
+    # Land 2ship.o2r where the install rules read it (${CMAKE_BINARY_DIR}/mm/)
+    # and at the source root, mirroring what copy-existing-otrs.cmake does for
+    # soh.o2r. Extraction writes into WORKING_DIRECTORY (games/mm), which
+    # nothing installs from.
+    COMMAND ${CMAKE_COMMAND} -E copy 2ship.o2r ${CMAKE_SOURCE_DIR}
+    COMMAND ${CMAKE_COMMAND} -E make_directory ${CMAKE_BINARY_DIR}/mm
+    COMMAND ${CMAKE_COMMAND} -E copy 2ship.o2r ${CMAKE_BINARY_DIR}/mm/
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/games/mm
     COMMENT "Running MM asset extraction..."
     DEPENDS ZAPD_MM
@@ -394,9 +411,18 @@ add_custom_target(
     Generate2ShipOtr
     COMMAND ${CMAKE_COMMAND} -E rm -f 2ship.o2r
     COMMAND ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/OTRExporter/extract_assets.py -z "$<TARGET_FILE:ZAPD_MM>" --norom --custom-otr-file 2ship.o2r "--custom-assets-path" ${CMAKE_CURRENT_SOURCE_DIR}/games/mm/assets/custom --port-ver "${CMAKE_PROJECT_VERSION}"
+    # Land 2ship.o2r where the install rules read it (${CMAKE_BINARY_DIR}/mm/)
+    # and at the source root (which CI uploads as the 2ship.o2r artifact),
+    # mirroring what copy-existing-otrs.cmake does for GenerateSohOtr.
+    COMMAND ${CMAKE_COMMAND} -E copy 2ship.o2r ${CMAKE_SOURCE_DIR}
+    COMMAND ${CMAKE_COMMAND} -E make_directory ${CMAKE_BINARY_DIR}/mm
+    COMMAND ${CMAKE_COMMAND} -E copy 2ship.o2r ${CMAKE_BINARY_DIR}/mm/
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/games/mm
     COMMENT "Generating 2ship.o2r..."
     DEPENDS ZAPD_MM
+    # No BYPRODUCTS: ExtractMMAssets already declares ${CMAKE_SOURCE_DIR}/2ship.o2r,
+    # and Ninja rejects two rules generating the same file (GenerateSohOtr
+    # follows the same convention for soh.o2r).
 )
 
 if(CMAKE_SYSTEM_NAME MATCHES "Linux")

--- a/games/mm/2s2h/GameExports_SingleExe.cpp
+++ b/games/mm/2s2h/GameExports_SingleExe.cpp
@@ -510,14 +510,31 @@ static int LoadMMArchives() {
         }
     }
 
-    // Load 2ship.o2r (MM's equivalent of soh.o2r)
-    std::string shipPath = Ship::Context::GetPathRelativeToAppBundle("2ship.o2r");
-    if (!shipPath.empty() && std::filesystem::exists(shipPath)) {
-        if (archiveMgr->AddArchive(shipPath)) {
-            fprintf(stderr, "[MM] Loaded archive: %s\n", shipPath.c_str());
-            RecordMMArchivePath(shipPath);
-            loaded++;
+    // Load 2ship.o2r (MM's port-asset archive — the equivalent of soh.o2r).
+    // Probes the same locations ArchiveCheck_PortArchiveAvailable checks
+    // (src/common/archive_check.cpp — keep the two in sync): next to the
+    // executable, then the working directory. A missing 2ship.o2r means an
+    // incomplete install, and MM's early boot dereferences null resources
+    // (boot-logo textures, fonts) without it, so fail hard instead of
+    // continuing into undefined behavior. The harness gates in
+    // rsbs/src/main.cpp normally catch this earlier with a user dialog;
+    // this is the backstop for direct callers.
+    bool shipLoaded = false;
+    for (const std::string& shipPath :
+         { Ship::Context::GetPathRelativeToAppBundle("2ship.o2r"), std::string("./2ship.o2r") }) {
+        if (!shipPath.empty() && std::filesystem::exists(shipPath)) {
+            if (archiveMgr->AddArchive(shipPath)) {
+                fprintf(stderr, "[MM] Loaded archive: %s\n", shipPath.c_str());
+                RecordMMArchivePath(shipPath);
+                loaded++;
+                shipLoaded = true;
+            }
+            break;
         }
+    }
+    if (!shipLoaded) {
+        fprintf(stderr, "[MM] ERROR: 2ship.o2r not found or unreadable — incomplete install, cannot start MM\n");
+        return -1;
     }
 
     fprintf(stderr, "[MM] Loaded %d MM archive(s) into shared context\n", loaded);

--- a/games/mm/src/code/z_play.c
+++ b/games/mm/src/code/z_play.c
@@ -2244,8 +2244,17 @@ void MM_Play_Init(GameState* thisx) {
         uint16_t startupEntrance = Combo_GetStartupEntrance();
         if (startupEntrance != 0) {
             gSaveContext.save.entrance = startupEntrance;
+            // On a first MM entry this Play_Init is reached through MM's
+            // title-screen boot (TitleSetup_SetupTitleScreen), so the save
+            // still carries the title-demo cutscene state: cutsceneIndex
+            // 0xFFFA resolves sceneLayer 0xB below, which indexes past the
+            // end of the target entrance's layer table and loads a garbage
+            // scene. A cross-game arrival is a plain gameplay spawn — reset
+            // the cutscene/game-mode state so the entrance resolves layer 0.
+            gSaveContext.save.cutsceneIndex = 0;
+            gSaveContext.nextCutsceneIndex = 0xFFEF;
+            gSaveContext.gameMode = GAMEMODE_NORMAL;
             Combo_ClearStartupEntrance();
-            // Note: Using PRINTF macro if available, or just skip logging
         }
     }
 

--- a/games/oot/soh/OTRGlobals.cpp
+++ b/games/oot/soh/OTRGlobals.cpp
@@ -1117,6 +1117,16 @@ int AudioPlayer_Buffered(void);
 extern "C" int AudioPlayer_GetDesiredBuffered(void);
 std::unordered_map<std::string, ExtensionEntry> ExtensionCache;
 
+// OoT's gGameInfo is allocated by func_800636C0, which only runs inside OoT's
+// Main(). In single-exe builds the Graph_* / audio bridges below are shared
+// with MM (MM's BenPort.cpp copies are excluded from the build), so on an
+// MM-first boot they execute for MM frames while gGameInfo is still NULL and
+// R_UPDATE_RATE would dereference it (issue #330 follow-up). Fall back to the
+// vanilla update rate (3, the GameState default from game.c) until OoT boots.
+static s32 Ship_GetUpdateRate() {
+    return (gGameInfo != NULL && R_UPDATE_RATE > 0) ? R_UPDATE_RATE : 3;
+}
+
 void OTRAudio_Thread() {
     while (audio.running) {
         {
@@ -1136,14 +1146,18 @@ void OTRAudio_Thread() {
 #define SAMPLES_HIGH 560
 #define SAMPLES_LOW 528
 
-#define AUDIO_FRAMES_PER_UPDATE (R_UPDATE_RATE > 0 ? R_UPDATE_RATE : 1)
+#define AUDIO_FRAMES_PER_UPDATE (Ship_GetUpdateRate())
 #define NUM_AUDIO_CHANNELS 2
 
         int samples_left = AudioPlayer_Buffered();
         u32 num_audio_samples = samples_left < AudioPlayer_GetDesiredBuffered() ? SAMPLES_HIGH : SAMPLES_LOW;
 
         // 3 is the maximum authentic frame divisor.
-        s16 audio_buffer[SAMPLES_HIGH * NUM_AUDIO_CHANNELS * 3];
+        // Zero-initialized: with OoT's audio context not (yet) initialized —
+        // MM-first boot, or MM running after OoT_Game_Suspend's reset — the
+        // synth below writes nothing, and the buffer must play as silence
+        // rather than uninitialized stack memory.
+        s16 audio_buffer[SAMPLES_HIGH * NUM_AUDIO_CHANNELS * 3] = { 0 };
         for (int i = 0; i < AUDIO_FRAMES_PER_UPDATE; i++) {
             OoT_AudioMgr_CreateNextAudioBuffer(audio_buffer + i * (num_audio_samples * NUM_AUDIO_CHANNELS),
                                            num_audio_samples);
@@ -1954,14 +1968,14 @@ extern "C" void Graph_ProcessGfxCommands(Gfx* commands) {
     static int last_update_rate;
     static int time;
     int fps = target_fps;
-    int original_fps = 60 / R_UPDATE_RATE;
+    int original_fps = 60 / Ship_GetUpdateRate();
     auto wnd = std::dynamic_pointer_cast<Fast::Fast3dWindow>(Ship::Context::GetInstance()->GetWindow());
 
     if (target_fps == 20 || original_fps > target_fps) {
         fps = original_fps;
     }
 
-    if (last_fps != fps || last_update_rate != R_UPDATE_RATE) {
+    if (last_fps != fps || last_update_rate != Ship_GetUpdateRate()) {
         time = 0;
     }
 
@@ -1992,7 +2006,7 @@ extern "C" void Graph_ProcessGfxCommands(Gfx* commands) {
     RunCommands(commands, mtx_replacements);
 
     last_fps = fps;
-    last_update_rate = R_UPDATE_RATE;
+    last_update_rate = Ship_GetUpdateRate();
 
     {
         std::unique_lock<std::mutex> Lock(audio.mutex);

--- a/rsbs/src/main.cpp
+++ b/rsbs/src/main.cpp
@@ -391,6 +391,16 @@ int main(int argc, char** argv) {
         }
     }
 
+    // MM also needs its port-asset archive (2ship.o2r), which ships with the
+    // package and cannot be generated from a ROM. Without it MM's early boot
+    // dereferences null resources (fonts, boot-logo textures), so refuse up
+    // front with an "incomplete install" message instead of crashing later.
+    if (selectedGame == GAME_MM && !ArchiveCheck_PortArchiveAvailable(GAME_MM)) {
+        ArchiveCheck_ReportMissingPortArchive(GAME_MM,
+                                              /*showDialog=*/!TestRunner_IsIntegrationTestMode());
+        return 1;
+    }
+
     // Build filtered argv (remove our flags before passing to game)
     char** gameArgv = (char**)malloc(sizeof(char*) * (argc + 1));
     int gameArgc = 0;
@@ -497,6 +507,20 @@ int main(int argc, char** argv) {
                 Combo_ClearGameSwitchRequest();
                 Entrance_ClearPendingSwitch();
                 printf("Switch to %s refused (missing game archive) — continuing %s.\n",
+                       Game_ToString(nextGame), Game_ToString(GameRunner_GetActive(&runner)));
+                continue;
+            }
+
+            // Same up-front refusal for the target game's port-asset archive
+            // (2ship.o2r for MM): a switch into MM without it would fail in
+            // MM_Game_Init and take down the whole app, or worse, boot into
+            // null-resource crashes. Keep the current game running instead.
+            if (!ArchiveCheck_PortArchiveAvailable(nextGame)) {
+                ArchiveCheck_ReportMissingPortArchive(nextGame,
+                                                      /*showDialog=*/!TestRunner_IsIntegrationTestMode());
+                Combo_ClearGameSwitchRequest();
+                Entrance_ClearPendingSwitch();
+                printf("Switch to %s refused (missing port-asset archive) — continuing %s.\n",
                        Game_ToString(nextGame), Game_ToString(GameRunner_GetActive(&runner)));
                 continue;
             }

--- a/src/common/archive_check.cpp
+++ b/src/common/archive_check.cpp
@@ -80,6 +80,19 @@ bool ArchiveExists(const char* filename, const char* appName) {
     return false;
 }
 
+// Port-asset archive locations. MUST stay in sync with LoadMMArchives
+// (games/mm/2s2h/GameExports_SingleExe.cpp): a location this check accepts
+// but the loader does not probe would pass the gate and still boot MM into
+// null-resource territory. Deliberately NOT the per-app data directory — a
+// standalone 2Ship2Harkinian install's 2ship.o2r there would be
+// version-mismatched with this build's MM.
+std::vector<std::string> PortArchiveSearchPaths(const char* filename) {
+    return {
+        Ship::Context::GetPathRelativeToAppBundle(filename),
+        "./" + std::string(filename),
+    };
+}
+
 } // namespace
 
 extern "C" bool ArchiveCheck_GameAvailable(GameId game) {
@@ -93,6 +106,47 @@ extern "C" bool ArchiveCheck_GameAvailable(GameId game) {
         }
     }
     return false;
+}
+
+extern "C" bool ArchiveCheck_PortArchiveAvailable(GameId game) {
+    if (game != GAME_MM) {
+        return true;
+    }
+    for (const auto& path : PortArchiveSearchPaths("2ship.o2r")) {
+        std::error_code ec;
+        if (!path.empty() && std::filesystem::exists(path, ec)) {
+            return true;
+        }
+    }
+    return false;
+}
+
+extern "C" void ArchiveCheck_ReportMissingPortArchive(GameId game, bool showDialog) {
+    if (game != GAME_MM) {
+        return;
+    }
+
+    std::string msg =
+        "Majora's Mask cannot start: the port-asset archive \"2ship.o2r\" was not found.\n\n"
+        "RedShipBlueShip looked in:\n";
+    for (const auto& path : PortArchiveSearchPaths("2ship.o2r")) {
+        msg += "  " + path + "\n";
+    }
+    msg += "\n"
+           "Unlike mm.o2r, 2ship.o2r is not generated from your ROM — it ships\n"
+           "with RedShipBlueShip itself (fonts and port assets). Your download or\n"
+           "install is incomplete, or it came from a package that was missing the\n"
+           "file. Re-download the latest RedShipBlueShip package and make sure\n"
+           "2ship.o2r sits next to the redship executable.\n";
+
+    const char* title = "Majora's Mask port archive missing";
+
+    fprintf(stderr, "\n[RSBS] === %s ===\n%s\n", title, msg.c_str());
+    fflush(stderr);
+
+    if (showDialog) {
+        SDL_ShowSimpleMessageBox(SDL_MESSAGEBOX_ERROR, title, msg.c_str(), nullptr);
+    }
 }
 
 extern "C" void ArchiveCheck_ReportMissing(GameId game, bool showDialog) {

--- a/src/common/archive_check.h
+++ b/src/common/archive_check.h
@@ -43,6 +43,26 @@ bool ArchiveCheck_GameAvailable(GameId game);
  */
 void ArchiveCheck_ReportMissing(GameId game, bool showDialog);
 
+/**
+ * Check whether the game's PORT-ASSET archive is present. Unlike the
+ * ROM-derived archives above, these ship with RedShipBlueShip itself
+ * (2ship.o2r for MM — fonts, port textures, overlays from
+ * games/mm/assets/custom) and cannot be regenerated from a ROM, so a miss
+ * means an incomplete install, not a missing ROM. Probes the same locations
+ * LoadMMArchives uses: next to the executable, then the working directory.
+ *
+ * OoT's port archive (soh.o2r) is loaded and validated by its own port
+ * layer, so this returns true for every game except GAME_MM.
+ */
+bool ArchiveCheck_PortArchiveAvailable(GameId game);
+
+/**
+ * Report a missing port-asset archive: explains that the install/download is
+ * incomplete (re-download, don't re-extract a ROM). Mirrors
+ * ArchiveCheck_ReportMissing's stderr + optional message-box behavior.
+ */
+void ArchiveCheck_ReportMissingPortArchive(GameId game, bool showDialog);
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
## Summary

Fixes the two Windows access violations reported against the PR #343 `rsbs-windows` artifact, root-caused at the instruction level by symbolizing the crash RIPs against the shipped binary (module base `0x7FF740CE0000`, confirmed by crash #2's R10):

**Crash 1 — booting straight into MM** (`RIP` → `Graph_ProcessGfxCommands`, `OTRGlobals.cpp:1936`): MM's frame loop uses OoT's shared `Graph_ProcessGfxCommands`/`OTRAudio_Thread` bridges (MM's `BenPort.cpp` copies are excluded from single-exe builds), and both read `R_UPDATE_RATE` through OoT's `gGameInfo`, which is only allocated inside OoT's `Main()` — NULL on an MM-first boot, so the very first rendered MM frame crashed. Fixed with a null-safe `Ship_GetUpdateRate()` (fallback 3, the vanilla GameState default — also covering the `60 / 0` division that plain allocation would have left behind) at all four `R_UPDATE_RATE` sites, plus zero-initializing the audio scratch buffer so an uninitialized OoT audio context plays silence instead of stack garbage.

**Crash 2 — OoT → MM via the Happy Mask Shop** (`RIP` → `MM_Actor_SpawnEntry`, `z_actor.c:3866`): the startup entrance `0xC010` is consumed during MM's title-screen `Play_Init` while the save still carries the title-demo cutscene state; `cutsceneIndex 0xFFFA` resolved `sceneLayer 0xB` and read past the end of the one-entry Clock Tower entrance layer table (the observed garbage `sceneNum 0x9`). The hijack now resets `cutsceneIndex`/`nextCutsceneIndex`/`gameMode` to plain gameplay state. **Note:** the switch still cannot reach MM gameplay until MM's scene loader is ported — that deeper, separately-verified gap (MM's `z_play_2SH.cpp`/`z_scene_2SH.cpp` are excluded, so `MM_Play_SpawnScene` links to **OoT's** `OTRPlay_SpawnScene` and `linkActorEntry` is never assigned) is filed as #344. With this PR the failure is refused or deterministic instead of a memory-layout-dependent crash.

**Packaging — `2ship.o2r` has never shipped** (same defect class as #334, which fixed only `soh.o2r`): the `2s2h` CPack component is never packaged, no CI workflow built `Generate2ShipOtr`, and the generator wrote to a directory no install rule reads. The user-downloaded zip was confirmed to contain no `2ship.o2r`, and both archive loaders skipped it silently, leaving MM's port assets (fonts, boot-logo textures) to load as null.

## Changes

- `games/oot/soh/OTRGlobals.cpp`: null-safe `Ship_GetUpdateRate()` used by the shared graph/audio bridges; zero-init audio buffer
- `games/mm/src/code/z_play.c`: reset cutscene/game-mode state when consuming a cross-game startup entrance
- `src/common/archive_check.{h,cpp}`: new `ArchiveCheck_PortArchiveAvailable` / `ArchiveCheck_ReportMissingPortArchive` ("incomplete install" message, distinct from the missing-ROM-archive flow)
- `rsbs/src/main.cpp`: refuse MM boot up front, and refuse (rather than crash) game switches into MM, when `2ship.o2r` is missing
- `games/mm/2s2h/GameExports_SingleExe.cpp`: `LoadMMArchives` hard-fails on missing `2ship.o2r` as a backstop, probing the same paths as the gate
- `CMakeLists.txt`: `Generate2ShipOtr`/`ExtractMMAssets` copy `2ship.o2r` to the source root and `${CMAKE_BINARY_DIR}/mm/`; single-exe Linux + Windows installs bundle it in component `ship` next to `soh.o2r`
- `.github/`: `generate-builds.yml` and `integration-tests.yml` generate, cache, and download `2ship.o2r` alongside `soh.o2r` (`otr-cache-key` bumped to v3, now hashing `games/mm/assets` too); `pr-artifacts.yml` hides the new artifact from the PR download list

## Validation

- All five changed C/C++ files compile clean (`-fsyntax-only` with the project's real compile flags from `compile_commands.json`)
- CMake configure + Ninja manifest generation pass with the new targets/install rules; `Generate2ShipOtr` run end-to-end locally to verify `2ship.o2r` lands where the install rules read it
- Workflow YAML validated; unit tests (`ctest` label `redship`) don't touch the new gates — the boot-mm regression test exercises factory registration via the headless helper, not archive loading
- Root cause verified by 17-agent investigation incl. downloading the exact CI artifact (sha256-verified) and symbolizing both crash RIPs from the export table + `.pdata` + disassembly

Fixes the boot-to-MM crash. The mask-shop switch is made safe pending #344.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HTF3bLbiVbDJPzQdpiBEoa

---
_Generated by [Claude Code](https://claude.ai/code/session_01HTF3bLbiVbDJPzQdpiBEoa)_

<!--- section:artifacts:start -->
### Build Artifacts
  - [rsbs-windows.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/8331875888.zip)
  - [rsbs-linux.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/8331765179.zip)
  - [2ship.o2r.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/8331726368.zip)
<!--- section:artifacts:end -->