### PR TITLE
Harden MM single-exe scene loader: bounds-check alternate-header index

### DIFF
--- a/games/mm/2s2h/z_scene_2SH.cpp
+++ b/games/mm/2s2h/z_scene_2SH.cpp
@@ -374,15 +374,25 @@ void Scene_CommandAltHeaderList(PlayState* play, S2H::ISceneCommand* cmd) {
     S2H::SetAlternateHeaders* headers = (S2H::SetAlternateHeaders*)cmd;
 
     if (gSaveContext.sceneLayer != 0) {
-        S2H::Scene* desiredHeader =
-            std::static_pointer_cast<S2H::Scene>(headers->headers[gSaveContext.sceneLayer - 1]).get();
+        size_t headerIndex = (size_t)gSaveContext.sceneLayer - 1;
 
-        if (desiredHeader != nullptr) {
-            MM_OTRScene_ExecuteCommands(play, desiredHeader);
-            // 2S2H [Port] The original source would grab the next command after the alternate header list
-            // and change the command id to SCENE_CMD_ID_END. We can't modify LUS resources, so we'll just
-            // set a flag to end the scene commands
-            shouldEndSceneCommands = true;
+        // Guard against a sceneLayer that exceeds this scene's alternate-header
+        // count. On N64 the vanilla header array is NULL-padded, so an out-of-range
+        // layer simply reads a NULL slot and falls through to the base header. Here
+        // headers->headers is sized to the real count, so an out-of-bounds index is
+        // undefined behavior (garbage shared_ptr -> access violation). Treat an
+        // out-of-range layer as "no alternate header," matching the NULL-slot path.
+        if (headerIndex < headers->headers.size()) {
+            S2H::Scene* desiredHeader =
+                std::static_pointer_cast<S2H::Scene>(headers->headers[headerIndex]).get();
+
+            if (desiredHeader != nullptr) {
+                MM_OTRScene_ExecuteCommands(play, desiredHeader);
+                // 2S2H [Port] The original source would grab the next command after the alternate header list
+                // and change the command id to SCENE_CMD_ID_END. We can't modify LUS resources, so we'll just
+                // set a flag to end the scene commands
+                shouldEndSceneCommands = true;
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary

`Scene_CommandAltHeaderList` (added with the ported MM scene loader in #346) dereferences `headers->headers[gSaveContext.sceneLayer - 1]` with **no bounds check**. On N64 the alternate-header array is NULL-padded, so an out-of-range scene layer harmlessly reads a NULL slot and falls through to the base header. In the ported S2H loader `headers` is a `std::vector` sized to the real header count, so an out-of-range index is undefined behavior — a garbage `shared_ptr` deref → `0xC0000005`.

This is the **actual faulting instruction** behind the OoT→MM Happy Mask Shop switch crash: on the first cross-game switch MM booted through its title sequence, leaving `cutsceneIndex = 0xFFFA`, which drove `sceneLayer = (0xFFFA & 0xF) + 1 = 11` and indexed Clock Tower Interior's short header vector out of bounds.

## Relationship to #345

That specific trigger was **fixed on `main` in #345** — `MM_Play_Init` now resets the cutscene/game-mode state on a cross-game entry, so `sceneLayer` resolves to 0. This PR was originally the same root-cause fix plus this guard; after rebasing on #345 the redundant `MM_Play_Init` change is dropped and only the loader hardening remains.

## Change

- **`games/mm/2s2h/z_scene_2SH.cpp`** (`Scene_CommandAltHeaderList`) — bounds-check the alternate-header index before dereferencing; treat an out-of-range layer as "no alternate header" (fall through to the base header), restoring the N64 NULL-slot semantics. Defense-in-depth against any future out-of-range `sceneLayer` from any entrance, independent of the #345 seeding fix.

## Testing

No behavior change on the normal path (in-range layers index exactly as before). Couldn't build locally (submodules uninitialized, no ROMs in this environment); relies on CI. The `int-switch-oot-hms-to-mm` integration test exercises the MM cross-game scene-load path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R13ZusmChXD2CADjsHiuT7

<!--- section:artifacts:start -->
### Build Artifacts
  - [rsbs-windows.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/8332519004.zip)
  - [rsbs-linux.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/8332386893.zip)
<!--- section:artifacts:end -->