### PR TITLE
Link soh_enh with WHOLE_ARCHIVE: 171/220 enhancement registrars were elided

### DIFF
--- a/.github/scripts/check-registrar-elision.sh
+++ b/.github/scripts/check-registrar-elision.sh
@@ -60,6 +60,7 @@ check_archive() {
 }
 
 check_archive "$BUILD_DIR/games/oot/libsoh_rando.a"  required
+check_archive "$BUILD_DIR/games/oot/libsoh_enh.a"    required
 # Not yet WHOLE_ARCHIVE-wrapped — report drops without failing so the
 # remaining #341 exposure stays visible in every CI run. The MM archives
 # cannot be wrapped today: force-linking them surfaces ~27 unresolved
@@ -69,7 +70,6 @@ check_archive "$BUILD_DIR/games/oot/libsoh_rando.a"  required
 # WHOLE_ARCHIVE in its CMakeLists.
 check_archive "$BUILD_DIR/games/mm/lib2ship_enh.a"   report-only
 check_archive "$BUILD_DIR/games/mm/lib2ship_rando.a" report-only
-check_archive "$BUILD_DIR/games/oot/libsoh_enh.a"    report-only
 
 if [ "$overall" -ne 0 ]; then
     echo "FAIL: registrar symbols were elided from a WHOLE_ARCHIVE-protected archive (#341)" >&2

--- a/.github/workflows/generate-builds.yml
+++ b/.github/workflows/generate-builds.yml
@@ -266,6 +266,10 @@ jobs:
       # instead of ctest exiting 0 with "No tests were found".
       run: ctest --test-dir build-cmake --output-on-failure --label-regex "^redship$" --no-tests=error
     - name: Run rando seed generation test
+      env:
+        # Name each ShipInit func as it runs so a hang/crash inside one is
+        # attributable from the log alone (see ShipInit.hpp; added for #361).
+        RSBS_TRACE_SHIP_INIT: "1"
       # Generates a real seed with default settings (issue #337). Needs a
       # display for the Fast3dWindow bring-up (hence xvfb-run) but NO game
       # archives, so unlike the int-* tier it can run on hosted runners.

--- a/games/oot/CMakeLists.txt
+++ b/games/oot/CMakeLists.txt
@@ -273,7 +273,16 @@ if(SINGLE_EXECUTABLE_BUILD)
     # messages, and static hints from the shipped binaries on every platform.
     # Upstream SoH links all of these objects directly into its executable;
     # WHOLE_ARCHIVE restores that behavior for the randomizer split.
-    set(SOH_STATIC_TARGETS soh_src soh_port soh_enh "$<LINK_LIBRARY:WHOLE_ARCHIVE,soh_rando>" PARENT_SCOPE)
+    #
+    # soh_enh gets the same treatment (#341): the registrar-elision CI check
+    # measured 171 of its 220 registrar symbols missing from the linked binary
+    # (tts, timesaver hook handlers, ToTMedallions, TreesDropSticks, ...) —
+    # i.e. most self-registering enhancements were silently absent. Unlike the
+    # MM archives (whose deps are unported — see games/mm/CMakeLists.txt),
+    # soh_enh's dependencies are already in the OoT link.
+    set(SOH_STATIC_TARGETS soh_src soh_port
+        "$<LINK_LIBRARY:WHOLE_ARCHIVE,soh_enh>"
+        "$<LINK_LIBRARY:WHOLE_ARCHIVE,soh_rando>" PARENT_SCOPE)
 else()
     # Build as SHARED library for dynamic loading
     add_library(${PROJECT_NAME} SHARED ${ALL_FILES})

--- a/games/oot/soh/Enhancements/Restorations/GraveHoleJumps.cpp
+++ b/games/oot/soh/Enhancements/Restorations/GraveHoleJumps.cpp
@@ -1,5 +1,6 @@
 #include <libultraship/bridge/consolevariablebridge.h>
 #include "soh/Enhancements/game-interactor/GameInteractor_Hooks.h"
+#include "soh/OTRGlobals.h"
 #include "soh/ShipInit.hpp"
 #include "functions.h"
 #include "soh/Enhancements/enhancementTypes.h"
@@ -57,6 +58,15 @@ CollisionHeader* getGraveyardCollisionHeader() {
 }
 
 void ApplyGraveyardGeometryPatches() {
+    // The graveyard scene lives in the game archive. This runs at ShipInit
+    // time (and on CVar change) now that soh_enh is force-linked (#361), and
+    // LoadResource in RSBS's supported no-game-archive boots (#330) blocks
+    // forever — it hung the rando-gen CI tests at 180s. Same gate as
+    // OTRMessage_Init and InitTTSBank; re-runs apply once an archive exists.
+    if (OTRGlobals::Instance == nullptr ||
+        (!OTRGlobals::Instance->HasMasterQuest() && !OTRGlobals::Instance->HasOriginal())) {
+        return;
+    }
     static CollisionHeader* graveyardColHeader = getGraveyardCollisionHeader();
     for (auto& mappingPatch : graveyardGeometryPatches) {
         for (int i = mappingPatch.first.first; i <= mappingPatch.first.second; i++) {

--- a/games/oot/soh/Enhancements/tts/tts.cpp
+++ b/games/oot/soh/Enhancements/tts/tts.cpp
@@ -1124,6 +1124,17 @@ void RegisterOnDialogMessageHook() {
 // MARK: - Main Registration
 
 void InitTTSBank() {
+    // The accessibility text banks live in the game archive. RSBS supports
+    // booting without oot.o2r (#330), and this runs unconditionally at
+    // ShipInit time now that soh_enh is force-linked (#341/#361) — loading
+    // from the empty archive set stalls/faults the boot. Skip like
+    // OTRMessage_Init and the GUI layer do; the OnSetGameLanguage hook
+    // re-runs this once a real archive state exists.
+    if (OTRGlobals::Instance == nullptr ||
+        (!OTRGlobals::Instance->HasMasterQuest() && !OTRGlobals::Instance->HasOriginal())) {
+        return;
+    }
+
     std::string languageSuffix = "_eng.json";
     switch (CVarGetInteger(CVAR_SETTING("Languages"), 0)) {
         case LANGUAGE_FRA:
@@ -1139,23 +1150,18 @@ void InitTTSBank() {
     initData->Type = static_cast<uint32_t>(Ship::ResourceType::Json);
     initData->ResourceVersion = 0;
 
-    sceneMap = std::static_pointer_cast<Ship::Json>(Ship::Context::GetInstance()->GetResourceManager()->LoadResource(
-                                                        "accessibility/texts/scenes" + languageSuffix, true, initData))
-                   ->Data;
+    auto loadBank = [&initData, &languageSuffix](const char* bank) -> nlohmann::json {
+        auto res = std::static_pointer_cast<Ship::Json>(
+            Ship::Context::GetInstance()->GetResourceManager()->LoadResource(
+                std::string("accessibility/texts/") + bank + languageSuffix, true, initData));
+        // Missing bank file: keep the null json rather than dereferencing.
+        return res == nullptr ? nlohmann::json(nullptr) : res->Data;
+    };
 
-    miscMap = std::static_pointer_cast<Ship::Json>(Ship::Context::GetInstance()->GetResourceManager()->LoadResource(
-                                                       "accessibility/texts/misc" + languageSuffix, true, initData))
-                  ->Data;
-
-    kaleidoMap =
-        std::static_pointer_cast<Ship::Json>(Ship::Context::GetInstance()->GetResourceManager()->LoadResource(
-                                                 "accessibility/texts/kaleidoscope" + languageSuffix, true, initData))
-            ->Data;
-
-    fileChooseMap =
-        std::static_pointer_cast<Ship::Json>(Ship::Context::GetInstance()->GetResourceManager()->LoadResource(
-                                                 "accessibility/texts/filechoose" + languageSuffix, true, initData))
-            ->Data;
+    sceneMap = loadBank("scenes");
+    miscMap = loadBank("misc");
+    kaleidoMap = loadBank("kaleidoscope");
+    fileChooseMap = loadBank("filechoose");
 }
 
 void RegisterOnSetGameLanguageHook() {

--- a/games/oot/soh/ShipInit.hpp
+++ b/games/oot/soh/ShipInit.hpp
@@ -3,15 +3,23 @@
 
 #ifdef __cplusplus
 
+#include <cstdio>
+#include <cstdlib>
 #include <string>
 #include <vector>
 #include <set>
+#include <source_location>
 #include <unordered_map>
 #include <functional>
 
+struct ShipInitEntry {
+    std::function<void()> initFunc;
+    std::source_location registeredAt;
+};
+
 struct ShipInit {
-    static std::unordered_map<std::string, std::vector<std::function<void()>>>& GetAll() {
-        static std::unordered_map<std::string, std::vector<std::function<void()>>> shipInitFuncs;
+    static std::unordered_map<std::string, std::vector<ShipInitEntry>>& GetAll() {
+        static std::unordered_map<std::string, std::vector<ShipInitEntry>> shipInitFuncs;
         return shipInitFuncs;
     }
 
@@ -20,9 +28,22 @@ struct ShipInit {
     }
 
     static void Init(const std::string& path) {
+        // RSBS_TRACE_SHIP_INIT=1 names each init func's registration site as
+        // it starts, so a hang or crash inside one is attributable from the
+        // log alone (the #361 rando-gen timeout took a CI cycle to localize
+        // without this).
+        static const bool trace = []() {
+            const char* v = std::getenv("RSBS_TRACE_SHIP_INIT");
+            return v != nullptr && v[0] == '1';
+        }();
         auto& shipInitFuncs = ShipInit::GetAll();
-        for (const auto& initFunc : shipInitFuncs[path]) {
-            initFunc();
+        for (const auto& entry : shipInitFuncs[path]) {
+            if (trace) {
+                fprintf(stderr, "[ShipInit] %s:%u\n", entry.registeredAt.file_name(),
+                        static_cast<unsigned>(entry.registeredAt.line()));
+                fflush(stderr);
+            }
+            entry.initFunc();
         }
     }
 };
@@ -59,13 +80,14 @@ struct ShipInit {
  * you can look for `ShipInit::Init` calls throughout the codebase
  */
 struct RegisterShipInitFunc {
-    RegisterShipInitFunc(std::function<void()> initFunc, const std::set<std::string>& updatePaths = {}) {
+    RegisterShipInitFunc(std::function<void()> initFunc, const std::set<std::string>& updatePaths = {},
+                         const std::source_location loc = std::source_location::current()) {
         auto& shipInitFuncs = ShipInit::GetAll();
 
-        shipInitFuncs["*"].push_back(initFunc);
+        shipInitFuncs["*"].push_back({ initFunc, loc });
 
         for (const auto& path : updatePaths) {
-            shipInitFuncs[path].push_back(initFunc);
+            shipInitFuncs[path].push_back({ initFunc, loc });
         }
     }
 };


### PR DESCRIPTION
## Why

The registrar-elision CI check (#360) measured on its first run against main (`e3112cd9`):

```
build-cmake/games/oot/libsoh_enh.a: 220 registrar symbol(s), 171 missing [report-only]
```

Most of `soh_enh`'s self-registering enhancement TUs — `tts.cpp`, `timesaver_hook_handlers.cpp`, `ToTMedallions.cpp`, `TreesDropSticks.cpp`, `UnrestrictedItems.cpp`, `SpeechLogger.cpp`, `SwitchTimerMultiplier.cpp`, and roughly a hundred more distinct TUs — were silently absent from the shipped Linux binary. Any enhancement wired only through `RegisterShipInitFunc` in those TUs was structurally nonfunctional in `redship`. Same failure class as PR #340's song-shuffle bug.

## What

- `soh_enh` gets `$<LINK_LIBRARY:WHOLE_ARCHIVE,...>`, exactly like `soh_rando` (`games/oot/CMakeLists.txt`), and is promoted to **enforced** in `.github/scripts/check-registrar-elision.sh`.
- **First-run finding + fix:** the link succeeded and all `redship` tests passed, but the three rando-gen tests hung to their 180s timeout — the ~100 newly-active boot initializers include `InitTTSBank()` (`tts.cpp`), which loads four accessibility text banks from the game archive **unconditionally at ShipInit time** and dereferences each result unchecked. In RSBS's supported no-game-archive boots (#330 — and the rando-gen CI env, which has no `soh.o2r`) that stalls the bring-up. Fixed by gating it on the same `HasMasterQuest()/HasOriginal()` check `OTRMessage_Init` and the GUI layer use (the `OnSetGameLanguage` hook re-runs it later), plus null-tolerant bank loads.
- **Diagnosability:** `ShipInit` now records each registrar's `std::source_location` and, with `RSBS_TRACE_SHIP_INIT=1` (enabled for the rando ctest step), names each init func as it starts — the next hang inside one is attributable from the CI log alone.

Second installment of #341 (after #360's monitoring). Remaining after this: the MM archives, blocked on subsystem ports (findings on #341).

Risk note: this intentionally turns ON ~100 OoT enhancements that have been silently disabled in `redship` builds — behavior users have never seen in this port. If any of them proves problematic at runtime, it's individually toggleable via its CVar like upstream SoH.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SDWdRGxEryXXcAV7bEdfZo

<!--- section:artifacts:start -->
### Build Artifacts
  - [rsbs-windows.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/8395534719.zip)
  - [rsbs-linux.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/8395377681.zip)
<!--- section:artifacts:end -->