### PR TITLE
Registrar-elision monitoring for MM archives; WHOLE_ARCHIVE blocked by port gaps (#341 partial)

### DIFF
--- a/.github/scripts/check-registrar-elision.sh
+++ b/.github/scripts/check-registrar-elision.sh
@@ -60,10 +60,15 @@ check_archive() {
 }
 
 check_archive "$BUILD_DIR/games/oot/libsoh_rando.a"  required
-check_archive "$BUILD_DIR/games/mm/lib2ship_enh.a"   required
-check_archive "$BUILD_DIR/games/mm/lib2ship_rando.a" required
 # Not yet WHOLE_ARCHIVE-wrapped — report drops without failing so the
-# remaining #341 exposure stays visible in every CI run.
+# remaining #341 exposure stays visible in every CI run. The MM archives
+# cannot be wrapped today: force-linking them surfaces ~27 unresolved
+# dependencies (BenGui::BenMenu, CustomMessage, CustomItem, Ship_* utils,
+# UpdateGameTime, HudEditor, ...) — single-exe port gaps that elision
+# currently masks. Promote an archive to `required` above when it gains
+# WHOLE_ARCHIVE in its CMakeLists.
+check_archive "$BUILD_DIR/games/mm/lib2ship_enh.a"   report-only
+check_archive "$BUILD_DIR/games/mm/lib2ship_rando.a" report-only
 check_archive "$BUILD_DIR/games/oot/libsoh_enh.a"    report-only
 
 if [ "$overall" -ne 0 ]; then

--- a/.github/scripts/check-registrar-elision.sh
+++ b/.github/scripts/check-registrar-elision.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+# Post-link guard for #341: translation units whose only effect is a static
+# initializer (RegisterShipInitFunc and friends) are silently dropped by plain
+# archive linking unless something references a symbol they export. This
+# script compares each archive's _GLOBAL__sub_I_* registrar symbols against
+# the linked redship binary and fails when a WHOLE_ARCHIVE-protected archive
+# lost members anyway (a regression in the link setup).
+#
+# Symbol ground truth per the PR #340 investigation: nm, not strings — GCC
+# inlines short std::string constructions, so strings-based checks give false
+# negatives.
+#
+# Usage: check-registrar-elision.sh [build-dir]   (default: build-cmake)
+
+set -uo pipefail
+
+BUILD_DIR="${1:-build-cmake}"
+BIN="$BUILD_DIR/redship"
+
+if [ ! -f "$BIN" ]; then
+    echo "error: $BIN not found (run after the redship link)" >&2
+    exit 2
+fi
+
+BIN_SYMS="$(mktemp)"
+trap 'rm -f "$BIN_SYMS"' EXIT
+nm "$BIN" 2>/dev/null | awk '{print $NF}' | grep '^_GLOBAL__sub_I_' | sort -u > "$BIN_SYMS" || true
+
+overall=0
+
+# check_archive <path> <required|report-only>
+#   required:    any missing registrar fails the build (WHOLE_ARCHIVE-wrapped
+#                archives must be fully present by construction).
+#   report-only: print what is missing without failing — visibility for
+#                archives not yet wrapped (soh_enh, see #341 remaining scope).
+check_archive() {
+    local archive="$1" mode="$2"
+    if [ ! -f "$archive" ]; then
+        if [ "$mode" = "required" ]; then
+            echo "error: required archive $archive not found — build layout changed? Fix the path here rather than losing the guard." >&2
+            overall=1
+        else
+            echo "note: $archive not found, skipping"
+        fi
+        return
+    fi
+    local missing=0 total=0 sym
+    while IFS= read -r sym; do
+        [ -z "$sym" ] && continue
+        total=$((total + 1))
+        if ! grep -qxF "$sym" "$BIN_SYMS"; then
+            echo "  MISSING from redship: $sym"
+            missing=$((missing + 1))
+        fi
+    done < <(nm "$archive" 2>/dev/null | awk '{print $NF}' | grep '^_GLOBAL__sub_I_' | sort -u || true)
+    echo "$archive: $total registrar symbol(s), $missing missing [$mode]"
+    if [ "$missing" -gt 0 ] && [ "$mode" = "required" ]; then
+        overall=1
+    fi
+}
+
+check_archive "$BUILD_DIR/games/oot/libsoh_rando.a"  required
+check_archive "$BUILD_DIR/games/mm/lib2ship_enh.a"   required
+check_archive "$BUILD_DIR/games/mm/lib2ship_rando.a" required
+# Not yet WHOLE_ARCHIVE-wrapped — report drops without failing so the
+# remaining #341 exposure stays visible in every CI run.
+check_archive "$BUILD_DIR/games/oot/libsoh_enh.a"    report-only
+
+if [ "$overall" -ne 0 ]; then
+    echo "FAIL: registrar symbols were elided from a WHOLE_ARCHIVE-protected archive (#341)" >&2
+    exit 1
+fi
+echo "OK: no registrar elision in protected archives"

--- a/.github/workflows/generate-builds.yml
+++ b/.github/workflows/generate-builds.yml
@@ -256,6 +256,11 @@ jobs:
         # mtime+size, so caches survive container image rebuilds (which reset
         # mtimes and otherwise force a full ~20 min recompile).
         CCACHE_COMPILERCHECK: content
+    - name: Check registrar elision (#341)
+      # Self-registering TUs (RegisterShipInitFunc static initializers) must
+      # survive the archive link — plain archive semantics silently drop them
+      # (the PR #340 song-shuffle failure class). nm-based, Linux-only.
+      run: bash .github/scripts/check-registrar-elision.sh build-cmake
     - name: Run tests
       # --no-tests=error: if the "redship" test label ever regresses, fail loudly
       # instead of ctest exiting 0 with "No tests were found".

--- a/games/mm/CMakeLists.txt
+++ b/games/mm/CMakeLists.txt
@@ -320,8 +320,21 @@ if(SINGLE_EXECUTABLE_BUILD)
         target_link_libraries(${_t} PRIVATE redship_common rsbs libultraship ZAPDLib)
     endforeach()
 
-    # Export static targets for root CMakeLists to link into redship
-    set(TWOSHIP_STATIC_TARGETS 2ship_src 2ship_port 2ship_enh 2ship_rando PARENT_SCOPE)
+    # Export static targets for root CMakeLists to link into redship.
+    #
+    # 2ship_enh and 2ship_rando link with WHOLE_ARCHIVE: ~200 of their
+    # translation units register themselves purely through RegisterShipInitFunc
+    # static initializers and export no symbol anything references. With plain
+    # archive semantics the linker drops those members silently — the class of
+    # loss PR #340 fixed for soh_rando (see #341; games/oot/CMakeLists.txt has
+    # the same treatment). Upstream 2S2H links all of these objects directly
+    # into its executable; WHOLE_ARCHIVE restores that behavior for the split
+    # archives. 2ship_src/2ship_port stay plain: their members are reached via
+    # direct symbol references, and resource factories are registered
+    # explicitly in BenPort.cpp.
+    set(TWOSHIP_STATIC_TARGETS 2ship_src 2ship_port
+        "$<LINK_LIBRARY:WHOLE_ARCHIVE,2ship_enh>"
+        "$<LINK_LIBRARY:WHOLE_ARCHIVE,2ship_rando>" PARENT_SCOPE)
 else()
     # Build as SHARED library for dynamic loading
     add_library(${PROJECT_NAME} SHARED ${ALL_FILES})

--- a/games/mm/CMakeLists.txt
+++ b/games/mm/CMakeLists.txt
@@ -322,19 +322,15 @@ if(SINGLE_EXECUTABLE_BUILD)
 
     # Export static targets for root CMakeLists to link into redship.
     #
-    # 2ship_enh and 2ship_rando link with WHOLE_ARCHIVE: ~200 of their
-    # translation units register themselves purely through RegisterShipInitFunc
-    # static initializers and export no symbol anything references. With plain
-    # archive semantics the linker drops those members silently — the class of
-    # loss PR #340 fixed for soh_rando (see #341; games/oot/CMakeLists.txt has
-    # the same treatment). Upstream 2S2H links all of these objects directly
-    # into its executable; WHOLE_ARCHIVE restores that behavior for the split
-    # archives. 2ship_src/2ship_port stay plain: their members are reached via
-    # direct symbol references, and resource factories are registered
-    # explicitly in BenPort.cpp.
-    set(TWOSHIP_STATIC_TARGETS 2ship_src 2ship_port
-        "$<LINK_LIBRARY:WHOLE_ARCHIVE,2ship_enh>"
-        "$<LINK_LIBRARY:WHOLE_ARCHIVE,2ship_rando>" PARENT_SCOPE)
+    # 2ship_enh/2ship_rando deliberately do NOT get the WHOLE_ARCHIVE
+    # treatment soh_rando has (#341): force-linking them surfaces ~27
+    # unresolved dependencies (BenGui::BenMenu + tracker windows, the
+    # CustomMessage system, CustomItem, Ship_Random/Ship_Hash utils,
+    # UpdateGameTime, HudEditor, ...) — subsystems not yet ported into the
+    # single-exe link. Until those port, member elision is what keeps redship
+    # linking; the registrar drops it causes are surfaced (report-only) by
+    # .github/scripts/check-registrar-elision.sh in Linux CI.
+    set(TWOSHIP_STATIC_TARGETS 2ship_src 2ship_port 2ship_enh 2ship_rando PARENT_SCOPE)
 else()
     # Build as SHARED library for dynamic loading
     add_library(${PROJECT_NAME} SHARED ${ALL_FILES})


### PR DESCRIPTION
## Why

#341: TUs whose only effect is a `RegisterShipInitFunc` static initializer are silently dropped by plain archive linking (the class PR #340 fixed for `soh_rando`). This PR set out to wrap `2ship_enh`/`2ship_rando` in WHOLE_ARCHIVE plus add an nm-based CI guard.

## What the first CI run proved (valuable negative result)

Force-linking the MM archives failed the Linux link with **~27 distinct unresolved dependencies** across `BenGui::BenMenu` (+ item/check tracker windows), the entire `CustomMessage` system, `CustomItem::Spawn`, `Ship_Random`/`Ship_Random_Seed`/`Ship_Hash`/`Ship_GetItemColorTint`/`Ship_FormatTimeDisplay`/`Ship_RemoveSpecialCharacters`, `UpdateGameTime`, `HudEditor_OverrideNextElementMode`, `convertEnumToReadableName`, and data tables (`digitList`, `sOwlWarpEntrancesForMods`, `safeItemsForInventorySlot`). These subsystems are not yet ported into the single-exe link — **member elision is currently load-bearing**: it is exactly what keeps `redship` linking while masking those port gaps.

## What ships instead

- **Option C only**: `.github/scripts/check-registrar-elision.sh`, run in `build-linux` right after the link. `soh_rando` (already WHOLE_ARCHIVE on main) is **enforced** — drops or a moved archive path fail CI. `2ship_enh`, `2ship_rando`, and `soh_enh` are **report-only**: every Linux CI run prints exactly how many registrar TUs each archive drops, so the loss is a visible number instead of silence. Promoting an archive to enforced is a one-line change once it gains WHOLE_ARCHIVE.
- CMake comment at the `TWOSHIP_STATIC_TARGETS` export documenting *why* the MM archives are not wrapped and what unblocks it.

Does **not** close #341 — the wrap half is blocked on porting the missing subsystems (or a per-TU forced-inclusion approach). Findings posted to #341.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SDWdRGxEryXXcAV7bEdfZo

<!--- section:artifacts:start -->
### Build Artifacts
  - [rsbs-windows.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/8393826947.zip)
  - [rsbs-linux.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/8393650814.zip)
<!--- section:artifacts:end -->