### PR TITLE
Fix OoT Market cutscene crash from cross-game entrance leaking into entranceIndex

### DIFF
--- a/games/mm/2s2h/GameExports_SingleExe.cpp
+++ b/games/mm/2s2h/GameExports_SingleExe.cpp
@@ -860,9 +860,13 @@ void MM_Game_Resume(void) {
         // return entrance recorded when we last froze MM. Use the explicit
         // Has accessor because entrance 0x0000 is a valid id and treating it
         // as "unset" would silently drop a legitimate restore.
-        bool hasStartup = Combo_HasStartupEntrance();
+        // Query the MM-scoped accessor: an OoT-tagged value that leaked into
+        // the shared startup global stays invisible to MM, so we fall back to
+        // MM's frozen return entrance instead of spawning from an OoT id
+        // (symmetric with OoT_Game_Resume).
+        bool hasStartup = Combo_HasStartupEntranceForGame("mm");
         uint16_t targetEntrance = hasStartup
-            ? Combo_GetStartupEntrance()
+            ? Combo_GetStartupEntranceForGame("mm")
             : Context_GetFrozenReturnEntrance(GAME_MM);
         gSaveContext.save.entrance = targetEntrance;
         fprintf(stderr, "[MM] Resume entrance: 0x%04X (startup=%u)\n",

--- a/games/mm/src/code/z_play.c
+++ b/games/mm/src/code/z_play.c
@@ -53,6 +53,7 @@ extern uint16_t Combo_CheckEntranceSwitch(uint16_t entranceIndex);
 extern bool Combo_IsCrossGameSwitch(void);
 extern uint16_t Combo_GetStartupEntrance(void);
 extern void Combo_ClearStartupEntrance(void);
+extern uint16_t Combo_GetStartupEntranceForGame(const char* gameId);
 
 s32 MM_gDbgCamEnabled = false;
 u8 D_801D0D54 = false;
@@ -2241,7 +2242,10 @@ void MM_Play_Init(GameState* thisx) {
 
     // Cross-game combo: Check if we're entering from another game
     {
-        uint16_t startupEntrance = Combo_GetStartupEntrance();
+        // Only consume an entrance tagged for MM. A value tagged for OoT that
+        // leaked into the shared startup global stays invisible here, so MM
+        // won't spawn from an OoT entrance id (symmetric with OoT's guard).
+        uint16_t startupEntrance = Combo_GetStartupEntranceForGame("mm");
         if (startupEntrance != 0) {
             gSaveContext.save.entrance = startupEntrance;
             // On a first MM entry this Play_Init is reached through MM's

--- a/games/oot/soh/GameExports_SingleExe.cpp
+++ b/games/oot/soh/GameExports_SingleExe.cpp
@@ -346,14 +346,20 @@ void OoT_Game_Resume(void) {
 
         // Prefer an explicit startup entrance (set by main.cpp for this
         // switch); fall back to the return entrance recorded at freeze time.
-        // Use Combo_HasStartupEntrance rather than (entrance != 0) — entrance
-        // 0x0000 is the real id for Kokiri Forest from Deku Tree, so a legit
-        // restore to 0 must not be silently dropped. The frozen return
-        // entrance is always trustworthy here because we already checked
-        // Context_HasFrozenState above.
-        bool hasStartup = Combo_HasStartupEntrance();
+        // Query the OoT-scoped accessor rather than the game-agnostic one: a
+        // value tagged for MM (e.g. 0xC010) that leaked into the shared startup
+        // global must NOT be applied to OoT's entranceIndex — it is a direct
+        // linear index into gEntranceTable and would read far out of bounds
+        // (crash) once Play_Init runs. When the leaked value is invisible to
+        // OoT, hasStartup is false and we fall back to the frozen OoT return
+        // entrance, which is the correct resume target and always in range.
+        // Use the Has check rather than (entrance != 0) — entrance 0x0000 is the
+        // real id for Kokiri Forest from Deku Tree, so a legit restore to 0 must
+        // not be silently dropped. The frozen return entrance is always
+        // trustworthy here because we already checked Context_HasFrozenState.
+        bool hasStartup = Combo_HasStartupEntranceForGame("oot");
         uint16_t targetEntrance = hasStartup
-            ? Combo_GetStartupEntrance()
+            ? Combo_GetStartupEntranceForGame("oot")
             : Context_GetFrozenReturnEntrance(GAME_OOT);
         gSaveContext.entranceIndex = targetEntrance;
         fprintf(stderr, "[OoT] Resume entrance: 0x%04X (startup=%u)\n",

--- a/games/oot/src/code/z_play.c
+++ b/games/oot/src/code/z_play.c
@@ -24,6 +24,7 @@
 // Cross-game combo support - check for startup entrance from game switch
 extern uint16_t Combo_GetStartupEntrance(void);
 extern void Combo_ClearStartupEntrance(void);
+extern uint16_t Combo_GetStartupEntranceForGame(const char* gameId);
 
 // Cross-game combo support - entrance switch checking
 extern uint16_t Combo_CheckEntranceSwitch(uint16_t entranceIndex);
@@ -393,13 +394,25 @@ void OoT_Play_Init(GameState* thisx) {
 
     enableBetaQuest();
 
-    // Cross-game combo: Check if we're entering from another game
+    // Cross-game combo: Check if we're entering from another game.
     {
-        uint16_t startupEntrance = Combo_GetStartupEntrance();
+        // Only consume an entrance tagged for OoT. A value tagged for MM (e.g.
+        // 0xC010 = Clock Tower Interior) that leaked into the shared startup
+        // global must never reach gSaveContext.entranceIndex — it is a direct
+        // linear index into gEntranceTable[ENTR_MAX], so an MM value reads far
+        // out of bounds and crashes (0xC0000005) in Cutscene_HandleConditionalTriggers.
+        uint16_t startupEntrance = Combo_GetStartupEntranceForGame("oot");
         if (startupEntrance != 0) {
-            gSaveContext.entranceIndex = startupEntrance;
-            Combo_ClearStartupEntrance();
-            osSyncPrintf("[OoT] Cross-game switch: loading entrance 0x%04X\n", startupEntrance);
+            if (startupEntrance >= ENTR_MAX) {
+                // Defense in depth: never index gEntranceTable out of range,
+                // even if a bogus value slips past the game-affinity check.
+                osSyncPrintf("[OoT] Ignoring out-of-range startup entrance 0x%04X\n", startupEntrance);
+                Combo_ClearStartupEntrance();
+            } else {
+                gSaveContext.entranceIndex = startupEntrance;
+                Combo_ClearStartupEntrance();
+                osSyncPrintf("[OoT] Cross-game switch: loading entrance 0x%04X\n", startupEntrance);
+            }
         }
     }
 

--- a/rsbs/src/main.cpp
+++ b/rsbs/src/main.cpp
@@ -546,9 +546,12 @@ int main(int argc, char** argv) {
             Combo_ClearGameSwitchRequest();
             Entrance_ClearPendingSwitch();
 
-            // Set startup entrance if this is an entrance-based switch
+            // Set startup entrance if this is an entrance-based switch. Tag it
+            // with the destination game so only that game can consume it — this
+            // prevents an MM entrance (e.g. 0xC010) from leaking into OoT's
+            // entranceIndex and reading gEntranceTable out of bounds (crash).
             if (isEntranceSwitch && targetEntrance != 0) {
-                Entrance_SetStartupEntrance(targetEntrance);
+                Entrance_SetStartupEntrance(targetEntrance, nextGame);
             }
 
             // Hot-swap resource archives before game init/resume

--- a/src/common/entrance.cpp
+++ b/src/common/entrance.cpp
@@ -25,6 +25,11 @@ std::vector<CrossGameEntranceLink> gEntranceLinks;
 // rather than overloading 0 as "unset".
 uint16_t sStartupEntrance = 0;
 bool sStartupEntrancePresent = false;
+// Which game the startup entrance targets. GAME_NONE = wildcard (the legacy
+// 1-arg setter), so only the matching game consumes a tagged value. This is
+// what stops an MM entrance (e.g. 0xC010) from leaking into OoT's linear
+// gEntranceTable index and reading far out of bounds (crash 0xC0000005).
+GameId sStartupEntranceGame = GAME_NONE;
 
 // Game switch request flag (for F10 hotkey)
 bool sGameSwitchRequested = false;
@@ -43,6 +48,7 @@ void Entrance_Init(void) {
     gPendingSwitch = {};
     sStartupEntrance = 0;
     sStartupEntrancePresent = false;
+    sStartupEntranceGame = GAME_NONE;
     sGameSwitchRequested = false;
 }
 
@@ -142,8 +148,15 @@ void Entrance_ClearPendingSwitch(void) {
 }
 
 void Entrance_SetStartupEntrance(uint16_t entrance) {
+    // Legacy 1-arg form: tag as wildcard so existing (non-production) callers
+    // keep their current game-agnostic behavior.
+    Entrance_SetStartupEntrance(entrance, GAME_NONE);
+}
+
+void Entrance_SetStartupEntrance(uint16_t entrance, GameId targetGame) {
     sStartupEntrance = entrance;
     sStartupEntrancePresent = true;
+    sStartupEntranceGame = targetGame;
 }
 
 uint16_t Entrance_GetStartupEntrance(void) {
@@ -154,9 +167,19 @@ bool Entrance_HasStartupEntrance(void) {
     return sStartupEntrancePresent;
 }
 
+bool Entrance_HasStartupEntranceForGame(GameId game) {
+    return sStartupEntrancePresent &&
+           (sStartupEntranceGame == GAME_NONE || sStartupEntranceGame == game);
+}
+
+uint16_t Entrance_GetStartupEntranceForGame(GameId game) {
+    return Entrance_HasStartupEntranceForGame(game) ? sStartupEntrance : 0;
+}
+
 void Entrance_ClearStartupEntrance(void) {
     sStartupEntrance = 0;
     sStartupEntrancePresent = false;
+    sStartupEntranceGame = GAME_NONE;
 }
 
 // ============================================================================
@@ -210,6 +233,18 @@ bool Combo_HasStartupEntrance(void) {
 
 void Combo_ClearStartupEntrance(void) {
     Entrance_ClearStartupEntrance();
+}
+
+uint16_t Combo_GetStartupEntranceForGame(const char* gameId) {
+    GameId game = Game_FromString(gameId);
+    if (game == GAME_NONE) return 0;
+    return Entrance_GetStartupEntranceForGame(game);
+}
+
+bool Combo_HasStartupEntranceForGame(const char* gameId) {
+    GameId game = Game_FromString(gameId);
+    if (game == GAME_NONE) return false;
+    return Entrance_HasStartupEntranceForGame(game);
 }
 
 // ============================================================================

--- a/src/common/entrance.h
+++ b/src/common/entrance.h
@@ -87,6 +87,12 @@ uint16_t Combo_GetStartupEntrance(void);
 // separately from the value — callers must check this before trusting the id.
 bool Combo_HasStartupEntrance(void);
 void Combo_ClearStartupEntrance(void);
+// Game-scoped variants: only return/report the startup entrance when it was
+// tagged for `gameId` (or tagged as wildcard via the 1-arg setter). This
+// prevents a cross-game entrance (e.g. MM 0xC010) from being consumed by the
+// wrong game and indexing that game's entrance table out of bounds.
+uint16_t Combo_GetStartupEntranceForGame(const char* gameId);
+bool Combo_HasStartupEntranceForGame(const char* gameId);
 
 // Game switch request API
 void Combo_RequestGameSwitch(void);
@@ -182,6 +188,12 @@ void Entrance_ClearPendingSwitch(void);
 void Entrance_SetStartupEntrance(uint16_t entrance);
 
 /**
+ * Set the startup entrance tagged with the game it targets, so only that game
+ * consumes it. The 1-arg overload above tags GAME_NONE (wildcard).
+ */
+void Entrance_SetStartupEntrance(uint16_t entrance, GameId targetGame);
+
+/**
  * Get the startup entrance. Use Entrance_HasStartupEntrance() to check
  * whether one is actually set — entrance 0x0000 is a valid id.
  */
@@ -191,6 +203,16 @@ uint16_t Entrance_GetStartupEntrance(void);
  * Whether a startup entrance has been set since the last clear.
  */
 bool Entrance_HasStartupEntrance(void);
+
+/**
+ * Whether a startup entrance is set and targets `game` (or is a wildcard).
+ */
+bool Entrance_HasStartupEntranceForGame(GameId game);
+
+/**
+ * The startup entrance if it targets `game` (or is a wildcard), else 0.
+ */
+uint16_t Entrance_GetStartupEntranceForGame(GameId game);
 
 /**
  * Clear the startup entrance (called after game reads it)

--- a/src/common/test_runner.cpp
+++ b/src/common/test_runner.cpp
@@ -421,7 +421,59 @@ TestResult Test_StartupEntrance(void) {
         return TEST_FAIL;
     }
 
-    printf("[TEST] PASS: Startup entrance flow verified\n");
+    // ------------------------------------------------------------------
+    // Step 5: Game affinity — the exact condition behind the Market
+    // cutscene crash. An entrance tagged for one game must be invisible to
+    // the other, so a cross-game value (MM Clock Tower 0xC010) can never be
+    // applied to OoT's entranceIndex and index gEntranceTable out of bounds.
+    // ------------------------------------------------------------------
+    Entrance_SetStartupEntrance(MM_ENTR_CLOCK_TOWER_INTERIOR_1, GAME_MM);
+
+    // MM (the tagged game) sees it...
+    if (!Entrance_HasStartupEntranceForGame(GAME_MM) ||
+        Entrance_GetStartupEntranceForGame(GAME_MM) != MM_ENTR_CLOCK_TOWER_INTERIOR_1) {
+        printf("[TEST] FAIL: MM-tagged startup entrance not visible to MM\n");
+        return TEST_FAIL;
+    }
+    // ...but OoT must NOT — this is precisely what prevents the OOB crash.
+    if (Entrance_HasStartupEntranceForGame(GAME_OOT) ||
+        Entrance_GetStartupEntranceForGame(GAME_OOT) != 0) {
+        printf("[TEST] FAIL: MM-tagged startup entrance leaked to OoT (crash condition)\n");
+        return TEST_FAIL;
+    }
+    // The C API used by the game code must agree with the C++ API.
+    if (!Combo_HasStartupEntranceForGame("mm") || Combo_HasStartupEntranceForGame("oot") ||
+        Combo_GetStartupEntranceForGame("oot") != 0 ||
+        Combo_GetStartupEntranceForGame("mm") != MM_ENTR_CLOCK_TOWER_INTERIOR_1) {
+        printf("[TEST] FAIL: Combo_*ForGame C API disagrees with affinity\n");
+        return TEST_FAIL;
+    }
+
+    // Symmetric: an OoT-tagged entrance must be invisible to MM.
+    Entrance_SetStartupEntrance(OOT_ENTR_MARKET_FROM_MASK_SHOP, GAME_OOT);
+    if (!Entrance_HasStartupEntranceForGame(GAME_OOT) ||
+        Entrance_HasStartupEntranceForGame(GAME_MM)) {
+        printf("[TEST] FAIL: OoT-tagged startup entrance leaked to MM\n");
+        return TEST_FAIL;
+    }
+
+    // Back-compat: the legacy 1-arg setter tags wildcard, visible to both.
+    Entrance_SetStartupEntrance(OOT_ENTR_HAPPY_MASK_SHOP);
+    if (!Entrance_HasStartupEntranceForGame(GAME_OOT) ||
+        !Entrance_HasStartupEntranceForGame(GAME_MM)) {
+        printf("[TEST] FAIL: wildcard (1-arg) startup entrance not visible to both games\n");
+        return TEST_FAIL;
+    }
+
+    // Clearing resets the affinity tag too.
+    Combo_ClearStartupEntrance();
+    if (Entrance_HasStartupEntranceForGame(GAME_OOT) ||
+        Entrance_HasStartupEntranceForGame(GAME_MM)) {
+        printf("[TEST] FAIL: startup entrance affinity not cleared\n");
+        return TEST_FAIL;
+    }
+
+    printf("[TEST] PASS: Startup entrance flow + game affinity verified\n");
     Entrance_ClearPendingSwitch();
     return TEST_PASS;
 }


### PR DESCRIPTION
## Summary

Fixes the reported Windows crash: `0xC0000005` in `Cutscene_HandleConditionalTriggers` with `entrance: 49168`, scene `SCENE_MARKET_DAY` (child, day).

It's an **out-of-bounds read of OoT's `gEntranceTable`**:
- `49168 = 0xC010 = MM_ENTR_CLOCK_TOWER_INTERIOR_1` — an **MM** cross-game entrance.
- OoT's `gSaveContext.entranceIndex` is a **direct linear index** into `gEntranceTable[ENTR_MAX = 0x614]`, so applying an MM value reads ~32× past the table and faults at `z_demo.c:2255` (reached via `OoT_Play_Init → Cutscene_HandleConditionalTriggers`). That branch is gated only by an event flag that's unset on a normal save, so it's reachable by a child in the Market — matching the crash log exactly.

## Root cause

The cross-game "startup entrance" is a single **game-agnostic** global. On an OoT→MM switch, `main.cpp` writes the MM target (`0xC010`) into it; the production resume paths (`OoT_Game_Resume` / `MM_Game_Resume`) read it **without clearing**. A stale MM value can therefore survive — e.g. an F10 switch-back to OoT before MM's `Play_Init` consumes it — and OoT applies it to `entranceIndex` with no game check.

MM is structurally immune (its entrance is bit-packed, so an OoT-range value mis-loads a scene rather than reading out of bounds), so the crash and the fix are OoT-focused.

## Changes

- **Game affinity (root cause)** — `src/common/entrance.{cpp,h}`: tag the startup entrance with its destination game and add game-scoped accessors (`*ForGame`) so only the matching game can consume it. `main.cpp` tags the value with the switch's target game; OoT/MM `Play_Init` and `Game_Resume` query `"oot"`/`"mm"`. A leaked MM value is now invisible to OoT, which falls back to its frozen return entrance (the correct resume target). The existing 1-arg setter stays as a wildcard shim, so the dead `switch.cpp` path and existing tests compile unchanged.
- **Defense in depth** — `games/oot/src/code/z_play.c`: bounds-guard the startup entrance in `OoT_Play_Init` (a value `>= ENTR_MAX` is ignored), protecting the crash site and all downstream `gEntranceTable[entranceIndex]` reads in `Play_Init` in one place.
- **Symmetric MM protection** — MM's `Play_Init` and `Game_Resume` use the `"mm"`-scoped accessor so an OoT-tagged value can't drive MM either.
- **Regression test** — `src/common/test_runner.cpp`: `Test_StartupEntrance` now asserts an MM-tagged `0xC010` is invisible to OoT (the exact crash condition), the symmetric case for MM, and that the 1-arg wildcard stays visible to both games. Runs ROM-less in the Tier-1 `redship` ctest suite.

## Verification

- The root cause, the full set of `gEntranceTable` OOB sites, and the fix design were cross-checked with a multi-agent investigation plus three adversarial review passes (breaks-switch / misses-OOB / logic-compile), all of which came back clean.
- Syntax-checked the core `entrance.cpp`/`entrance.h`/`game.c` change locally (`g++ -fsyntax-only`, clean) and confirmed the game-scoped symbols resolve in the edited game code.
- **Not run locally:** a full build/ctest — this checkout has uninitialized submodules, no ROMs/`.o2r` assets, and is network-isolated. CI's ROM-less `redship` tier (including the extended `Test_StartupEntrance` via `AllTests`) covers verification here.

## Fix confirmation (post-fix trace)

For the repro (OoT → Happy Mask Shop → F10 back before MM consumes `0xC010`): `OoT_Game_Resume` sees `Combo_HasStartupEntranceForGame("oot") == false` (value is MM-tagged) → falls back to the frozen return entrance `0x01D1` (Market); `Play_Init` reads `0` for OoT → keeps `0x01D1`; `gEntranceTable[0x01D1]` is in range. No OOB, and OoT resumes at the correct Market entrance. Normal OoT↔MM round-trips are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016c1SX9RMsYtFu1ZVDyGwbm

---
_Generated by [Claude Code](https://claude.ai/code/session_016c1SX9RMsYtFu1ZVDyGwbm)_

<!--- section:artifacts:start -->
### Build Artifacts
  - [rsbs-windows.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/8336507109.zip)
  - [rsbs-linux.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/8336276138.zip)
<!--- section:artifacts:end -->