### PR TITLE
Fix MM boot crash: skip OoT-bound GameInteractor actor hooks in single-exe

### DIFF
--- a/games/mm/src/code/z_actor.c
+++ b/games/mm/src/code/z_actor.c
@@ -1284,6 +1284,19 @@ void MM_Actor_Init(Actor* actor, PlayState* play) {
     if (MM_Object_IsLoaded(&play->objectCtx, actor->objectSlot)) {
         MM_Actor_SetObjectDependency(play, actor);
 
+#ifdef RSBS_SINGLE_EXECUTABLE
+        // MM's GameInteractor enhancement layer is excluded from single-exe
+        // builds, so these unprefixed GameInteractor_* calls bind to OoT's
+        // implementation. OoT's GameInteractor_ShouldActorInit casts the
+        // argument to OoT's Actor and dispatches hooks by actor id — but the
+        // actor here is an MM actor (different struct layout, and ids alias
+        // between the games), so it faults on the first MM actor spawned (the
+        // player), which blocks every MM boot. Initialize the actor directly,
+        // skipping the cross-game hooks. Mirrors the #344 guard on
+        // GameInteractor_ExecuteOnSceneInit in z_play.c.
+        actor->init(actor, play);
+        actor->init = NULL;
+#else
         if (GameInteractor_ShouldActorInit(actor)) {
             actor->init(actor, play);
             actor->init = NULL;
@@ -1292,6 +1305,7 @@ void MM_Actor_Init(Actor* actor, PlayState* play) {
             actor->init = NULL;
             MM_Actor_Kill(actor);
         }
+#endif
     }
 }
 
@@ -2713,6 +2727,12 @@ Actor* Actor_UpdateActor(UpdateActor_Params* params) {
         if (MM_Object_IsLoaded(&play->objectCtx, actor->objectSlot)) {
             MM_Actor_SetObjectDependency(play, actor);
 
+#ifdef RSBS_SINGLE_EXECUTABLE
+            // Skip the OoT-bound GameInteractor hooks in single-exe — see the
+            // detailed note in MM_Actor_Init above. Init the actor directly.
+            actor->init(actor, play);
+            actor->init = NULL;
+#else
             if (GameInteractor_ShouldActorInit(actor)) {
                 actor->init(actor, play);
                 actor->init = NULL;
@@ -2721,6 +2741,7 @@ Actor* Actor_UpdateActor(UpdateActor_Params* params) {
                 actor->init = NULL;
                 MM_Actor_Kill(actor);
             }
+#endif
         }
         nextActor = actor->next;
     } else if (actor->update == NULL) {


### PR DESCRIPTION
## Summary

Every MM boot in single-exe mode crashed (`0xC0000005`) while spawning the **player actor** — reproducible both on a **direct MM boot** and on the **OoT→MM Happy Mask Shop switch** into Clock Tower Interior, since both share the actor-spawn path.

This is the same crash originally reported as the "OoT Market cutscene crash." That crash log's `Cutscene_HandleConditionalTriggers: entrance: 49168` line is actually **MM's `func_800EDDB0`** (`games/mm/src/code/z_demo.c`) during MM's `Play_Init` — with the OoT Market scene still resident in memory from just before the switch, which is why the crash dump showed `SCENE_MARKET_DAY`.

## Root cause

MM's `MM_Actor_Init` and `Actor_UpdateActor` wrap `actor->init()` with unprefixed `GameInteractor_ShouldActorInit()` / `GameInteractor_ExecuteOnActorInit()`:

```c
if (GameInteractor_ShouldActorInit(actor)) {
    actor->init(actor, play);
    actor->init = NULL;
    GameInteractor_ExecuteOnActorInit(actor);
}
```

MM's GameInteractor enhancement layer is **excluded** from single-exe builds, so these unprefixed calls bind to **OoT's** implementation. OoT's `GameInteractor_ShouldActorInit(void* actor)` does `((Actor*)actor)->id` and dispatches OoT's actor hooks by id — but the actor here is an **MM actor** (different `Actor` struct layout, and actor ids alias between the two games). It faults on the **first MM actor spawned — the player** — before any MM scene can finish loading, so MM never boots.

This is the same cross-game hook-binding hazard the `#344` changes already fence off elsewhere (e.g. the `GameInteractor_ExecuteOnSceneInit` guard in `z_play.c`); these two `z_actor.c` sites were simply missed.

## Change

Guard both MM `z_actor.c` call sites with `#ifdef RSBS_SINGLE_EXECUTABLE` and initialize the actor directly, skipping the cross-game hooks. OoT's own `z_actor.c` calls (OoT actor → OoT GameInteractor) are correct and left unchanged. +21 lines, one file.

## How this was found & verified

Root-caused with a staged diagnostic build (temporary `[MM-DIAG]` tracing through `Play_Init` → scene/room setup → `Actor_InitContext`), which pinpointed the fault to the player spawn inside `MM_Actor_Init`. With this guard applied, a Windows build boots MM end-to-end: the player and every room actor spawn, `Play_Init` completes, and MM reaches its render loop — via **both** the direct boot and the OoT→MM switch.

Note: this is a **targeted interim fix** for the actor-init hooks. A broader, systemic guard for cross-game GameInteractor binding in single-exe is being handled separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016c1SX9RMsYtFu1ZVDyGwbm

---
_Generated by [Claude Code](https://claude.ai/code/session_016c1SX9RMsYtFu1ZVDyGwbm)_

<!--- section:artifacts:start -->
### Build Artifacts
  - [rsbs-windows.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/8359604289.zip)
  - [rsbs-linux.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/8359394632.zip)
<!--- section:artifacts:end -->