### PR TITLE
Skip boot logo splash on cross-game switch

### DIFF
--- a/games/mm/src/overlays/gamestates/ovl_title/z_title.c
+++ b/games/mm/src/overlays/gamestates/ovl_title/z_title.c
@@ -18,6 +18,11 @@
 #include <stdlib.h>
 #include <libultraship/bridge/consolevariablebridge.h>
 
+// Cross-game combo support - a switch into MM arrives with a pending startup
+// entrance set by the launcher (see rsbs/src/main.cpp). Defined in
+// src/common/entrance.cpp. Matches the extern in z_play.c.
+extern uint16_t Combo_GetStartupEntrance(void);
+
 #define dgShipLogoDL "__OTR__misc/nintendo_rogo_static/gShipLogoDL"
 static const ALIGN_ASSET(2) char gShipLogoDL[] = dgShipLogoDL;
 
@@ -198,6 +203,22 @@ void ConsoleLogo_Draw(GameState* thisx) {
 
 void ConsoleLogo_Main(GameState* thisx) {
     ConsoleLogoState* this = (ConsoleLogoState*)thisx;
+
+    // Cross-game combo: when arriving from a game switch (a startup entrance is
+    // pending), skip the "powered by libultraship" boot logo entirely and hand
+    // straight off to the title-setup -> play boot. We just want the scene
+    // change, not the splash. Mirrors the transition ConsoleLogo normally makes
+    // when it finishes below. The startup entrance is consumed later in
+    // Play_Init, so we only test it here without clearing it.
+    if (Combo_GetStartupEntrance() != 0) {
+        gSaveContext.seqId = NA_BGM_DISABLED;
+        gSaveContext.ambienceId = AMBIENCE_ID_DISABLED;
+        gSaveContext.gameMode = GAMEMODE_TITLE_SCREEN;
+
+        STOP_GAMESTATE(&this->state);
+        SET_NEXT_GAMESTATE(&this->state, MM_TitleSetup_Init, sizeof(TitleSetupState));
+        return;
+    }
 
     func_8012CF0C(this->state.gfxCtx, true, true, 0, 0, 0);
 

--- a/games/oot/src/overlays/gamestates/ovl_title/z_title.c
+++ b/games/oot/src/overlays/gamestates/ovl_title/z_title.c
@@ -17,6 +17,11 @@
 
 #include "time.h"
 
+// Cross-game combo support - a switch into OoT arrives with a pending startup
+// entrance set by the launcher (see rsbs/src/main.cpp). Defined in
+// src/common/entrance.cpp. Matches the extern in z_play.c.
+extern uint16_t Combo_GetStartupEntrance(void);
+
 // Note: In other rom versions this function also updates unk_1D4, coverAlpha, addAlpha, visibleDuration to calculate
 // the fade-in/fade-out + the duration of the n64 logo animation
 void Title_Calc(TitleContext* this) {
@@ -124,6 +129,21 @@ void Title_Draw(TitleContext* this) {
 
 void Title_Main(GameState* thisx) {
     TitleContext* this = (TitleContext*)thisx;
+
+    // Cross-game combo: when arriving from a game switch (a startup entrance is
+    // pending), skip the "powered by libultraship" boot logo entirely and hand
+    // straight off to the opening -> play boot. We just want the scene change,
+    // not the splash. Mirrors the transition Title normally makes when it
+    // finishes below. The startup entrance is consumed later in Play_Init, so
+    // we only test it here without clearing it.
+    if (Combo_GetStartupEntrance() != 0) {
+        gSaveContext.seqId = (u8)NA_BGM_DISABLED;
+        gSaveContext.natureAmbienceId = 0xFF;
+        gSaveContext.gameMode = GAMEMODE_TITLE_SCREEN;
+        this->state.running = false;
+        SET_NEXT_GAMESTATE(&this->state, Opening_Init, OpeningContext);
+        return;
+    }
 
     OPEN_DISPS(this->state.gfxCtx);
 


### PR DESCRIPTION
## Summary

Switching between games (e.g. OoT → MM via the Happy Mask Shop) booted the target game fresh through its console-logo gamestate, showing the "powered by libultraship" splash for ~1.7s before the scene loaded. That was useful while bringing up the switch, but now we just want the scene change.

This skips the logo animation **only when arriving from a cross-game switch**, so the boot goes straight to the scene.

## How it works

The target game's boot chain is `Setup → ConsoleLogo/Title (logo) → TitleSetup/Opening → Play`. A **startup entrance** is pending (set by the launcher in `rsbs/src/main.cpp`) whenever the boot is a cross-game arrival, and it is never set on a normal first boot — the same signal `Play_Init` already consumes to place the player.

At the top of the logo gamestate's `Main`, when a startup entrance is pending, hand straight off to the next gamestate — the exact transition the logo already makes when its animation finishes:

- `games/mm/.../ovl_title/z_title.c` — `ConsoleLogo_Main` → `MM_TitleSetup_Init`
- `games/oot/.../ovl_title/z_title.c` — `Title_Main` → `Opening_Init`

The rest of the boot chain is unchanged: every state's `Init`/`Destroy` (SRAM/save setup) still runs identically, and `Play_Init` still applies + clears the startup entrance. Only the visible splash frames are dropped. The startup entrance is read (not cleared) here, so `Play_Init` still consumes it.

## Behavior

| Scenario | Result |
|---|---|
| OoT → MM switch | splash skipped, straight to the scene |
| Normal fresh launch (no pending entrance) | startup logo preserved |
| Return to a suspended game | unchanged — already continued its Play state, no logo |

Applied symmetrically to both games so either switch direction does a clean scene change. In the default OoT-first flow only the MM side is exercised (a return to a game resumes its suspended Play state rather than re-running the logo); the OoT branch is dormant unless MM is the starting game.

## Testing

- `clang-format` clean on both changed files.
- Every symbol used already appears in the same translation units (the `Combo_GetStartupEntrance` extern matches `z_play.c`; `SET_NEXT_GAMESTATE`, `MM_TitleSetup_Init`/`Opening_Init`, and the disabled-audio/game-mode setup are copied from each file's existing logo-exit block).
- No test depends on the logo being shown — per #344 the boot/switch integration tests wait for actual scene-load completion, which this reaches sooner.
- A full local build isn't possible without the original ROMs (asset extraction); relying on CI for the build/clang-format/static-analysis checks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NcZzZTkNifbZJ14CcoaVwN

---
_Generated by [Claude Code](https://claude.ai/code/session_01NcZzZTkNifbZJ14CcoaVwN)_

<!--- section:artifacts:start -->
### Build Artifacts
  - [rsbs-windows.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/8352568328.zip)
  - [rsbs-linux.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/8352304027.zip)
<!--- section:artifacts:end -->