### PR TITLE
Remove startup game-select prompt; boot straight into OoT

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,8 +78,8 @@ redshipblueship/
 
 1. Place `oot.z64` and `mm.z64` ROMs in the game directory
 2. Run asset extraction to generate `oot.otr` and `mm.otr`
-3. Launch `redshipblueship`
-4. Select game or load existing combo save
+3. Launch `redshipblueship` (boots into Ocarina of Time by default)
+4. Switch to Majora's Mask in-game, or launch with `--game mm`
 
 ## Default Controls
 

--- a/rsbs/src/main.cpp
+++ b/rsbs/src/main.cpp
@@ -12,7 +12,7 @@
  *   redship --game oot    # Run Ocarina of Time
  *   redship --game mm     # Run Majora's Mask
  *   redship --test <name> # Run integration tests
- *   redship               # Show game selector menu
+ *   redship               # Run Ocarina of Time (default)
  */
 
 #include <cstdio>
@@ -215,33 +215,6 @@ void PrintUsage(const char* progName) {
     printf("  F10              Switch between OoT and MM\n");
 }
 
-GameId ShowGameMenu(void) {
-    printf("\n=== %s %s ===\n\n", RSBS_APP_NAME, RSBS_VERSION_STRING);
-    printf("Select a game to play:\n");
-    printf("  1) Ocarina of Time\n");
-    printf("  2) Majora's Mask\n\n");
-    printf("Enter choice (1 or 2): ");
-    fflush(stdout);
-
-    char input[32];
-    if (fgets(input, sizeof(input), stdin) == nullptr) {
-        return GAME_OOT;  // Default
-    }
-
-    // Remove newline
-    input[strcspn(input, "\n")] = 0;
-
-    if (strcmp(input, "1") == 0 || strcmp(input, "oot") == 0) {
-        return GAME_OOT;
-    }
-    if (strcmp(input, "2") == 0 || strcmp(input, "mm") == 0) {
-        return GAME_MM;
-    }
-
-    printf("Invalid choice. Defaulting to OoT.\n");
-    return GAME_OOT;
-}
-
 } // anonymous namespace
 
 // ============================================================================
@@ -362,7 +335,11 @@ int main(int argc, char** argv) {
     } else {
         selectedGame = ParseGameArg(argc, argv);
         if (selectedGame == GAME_NONE) {
-            selectedGame = ShowGameMenu();
+            // No --game argument: boot straight into Ocarina of Time (landing
+            // on its title/file-select menu) instead of prompting the user to
+            // pick a game. MM is still reachable via `--game mm` or by
+            // switching in-game (Happy Mask Shop <-> Clock Tower, or F10).
+            selectedGame = GAME_OOT;
         }
     }
 


### PR DESCRIPTION
## Summary

When launched with no `--game` argument, the unified executable previously printed an interactive text menu (`ShowGameMenu`) over stdin asking the user to pick OoT or MM. This removes that prompt entirely and defaults to Ocarina of Time, landing on its normal title/file-select menu.

## Changes

- **`rsbs/src/main.cpp`**
  - Deleted the `ShowGameMenu()` function (the `1) Ocarina of Time / 2) Majora's Mask` stdin prompt).
  - The no-`--game` path now defaults directly to `GAME_OOT`.
  - Updated the file-header usage comment (`redship  # Run Ocarina of Time (default)`).
- **`README.md`**
  - Updated the Quick Start step that described "Select game" to reflect the default-to-OoT behavior.

## Behavior preserved

- `--game oot` / `--game mm` still work explicitly.
- Majora's Mask remains reachable in-game (Happy Mask Shop ↔ Clock Tower, or the F10 hotkey).
- Integration-test mode still overrides game selection; all archive pre-flight checks are untouched.

## Verification

Confirmed no other code referenced `ShowGameMenu` and no remaining `fgets`/`stdin` usage exists in `rsbs/`, so nothing else depended on the interactive prompt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TBZNT9GtswjiGnL8WXJKWY

---
_Generated by [Claude Code](https://claude.ai/code/session_01TBZNT9GtswjiGnL8WXJKWY)_

<!--- section:artifacts:start -->
### Build Artifacts
  - [rsbs-windows.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/8352373822.zip)
  - [rsbs-linux.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/8352104134.zip)
<!--- section:artifacts:end -->