### PR TITLE
Fix three save/memory bugs: SaveContext truncation, MM object-list overflow, GraveHoleJumps UAF

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,7 +55,7 @@ Naming:
 **Game lifecycle** (`src/common/game_lifecycle.h`):
 `Game_Init` → `Game_Run` → `Game_Suspend`/`Game_Resume` → `Game_Shutdown`
 
-**Cross-game state**: `Context_FreezeState` / `Context_RestoreState` (`src/common/context.h`) preserve SaveContexts across game switches. OoT SaveContext = 5160B, MM SaveContext = 18632B — both kept in memory.
+**Cross-game state**: `Context_FreezeState` / `Context_RestoreState` (`src/common/context.h`) preserve SaveContexts across game switches. Blob capacities come from `src/common/game.h` (`OOT_SAVE_CONTEXT_SIZE` 0x22000, `MM_SAVE_CONTEXT_SIZE` 0x10000 — the ports' runtime structs are far larger than the N64 sizes); each game's `GameExports_SingleExe.cpp` static-asserts `sizeof(SaveContext)` fits. Both shadows are kept in memory.
 
 **MM stubs**: `src/common/mm_stubs.c` has stubs for MM functions not yet ported to single-exe mode. When working on MM integration, check this file for functions that may need real implementations.
 

--- a/CMake/SingleExecutable.cmake
+++ b/CMake/SingleExecutable.cmake
@@ -229,6 +229,7 @@ if(BUILD_TESTING)
     add_test(NAME SaveHasDelete COMMAND redship --test save-has-delete)
     add_test(NAME SaveVersionReject COMMAND redship --test save-version-reject)
     add_test(NAME SaveSizeMismatch COMMAND redship --test save-size-mismatch)
+    add_test(NAME SaveLegacySize COMMAND redship --test save-legacy-size)
     add_test(NAME SaveCrcCorrupt COMMAND redship --test save-crc-corrupt)
     add_test(NAME Context COMMAND redship --test context)
     # MM scene-command parse + execute regressions — display-free, no ROM
@@ -242,7 +243,7 @@ if(BUILD_TESTING)
     set(REDSHIP_TEST_TIMEOUT 60 CACHE STRING "Test timeout in seconds")
     set_tests_properties(
         BootOoT BootMM SwitchOoTMM SwitchMMOoT StartupEntrance Roundtrip RoundtripIntegrity SharedRoundtrip ArchiveHotswapLogic
-        SaveRoundtripTiers SaveHeader SaveHasDelete SaveVersionReject SaveSizeMismatch SaveCrcCorrupt
+        SaveRoundtripTiers SaveHeader SaveHasDelete SaveVersionReject SaveSizeMismatch SaveLegacySize SaveCrcCorrupt
         Context MMSceneParse MMSceneExecute AllTests
         PROPERTIES
         TIMEOUT ${REDSHIP_TEST_TIMEOUT}

--- a/docs/phase2-T6-unified-save-plan.md
+++ b/docs/phase2-T6-unified-save-plan.md
@@ -43,6 +43,13 @@ Add a host-side `SaveManager` (in `src/common/save.{h,cpp}`) that writes one bin
 
 ### 3.1 Size-conflict resolution (DO THIS FIRST — blocks everything)
 
+> **RESOLVED.** `src/common/game.h` is now the single source of truth: `OOT_SAVE_CONTEXT_SIZE` (0x22000) and
+> `MM_SAVE_CONTEXT_SIZE` (0x10000) are blob *capacities* covering the ports' full runtime SaveContexts (SoH ~0x21C30,
+> 2S2H ~0xC000), `unified_save.c` includes `game.h` instead of redefining, and each game's `GameExports_SingleExe.cpp`
+> static-asserts `sizeof(SaveContext) <= *_SAVE_CONTEXT_SIZE`. The `.redsave` loader reads the header's stored tier
+> sizes and zero-extends shorter (pre-fix) blobs. The truncation bug predicted below was real: freeze/restore clamped
+> OoT to the N64 0x1428 and dropped all SoH `ship.*` state (and MM's 2S2H extension likewise) on every switch.
+
 `game.h` says OoT save is `0x1428`; `unified_save.c` allocates `0x22000`. SoH's *runtime* `gSaveContext` is the larger SoH struct (extra `ship.*`). The N64 `// size = 0x1428` comment refers to the original sub-struct, not SoH's full object.
 
 **Resolution:**

--- a/games/mm/2s2h/GameExports_SingleExe.cpp
+++ b/games/mm/2s2h/GameExports_SingleExe.cpp
@@ -104,6 +104,16 @@ extern "C" {
 
 }
 
+// The cross-game shadow buffers and unified gSaveContext storage are sized at
+// MM_SAVE_CONTEXT_SIZE (src/common/game.h), which src/common code cannot
+// derive from sizeof(SaveContext) because it never includes MM's z64save.h.
+// This TU can, so it enforces the capacity here: if 2S2H's shipSaveInfo /
+// rando tables grow past the capacity, the build fails instead of
+// freeze/restore silently truncating MM save state on every cross-game switch.
+static_assert(sizeof(SaveContext) <= MM_SAVE_CONTEXT_SIZE,
+              "MM_SAVE_CONTEXT_SIZE (src/common/game.h) is smaller than 2S2H's runtime SaveContext; "
+              "raise the capacity or cross-game freeze/restore will truncate save state");
+
 // Archive hot-swap cycle helpers (#263). Defined in
 // src/common/tests/test_archive_hotswap.c (compiled into redship_common via
 // test_runner.cpp); resolved at final link. Record this MM arrival, query the

--- a/games/mm/2s2h/z_scene_2SH.cpp
+++ b/games/mm/2s2h/z_scene_2SH.cpp
@@ -175,13 +175,24 @@ void MM_Scene_CommandObjectList(PlayState* play, S2H::ISceneCommand* cmd) {
     s32 i;
     s32 j;
     s32 k;
+    s32 numObjects;
+    s32 maxObjects;
 
     // #region 2S2H [Port] Cleaner version of decomps loops for nicer presentation
+
+    // Clamp the object count to the available slots so oversized scenes cannot overflow the slots array
+    numObjects = (s32)objList->objects.size();
+    maxObjects = ARRAY_COUNT(play->objectCtx.slots) - play->objectCtx.numPersistentEntries;
+    if (numObjects > maxObjects) {
+        osSyncPrintf("Scene object list has %d entries but only %d slots are available; ignoring the excess\n",
+                     numObjects, maxObjects);
+        numObjects = maxObjects;
+    }
 
     // Loop until a mismatch in the object lists
     // Then clear all object ids past that in the context object list and kill actors for those objects
     for (i = play->objectCtx.numPersistentEntries, k = 0; i < play->objectCtx.numEntries; i++, k++) {
-        if (k >= objList->objects.size() || play->objectCtx.slots[i].id != objList->objects[k]) {
+        if (k >= numObjects || play->objectCtx.slots[i].id != objList->objects[k]) {
             for (j = i; j < play->objectCtx.numEntries; j++) {
                 play->objectCtx.slots[j].id = 0;
             }
@@ -191,7 +202,7 @@ void MM_Scene_CommandObjectList(PlayState* play, S2H::ISceneCommand* cmd) {
     }
 
     // Continuing from the last index, add the remaining object ids from the command object list
-    for (; k < objList->objects.size(); i++, k++) {
+    for (; k < numObjects; i++, k++) {
         play->objectCtx.slots[i].id = -objList->objects[k];
     }
 

--- a/games/mm/src/code/z_scene.c
+++ b/games/mm/src/code/z_scene.c
@@ -284,6 +284,8 @@ void MM_Scene_CommandObjectList(PlayState* play, SceneCmd* cmd) {
     s32 i;
     s32 j;
     s32 k;
+    s32 numObjects;
+    s32 maxObjects;
     ObjectEntry* firstObject;
     ObjectEntry* entry;
     ObjectEntry* invalidatedEntry;
@@ -295,6 +297,15 @@ void MM_Scene_CommandObjectList(PlayState* play, SceneCmd* cmd) {
     i = play->objectCtx.numPersistentEntries;
     entry = &play->objectCtx.slots[i];
     firstObject = &play->objectCtx.slots[0];
+
+    // Clamp the object count to the available slots so oversized scenes cannot overflow the slots array
+    numObjects = cmd->objectList.num;
+    maxObjects = ARRAY_COUNT(play->objectCtx.slots) - play->objectCtx.numPersistentEntries;
+    if (numObjects > maxObjects) {
+        osSyncPrintf("Scene object list has %d entries but only %d slots are available; ignoring the excess\n",
+                     numObjects, maxObjects);
+        numObjects = maxObjects;
+    }
 
     while (i < play->objectCtx.numEntries) {
         if (entry->id != *objectEntry) {
@@ -317,7 +328,7 @@ void MM_Scene_CommandObjectList(PlayState* play, SceneCmd* cmd) {
         entry++;
     }
 
-    while (k < cmd->objectList.num) {
+    while (k < numObjects) {
         nextPtr = func_8012F73C(&play->objectCtx, i, *objectEntry);
 
         if (i < ARRAY_COUNT(play->objectCtx.slots) - 1) {

--- a/games/oot/soh/Enhancements/Restorations/GraveHoleJumps.cpp
+++ b/games/oot/soh/Enhancements/Restorations/GraveHoleJumps.cpp
@@ -49,10 +49,12 @@ CollisionHeader* getGraveyardCollisionHeader() {
      * are shifted somewhat between versions, so to be safe we just create an extra slot that is not in any version.
      */
     static SurfaceType newSurfaceTypes[33];
-    memcpy(newSurfaceTypes, graveyardColHeader->surfaceTypeList, sizeof(SurfaceType) * surfaceTypesCount);
-    newSurfaceTypes[CUSTOM_SURFACE_TYPE].data[0] = 0x24000004;
-    newSurfaceTypes[CUSTOM_SURFACE_TYPE].data[1] = 0xFC8;
-    graveyardColHeader->surfaceTypeList = newSurfaceTypes;
+    if (graveyardColHeader->surfaceTypeList != newSurfaceTypes) {
+        memcpy(newSurfaceTypes, graveyardColHeader->surfaceTypeList, sizeof(SurfaceType) * surfaceTypesCount);
+        newSurfaceTypes[CUSTOM_SURFACE_TYPE].data[0] = 0x24000004;
+        newSurfaceTypes[CUSTOM_SURFACE_TYPE].data[1] = 0xFC8;
+        graveyardColHeader->surfaceTypeList = newSurfaceTypes;
+    }
 
     return graveyardColHeader;
 }
@@ -67,7 +69,13 @@ void ApplyGraveyardGeometryPatches() {
         (!OTRGlobals::Instance->HasMasterQuest() && !OTRGlobals::Instance->HasOriginal())) {
         return;
     }
-    static CollisionHeader* graveyardColHeader = getGraveyardCollisionHeader();
+    // Re-fetch the collision header on every run instead of caching it in a static. The graveyard scene
+    // lives in oot.o2r, which is hot-swapped on cross-game switches (OoT archives are unloaded when
+    // switching to MM and re-added on the way back, see EnsureGameArchivesLoaded in rsbs/src/main.cpp).
+    // A cached pointer into the old resource dangles after that swap, so writing through it on the next
+    // ShipInit/CVar-change re-run was a use-after-free. LoadResource is a cache hit while the resource
+    // is loaded, so re-fetching is cheap, and it also re-applies the patch to a freshly reloaded scene.
+    CollisionHeader* graveyardColHeader = getGraveyardCollisionHeader();
     for (auto& mappingPatch : graveyardGeometryPatches) {
         for (int i = mappingPatch.first.first; i <= mappingPatch.first.second; i++) {
             CollisionPoly* poly = &graveyardColHeader->polyList[i];

--- a/games/oot/soh/GameExports_SingleExe.cpp
+++ b/games/oot/soh/GameExports_SingleExe.cpp
@@ -44,6 +44,16 @@ extern "C" {
     extern SaveContext gSaveContext;
 }
 
+// The cross-game shadow buffers and unified gSaveContext storage are sized at
+// OOT_SAVE_CONTEXT_SIZE (src/common/game.h), which src/common code cannot
+// derive from sizeof(SaveContext) because it never includes z64save.h. This TU
+// can, so it enforces the capacity here: if SoH's ship.* extension grows past
+// the capacity, the build fails instead of freeze/restore silently truncating
+// OoT save state on every cross-game switch.
+static_assert(sizeof(SaveContext) <= OOT_SAVE_CONTEXT_SIZE,
+              "OOT_SAVE_CONTEXT_SIZE (src/common/game.h) is smaller than SoH's runtime SaveContext; "
+              "raise the capacity or cross-game freeze/restore will truncate save state");
+
 // Archive hot-swap cycle helpers (#263). Defined in
 // src/common/tests/test_archive_hotswap.c (compiled into redship_common via
 // test_runner.cpp); resolved at final link. Record this OoT arrival, query the
@@ -516,9 +526,11 @@ extern "C" uint16_t Combo_CheckEntranceSwitch(uint16_t entranceIndex) {
                 gameId, entranceIndex);
 
         uint16_t returnEntrance = Combo_GetSwitchReturnEntrance();
-        // sizeof(gSaveContext) in this TU is OoT's SaveContext layout, but the
-        // underlying unified storage is identical regardless of caller and
-        // Context_FreezeState clamps to the per-game N64 size anyway.
+        // sizeof(gSaveContext) in this TU is OoT's SaveContext layout. When MM
+        // is the active game this over-reads relative to MM's smaller struct,
+        // but the underlying unified storage (unified_save.c) is
+        // OOT_SAVE_CONTEXT_SIZE for both games, so the read stays in bounds
+        // and Context_FreezeState clamps to the per-game blob capacity.
         Combo_FreezeState(gameId, returnEntrance, &gSaveContext, sizeof(gSaveContext));
         Combo_SignalReadyToSwitch();
     }

--- a/src/common/context.cpp
+++ b/src/common/context.cpp
@@ -51,6 +51,15 @@ public:
         mInitialized = true;
     }
 
+    // The shadow buffers are sized at the *_SAVE_CONTEXT_SIZE capacities from
+    // game.h, which are asserted (in each game's GameExports_SingleExe.cpp) to
+    // be >= that game's real sizeof(SaveContext). Callers pass
+    // sizeof(gSaveContext) as seen by their own TU, so the min() below only
+    // ever trims a caller that claims MORE than the capacity — it must never
+    // trim real save data (that was the pre-fix truncation bug: the OoT
+    // capacity was the N64 0x1428, and every freeze dropped SoH's ship.*
+    // state). The tail beyond `size` is zeroed so the blob is deterministic
+    // for serialization/CRC regardless of what was frozen before.
     void FreezeState(GameId game, uint16_t returnEntrance,
                      const void* saveContextData, size_t size) {
         if (!mInitialized) Initialize();
@@ -67,6 +76,7 @@ public:
         }
 
         std::memcpy(state.saveContext.data(), saveContextData, size);
+        std::memset(state.saveContext.data() + size, 0, expectedSize - size);
         state.returnEntrance = returnEntrance;
         state.hasBeenFrozen = true;
     }
@@ -141,6 +151,10 @@ public:
             state.saveContext.resize(expectedSize, 0);
         }
 
+        // Unlike FreezeState, do NOT zero the tail: callers legitimately push
+        // partial updates (MM's SaveManager mirrors just the Save substruct at
+        // offset 0), relying on the rest of the shadow keeping the last full
+        // snapshot's bytes.
         std::memcpy(state.saveContext.data(), saveContextData, size);
     }
 

--- a/src/common/game.h
+++ b/src/common/game.h
@@ -26,11 +26,27 @@ typedef enum {
     GAME_MM = 2     // Majora's Mask
 } GameId;
 
-// SaveContext sizes from the game headers
-// OoT: z64save.h line 354: size = 0x1428
-// MM:  z64save.h line 527: size = 0x48C8
-#define OOT_SAVE_CONTEXT_SIZE 0x1428  // 5160 bytes
-#define MM_SAVE_CONTEXT_SIZE  0x48C8  // 18632 bytes
+// SaveContext blob capacities — the SINGLE source of truth for every buffer
+// that holds a full runtime SaveContext image (context.cpp shadow copies,
+// unified_save.c storage, the .redsave tiers, and the headless tests).
+//
+// These are CAPACITIES, not exact struct sizes. Each port's runtime
+// SaveContext is much larger than the original N64 struct the "// size ="
+// comments in z64save.h describe:
+//   OoT: N64 struct 0x1428, but SoH appends ShipSaveContextData (SohStats
+//        with sceneTimestamps[8191], ...) — sizeof(SaveContext) ~= 0x21C30.
+//   MM:  N64 struct 0x48C8, but 2S2H appends ShipSaveInfo (rando check
+//        tables, ...) and ShipSaveContext — sizeof(SaveContext) ~= 0xC000.
+// Those extension sections grow as the upstream ports evolve, so the exact
+// sizeof cannot be hardcoded here (this header must stay free of game
+// includes). Instead each capacity carries headroom, and a static_assert in a
+// TU that CAN see the real struct (games/oot/soh/GameExports_SingleExe.cpp,
+// games/mm/2s2h/GameExports_SingleExe.cpp) verifies
+// sizeof(SaveContext) <= *_SAVE_CONTEXT_SIZE so drift fails the build loudly
+// instead of silently truncating cross-game save state (issue: freeze/restore
+// used to clamp OoT to 0x1428, losing all SoH ship.* state per switch).
+#define OOT_SAVE_CONTEXT_SIZE 0x22000  // ~136KB capacity (SoH runtime struct ~0x21C30)
+#define MM_SAVE_CONTEXT_SIZE  0x10000  // 64KB capacity (2S2H runtime struct ~0xC000)
 
 /**
  * Convert game ID string to enum

--- a/src/common/save.cpp
+++ b/src/common/save.cpp
@@ -23,10 +23,11 @@ namespace rsbs {
 
 namespace {
 
-// Tier sizes as this build understands them. A loaded file must match these
-// exactly (guarded in Load); the constants come from game.h, which is also what
-// the context-layer shadow buffers are sized at, so reading the shadows here is
-// always in-bounds.
+// Tier sizes as this build writes them. The game-tier constants are the blob
+// CAPACITIES from game.h — the same values the context-layer shadow buffers
+// are allocated at, so reading the shadows here is always in-bounds. On Load
+// the header's stored sizes drive the reads instead: older files with shorter
+// game tiers are accepted and zero-extended (see DeserializeHeader).
 constexpr uint32_t kComboSize = static_cast<uint32_t>(sizeof(ComboContext));
 constexpr uint32_t kOoTSize = static_cast<uint32_t>(OOT_SAVE_CONTEXT_SIZE);
 constexpr uint32_t kMMSize = static_cast<uint32_t>(MM_SAVE_CONTEXT_SIZE);
@@ -153,9 +154,18 @@ bool SaveManager::DeserializeHeader(std::istream& in, RsbsSaveHeader& outHeader)
     if (h.headerSize != sizeof(RsbsSaveHeader)) {
         return false;
     }
-    // Tier sizes must match this build exactly; a mismatch means the struct
-    // layout changed, so the blobs are not safe to memcpy back.
-    if (h.comboSize != kComboSize || h.ootSize != kOoTSize || h.mmSize != kMMSize) {
+    // Tier-1 must match exactly: ComboContext has no capacity headroom, and a
+    // different size means a different struct layout.
+    if (h.comboSize != kComboSize) {
+        return false;
+    }
+    // Game tiers are size-field-driven: a STORED size smaller than this
+    // build's blob capacity is a file from an older build (e.g. the OoT tier
+    // was the N64 0x1428 before the capacity covered SoH's full runtime
+    // struct) — its bytes are a prefix of the same layout, so Load accepts it
+    // and zero-extends. Larger than capacity means a newer/foreign layout that
+    // cannot fit the shadow buffers: refuse rather than truncate.
+    if (h.ootSize == 0 || h.ootSize > kOoTSize || h.mmSize == 0 || h.mmSize > kMMSize) {
         return false;
     }
 
@@ -180,31 +190,34 @@ bool SaveManager::Load(int slot) {
 
     // Read the whole payload into locals FIRST and validate everything before
     // committing — a bad file (short read, CRC mismatch, bad inner magic) must
-    // not clobber live state.
+    // not clobber live state. Reads are driven by the header's STORED tier
+    // sizes; the blobs are allocated at full capacity and zero-filled so a
+    // shorter tier from an older build is zero-extended.
     ComboContext combo;
-    std::vector<uint8_t> ootBlob(kOoTSize);
-    std::vector<uint8_t> mmBlob(kMMSize);
+    std::vector<uint8_t> ootBlob(kOoTSize, 0);
+    std::vector<uint8_t> mmBlob(kMMSize, 0);
 
     in.read(reinterpret_cast<char*>(&combo), kComboSize);
     if (!in || in.gcount() != static_cast<std::streamsize>(kComboSize)) {
         return false;
     }
-    in.read(reinterpret_cast<char*>(ootBlob.data()), kOoTSize);
-    if (!in || in.gcount() != static_cast<std::streamsize>(kOoTSize)) {
+    in.read(reinterpret_cast<char*>(ootBlob.data()), header.ootSize);
+    if (!in || in.gcount() != static_cast<std::streamsize>(header.ootSize)) {
         return false;
     }
-    in.read(reinterpret_cast<char*>(mmBlob.data()), kMMSize);
-    if (!in || in.gcount() != static_cast<std::streamsize>(kMMSize)) {
+    in.read(reinterpret_cast<char*>(mmBlob.data()), header.mmSize);
+    if (!in || in.gcount() != static_cast<std::streamsize>(header.mmSize)) {
         return false;
     }
 
-    // CRC over Tiers 1..3, in the same contiguous order they were written.
+    // CRC over Tiers 1..3 exactly as stored (not the zero-extended tails), in
+    // the same contiguous order they were written.
     std::vector<uint8_t> payload;
-    payload.reserve(kComboSize + kOoTSize + kMMSize);
+    payload.reserve(kComboSize + header.ootSize + header.mmSize);
     const uint8_t* comboBytes = reinterpret_cast<const uint8_t*>(&combo);
     payload.insert(payload.end(), comboBytes, comboBytes + kComboSize);
-    payload.insert(payload.end(), ootBlob.begin(), ootBlob.end());
-    payload.insert(payload.end(), mmBlob.begin(), mmBlob.end());
+    payload.insert(payload.end(), ootBlob.begin(), ootBlob.begin() + header.ootSize);
+    payload.insert(payload.end(), mmBlob.begin(), mmBlob.begin() + header.mmSize);
     if (Crc32(payload.data(), payload.size()) != header.crc32) {
         return false;
     }
@@ -331,9 +344,10 @@ SlotMeta SaveManager::ReadMeta(int slot) const {
     meta.valid = true;
     meta.slot = header.slot;
 
-    // Read Tier-1 (ComboContext) and just enough of Tier-2 / Tier-3 to pull
-    // the registered metadata bytes. We deliberately do NOT CRC the file here:
-    // ReadMeta is called for every slot every menu frame, and CRC over ~24KB
+    // Read Tier-1 (ComboContext) and the game tiers at their STORED sizes to
+    // pull the registered metadata bytes (offsets past a shorter legacy blob
+    // simply read as "absent"). We deliberately do NOT CRC the file here:
+    // ReadMeta is called for every slot every menu frame, and CRC over ~200KB
     // each time would dominate the file-select draw. Load() still CRC-checks
     // when the user actually picks a slot.
     ComboContext combo;
@@ -346,15 +360,15 @@ SlotMeta SaveManager::ReadMeta(int slot) const {
         meta.lastGame = combo.sourceGame;
     }
 
-    std::vector<uint8_t> ootBlob(kOoTSize);
-    in.read(reinterpret_cast<char*>(ootBlob.data()), kOoTSize);
-    if (!in || in.gcount() != static_cast<std::streamsize>(kOoTSize)) {
+    std::vector<uint8_t> ootBlob(header.ootSize);
+    in.read(reinterpret_cast<char*>(ootBlob.data()), header.ootSize);
+    if (!in || in.gcount() != static_cast<std::streamsize>(header.ootSize)) {
         meta.valid = false;
         return meta;
     }
-    std::vector<uint8_t> mmBlob(kMMSize);
-    in.read(reinterpret_cast<char*>(mmBlob.data()), kMMSize);
-    if (!in || in.gcount() != static_cast<std::streamsize>(kMMSize)) {
+    std::vector<uint8_t> mmBlob(header.mmSize);
+    in.read(reinterpret_cast<char*>(mmBlob.data()), header.mmSize);
+    if (!in || in.gcount() != static_cast<std::streamsize>(header.mmSize)) {
         meta.valid = false;
         return meta;
     }

--- a/src/common/save.h
+++ b/src/common/save.h
@@ -6,8 +6,8 @@
  * A `.redsave` file holds, in one slot, three tiers:
  *   Tier 0  RsbsSaveHeader   (fixed 32 bytes: magic, version, slot, sizes, crc)
  *   Tier 1  ComboContext     (cross-game flags / shared items / last game)
- *   Tier 2  OoT SaveContext  (OOT_SAVE_CONTEXT_SIZE bytes)
- *   Tier 3  MM  SaveContext  (MM_SAVE_CONTEXT_SIZE bytes)
+ *   Tier 2  OoT SaveContext  (header.ootSize bytes; OOT_SAVE_CONTEXT_SIZE when written by this build)
+ *   Tier 3  MM  SaveContext  (header.mmSize bytes; MM_SAVE_CONTEXT_SIZE when written by this build)
  *
  * This is the HEADLESS CORE: the format, the SaveManager, and round-trip /
  * validation unit tests. It serializes the cross-game shadow copies that the
@@ -21,10 +21,13 @@
  * - Little-endian, host-native. Both shipped targets are LE (x86-64 / arm64);
  *   the header records endian=1 and Load asserts it so a future big-endian port
  *   fails loudly instead of silently corrupting.
- * - A `.redsave` is tied to the SaveContext struct sizes of the build that
- *   wrote it: the header stores each tier's byte length and Load rejects a file
- *   whose tier sizes or version do not match the current build (fail-safe, no
- *   partial load) rather than memcpy-ing a mismatched blob.
+ * - The header stores each tier's byte length, so the file is self-describing:
+ *   Load reads the STORED sizes, not this build's constants. A game tier that
+ *   is shorter than the current blob capacity (a file written by an older
+ *   build, e.g. before the OoT tier grew from the N64 0x1428 to the full SoH
+ *   runtime size) is accepted and zero-extended to capacity; a tier LARGER
+ *   than this build's capacity, an unknown version, or a comboSize that does
+ *   not match sizeof(ComboContext) is rejected (fail-safe, no partial load).
  */
 
 #ifndef RSBS_COMMON_SAVE_H
@@ -68,7 +71,7 @@ namespace rsbs {
 /**
  * Per-slot summary, cheap to compute (one header read + a handful of byte
  * pulls). Built so the unified file-select panel can render a slot without
- * loading + committing the whole 24KB payload. `valid` is true iff the header
+ * loading + committing the whole ~200KB payload. `valid` is true iff the header
  * passes every check Load() does, EXCLUDING CRC — slot listing must stay fast,
  * and a bad CRC will still be caught when the user actually clicks Load.
  */
@@ -97,8 +100,8 @@ struct RsbsSaveHeader {
     uint8_t  slot;        // 0..RSBS_SAVE_MAX_SLOTS-1
     uint16_t headerSize;  // sizeof(RsbsSaveHeader) == 32 (forward-compat probe)
     uint32_t comboSize;   // Tier-1 bytes == sizeof(ComboContext)
-    uint32_t ootSize;     // Tier-2 bytes == OOT_SAVE_CONTEXT_SIZE at write time
-    uint32_t mmSize;      // Tier-3 bytes == MM_SAVE_CONTEXT_SIZE at write time
+    uint32_t ootSize;     // Tier-2 bytes as stored (== OOT_SAVE_CONTEXT_SIZE at write time)
+    uint32_t mmSize;      // Tier-3 bytes as stored (== MM_SAVE_CONTEXT_SIZE at write time)
     uint32_t crc32;       // CRC32 over Tiers 1..3 (the payload after the header)
 };
 #pragma pack(pop)
@@ -152,9 +155,11 @@ public:
 private:
     SaveManager() = default;
 
-    // Validates magic / version / endian / headerSize / tier sizes against the
-    // current build. Returns true and fills outHeader only on a fully valid
-    // header; never mutates live state.
+    // Validates magic / version / endian / headerSize, that comboSize matches
+    // this build's ComboContext, and that the stored game-tier sizes fit the
+    // current blob capacities (stored sizes may be SMALLER — older builds wrote
+    // shorter blobs — but never larger). Returns true and fills outHeader only
+    // on a fully valid header; never mutates live state.
     bool DeserializeHeader(std::istream& in, RsbsSaveHeader& outHeader) const;
 
     std::string mSaveDir = "Save";

--- a/src/common/test_runner.cpp
+++ b/src/common/test_runner.cpp
@@ -308,7 +308,10 @@ TestResult Test_Roundtrip(void) {
     }
 
     // Freeze a fingerprint for OoT so we can verify integrity after the trip.
-    uint8_t fakeOoTSave[OOT_SAVE_CONTEXT_SIZE] = {0};
+    // Static: at the full runtime blob capacity these buffers are too large to
+    // keep on the stack (OoT alone is ~136KB).
+    static uint8_t fakeOoTSave[OOT_SAVE_CONTEXT_SIZE];
+    memset(fakeOoTSave, 0, sizeof(fakeOoTSave));
     fakeOoTSave[0] = 0xDE;
     fakeOoTSave[1] = 0xAD;
     fakeOoTSave[OOT_SAVE_CONTEXT_SIZE - 1] = 0xEF;  // Tail marker
@@ -334,7 +337,8 @@ TestResult Test_Roundtrip(void) {
     }
 
     // Also freeze MM state; both games' frozen states must coexist.
-    uint8_t fakeMMSave[MM_SAVE_CONTEXT_SIZE] = {0};
+    static uint8_t fakeMMSave[MM_SAVE_CONTEXT_SIZE];
+    memset(fakeMMSave, 0, sizeof(fakeMMSave));
     fakeMMSave[0] = 0xBE;
     fakeMMSave[1] = 0xEF;
     Combo_FreezeState("mm", Combo_GetSwitchReturnEntrance(),
@@ -343,7 +347,8 @@ TestResult Test_Roundtrip(void) {
     // ------------------------------------------------------------------
     // Leg 3: Verify OoT state can be restored after the round-trip.
     // ------------------------------------------------------------------
-    uint8_t restoredSave[OOT_SAVE_CONTEXT_SIZE] = {0};
+    static uint8_t restoredSave[OOT_SAVE_CONTEXT_SIZE];
+    memset(restoredSave, 0, sizeof(restoredSave));
     if (!Combo_RestoreState("oot", restoredSave, sizeof(restoredSave))) {
         printf("[TEST] FAIL: Leg 3 - OoT state restore failed\n");
         return TEST_FAIL;
@@ -355,7 +360,8 @@ TestResult Test_Roundtrip(void) {
     }
 
     // And MM's frozen state is still intact.
-    uint8_t restoredMM[MM_SAVE_CONTEXT_SIZE] = {0};
+    static uint8_t restoredMM[MM_SAVE_CONTEXT_SIZE];
+    memset(restoredMM, 0, sizeof(restoredMM));
     if (!Combo_RestoreState("mm", restoredMM, sizeof(restoredMM))) {
         printf("[TEST] FAIL: Leg 3 - MM state restore failed\n");
         return TEST_FAIL;
@@ -516,8 +522,9 @@ TestResult Test_Context(void) {
         return TEST_FAIL;
     }
 
-    // Freeze a state
-    uint8_t testData[OOT_SAVE_CONTEXT_SIZE] = {0};
+    // Freeze a state (static: too large for the stack at the full blob capacity)
+    static uint8_t testData[OOT_SAVE_CONTEXT_SIZE];
+    memset(testData, 0, sizeof(testData));
     testData[100] = 0x42;
     Context_FreezeState(GAME_OOT, 0x1234, testData, sizeof(testData));
 
@@ -534,7 +541,8 @@ TestResult Test_Context(void) {
     }
 
     // Restore and verify
-    uint8_t restored[OOT_SAVE_CONTEXT_SIZE] = {0};
+    static uint8_t restored[OOT_SAVE_CONTEXT_SIZE];
+    memset(restored, 0, sizeof(restored));
     if (!Context_RestoreState(GAME_OOT, restored, sizeof(restored))) {
         printf("[TEST] FAIL: Restore failed\n");
         return TEST_FAIL;
@@ -584,7 +592,8 @@ const TestDescriptor gTests[] = {
     {"save-header", "Unified .redsave header fields + CRC are well-formed (#35)", Test_SaveHeader},
     {"save-has-delete", "Unified save HasSave/DeleteSave lifecycle (#35)", Test_SaveHasDelete},
     {"save-version-reject", "Unified save Load rejects unknown version, no clobber (#35)", Test_SaveVersionReject},
-    {"save-size-mismatch", "Unified save Load rejects mismatched tier size, no clobber (#35)", Test_SaveSizeMismatch},
+    {"save-size-mismatch", "Unified save Load rejects oversized tier, no clobber (#35)", Test_SaveSizeMismatch},
+    {"save-legacy-size", "Unified save Load zero-extends shorter legacy tiers (#35)", Test_SaveLegacySize},
     {"save-crc-corrupt", "Unified save Load rejects corrupt payload, no clobber (#35)", Test_SaveCrcCorrupt},
     {"mm-scene-parse", "MM scene commands parse via the S2H factory (#344)", Test_MMSceneParse},
     {"mm-scene-execute", "MM scene commands execute against a PlayState (#344)", Test_MMSceneExecute},

--- a/src/common/tests/test_archive_hotswap.c
+++ b/src/common/tests/test_archive_hotswap.c
@@ -218,9 +218,10 @@ TestResult Test_ArchiveHotswapLogic(void) {
     ArchiveHotswap_ResetCycle();
 
     /* Golden buffers -- what each game's SaveContext should always read back
-     * as. We deliberately use the full N64 sizes the freeze layer clamps to. */
-    uint8_t ootGolden[OOT_SAVE_CONTEXT_SIZE];
-    uint8_t mmGolden[MM_SAVE_CONTEXT_SIZE];
+     * as. We deliberately use the full blob capacities the freeze layer
+     * allocates (static: too large for the stack). */
+    static uint8_t ootGolden[OOT_SAVE_CONTEXT_SIZE];
+    static uint8_t mmGolden[MM_SAVE_CONTEXT_SIZE];
     HotswapFillPattern(ootGolden, sizeof(ootGolden), 0xA1);
     HotswapFillPattern(mmGolden, sizeof(mmGolden), 0x5C);
 
@@ -252,7 +253,7 @@ TestResult Test_ArchiveHotswapLogic(void) {
 
             /* Freeze OoT (source), restore MM (destination). */
             Combo_FreezeState("oot", Combo_GetSwitchReturnEntrance(), ootGolden, sizeof(ootGolden));
-            uint8_t mmScratch[MM_SAVE_CONTEXT_SIZE];
+            static uint8_t mmScratch[MM_SAVE_CONTEXT_SIZE];
             memset(mmScratch, 0, sizeof(mmScratch));
             HOTSWAP_ASSERT(Combo_RestoreState("mm", mmScratch, sizeof(mmScratch)), "MM restore failed mid-cycle");
             HOTSWAP_ASSERT(HotswapBufferMatches(mmScratch, sizeof(mmScratch), 0x5C),
@@ -265,7 +266,7 @@ TestResult Test_ArchiveHotswapLogic(void) {
 
             /* Freeze MM (source), restore OoT (destination). */
             Combo_FreezeState("mm", Combo_GetSwitchReturnEntrance(), mmGolden, sizeof(mmGolden));
-            uint8_t ootScratch[OOT_SAVE_CONTEXT_SIZE];
+            static uint8_t ootScratch[OOT_SAVE_CONTEXT_SIZE];
             memset(ootScratch, 0, sizeof(ootScratch));
             HOTSWAP_ASSERT(Combo_RestoreState("oot", ootScratch, sizeof(ootScratch)), "OoT restore failed mid-cycle");
             HOTSWAP_ASSERT(HotswapBufferMatches(ootScratch, sizeof(ootScratch), 0xA1),
@@ -286,8 +287,8 @@ TestResult Test_ArchiveHotswapLogic(void) {
     HOTSWAP_ASSERT(!ArchiveHotswap_RssExceeded(), "steady-state RSS delta exceeded bound across switches");
 
     /* Both golden states are still intact after the whole round-trip. */
-    uint8_t ootFinal[OOT_SAVE_CONTEXT_SIZE];
-    uint8_t mmFinal[MM_SAVE_CONTEXT_SIZE];
+    static uint8_t ootFinal[OOT_SAVE_CONTEXT_SIZE];
+    static uint8_t mmFinal[MM_SAVE_CONTEXT_SIZE];
     memset(ootFinal, 0, sizeof(ootFinal));
     memset(mmFinal, 0, sizeof(mmFinal));
     HOTSWAP_ASSERT(Combo_RestoreState("oot", ootFinal, sizeof(ootFinal)), "final OoT restore failed");

--- a/src/common/tests/test_roundtrip_integrity.c
+++ b/src/common/tests/test_roundtrip_integrity.c
@@ -105,9 +105,11 @@ static int TestRoundtripIntegrity_Run(void) {
     Entrance_Init();
     Entrance_RegisterDefaultLinks();
 
-    /* Build a populated (non-zero, deterministic) OoT SaveContext and snapshot it. */
-    uint8_t ootSave[OOT_SAVE_CONTEXT_SIZE];
-    uint8_t snapshot[OOT_SAVE_CONTEXT_SIZE];
+    /* Build a populated (non-zero, deterministic) OoT SaveContext and snapshot
+     * it. Static: at the full runtime blob capacity (~136KB each) these three
+     * buffers would otherwise put ~400KB on one stack frame. */
+    static uint8_t ootSave[OOT_SAVE_CONTEXT_SIZE];
+    static uint8_t snapshot[OOT_SAVE_CONTEXT_SIZE];
     RoundtripIntegrity_FillDeterministic(ootSave, sizeof(ootSave));
     memcpy(snapshot, ootSave, sizeof(snapshot));
 
@@ -153,7 +155,7 @@ static int TestRoundtripIntegrity_Run(void) {
      * with the pre-switch snapshot (modulo the gComboCtx exclusion list,
      * which is not part of this buffer).
      * ---------------------------------------------------------------- */
-    uint8_t restored[OOT_SAVE_CONTEXT_SIZE];
+    static uint8_t restored[OOT_SAVE_CONTEXT_SIZE];
     memset(restored, 0x00, sizeof(restored));
     RT_ASSERT(Combo_RestoreState("oot", restored, sizeof(restored)) != 0);
 

--- a/src/common/tests/test_save_roundtrip.c
+++ b/src/common/tests/test_save_roundtrip.c
@@ -250,7 +250,7 @@ TestResult Test_SaveVersionReject(void) {
 }
 
 TestResult Test_SaveSizeMismatch(void) {
-    printf("[TEST] save-size-mismatch: Load refuses a mismatched tier size without clobbering state (#35)\n");
+    printf("[TEST] save-size-mismatch: Load refuses an oversized tier without clobbering state (#35)\n");
 
     rsbs::SaveManager& mgr = rsbs::SaveManager::Instance();
     mgr.SetSaveDirectory(kSaveTestDir);
@@ -258,7 +258,9 @@ TestResult Test_SaveSizeMismatch(void) {
     mgr.DeleteSave(0);
     SAVE_ASSERT(mgr.Save(0), "Save(0) failed");
 
-    // Claim a different OoT tier size than this build expects.
+    // Claim an OoT tier LARGER than this build's blob capacity. (A smaller
+    // stored size is legal — see Test_SaveLegacySize — but larger can never
+    // fit the shadow buffers and must be refused.)
     SAVE_ASSERT(SaveTestPatchU32(mgr.SlotPath(0), offsetof(rsbs::RsbsSaveHeader, ootSize),
                                  static_cast<uint32_t>(OOT_SAVE_CONTEXT_SIZE) + 4u),
                 "could not patch ootSize");
@@ -272,6 +274,90 @@ TestResult Test_SaveSizeMismatch(void) {
 
     mgr.DeleteSave(0);
     printf("[TEST] PASS: tier-size mismatch rejected, live state intact\n");
+    return TEST_PASS;
+}
+
+TestResult Test_SaveLegacySize(void) {
+    printf("[TEST] save-legacy-size: Load accepts a shorter (pre-capacity-fix) tier and zero-extends (#35)\n");
+
+    // Tier sizes written by builds from before the blob capacities covered the
+    // ports' full runtime SaveContexts (the N64 struct sizes). The header is
+    // self-describing, so such files must still load; the missing tail is the
+    // ship.* state those builds truncated away and is restored as zeros.
+    const uint32_t kLegacyOoTSize = 0x1428;
+    const uint32_t kLegacyMMSize = 0x48C8;
+
+    rsbs::SaveManager& mgr = rsbs::SaveManager::Instance();
+    mgr.SetSaveDirectory(kSaveTestDir);
+    const uint32_t tag = 0x4C454741u;  // "LEGA"
+    SaveTestSeed(tag);
+    mgr.DeleteSave(0);
+
+    // Hand-craft the legacy file: same v1 layout, shorter game tiers.
+    std::vector<uint8_t> payload;
+    payload.reserve(sizeof(ComboContext) + kLegacyOoTSize + kLegacyMMSize);
+    const uint8_t* comboBytes = reinterpret_cast<const uint8_t*>(&gComboCtx);
+    payload.insert(payload.end(), comboBytes, comboBytes + sizeof(ComboContext));
+    for (size_t i = 0; i < kLegacyOoTSize; i++) {
+        payload.push_back(SaveTestOoTByte(i));
+    }
+    for (size_t i = 0; i < kLegacyMMSize; i++) {
+        payload.push_back(SaveTestMMByte(i));
+    }
+
+    rsbs::RsbsSaveHeader h;
+    std::memset(&h, 0, sizeof(h));
+    std::memcpy(h.magic, RSBS_SAVE_MAGIC, sizeof(h.magic));
+    h.version = RSBS_SAVE_VERSION;
+    h.endian = RSBS_SAVE_ENDIAN_LE;
+    h.slot = 0;
+    h.headerSize = sizeof(rsbs::RsbsSaveHeader);
+    h.comboSize = static_cast<uint32_t>(sizeof(ComboContext));
+    h.ootSize = kLegacyOoTSize;
+    h.mmSize = kLegacyMMSize;
+    h.crc32 = rsbs::SaveManager::Crc32(payload.data(), payload.size());
+
+    std::filesystem::create_directories(kSaveTestDir);
+    {
+        std::ofstream out(mgr.SlotPath(0), std::ios::binary | std::ios::trunc);
+        SAVE_ASSERT(static_cast<bool>(out), "could not write legacy slot file");
+        out.write(reinterpret_cast<const char*>(&h), sizeof(h));
+        out.write(reinterpret_cast<const char*>(payload.data()), static_cast<std::streamsize>(payload.size()));
+        SAVE_ASSERT(static_cast<bool>(out), "short write of legacy slot file");
+    }
+
+    // Wipe live state with a recognizable non-zero fill so both "restored" and
+    // "zero-extended" outcomes are distinguishable from leftovers.
+    ComboContext_Init();
+    gComboCtx.saveSlot = 0x7FFFFFFF;
+    std::vector<uint8_t> junkOoT(OOT_SAVE_CONTEXT_SIZE, 0x5A);
+    std::vector<uint8_t> junkMM(MM_SAVE_CONTEXT_SIZE, 0x5A);
+    Context_UpdateShadowCopy(GAME_OOT, junkOoT.data(), junkOoT.size());
+    Context_UpdateShadowCopy(GAME_MM, junkMM.data(), junkMM.size());
+
+    SAVE_ASSERT(mgr.Load(0), "Load refused a valid legacy-size file");
+    SAVE_ASSERT(gComboCtx.saveSlot == static_cast<int32_t>(tag), "ComboContext not restored from legacy file");
+
+    const uint8_t* oot = static_cast<const uint8_t*>(Context_GetOoTSaveContext());
+    SAVE_ASSERT(oot != nullptr, "OoT shadow missing after legacy load");
+    for (size_t i = 0; i < kLegacyOoTSize; i++) {
+        SAVE_ASSERT(oot[i] == SaveTestOoTByte(i), "legacy OoT bytes not restored");
+    }
+    for (size_t i = kLegacyOoTSize; i < OOT_SAVE_CONTEXT_SIZE; i++) {
+        SAVE_ASSERT(oot[i] == 0, "OoT tail beyond legacy size not zero-extended");
+    }
+
+    const uint8_t* mm = static_cast<const uint8_t*>(Context_GetMMSaveContext());
+    SAVE_ASSERT(mm != nullptr, "MM shadow missing after legacy load");
+    for (size_t i = 0; i < kLegacyMMSize; i++) {
+        SAVE_ASSERT(mm[i] == SaveTestMMByte(i), "legacy MM bytes not restored");
+    }
+    for (size_t i = kLegacyMMSize; i < MM_SAVE_CONTEXT_SIZE; i++) {
+        SAVE_ASSERT(mm[i] == 0, "MM tail beyond legacy size not zero-extended");
+    }
+
+    mgr.DeleteSave(0);
+    printf("[TEST] PASS: legacy-size tiers load and zero-extend to the current capacities\n");
     return TEST_PASS;
 }
 

--- a/src/common/unified_save.c
+++ b/src/common/unified_save.c
@@ -3,8 +3,9 @@
  * @brief Unified SaveContext storage for single-executable builds
  *
  * Both OoT and MM define `SaveContext gSaveContext`, but with different
- * struct layouts (OoT: ~5KB, MM: ~18KB). In single-exe mode, we provide
- * a single storage area large enough for either game.
+ * struct layouts (SoH OoT: ~136KB, 2S2H MM: ~48KB — far larger than the N64
+ * structs; see game.h). In single-exe mode, we provide a single storage area
+ * large enough for either game.
  *
  * The games' code has `extern SaveContext gSaveContext` declarations that
  * resolve to this storage. Since C doesn't do type checking at link time,
@@ -19,17 +20,12 @@
 #include <stddef.h>
 #include <stdalign.h>
 
-/* SaveContext sizes:
- * OoT: 0x21C30 (~138KB) - includes SohStats with 8191 SceneTimestamps
- * MM:  0x48C8 (~18KB)
- *
- * Note: OoT's SaveContext grew significantly when Ship of Harkinian added
- * SohStats with extensive timing/tracking arrays. The original N64 size
- * was 0x1428 but modern SoH is much larger.
- */
-#define OOT_SAVE_CONTEXT_SIZE 0x22000  /* ~138KB with padding */
-#define MM_SAVE_CONTEXT_SIZE  0x48C8
-#define UNIFIED_SAVE_SIZE     OOT_SAVE_CONTEXT_SIZE  /* OoT is now larger */
+#include "game.h"
+
+/* Blob capacities come from game.h (single source of truth; see the comment
+ * there). OoT's runtime SaveContext (~0x21C30, SoH SohStats et al.) is the
+ * larger of the two, so it sizes the unified storage. */
+#define UNIFIED_SAVE_SIZE OOT_SAVE_CONTEXT_SIZE
 
 /**
  * Unified SaveContext storage.


### PR DESCRIPTION
Fixes three memory/save-integrity bugs surfaced by the earlier cross-game crash investigation.

## 1. OoT/MM cross-game save truncation (`b39ded7`)

`OOT_SAVE_CONTEXT_SIZE` was defined twice with conflicting values: `game.h` said `0x1428` (the original N64 struct size) while `unified_save.c` said `0x22000` (SoH's actual runtime `gSaveContext`). `context.cpp` sized the freeze/restore shadow buffers from the `game.h` value, so every cross-game switch silently truncated ~133 KB of OoT save state (all SoH `ship.*` data: stats, quest/rando state, backup Farore's Wind). MM had the same bug in miniature — its `0x48C8` N64 size dropped 2S2H's `shipSaveInfo` (~30 KB of rando check tables, playtime, respawn data).

- `src/common/game.h` is now the single source of truth; the macros are documented blob **capacities** with headroom (`0x22000` OoT, `0x10000` MM).
- Each game's `GameExports_SingleExe.cpp` (TUs that can see the real struct) adds `static_assert(sizeof(SaveContext) <= *_SAVE_CONTEXT_SIZE)` so future upstream struct growth fails the build instead of truncating again.
- `.redsave` compatibility: the header already stores per-tier sizes, so the loader is now size-field-driven — pre-fix files load and are zero-extended; oversize tiers are refused fail-safe. No version bump needed.
- New `SaveLegacySize` test hand-crafts a pre-fix-size file and asserts load + zero-extension.

## 2. `MM_Scene_CommandObjectList` slots overflow (`abed0bf`)

Both the decomp C path (`games/mm/src/code/z_scene.c`) and the 2S2H OTR path (`games/mm/2s2h/z_scene_2SH.cpp`) copied the scene command's object list into `ObjectContext.slots[35]` without bounds checks — a scene declaring more than 35 objects wrote past the array. Both paths now clamp the incoming count to `ARRAY_COUNT(slots) - numPersistentEntries` and log the excess via `osSyncPrintf`.

## 3. GraveHoleJumps use-after-free across archive swaps (`a879268`)

`ApplyGraveyardGeometryPatches()` cached the graveyard scene's `CollisionHeader*` in a function-local static. The pointer targets `SOH::Scene` resource data in `oot.o2r`, which is hot-swapped on cross-game switches, so any re-run of the ShipInit func after a switch (boot re-init, CVar change, preset load) wrote through freed memory. The fix drops the cache and re-fetches per run (a resource-manager cache hit while loaded), with a guard so repeated fetches don't self-`memcpy` the static replacement surface-type array.

## Testing

- Full single-exe build passes, including the new `static_assert`s against the real SoH/2S2H structs (confirming the capacity values hold).
- `ctest -LE integration`: 23/23 pass, including the new `SaveLegacySize` test (the `prism` entry is Not Run in this environment pre-existing, unrelated).
- Integration/boot tests need ROM-extracted archives and a display, so they're left to CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018VHEt9DjjSjXW3HwVnsHfb

---
_Generated by [Claude Code](https://claude.ai/code/session_018VHEt9DjjSjXW3HwVnsHfb)_

<!--- section:artifacts:start -->
### Build Artifacts
  - [rsbs-windows.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/8420488673.zip)
  - [rsbs-linux.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/8420327997.zip)
<!--- section:artifacts:end -->