### PR TITLE
Fix Fire Temple boss-key hint: register RC_FIRE_BOSS_KEY_HINT, not Forest's

### DIFF
--- a/games/oot/soh/Enhancements/randomizer/location_access/dungeons/fire_temple.cpp
+++ b/games/oot/soh/Enhancements/randomizer/location_access/dungeons/fire_temple.cpp
@@ -1054,7 +1054,7 @@ void RegionTable_Init_FireTemple() {
     // Boss Room
     areaTable[RR_FIRE_TEMPLE_BOSS_ENTRYWAY] = Region("Fire Temple Boss Entryway", SCENE_FIRE_TEMPLE, {}, {
         // Locations
-        LOCATION(RC_FOREST_BOSS_KEY_HINT, true),
+        LOCATION(RC_FIRE_BOSS_KEY_HINT, true),
     }, {
         // Exits
         Entrance(RR_FIRE_TEMPLE_NEAR_BOSS_ROOM,    []{return ctx->GetDungeon(FIRE_TEMPLE)->IsVanilla() && false;}),


### PR DESCRIPTION
## Why

#338: `fire_temple.cpp:1057` placed `RC_FOREST_BOSS_KEY_HINT` — the same check `forest_temple.cpp:831` correctly places — so `RC_FIRE_BOSS_KEY_HINT` existed in the location table but was placed in no region: Fire Temple's boss-key static hint was unreachable, and the Forest hint check was registered twice. Cosmetic severity (static-hint locations are excluded from fill pools, so seed generation was unaffected).

## What

One token: `RC_FOREST_BOSS_KEY_HINT` → `RC_FIRE_BOSS_KEY_HINT` in Fire Temple's boss entryway region. Verified `RC_FIRE_BOSS_KEY_HINT` is fully defined in `randomizerTypes.h`, `location_list.cpp` (SCENE_FIRE_TEMPLE), and `static_data.cpp` (RH_FIRE_BOSS_KEY_HINT → RG_FIRE_TEMPLE_BOSS_KEY).

Closes #338.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SDWdRGxEryXXcAV7bEdfZo

---
_Generated by [Claude Code](https://claude.ai/code/session_01SDWdRGxEryXXcAV7bEdfZo)_

<!--- section:artifacts:start -->
### Build Artifacts
  - [rsbs-windows.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/8393734354.zip)
  - [rsbs-linux.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/8393560904.zip)
<!--- section:artifacts:end -->