### PR TITLE
Drain the OTR audio thread before a cross-game switch hot-swaps archives

### DIFF
--- a/games/oot/soh/GameExports_SingleExe.cpp
+++ b/games/oot/soh/GameExports_SingleExe.cpp
@@ -33,6 +33,9 @@ extern "C" {
 
     // Audio cleanup for suspend (issue #160)
     void OoT_Audio_PreNMI(void);
+    // Wait for the OTR audio std::thread to finish any in-flight buffer before
+    // the switch hot-swaps resource archives (OTRGlobals.cpp).
+    void OoT_Audio_DrainForSuspend(void);
     extern s32 gAudioContextInitalized;
     void Audio_InitMesgQueues(void);
 
@@ -311,10 +314,18 @@ void OoT_Game_Suspend(void) {
     // OoT_Audio_PreNMI triggers the audio reset path which stops all sequences
     // and puts the audio system into a quiescent state.
     //
-    // Note: No race with the audio thread here — in the SoH port, the audio
-    // thread is not a real OS thread (osCreateThread is commented out in
-    // audioMgr.c). Audio is processed synchronously from the game loop, which
-    // has already returned from Main() before suspend is called.
+    // FIRST drain the OTR audio thread. It IS a real std::thread
+    // (OTRGlobals.cpp OTRAudio_Init: audio.thread = std::thread(OTRAudio_Thread)),
+    // NOT the commented-out N64 audioMgr thread — an earlier note here wrongly
+    // claimed audio was synchronous. While it is mid-buffer it can load
+    // sequences/soundfonts through the shared ResourceManager, so the switch's
+    // archive hot-swap that follows suspend must not free a resource it is
+    // using (that use-after-free corrupts the process heap and later faults in
+    // RtlAllocateHeap). Wait for the in-flight buffer to finish before PreNMI.
+    fprintf(stderr, "[OoT] Draining audio thread before suspend...\n");
+    fflush(stderr);
+    OoT_Audio_DrainForSuspend();
+
     fprintf(stderr, "[OoT] Stopping audio via PreNMI path...\n");
     fflush(stderr);
     OoT_Audio_PreNMI();

--- a/games/oot/soh/OTRGlobals.cpp
+++ b/games/oot/soh/OTRGlobals.cpp
@@ -1181,6 +1181,29 @@ void OTRAudio_Init() {
     }
 }
 
+// Wait for any in-flight audio buffer to finish before a cross-game switch
+// hot-swaps resource archives (#160/#170 switch path). OTRAudio_Thread is a
+// REAL std::thread; while audio.processing is set it runs
+// OoT_AudioMgr_CreateNextAudioBuffer, whose sequence/soundfont load path
+// allocates on the SHARED process heap / ResourceManager. If it is mid-load
+// when the switch replaces the ResourceManager factories, the freed resource
+// is a use-after-free -> heap-metadata corruption. Draining here (same
+// primitives as the per-frame wait in Graph_ProcessGfxCommands) closes that
+// race. Called from OoT_Game_Suspend BEFORE the archive hot-swap. Safe to call
+// from the switch/main thread: it only waits, and returns immediately when no
+// buffer is in flight (or when the audio thread was never started).
+extern "C" void OoT_Audio_DrainForSuspend(void) {
+    std::unique_lock<std::mutex> Lock(audio.mutex);
+    bool waited = audio.processing;
+    while (audio.processing) {
+        audio.cv_from_thread.wait(Lock);
+    }
+    if (waited) {
+        fprintf(stderr, "[OoT] Audio thread drained before suspend (buffer was in flight)\n");
+        fflush(stderr);
+    }
+}
+
 // C->C++ Bridge
 extern "C" char** sequenceMap;
 extern "C" size_t sequenceMapSize;


### PR DESCRIPTION
## Why

Leading fix for the OoT→MM switch crash that still reproduces on the #361 build (`942dfae`): `0xc0000005` inside ntdll `RtlAllocateHeap`, `RDX` = an encoded/clobbered heap free-list cookie, GFX stack in MM `graph.c`. A 5-agent adversarial investigation (with independent verification of every load-bearing fact) established:

- **The crash is heap-metadata corruption** on the shared Windows process heap — an *earlier* use-after-free/overflow that detonates later on an innocent allocation. It is **not** the original entrance-table OOB read; #356/#357 changed the outcome.
- **There is no entrance leak.** The `Cutscene_HandleConditionalTriggers: entrance: 49168` log line is **MM's own** `func_800EDDB0` (`games/mm/src/code/z_demo.c:1604`, `%d` decimal) reading MM's `gSaveContext.save.entrance = 0xC010` = Clock Tower Interior — the correct switch destination. OoT's real function logs `entranceIndex: %#x` (hex). `gSaveContext` is a single shared buffer (`src/common/unified_save.c:43`), so OoT and MM alias the same bytes; #356's game-affinity is correctly applied on every live consumer path.
- **#361 is a heap-layout trigger, not the corruptor** — it force-ran ~171 previously-elided static constructors at boot, shifting the heap so a latent bug now lands on live metadata. Do not revert it.

## What

Root-cause candidate (verified mechanism): `OTRAudio_Thread` is a **real `std::thread`** (`OTRGlobals.cpp` `OTRAudio_Init`), started at OoT boot and **never drained or joined at suspend**. While `audio.processing` is set it runs `OoT_AudioMgr_CreateNextAudioBuffer`, whose sequence/soundfont load path allocates on the **shared** ResourceManager / process heap — matching the dump's `RtlCreateUnicodeString`/`RtlAllocateHeap` frames. `OoT_Game_Suspend` only calls `PreNMI` + clears a flag, and its comment claiming the audio thread *"is not a real OS thread … processed synchronously"* is **false**. So the switch's archive hot-swap (`"Replacing resource factory"`) can free a resource the audio thread is mid-load of → UAF → heap corruption.

- New `OoT_Audio_DrainForSuspend()` (`OTRGlobals.cpp`) waits for any in-flight audio buffer to finish, reusing the same `audio.mutex`/`cv_from_thread` primitives as the existing per-frame drain.
- Called from `OoT_Game_Suspend` **before** the caller hot-swaps archives; corrects the false comment. Contained and reversible, in the style of #353/#356/#357.

## Confidence (honest)

**Medium** that this is *the* corruptor; **high** that it's correct hardening regardless — an un-joined audio thread racing the shared ResourceManager across an archive swap is a genuine bug. The decisive confirmation is a runtime **Windows PageHeap / Application Verifier** run on the exact switch (`gflags -p /enable redship.exe /full`), which traps the corrupting write at its origin. The runner-up hypothesis is a main-thread UAF inside the hot-swap itself. If a crash still reproduces, the new `[OoT] Draining audio thread…` / `…drained (buffer was in flight)` log lines (and whether they appear) localize the next corruptor.

## Separate real bugs surfaced (not this crash — filing follow-ups)

- `OOT_SAVE_CONTEXT_SIZE` is defined twice with different values (`src/common/game.h:32` = `0x1428` vs `unified_save.c:30` = `0x22000`); OoT's real SaveContext is ~`0x21C30`, so freeze/restore silently truncates ~133 KB of OoT state each round-trip (clamped both sides — a correctness bug, not the corruptor).
- `games/mm/2s2h/z_scene_2SH.cpp` `MM_Scene_CommandObjectList` dropped the vanilla `i < ARRAY_COUNT(slots)-1` bound → latent `slots[35]` overflow for scenes with >35 objects (not Clock Tower).
- `GraveHoleJumps.cpp` caches a resource-derived `CollisionHeader*` in a function-static across archive swaps → latent UAF on graveyard re-entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SDWdRGxEryXXcAV7bEdfZo

---
_Generated by [Claude Code](https://claude.ai/code/session_01SDWdRGxEryXXcAV7bEdfZo)_

<!--- section:artifacts:start -->
### Build Artifacts
  - [rsbs-windows.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/8417742494.zip)
  - [rsbs-linux.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/8417514601.zip)
<!--- section:artifacts:end -->