### PR TITLE
Guard MM first-room command execution: NULL room segment and NULL player

### DIFF
--- a/games/mm/2s2h/mm_scene_execute_test.cpp
+++ b/games/mm/2s2h/mm_scene_execute_test.cpp
@@ -65,6 +65,11 @@ ActorEntry* MM_Play_ResolveLinkActorEntry(EntranceEntry* setupEntranceList, s32 
 // unit-testable here.
 extern "C" Actor* MM_Actor_SpawnEntry(ActorContext* actorCtx, ActorEntry* actorEntry, PlayState* play);
 
+// First-room processor from z_play_2SH.cpp — its NULL-room guard returns before
+// any executor/actor/environment access, so a zeroed PlayState exercises it
+// safely.
+extern "C" s32 MM_OTRfunc_800973FC(PlayState* play, RoomContext* roomCtx);
+
 namespace {
 
 void MMSceneExec_PushU32(std::vector<char>& buf, uint32_t value) {
@@ -275,6 +280,32 @@ extern "C" int MM_SceneExecute_RunHeadless(void) {
             return 1;
         }
         printf("[TEST] PASS: MM_Actor_SpawnEntry NULL guard locked\n");
+    }
+
+    // === First-room NULL guard (cross-switch crash containment) ===
+    // Locks MM_OTRfunc_800973FC's containment for a first-room load failure:
+    // with status==1 and a NULL roomRequestAddr it must return 1 (so
+    // MM_Play_Init's busyloop terminates) WITHOUT running the command executor
+    // on the NULL room — previously this called
+    // MM_OTRScene_ExecuteCommands(play, NULL) and null-derefed before the
+    // post-busyloop player guard could run. The early return also skips
+    // func_80123140, whose unguarded player->actor.id read is the other
+    // in-busyloop crash on a player-less PlayState.
+    {
+        auto rg_play = std::make_unique<PlayState>();
+        RoomContext* rg_roomCtx = &rg_play->roomCtx;
+        rg_roomCtx->status = 1;
+        rg_roomCtx->roomRequestAddr = nullptr;
+        s32 processed = MM_OTRfunc_800973FC(rg_play.get(), rg_roomCtx);
+        if (processed != 1) {
+            printf("[TEST] FAIL: NULL-room guard returned %d, expected 1 (busyloop would spin)\n", (int)processed);
+            return 1;
+        }
+        if (rg_roomCtx->status != 0) {
+            printf("[TEST] FAIL: NULL-room guard left status=%d, expected 0\n", (int)rg_roomCtx->status);
+            return 1;
+        }
+        printf("[TEST] PASS: first-room NULL guard contained\n");
     }
 
     // === ObjectList (0x0B) via WIRE-BYTE (regression lock) ===

--- a/games/mm/2s2h/z_play_2SH.cpp
+++ b/games/mm/2s2h/z_play_2SH.cpp
@@ -65,12 +65,34 @@ extern "C" s32 MM_OTRfunc_800973FC(PlayState* play, RoomContext* roomCtx) {
     if (roomCtx->status == 1) {
         // if (!MM_osRecvMesg(&roomCtx->loadQueue, nullptr, OS_MESG_NOBLOCK)) {
         if (1) {
+            if (roomCtx->roomRequestAddr == nullptr) {
+                // Room resource failed to load (FATAL logged at request time in
+                // MM_OTRfunc_8009728C). Running the command executor on a NULL
+                // room would null-deref before Play_Init's post-busyloop guard
+                // can run; contain it instead, same policy as the scene-load
+                // guard in MM_OTRPlay_SpawnScene.
+                fprintf(stderr,
+                        "[MM] FATAL: first-room segment is NULL (sceneId %d, room %d), skipping room commands\n",
+                        (int)play->sceneId, (int)roomCtx->curRoom.num);
+                fflush(stderr);
+                roomCtx->status = 0;
+                return 1;
+            }
             roomCtx->status = 0;
             roomCtx->curRoom.segment = roomCtx->roomRequestAddr;
             MM_gSegments[3] = (uintptr_t)roomCtx->roomRequestAddr;
 
             MM_OTRScene_ExecuteCommands(play, (S2H::Scene*)roomCtx->curRoom.segment);
-            func_80123140(play, GET_PLAYER(play));
+            Player* player = GET_PLAYER(play);
+            if (player != NULL) {
+                func_80123140(play, player);
+            } else {
+                // func_80123140 reads player->actor.id unguarded. A player-less
+                // PlayState here means the spawn path failed; skip it and let
+                // MM_Play_Init's NULL-player guard unwind after the busyloop.
+                fprintf(stderr, "[MM] WARNING: no player during first-room commands, skipping func_80123140\n");
+                fflush(stderr);
+            }
             MM_Actor_SpawnTransitionActors(play, &play->actorCtx);
             if (((play->sceneId != SCENE_IKANA) || (roomCtx->curRoom.num != 1)) && (play->sceneId != SCENE_IKNINSIDE)) {
                 play->envCtx.lightSettingOverride = LIGHT_SETTING_OVERRIDE_NONE;

--- a/games/mm/2s2h/z_scene_2SH.cpp
+++ b/games/mm/2s2h/z_scene_2SH.cpp
@@ -559,6 +559,14 @@ extern "C" s32 MM_OTRfunc_8009728C(PlayState* play, RoomContext* roomCtx, s32 ro
         //&roomCtx->loadQueue, NULL, __FILE__, __LINE__);
         printf("File Name %s\n", play->roomList.romFiles[roomNum].fileName);
         auto roomData = std::static_pointer_cast<S2H::Scene>(ResourceLoad(play->roomList.romFiles[roomNum].fileName));
+        if (roomData == nullptr) {
+            // Fail loudly, same policy as MM_OTRPlay_SpawnScene's scene guard:
+            // the NULL still flows into roomRequestAddr and is contained in
+            // MM_OTRfunc_800973FC before anything dereferences it.
+            fprintf(stderr, "[MM] FATAL: failed to load room resource '%s' (sceneId %d)\n",
+                    play->roomList.romFiles[roomNum].fileName, (int)play->sceneId);
+            fflush(stderr);
+        }
         roomCtx->status = 1;
         roomCtx->roomRequestAddr = roomData.get();
 


### PR DESCRIPTION
## Why

The operator reports a switch crash still reproducing on the PR #356 artifact. #356 fixed the **return-to-OoT** leg (the entrance-id leak the crash dump proved). The **OoT→MM** leg has its own unguarded crash window, and the operator's original log is consistent with it: the MM fragment's *last line* was `File Name scenes/nonmq/Z2_INSIDETOWER/Z2_INSIDETOWER_room_00` — printed at `z_scene_2SH.cpp` immediately before first-room command execution.

First-room commands run inside `MM_Play_Init`'s busyloop (`Room_ProcessRoomRequest` → `MM_OTRfunc_800973FC`), **before** #353's post-busyloop NULL-player guard can run. Two derefs in that window were unguarded (Wave-3 worker-prompts §B candidates #1 and #2):

- `MM_OTRfunc_8009728C` stores `ResourceLoad(...).get()` into `roomRequestAddr` unchecked; `MM_OTRfunc_800973FC` hands it straight to `MM_OTRScene_ExecuteCommands`, which dereferences it. A missing/unloadable room file → crash with `File Name %s` as the last log line.
- `func_80123140` (`z_player_lib.c:602`) reads `player->actor.id` with no NULL check; `GET_PLAYER` is NULL whenever the player spawn path failed.

## What

Containment in #353's style — loud, minimal, no behavior change on the healthy path:

- FATAL log at the room-request site when the room resource fails to load.
- In `MM_OTRfunc_800973FC`: early-return on a NULL `roomRequestAddr` (status reset, return 1 so the busyloop terminates) without executing commands; skip `func_80123140` (with a WARNING log) when there is no player, so control falls through to the existing post-busyloop guard.
- ROM-free lock in the `mm-scene-execute` test (`redship` label, runs on Linux+Windows hosted CI): direct call with `status==1` / `roomRequestAddr==NULL` must return 1 with status reset, no crash on a zeroed PlayState.

If the operator's crash was this surface, it's now either gone or converted into an explicit `[MM] FATAL` log line that pinpoints the failing resource — either outcome makes the next log decisive.

Follows #356; companion to the Wave-3 §B lane in `.claude/worker-prompts.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SDWdRGxEryXXcAV7bEdfZo

---
_Generated by [Claude Code](https://claude.ai/code/session_01SDWdRGxEryXXcAV7bEdfZo)_

<!--- section:artifacts:start -->
### Build Artifacts
  - [rsbs-windows.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/8392012311.zip)
  - [rsbs-linux.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/8391864930.zip)
<!--- section:artifacts:end -->