### PR TITLE
Fix OoT crash on cross-game switch return: MM entrance id leaking into OoT's entranceIndex

### DIFF
--- a/CMake/SingleExecutable.cmake
+++ b/CMake/SingleExecutable.cmake
@@ -214,6 +214,11 @@ if(BUILD_TESTING)
     add_test(NAME BootMM COMMAND redship --test boot-mm)
     add_test(NAME SwitchOoTMM COMMAND redship --test switch-oot-mm)
     add_test(NAME SwitchMMOoT COMMAND redship --test switch-mm-oot)
+    # Startup-entrance flow incl. game-affinity regression: an MM-tagged
+    # entrance (0xC010) must be invisible to OoT, whose entranceIndex is a
+    # linear gEntranceTable index — the OOB-read crash behind the Market
+    # cutscene 0xC0000005.
+    add_test(NAME StartupEntrance COMMAND redship --test startup-entrance)
     add_test(NAME Roundtrip COMMAND redship --test roundtrip)
     add_test(NAME RoundtripIntegrity COMMAND redship --test roundtrip-integrity)
     add_test(NAME SharedRoundtrip COMMAND redship --test shared-roundtrip)
@@ -236,7 +241,7 @@ if(BUILD_TESTING)
     # Set reasonable timeout and label our tests
     set(REDSHIP_TEST_TIMEOUT 60 CACHE STRING "Test timeout in seconds")
     set_tests_properties(
-        BootOoT BootMM SwitchOoTMM SwitchMMOoT Roundtrip RoundtripIntegrity SharedRoundtrip ArchiveHotswapLogic
+        BootOoT BootMM SwitchOoTMM SwitchMMOoT StartupEntrance Roundtrip RoundtripIntegrity SharedRoundtrip ArchiveHotswapLogic
         SaveRoundtripTiers SaveHeader SaveHasDelete SaveVersionReject SaveSizeMismatch SaveCrcCorrupt
         Context MMSceneParse MMSceneExecute AllTests
         PROPERTIES

--- a/games/mm/2s2h/GameExports_SingleExe.cpp
+++ b/games/mm/2s2h/GameExports_SingleExe.cpp
@@ -860,9 +860,13 @@ void MM_Game_Resume(void) {
         // return entrance recorded when we last froze MM. Use the explicit
         // Has accessor because entrance 0x0000 is a valid id and treating it
         // as "unset" would silently drop a legitimate restore.
-        bool hasStartup = Combo_HasStartupEntrance();
+        // Query the MM-scoped accessor: an OoT-tagged value that leaked into
+        // the shared startup global stays invisible to MM, so we fall back to
+        // MM's frozen return entrance instead of spawning from an OoT id
+        // (symmetric with OoT_Game_Resume).
+        bool hasStartup = Combo_HasStartupEntranceForGame("mm");
         uint16_t targetEntrance = hasStartup
-            ? Combo_GetStartupEntrance()
+            ? Combo_GetStartupEntranceForGame("mm")
             : Context_GetFrozenReturnEntrance(GAME_MM);
         gSaveContext.save.entrance = targetEntrance;
         fprintf(stderr, "[MM] Resume entrance: 0x%04X (startup=%u)\n",

--- a/games/mm/src/code/z_play.c
+++ b/games/mm/src/code/z_play.c
@@ -53,6 +53,7 @@ extern uint16_t Combo_CheckEntranceSwitch(uint16_t entranceIndex);
 extern bool Combo_IsCrossGameSwitch(void);
 extern uint16_t Combo_GetStartupEntrance(void);
 extern void Combo_ClearStartupEntrance(void);
+extern uint16_t Combo_GetStartupEntranceForGame(const char* gameId);
 
 s32 MM_gDbgCamEnabled = false;
 u8 D_801D0D54 = false;
@@ -2241,7 +2242,10 @@ void MM_Play_Init(GameState* thisx) {
 
     // Cross-game combo: Check if we're entering from another game
     {
-        uint16_t startupEntrance = Combo_GetStartupEntrance();
+        // Only consume an entrance tagged for MM. A value tagged for OoT that
+        // leaked into the shared startup global stays invisible here, so MM
+        // won't spawn from an OoT entrance id (symmetric with OoT's guard).
+        uint16_t startupEntrance = Combo_GetStartupEntranceForGame("mm");
         if (startupEntrance != 0) {
             gSaveContext.save.entrance = startupEntrance;
             // On a first MM entry this Play_Init is reached through MM's

--- a/games/oot/soh/GameExports_SingleExe.cpp
+++ b/games/oot/soh/GameExports_SingleExe.cpp
@@ -346,14 +346,20 @@ void OoT_Game_Resume(void) {
 
         // Prefer an explicit startup entrance (set by main.cpp for this
         // switch); fall back to the return entrance recorded at freeze time.
-        // Use Combo_HasStartupEntrance rather than (entrance != 0) — entrance
-        // 0x0000 is the real id for Kokiri Forest from Deku Tree, so a legit
-        // restore to 0 must not be silently dropped. The frozen return
-        // entrance is always trustworthy here because we already checked
-        // Context_HasFrozenState above.
-        bool hasStartup = Combo_HasStartupEntrance();
+        // Query the OoT-scoped accessor rather than the game-agnostic one: a
+        // value tagged for MM (e.g. 0xC010) that leaked into the shared startup
+        // global must NOT be applied to OoT's entranceIndex — it is a direct
+        // linear index into gEntranceTable and would read far out of bounds
+        // (crash) once Play_Init runs. When the leaked value is invisible to
+        // OoT, hasStartup is false and we fall back to the frozen OoT return
+        // entrance, which is the correct resume target and always in range.
+        // Use the Has check rather than (entrance != 0) — entrance 0x0000 is the
+        // real id for Kokiri Forest from Deku Tree, so a legit restore to 0 must
+        // not be silently dropped. The frozen return entrance is always
+        // trustworthy here because we already checked Context_HasFrozenState.
+        bool hasStartup = Combo_HasStartupEntranceForGame("oot");
         uint16_t targetEntrance = hasStartup
-            ? Combo_GetStartupEntrance()
+            ? Combo_GetStartupEntranceForGame("oot")
             : Context_GetFrozenReturnEntrance(GAME_OOT);
         gSaveContext.entranceIndex = targetEntrance;
         fprintf(stderr, "[OoT] Resume entrance: 0x%04X (startup=%u)\n",

--- a/games/oot/src/code/z_play.c
+++ b/games/oot/src/code/z_play.c
@@ -24,6 +24,7 @@
 // Cross-game combo support - check for startup entrance from game switch
 extern uint16_t Combo_GetStartupEntrance(void);
 extern void Combo_ClearStartupEntrance(void);
+extern uint16_t Combo_GetStartupEntranceForGame(const char* gameId);
 
 // Cross-game combo support - entrance switch checking
 extern uint16_t Combo_CheckEntranceSwitch(uint16_t entranceIndex);
@@ -393,13 +394,25 @@ void OoT_Play_Init(GameState* thisx) {
 
     enableBetaQuest();
 
-    // Cross-game combo: Check if we're entering from another game
+    // Cross-game combo: Check if we're entering from another game.
     {
-        uint16_t startupEntrance = Combo_GetStartupEntrance();
+        // Only consume an entrance tagged for OoT. A value tagged for MM (e.g.
+        // 0xC010 = Clock Tower Interior) that leaked into the shared startup
+        // global must never reach gSaveContext.entranceIndex — it is a direct
+        // linear index into gEntranceTable[ENTR_MAX], so an MM value reads far
+        // out of bounds and crashes (0xC0000005) in Cutscene_HandleConditionalTriggers.
+        uint16_t startupEntrance = Combo_GetStartupEntranceForGame("oot");
         if (startupEntrance != 0) {
-            gSaveContext.entranceIndex = startupEntrance;
-            Combo_ClearStartupEntrance();
-            osSyncPrintf("[OoT] Cross-game switch: loading entrance 0x%04X\n", startupEntrance);
+            if (startupEntrance >= ENTR_MAX) {
+                // Defense in depth: never index gEntranceTable out of range,
+                // even if a bogus value slips past the game-affinity check.
+                osSyncPrintf("[OoT] Ignoring out-of-range startup entrance 0x%04X\n", startupEntrance);
+                Combo_ClearStartupEntrance();
+            } else {
+                gSaveContext.entranceIndex = startupEntrance;
+                Combo_ClearStartupEntrance();
+                osSyncPrintf("[OoT] Cross-game switch: loading entrance 0x%04X\n", startupEntrance);
+            }
         }
     }
 

--- a/rsbs/src/main.cpp
+++ b/rsbs/src/main.cpp
@@ -523,9 +523,12 @@ int main(int argc, char** argv) {
             Combo_ClearGameSwitchRequest();
             Entrance_ClearPendingSwitch();
 
-            // Set startup entrance if this is an entrance-based switch
+            // Set startup entrance if this is an entrance-based switch. Tag it
+            // with the destination game so only that game can consume it — this
+            // prevents an MM entrance (e.g. 0xC010) from leaking into OoT's
+            // entranceIndex and reading gEntranceTable out of bounds (crash).
             if (isEntranceSwitch && targetEntrance != 0) {
-                Entrance_SetStartupEntrance(targetEntrance);
+                Entrance_SetStartupEntrance(targetEntrance, nextGame);
             }
 
             // Hot-swap resource archives before game init/resume

--- a/src/common/entrance.cpp
+++ b/src/common/entrance.cpp
@@ -25,6 +25,11 @@ std::vector<CrossGameEntranceLink> gEntranceLinks;
 // rather than overloading 0 as "unset".
 uint16_t sStartupEntrance = 0;
 bool sStartupEntrancePresent = false;
+// Which game the startup entrance targets. GAME_NONE = wildcard (the legacy
+// 1-arg setter), so only the matching game consumes a tagged value. This is
+// what stops an MM entrance (e.g. 0xC010) from leaking into OoT's linear
+// gEntranceTable index and reading far out of bounds (crash 0xC0000005).
+GameId sStartupEntranceGame = GAME_NONE;
 
 // Game switch request flag (for F10 hotkey)
 bool sGameSwitchRequested = false;
@@ -43,6 +48,7 @@ void Entrance_Init(void) {
     gPendingSwitch = {};
     sStartupEntrance = 0;
     sStartupEntrancePresent = false;
+    sStartupEntranceGame = GAME_NONE;
     sGameSwitchRequested = false;
 }
 
@@ -142,8 +148,15 @@ void Entrance_ClearPendingSwitch(void) {
 }
 
 void Entrance_SetStartupEntrance(uint16_t entrance) {
+    // Legacy 1-arg form: tag as wildcard so existing (non-production) callers
+    // keep their current game-agnostic behavior.
+    Entrance_SetStartupEntrance(entrance, GAME_NONE);
+}
+
+void Entrance_SetStartupEntrance(uint16_t entrance, GameId targetGame) {
     sStartupEntrance = entrance;
     sStartupEntrancePresent = true;
+    sStartupEntranceGame = targetGame;
 }
 
 uint16_t Entrance_GetStartupEntrance(void) {
@@ -154,9 +167,19 @@ bool Entrance_HasStartupEntrance(void) {
     return sStartupEntrancePresent;
 }
 
+bool Entrance_HasStartupEntranceForGame(GameId game) {
+    return sStartupEntrancePresent &&
+           (sStartupEntranceGame == GAME_NONE || sStartupEntranceGame == game);
+}
+
+uint16_t Entrance_GetStartupEntranceForGame(GameId game) {
+    return Entrance_HasStartupEntranceForGame(game) ? sStartupEntrance : 0;
+}
+
 void Entrance_ClearStartupEntrance(void) {
     sStartupEntrance = 0;
     sStartupEntrancePresent = false;
+    sStartupEntranceGame = GAME_NONE;
 }
 
 // ============================================================================
@@ -210,6 +233,18 @@ bool Combo_HasStartupEntrance(void) {
 
 void Combo_ClearStartupEntrance(void) {
     Entrance_ClearStartupEntrance();
+}
+
+uint16_t Combo_GetStartupEntranceForGame(const char* gameId) {
+    GameId game = Game_FromString(gameId);
+    if (game == GAME_NONE) return 0;
+    return Entrance_GetStartupEntranceForGame(game);
+}
+
+bool Combo_HasStartupEntranceForGame(const char* gameId) {
+    GameId game = Game_FromString(gameId);
+    if (game == GAME_NONE) return false;
+    return Entrance_HasStartupEntranceForGame(game);
 }
 
 // ============================================================================

--- a/src/common/entrance.h
+++ b/src/common/entrance.h
@@ -87,6 +87,12 @@ uint16_t Combo_GetStartupEntrance(void);
 // separately from the value — callers must check this before trusting the id.
 bool Combo_HasStartupEntrance(void);
 void Combo_ClearStartupEntrance(void);
+// Game-scoped variants: only return/report the startup entrance when it was
+// tagged for `gameId` (or tagged as wildcard via the 1-arg setter). This
+// prevents a cross-game entrance (e.g. MM 0xC010) from being consumed by the
+// wrong game and indexing that game's entrance table out of bounds.
+uint16_t Combo_GetStartupEntranceForGame(const char* gameId);
+bool Combo_HasStartupEntranceForGame(const char* gameId);
 
 // Game switch request API
 void Combo_RequestGameSwitch(void);
@@ -182,6 +188,12 @@ void Entrance_ClearPendingSwitch(void);
 void Entrance_SetStartupEntrance(uint16_t entrance);
 
 /**
+ * Set the startup entrance tagged with the game it targets, so only that game
+ * consumes it. The 1-arg overload above tags GAME_NONE (wildcard).
+ */
+void Entrance_SetStartupEntrance(uint16_t entrance, GameId targetGame);
+
+/**
  * Get the startup entrance. Use Entrance_HasStartupEntrance() to check
  * whether one is actually set — entrance 0x0000 is a valid id.
  */
@@ -191,6 +203,16 @@ uint16_t Entrance_GetStartupEntrance(void);
  * Whether a startup entrance has been set since the last clear.
  */
 bool Entrance_HasStartupEntrance(void);
+
+/**
+ * Whether a startup entrance is set and targets `game` (or is a wildcard).
+ */
+bool Entrance_HasStartupEntranceForGame(GameId game);
+
+/**
+ * The startup entrance if it targets `game` (or is a wildcard), else 0.
+ */
+uint16_t Entrance_GetStartupEntranceForGame(GameId game);
 
 /**
  * Clear the startup entrance (called after game reads it)

--- a/src/common/test_runner.cpp
+++ b/src/common/test_runner.cpp
@@ -434,7 +434,59 @@ TestResult Test_StartupEntrance(void) {
         return TEST_FAIL;
     }
 
-    printf("[TEST] PASS: Startup entrance flow verified\n");
+    // ------------------------------------------------------------------
+    // Step 5: Game affinity — the exact condition behind the Market
+    // cutscene crash. An entrance tagged for one game must be invisible to
+    // the other, so a cross-game value (MM Clock Tower 0xC010) can never be
+    // applied to OoT's entranceIndex and index gEntranceTable out of bounds.
+    // ------------------------------------------------------------------
+    Entrance_SetStartupEntrance(MM_ENTR_CLOCK_TOWER_INTERIOR_1, GAME_MM);
+
+    // MM (the tagged game) sees it...
+    if (!Entrance_HasStartupEntranceForGame(GAME_MM) ||
+        Entrance_GetStartupEntranceForGame(GAME_MM) != MM_ENTR_CLOCK_TOWER_INTERIOR_1) {
+        printf("[TEST] FAIL: MM-tagged startup entrance not visible to MM\n");
+        return TEST_FAIL;
+    }
+    // ...but OoT must NOT — this is precisely what prevents the OOB crash.
+    if (Entrance_HasStartupEntranceForGame(GAME_OOT) ||
+        Entrance_GetStartupEntranceForGame(GAME_OOT) != 0) {
+        printf("[TEST] FAIL: MM-tagged startup entrance leaked to OoT (crash condition)\n");
+        return TEST_FAIL;
+    }
+    // The C API used by the game code must agree with the C++ API.
+    if (!Combo_HasStartupEntranceForGame("mm") || Combo_HasStartupEntranceForGame("oot") ||
+        Combo_GetStartupEntranceForGame("oot") != 0 ||
+        Combo_GetStartupEntranceForGame("mm") != MM_ENTR_CLOCK_TOWER_INTERIOR_1) {
+        printf("[TEST] FAIL: Combo_*ForGame C API disagrees with affinity\n");
+        return TEST_FAIL;
+    }
+
+    // Symmetric: an OoT-tagged entrance must be invisible to MM.
+    Entrance_SetStartupEntrance(OOT_ENTR_MARKET_FROM_MASK_SHOP, GAME_OOT);
+    if (!Entrance_HasStartupEntranceForGame(GAME_OOT) ||
+        Entrance_HasStartupEntranceForGame(GAME_MM)) {
+        printf("[TEST] FAIL: OoT-tagged startup entrance leaked to MM\n");
+        return TEST_FAIL;
+    }
+
+    // Back-compat: the legacy 1-arg setter tags wildcard, visible to both.
+    Entrance_SetStartupEntrance(OOT_ENTR_HAPPY_MASK_SHOP);
+    if (!Entrance_HasStartupEntranceForGame(GAME_OOT) ||
+        !Entrance_HasStartupEntranceForGame(GAME_MM)) {
+        printf("[TEST] FAIL: wildcard (1-arg) startup entrance not visible to both games\n");
+        return TEST_FAIL;
+    }
+
+    // Clearing resets the affinity tag too.
+    Combo_ClearStartupEntrance();
+    if (Entrance_HasStartupEntranceForGame(GAME_OOT) ||
+        Entrance_HasStartupEntranceForGame(GAME_MM)) {
+        printf("[TEST] FAIL: startup entrance affinity not cleared\n");
+        return TEST_FAIL;
+    }
+
+    printf("[TEST] PASS: Startup entrance flow + game affinity verified\n");
     Entrance_ClearPendingSwitch();
     return TEST_PASS;
 }


### PR DESCRIPTION
## Why

The 2026-07-16 operator crash log (build `d81a23d`, Windows, `0xc0000005` in SCENE_MARKET_DAY) decodes to: **entrance 49168 = 0xC010 = `MM_ENTR_CLOCK_TOWER_INTERIOR_1`** applied to **OoT's** `gSaveContext.entranceIndex`, which is a direct linear index into `gEntranceTable[ENTR_MAX=0x614]` — an out-of-bounds read ~32× past the table, faulting in `OoT_Play_Init` → `Cutscene_HandleConditionalTriggers` on the return/resume leg of a cross-game switch.

Root cause: the cross-game "startup entrance" is a single game-agnostic global. `main.cpp` writes the MM target (0xC010) into it on an OoT→MM entrance switch; the resume hooks on both sides read it without clearing; F10 switches never overwrite it; and no consumer checks which game the value was meant for. Any OoT resume/`Play_Init` that observes a stale MM value crashes. (MM is naturally OOB-resistant — its entrance ids are bit-packed scene/spawn, not a linear index.)

## What

Lands commit `7c6e7eec` from `claude/cutscene-crash-redship-4aukbd` (diagnosed 2026-07-15, never PR'd; cherry-picked cleanly onto main), plus the CTest wiring it was missing:

- **Game-affinity startup entrance**: the slot is tagged with the destination game (`Entrance_SetStartupEntrance(entrance, targetGame)`; `main.cpp` tags it); game-scoped accessors (`Combo_{Has,Get}StartupEntranceForGame`) make a wrong-game value invisible, so OoT falls back to its frozen return entrance — the correct resume target. The 1-arg setter remains as a wildcard shim for existing callers.
- **Defense in depth**: `OoT_Play_Init` ignores any startup entrance `>= ENTR_MAX`, directly guarding the crash site and all downstream `gEntranceTable[entranceIndex]` reads.
- **Consumption sites scoped**: `OoT_Play_Init`, `MM_Play_Init`, `OoT_Game_Resume`, `MM_Game_Resume`. The legacy `OoT_/MM_ResumeFromContext` readers are unreachable (`Context_ProcessSwitch` has no callers in single-exe) and the `z_title.c` splash-skip checks only test presence, never assign — both left as-is.
- **Regression test**: `Test_StartupEntrance` now asserts an MM-tagged 0xC010 is invisible to OoT (the exact crash condition), the symmetric OoT→MM case, and 1-arg wildcard back-compat — and is registered as a dedicated `StartupEntrance` CTest in the `redship` label (previously it only ran via `AllTests`), so hosted CI runs it ROM-free on Linux + Windows.

Companion to #355 (worker-prompts §A documents this same lane).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SDWdRGxEryXXcAV7bEdfZo

---
_Generated by [Claude Code](https://claude.ai/code/session_01SDWdRGxEryXXcAV7bEdfZo)_

<!--- section:artifacts:start -->
### Build Artifacts
  - [rsbs-windows.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/8391069512.zip)
  - [rsbs-linux.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/8390826350.zip)
<!--- section:artifacts:end -->