### PR TITLE
Gate OoT GameInteractor hooks by active game: MM VB calls crashed via enum aliasing

### DIFF
--- a/CMake/SingleExecutable.cmake
+++ b/CMake/SingleExecutable.cmake
@@ -219,6 +219,12 @@ if(BUILD_TESTING)
     # linear gEntranceTable index — the OOB-read crash behind the Market
     # cutscene 0xC0000005.
     add_test(NAME StartupEntrance COMMAND redship --test startup-entrance)
+    # VB-affinity regression: MM's GameInteractor_* calls bind to OoT's
+    # extern "C" wrappers in single-exe builds, and the two games' vanilla-
+    # behavior ordinals alias (MM VB_SETUP_TRANSITION == OoT
+    # VB_PLAY_RAINBOW_BRIDGE_CS == 206). The wrappers must return vanilla
+    # behavior while MM is active — the Market -> Clock Tower NULL-call crash.
+    add_test(NAME VBAffinity COMMAND redship --test vb-affinity)
     add_test(NAME Roundtrip COMMAND redship --test roundtrip)
     add_test(NAME RoundtripIntegrity COMMAND redship --test roundtrip-integrity)
     add_test(NAME SharedRoundtrip COMMAND redship --test shared-roundtrip)
@@ -242,7 +248,7 @@ if(BUILD_TESTING)
     # Set reasonable timeout and label our tests
     set(REDSHIP_TEST_TIMEOUT 60 CACHE STRING "Test timeout in seconds")
     set_tests_properties(
-        BootOoT BootMM SwitchOoTMM SwitchMMOoT StartupEntrance Roundtrip RoundtripIntegrity SharedRoundtrip ArchiveHotswapLogic
+        BootOoT BootMM SwitchOoTMM SwitchMMOoT StartupEntrance VBAffinity Roundtrip RoundtripIntegrity SharedRoundtrip ArchiveHotswapLogic
         SaveRoundtripTiers SaveHeader SaveHasDelete SaveVersionReject SaveSizeMismatch SaveLegacySize SaveCrcCorrupt
         Context MMSceneParse MMSceneExecute AllTests
         PROPERTIES

--- a/games/mm/src/code/z_play.c
+++ b/games/mm/src/code/z_play.c
@@ -684,6 +684,18 @@ void Play_UpdateTransition(PlayState* this) {
             s32 transFadeDuration;
             u32 color;
 
+            // Breadcrumb guard: if Play_SetupTransition was skipped (e.g. a
+            // VB_SETUP_TRANSITION veto), every transitionCtx callback is still
+            // NULL and calling init would jump to address 0. Disable the
+            // transition instead of crashing; the scene itself has already
+            // loaded.
+            if (this->transitionCtx.init == NULL) {
+                osSyncPrintf("Play_UpdateTransition: transitionCtx.init is NULL (setup was skipped); "
+                             "disabling transition\n");
+                this->transitionMode = TRANS_MODE_OFF;
+                break;
+            }
+
             this->transitionCtx.init(&this->transitionCtx.instanceData);
 
             if (this->transitionCtx.transitionType & (TRANS_TYPE_WIPE3 | TRANS_TYPE_WIPE4)) {

--- a/games/oot/soh/Enhancements/game-interactor/GameInteractor_Hooks.cpp
+++ b/games/oot/soh/Enhancements/game-interactor/GameInteractor_Hooks.cpp
@@ -1,24 +1,52 @@
 #include "GameInteractor_Hooks.h"
 
+#ifdef RSBS_SINGLE_EXECUTABLE
+#include "context.h" // src/common/context.h via redship_common's public include dir
+// In the single executable MM's own GameInteractor layer is not compiled, so
+// MM code links against these unprefixed extern "C" wrappers, and MM's
+// GIVanillaBehavior ordinals alias OoT's (e.g. MM VB_SETUP_TRANSITION == OoT
+// VB_PLAY_RAINBOW_BRIDGE_CS == 206 — an OoT TimeSaver hook answering that call
+// vetoed MM's transition setup and crashed on the NULL transitionCtx.init).
+// Suppress all OoT hook dispatch while MM is the active game: MM callers get
+// vanilla behavior, matching the explicit stubs in src/common/mm_stubs.c.
+// GAME_NONE (boot) and GAME_OOT keep today's behavior.
+#define GI_SINGLE_EXE_GATE() \
+    if (Context_GetCurrentGame() == GAME_MM) { \
+        return; \
+    }
+#define GI_SINGLE_EXE_GATE_RET(defaultValue) \
+    if (Context_GetCurrentGame() == GAME_MM) { \
+        return (defaultValue); \
+    }
+#else
+#define GI_SINGLE_EXE_GATE()
+#define GI_SINGLE_EXE_GATE_RET(defaultValue)
+#endif
+
 // MARK: - Gameplay
 
 void GameInteractor_ExecuteOnZTitleInit(void* gameState) {
+    GI_SINGLE_EXE_GATE();
     GameInteractor::Instance->ExecuteHooks<GameInteractor::OnZTitleInit>(gameState);
 }
 
 void GameInteractor_ExecuteOnZTitleUpdate(void* gameState) {
+    GI_SINGLE_EXE_GATE();
     GameInteractor::Instance->ExecuteHooks<GameInteractor::OnZTitleUpdate>(gameState);
 }
 
 void GameInteractor_ExecuteOnLoadGame(int32_t fileNum) {
+    GI_SINGLE_EXE_GATE();
     GameInteractor::Instance->ExecuteHooks<GameInteractor::OnLoadGame>(fileNum);
 }
 
 void GameInteractor_ExecuteOnExitGame(int32_t fileNum) {
+    GI_SINGLE_EXE_GATE();
     GameInteractor::Instance->ExecuteHooks<GameInteractor::OnExitGame>(fileNum);
 }
 
 void GameInteractor_ExecuteOnGameStateMainStart() {
+    GI_SINGLE_EXE_GATE();
     // Cleanup all hooks at the start of each frame
     GameInteractor::Instance->RemoveAllQueuedHooks();
 
@@ -26,111 +54,135 @@ void GameInteractor_ExecuteOnGameStateMainStart() {
 }
 
 void GameInteractor_ExecuteOnGameFrameUpdate() {
+    GI_SINGLE_EXE_GATE();
     GameInteractor::Instance->ExecuteHooks<GameInteractor::OnGameFrameUpdate>();
 }
 
 void GameInteractor_ExecuteOnCameraState(PlayState* play) {
+    GI_SINGLE_EXE_GATE();
     GameInteractor::Instance->ExecuteHooks<GameInteractor::OnCameraState>(play);
 }
 
 void GameInteractor_ExecuteOnItemReceiveHooks(GetItemEntry itemEntry) {
+    GI_SINGLE_EXE_GATE();
     GameInteractor::Instance->ExecuteHooks<GameInteractor::OnItemReceive>(itemEntry);
     GameInteractor::Instance->ExecuteHooksForFilter<GameInteractor::OnItemReceive>(itemEntry);
 }
 
 void GameInteractor_ExecuteOnEquipmentDelete(int16_t equipmentType, uint16_t equipValue) {
+    GI_SINGLE_EXE_GATE();
     GameInteractor::Instance->ExecuteHooks<GameInteractor::OnEquipmentDelete>(equipmentType, equipValue);
     GameInteractor::Instance->ExecuteHooksForFilter<GameInteractor::OnEquipmentDelete>(equipmentType, equipValue);
 }
 
 void GameInteractor_ExecuteOnSaleEndHooks(GetItemEntry itemEntry) {
+    GI_SINGLE_EXE_GATE();
     GameInteractor::Instance->ExecuteHooks<GameInteractor::OnSaleEnd>(itemEntry);
     GameInteractor::Instance->ExecuteHooksForFilter<GameInteractor::OnSaleEnd>(itemEntry);
 }
 
 void GameInteractor_ExecuteOnTransitionEndHooks(int16_t sceneNum) {
+    GI_SINGLE_EXE_GATE();
     GameInteractor::Instance->ExecuteHooks<GameInteractor::OnTransitionEnd>(sceneNum);
     GameInteractor::Instance->ExecuteHooksForID<GameInteractor::OnTransitionEnd>(sceneNum, sceneNum);
     GameInteractor::Instance->ExecuteHooksForFilter<GameInteractor::OnTransitionEnd>(sceneNum);
 }
 
 void GameInteractor_ExecuteOnSceneInit(int16_t sceneNum) {
+    GI_SINGLE_EXE_GATE();
     GameInteractor::Instance->ExecuteHooks<GameInteractor::OnSceneInit>(sceneNum);
     GameInteractor::Instance->ExecuteHooksForID<GameInteractor::OnSceneInit>(sceneNum, sceneNum);
     GameInteractor::Instance->ExecuteHooksForFilter<GameInteractor::OnSceneInit>(sceneNum);
 }
 
 void GameInteractor_ExecuteAfterSceneCommands(int16_t sceneNum) {
+    GI_SINGLE_EXE_GATE();
     GameInteractor::Instance->ExecuteHooks<GameInteractor::AfterSceneCommands>(sceneNum);
     GameInteractor::Instance->ExecuteHooksForID<GameInteractor::AfterSceneCommands>(sceneNum, sceneNum);
     GameInteractor::Instance->ExecuteHooksForFilter<GameInteractor::AfterSceneCommands>(sceneNum);
 }
 
 void GameInteractor_ExecuteOnSceneFlagSet(int16_t sceneNum, int16_t flagType, int16_t flag) {
+    GI_SINGLE_EXE_GATE();
     GameInteractor::Instance->ExecuteHooks<GameInteractor::OnSceneFlagSet>(sceneNum, flagType, flag);
     GameInteractor::Instance->ExecuteHooksForFilter<GameInteractor::OnSceneFlagSet>(sceneNum, flagType, flag);
 }
 
 void GameInteractor_ExecuteOnSceneFlagUnset(int16_t sceneNum, int16_t flagType, int16_t flag) {
+    GI_SINGLE_EXE_GATE();
     GameInteractor::Instance->ExecuteHooks<GameInteractor::OnSceneFlagUnset>(sceneNum, flagType, flag);
     GameInteractor::Instance->ExecuteHooksForFilter<GameInteractor::OnSceneFlagUnset>(sceneNum, flagType, flag);
 }
 
 void GameInteractor_ExecuteOnFlagSet(int16_t flagType, int16_t flag) {
+    GI_SINGLE_EXE_GATE();
     GameInteractor::Instance->ExecuteHooks<GameInteractor::OnFlagSet>(flagType, flag);
     GameInteractor::Instance->ExecuteHooksForFilter<GameInteractor::OnFlagSet>(flagType, flag);
 }
 
 void GameInteractor_ExecuteOnFlagUnset(int16_t flagType, int16_t flag) {
+    GI_SINGLE_EXE_GATE();
     GameInteractor::Instance->ExecuteHooks<GameInteractor::OnFlagUnset>(flagType, flag);
     GameInteractor::Instance->ExecuteHooksForFilter<GameInteractor::OnFlagUnset>(flagType, flag);
 }
 
 void GameInteractor_ExecuteOnSceneSpawnActors() {
+    GI_SINGLE_EXE_GATE();
     GameInteractor::Instance->ExecuteHooks<GameInteractor::OnSceneSpawnActors>();
 }
 
 void GameInteractor_ExecuteOnLinkSkeletonInit() {
+    GI_SINGLE_EXE_GATE();
     GameInteractor::Instance->ExecuteHooks<GameInteractor::OnLinkSkeletonInit>();
 }
 
 void GameInteractor_ExecuteOnLinkEquipmentChange() {
+    GI_SINGLE_EXE_GATE();
     GameInteractor::Instance->ExecuteHooks<GameInteractor::OnLinkEquipmentChange>();
 }
 
 void GameInteractor_ExecuteOnPlayerUpdate() {
+    GI_SINGLE_EXE_GATE();
     GameInteractor::Instance->ExecuteHooks<GameInteractor::OnPlayerUpdate>();
 }
 
 void GameInteractor_ExecuteOnSetDoAction(uint16_t action) {
+    GI_SINGLE_EXE_GATE();
     GameInteractor::Instance->ExecuteHooks<GameInteractor::OnSetDoAction>(action);
 }
 
 void GameInteractor_ExecuteOnPlayerSfx(u16 sfxId) {
+    GI_SINGLE_EXE_GATE();
     GameInteractor::Instance->ExecuteHooks<GameInteractor::OnPlayerSfx>(sfxId);
 }
 
 void GameInteractor_ExecuteOnOcarinaSongAction() {
+    GI_SINGLE_EXE_GATE();
     GameInteractor::Instance->ExecuteHooks<GameInteractor::OnOcarinaSongAction>();
 }
 
 void GameInteractor_ExecuteOnOcarinaNote(uint8_t note, float modulator, int8_t bend) {
+    GI_SINGLE_EXE_GATE();
     GameInteractor::Instance->ExecuteHooks<GameInteractor::OnOcarinaNote>(note, modulator, bend);
 }
 
 void GameInteractor_ExecuteOnCuccoOrChickenHatch() {
+    GI_SINGLE_EXE_GATE();
     GameInteractor::Instance->ExecuteHooks<GameInteractor::OnCuccoOrChickenHatch>();
 }
 
 void GameInteractor_ExecuteOnShopSlotChangeHooks(uint8_t cursorIndex, int16_t price) {
+    GI_SINGLE_EXE_GATE();
     GameInteractor::Instance->ExecuteHooks<GameInteractor::OnShopSlotChange>(cursorIndex, price);
 }
 
 void GameInteractor_ExecuteOnDungeonKeyUsedHooks(uint16_t mapIndex) {
+    GI_SINGLE_EXE_GATE();
     GameInteractor::Instance->ExecuteHooks<GameInteractor::OnDungeonKeyUsed>(mapIndex);
 }
 
 bool GameInteractor_ShouldActorInit(void* actor) {
+    GI_SINGLE_EXE_GATE_RET(true);
     bool result = true;
     GameInteractor::Instance->ExecuteHooks<GameInteractor::ShouldActorInit>(actor, &result);
     GameInteractor::Instance->ExecuteHooksForID<GameInteractor::ShouldActorInit>(((Actor*)actor)->id, actor, &result);
@@ -140,6 +192,7 @@ bool GameInteractor_ShouldActorInit(void* actor) {
 }
 
 void GameInteractor_ExecuteOnActorInit(void* actor) {
+    GI_SINGLE_EXE_GATE();
     GameInteractor::Instance->ExecuteHooks<GameInteractor::OnActorInit>(actor);
     GameInteractor::Instance->ExecuteHooksForID<GameInteractor::OnActorInit>(((Actor*)actor)->id, actor);
     GameInteractor::Instance->ExecuteHooksForPtr<GameInteractor::OnActorInit>((uintptr_t)actor, actor);
@@ -147,6 +200,7 @@ void GameInteractor_ExecuteOnActorInit(void* actor) {
 }
 
 void GameInteractor_ExecuteOnActorSpawn(void* actor) {
+    GI_SINGLE_EXE_GATE();
     GameInteractor::Instance->ExecuteHooks<GameInteractor::OnActorSpawn>(actor);
     GameInteractor::Instance->ExecuteHooksForID<GameInteractor::OnActorSpawn>(((Actor*)actor)->id, actor);
     GameInteractor::Instance->ExecuteHooksForPtr<GameInteractor::OnActorSpawn>((uintptr_t)actor, actor);
@@ -154,6 +208,7 @@ void GameInteractor_ExecuteOnActorSpawn(void* actor) {
 }
 
 bool GameInteractor_ShouldActorUpdate(void* actor) {
+    GI_SINGLE_EXE_GATE_RET(true);
     bool result = true;
     GameInteractor::Instance->ExecuteHooks<GameInteractor::ShouldActorUpdate>(actor, &result);
     GameInteractor::Instance->ExecuteHooksForID<GameInteractor::ShouldActorUpdate>(((Actor*)actor)->id, actor, &result);
@@ -163,6 +218,7 @@ bool GameInteractor_ShouldActorUpdate(void* actor) {
 }
 
 void GameInteractor_ExecuteOnActorUpdate(void* actor) {
+    GI_SINGLE_EXE_GATE();
     GameInteractor::Instance->ExecuteHooks<GameInteractor::OnActorUpdate>(actor);
     GameInteractor::Instance->ExecuteHooksForID<GameInteractor::OnActorUpdate>(((Actor*)actor)->id, actor);
     GameInteractor::Instance->ExecuteHooksForPtr<GameInteractor::OnActorUpdate>((uintptr_t)actor, actor);
@@ -170,6 +226,7 @@ void GameInteractor_ExecuteOnActorUpdate(void* actor) {
 }
 
 void GameInteractor_ExecuteOnActorKill(void* actor) {
+    GI_SINGLE_EXE_GATE();
     GameInteractor::Instance->ExecuteHooks<GameInteractor::OnActorKill>(actor);
     GameInteractor::Instance->ExecuteHooksForID<GameInteractor::OnActorKill>(((Actor*)actor)->id, actor);
     GameInteractor::Instance->ExecuteHooksForPtr<GameInteractor::OnActorKill>((uintptr_t)actor, actor);
@@ -177,6 +234,7 @@ void GameInteractor_ExecuteOnActorKill(void* actor) {
 }
 
 void GameInteractor_ExecuteOnActorDestroy(void* actor) {
+    GI_SINGLE_EXE_GATE();
     GameInteractor::Instance->ExecuteHooks<GameInteractor::OnActorDestroy>(actor);
     GameInteractor::Instance->ExecuteHooksForID<GameInteractor::OnActorDestroy>(((Actor*)actor)->id, actor);
     GameInteractor::Instance->ExecuteHooksForPtr<GameInteractor::OnActorDestroy>((uintptr_t)actor, actor);
@@ -184,6 +242,7 @@ void GameInteractor_ExecuteOnActorDestroy(void* actor) {
 }
 
 void GameInteractor_ExecuteOnEnemyDefeat(void* actor) {
+    GI_SINGLE_EXE_GATE();
     GameInteractor::Instance->ExecuteHooks<GameInteractor::OnEnemyDefeat>(actor);
     GameInteractor::Instance->ExecuteHooksForID<GameInteractor::OnEnemyDefeat>(((Actor*)actor)->id, actor);
     GameInteractor::Instance->ExecuteHooksForPtr<GameInteractor::OnEnemyDefeat>((uintptr_t)actor, actor);
@@ -191,6 +250,7 @@ void GameInteractor_ExecuteOnEnemyDefeat(void* actor) {
 }
 
 void GameInteractor_ExecuteOnBossDefeat(void* actor) {
+    GI_SINGLE_EXE_GATE();
     GameInteractor::Instance->ExecuteHooks<GameInteractor::OnBossDefeat>(actor);
     GameInteractor::Instance->ExecuteHooksForID<GameInteractor::OnBossDefeat>(((Actor*)actor)->id, actor);
     GameInteractor::Instance->ExecuteHooksForPtr<GameInteractor::OnBossDefeat>((uintptr_t)actor, actor);
@@ -198,54 +258,67 @@ void GameInteractor_ExecuteOnBossDefeat(void* actor) {
 }
 
 void GameInteractor_ExecuteOnTimestamp(u8 item) {
+    GI_SINGLE_EXE_GATE();
     GameInteractor::Instance->ExecuteHooks<GameInteractor::OnTimestamp>(item);
 }
 
 void GameInteractor_ExecuteOnPlayerBonk() {
+    GI_SINGLE_EXE_GATE();
     GameInteractor::Instance->ExecuteHooks<GameInteractor::OnPlayerBonk>();
 }
 
 void GameInteractor_ExecuteOnPlayerSetModels(Player* player, u8 modelGroup) {
+    GI_SINGLE_EXE_GATE();
     GameInteractor::Instance->ExecuteHooks<GameInteractor::OnPlayerSetModels>(player, modelGroup);
 }
 
 void GameInteractor_ExecuteOnPlayerHealthChange(int16_t amount) {
+    GI_SINGLE_EXE_GATE();
     GameInteractor::Instance->ExecuteHooks<GameInteractor::OnPlayerHealthChange>(amount);
 }
 
 void GameInteractor_ExecuteOnPlayerBottleUpdate(int16_t contents) {
+    GI_SINGLE_EXE_GATE();
     GameInteractor::Instance->ExecuteHooks<GameInteractor::OnPlayerBottleUpdate>(contents);
 }
 
 void GameInteractor_ExecuteOnPlayerHoldUpShield() {
+    GI_SINGLE_EXE_GATE();
     GameInteractor::Instance->ExecuteHooks<GameInteractor::OnPlayerHoldUpShield>();
 }
 
 void GameInteractor_ExecuteOnPlayerFirstPersonControl(Player* player) {
+    GI_SINGLE_EXE_GATE();
     GameInteractor::Instance->ExecuteHooks<GameInteractor::OnPlayerFirstPersonControl>(player);
 }
 
 void GameInteractor_ExecuteOnPlayerShieldControl(float_t* sp50, float_t* sp54) {
+    GI_SINGLE_EXE_GATE();
     GameInteractor::Instance->ExecuteHooks<GameInteractor::OnPlayerShieldControl>(sp50, sp54);
 }
 
 void GameInteractor_ExecuteOnPlayerProcessStick() {
+    GI_SINGLE_EXE_GATE();
     GameInteractor::Instance->ExecuteHooks<GameInteractor::OnPlayerProcessStick>();
 }
 
 void GameInteractor_ExecuteOnPlayDestroy() {
+    GI_SINGLE_EXE_GATE();
     GameInteractor::Instance->ExecuteHooks<GameInteractor::OnPlayDestroy>();
 }
 
 void GameInteractor_ExecuteOnPlayDrawBegin() {
+    GI_SINGLE_EXE_GATE();
     GameInteractor::Instance->ExecuteHooks<GameInteractor::OnPlayDrawBegin>();
 }
 
 void GameInteractor_ExecuteOnPlayDrawEnd() {
+    GI_SINGLE_EXE_GATE();
     GameInteractor::Instance->ExecuteHooks<GameInteractor::OnPlayDrawEnd>();
 }
 
 bool GameInteractor_Should(GIVanillaBehavior flag, u32 result, ...) {
+    GI_SINGLE_EXE_GATE_RET(static_cast<bool>(result));
     // Only the external function can use the Variadic Function syntax
     // To pass the va args to the next caller must be done using va_list and reading the args into it
     // Because there can be N subscribers registered to each template call, the subscribers will be responsible for
@@ -269,101 +342,124 @@ bool GameInteractor_Should(GIVanillaBehavior flag, u32 result, ...) {
 // MARK: -  Save Files
 
 void GameInteractor_ExecuteOnSaveFile(int32_t fileNum, int32_t sectionID) {
+    GI_SINGLE_EXE_GATE();
     GameInteractor::Instance->ExecuteHooks<GameInteractor::OnSaveFile>(fileNum, sectionID);
 }
 
 void GameInteractor_ExecuteOnLoadFile(int32_t fileNum) {
+    GI_SINGLE_EXE_GATE();
     GameInteractor::Instance->ExecuteHooks<GameInteractor::OnLoadFile>(fileNum);
 }
 
 void GameInteractor_ExecuteOnDeleteFile(int32_t fileNum) {
+    GI_SINGLE_EXE_GATE();
     GameInteractor::Instance->ExecuteHooks<GameInteractor::OnDeleteFile>(fileNum);
 }
 
 // MARK: - Dialog
 
 void GameInteractor_ExecuteOnDialogMessage() {
+    GI_SINGLE_EXE_GATE();
     GameInteractor::Instance->ExecuteHooks<GameInteractor::OnDialogMessage>();
 }
 
 void GameInteractor_ExecuteOnPresentTitleCard() {
+    GI_SINGLE_EXE_GATE();
     GameInteractor::Instance->ExecuteHooks<GameInteractor::OnPresentTitleCard>();
 }
 
 void GameInteractor_ExecuteOnInterfaceUpdate() {
+    GI_SINGLE_EXE_GATE();
     GameInteractor::Instance->ExecuteHooks<GameInteractor::OnInterfaceUpdate>();
 }
 
 void GameInteractor_ExecuteOnKaleidoscopeUpdate(int16_t inDungeonScene) {
+    GI_SINGLE_EXE_GATE();
     GameInteractor::Instance->ExecuteHooks<GameInteractor::OnKaleidoscopeUpdate>(inDungeonScene);
 }
 
 // MARK: - Main Menu
 
 void GameInteractor_ExecuteOnPresentFileSelect() {
+    GI_SINGLE_EXE_GATE();
     GameInteractor::Instance->ExecuteHooks<GameInteractor::OnPresentFileSelect>();
 }
 
 void GameInteractor_ExecuteOnUpdateFileSelectSelection(uint16_t optionIndex) {
+    GI_SINGLE_EXE_GATE();
     GameInteractor::Instance->ExecuteHooks<GameInteractor::OnUpdateFileSelectSelection>(optionIndex);
 }
 
 void GameInteractor_ExecuteOnUpdateFileSelectConfirmationSelection(uint16_t optionIndex) {
+    GI_SINGLE_EXE_GATE();
     GameInteractor::Instance->ExecuteHooks<GameInteractor::OnUpdateFileSelectConfirmationSelection>(optionIndex);
 }
 
 void GameInteractor_ExecuteOnUpdateFileCopySelection(uint16_t optionIndex) {
+    GI_SINGLE_EXE_GATE();
     GameInteractor::Instance->ExecuteHooks<GameInteractor::OnUpdateFileCopySelection>(optionIndex);
 }
 
 void GameInteractor_ExecuteOnUpdateFileCopyConfirmationSelection(uint16_t optionIndex) {
+    GI_SINGLE_EXE_GATE();
     GameInteractor::Instance->ExecuteHooks<GameInteractor::OnUpdateFileCopyConfirmationSelection>(optionIndex);
 }
 
 void GameInteractor_ExecuteOnUpdateFileEraseSelection(uint16_t optionIndex) {
+    GI_SINGLE_EXE_GATE();
     GameInteractor::Instance->ExecuteHooks<GameInteractor::OnUpdateFileEraseSelection>(optionIndex);
 }
 
 void GameInteractor_ExecuteOnUpdateFileEraseConfirmationSelection(uint16_t optionIndex) {
+    GI_SINGLE_EXE_GATE();
     GameInteractor::Instance->ExecuteHooks<GameInteractor::OnUpdateFileEraseConfirmationSelection>(optionIndex);
 }
 
 void GameInteractor_ExecuteOnUpdateFileAudioSelection(uint8_t optionIndex) {
+    GI_SINGLE_EXE_GATE();
     GameInteractor::Instance->ExecuteHooks<GameInteractor::OnUpdateFileAudioSelection>(optionIndex);
 }
 
 void GameInteractor_ExecuteOnUpdateFileTargetSelection(uint8_t optionIndex) {
+    GI_SINGLE_EXE_GATE();
     GameInteractor::Instance->ExecuteHooks<GameInteractor::OnUpdateFileTargetSelection>(optionIndex);
 }
 
 void GameInteractor_ExecuteOnUpdateFileLanguageSelection(uint8_t optionIndex) {
+    GI_SINGLE_EXE_GATE();
     GameInteractor::Instance->ExecuteHooks<GameInteractor::OnUpdateFileLanguageSelection>(optionIndex);
 }
 
 void GameInteractor_ExecuteOnUpdateFileQuestSelection(uint8_t questIndex) {
+    GI_SINGLE_EXE_GATE();
     GameInteractor::Instance->ExecuteHooks<GameInteractor::OnUpdateFileQuestSelection>(questIndex);
 }
 
 void GameInteractor_ExecuteOnUpdateFileBossRushOptionSelection(uint8_t optionIndex, uint8_t optionValue) {
+    GI_SINGLE_EXE_GATE();
     GameInteractor::Instance->ExecuteHooks<GameInteractor::OnUpdateFileBossRushOptionSelection>(optionIndex,
                                                                                                 optionValue);
 }
 
 void GameInteractor_ExecuteOnUpdateFileRandomizerOptionSelection(uint8_t optionIndex) {
+    GI_SINGLE_EXE_GATE();
     GameInteractor::Instance->ExecuteHooks<GameInteractor::OnUpdateFileRandomizerOptionSelection>(optionIndex);
 }
 
 void GameInteractor_ExecuteOnUpdateFileNameSelection(int16_t charCode) {
+    GI_SINGLE_EXE_GATE();
     GameInteractor::Instance->ExecuteHooks<GameInteractor::OnUpdateFileNameSelection>(charCode);
 }
 
 void GameInteractor_ExecuteOnFileChooseMain(void* gameState) {
+    GI_SINGLE_EXE_GATE();
     GameInteractor::Instance->ExecuteHooks<GameInteractor::OnFileChooseMain>(gameState);
 }
 
 // MARK: - Game
 
 void GameInteractor_ExecuteOnSetGameLanguage() {
+    GI_SINGLE_EXE_GATE();
     GameInteractor::Instance->ExecuteHooks<GameInteractor::OnSetGameLanguage>();
 }
 
@@ -376,11 +472,13 @@ void GameInteractor_RegisterOnAssetAltChange(void (*fn)(void)) {
 // MARK: Pause Menu
 
 void GameInteractor_ExecuteOnKaleidoUpdate() {
+    GI_SINGLE_EXE_GATE();
     GameInteractor::Instance->ExecuteHooks<GameInteractor::OnKaleidoUpdate>();
 }
 
 // MARK: Messages
 void GameInteractor_ExecuteOnOpenText(uint16_t* textId, bool* loadFromMessageTable) {
+    GI_SINGLE_EXE_GATE();
     GameInteractor::Instance->ExecuteHooks<GameInteractor::OnOpenText>(textId, loadFromMessageTable);
     GameInteractor::Instance->ExecuteHooksForID<GameInteractor::OnOpenText>(*textId, textId, loadFromMessageTable);
     GameInteractor::Instance->ExecuteHooksForFilter<GameInteractor::OnOpenText>(textId, loadFromMessageTable);
@@ -388,11 +486,39 @@ void GameInteractor_ExecuteOnOpenText(uint16_t* textId, bool* loadFromMessageTab
 
 // Mark: Audio
 void GameInteractor_ExecuteOnSeqPlayerInit(int32_t playerIdx, int32_t seqId) {
+    GI_SINGLE_EXE_GATE();
     GameInteractor::Instance->ExecuteHooks<GameInteractor::OnSeqPlayerInit>(playerIdx, seqId);
 }
 
 // MARK: - Rando
 void GameInteractor_ExecuteOnRandoEntranceDiscovered(u16 entranceIndex, u8 isReversedEntrance) {
+    GI_SINGLE_EXE_GATE();
     GameInteractor::Instance->ExecuteHooks<GameInteractor::OnRandoEntranceDiscovered>(entranceIndex,
                                                                                       isReversedEntrance);
 }
+
+#ifdef RSBS_SINGLE_EXECUTABLE
+// MARK: - Test support (redship --test vb-affinity, src/common/test_runner.cpp)
+// Arms a hook that vetoes one vanilla-behavior id so the test can prove the
+// GI_SINGLE_EXE_GATE above keeps MM-active calls at vanilla behavior. The
+// headless test binary never runs OTRGlobals init, so create the registry on
+// demand.
+static HOOK_ID sTestVBVetoHookId = 0;
+
+extern "C" void GameInteractor_TestDisarmVBVeto(void) {
+    if (GameInteractor::Instance != nullptr && sTestVBVetoHookId != 0) {
+        GameInteractor::Instance->UnregisterGameHookForID<GameInteractor::OnVanillaBehavior>(sTestVBVetoHookId);
+    }
+    sTestVBVetoHookId = 0;
+}
+
+extern "C" void GameInteractor_TestArmVBVeto(int32_t flag) {
+    if (GameInteractor::Instance == nullptr) {
+        GameInteractor::Instance = new GameInteractor();
+    }
+    GameInteractor_TestDisarmVBVeto();
+    sTestVBVetoHookId = GameInteractor::Instance->RegisterGameHookForID<GameInteractor::OnVanillaBehavior>(
+        static_cast<GIVanillaBehavior>(flag),
+        [](GIVanillaBehavior _, bool* should, va_list _originalArgs) { *should = false; });
+}
+#endif

--- a/src/common/mm_stubs.c
+++ b/src/common/mm_stubs.c
@@ -79,7 +79,17 @@ void MM_FaultDrawer_SetCharPad(int xPad, int yPad) { (void)xPad; (void)yPad; }
  * Enhancement layer stubs - these are excluded in single-exe mode
  * ========================================================================== */
 
-/* GameInteractor stubs */
+/* GameInteractor stubs.
+ *
+ * These cover MM's GameInteractor_* references that no linked TU defines. A
+ * second set of MM references (GameInteractor_Should, ExecuteOnFlagSet,
+ * ExecuteOnActorUpdate, ...) resolves to OoT's extern "C" wrappers in
+ * games/oot/soh/Enhancements/game-interactor/GameInteractor_Hooks.cpp instead
+ * — that is NOT a valid provider: MM's GIVanillaBehavior ordinals alias OoT's
+ * (MM VB_SETUP_TRANSITION == OoT VB_PLAY_RAINBOW_BRIDGE_CS == 206), so routing
+ * MM calls into OoT's hook registry runs OoT handlers against MM state. Those
+ * wrappers therefore gate on Context_GetCurrentGame() and return vanilla
+ * behavior while MM is active, making them equivalent to the stubs below. */
 void GameInteractor_ExecuteOnActorDraw(void* actor) { (void)actor; }
 void GameInteractor_ExecuteOnGameStateUpdate(void* state) { (void)state; }
 void GameInteractor_ExecuteOnGameStateMainFinish(void* state) { (void)state; }
@@ -90,10 +100,11 @@ void GameInteractor_ExecuteBeforeKaleidoDrawPage(void* state, int page) { (void)
 void GameInteractor_ExecuteAfterKaleidoDrawPage(void* state, int page) { (void)state; (void)page; }
 void GameInteractor_ExecuteOnSaveInit(int fileNum) { (void)fileNum; }
 void GameInteractor_ExecuteOnSaveLoad(int fileNum) { (void)fileNum; }
-/* GameInteractor_ExecuteOnOpenText is now defined for real in
- * games/oot/soh/Enhancements/game-interactor/GameInteractor_Hooks.cpp with
- * signature (uint16_t* textId, bool* loadFromMessageTable) as part of the
- * Custom Messages → Hooks/ShipInit refactor (#228). */
+/* GameInteractor_ExecuteOnOpenText resolves to OoT's wrapper in
+ * games/oot/soh/Enhancements/game-interactor/GameInteractor_Hooks.cpp
+ * (signature (uint16_t* textId, bool* loadFromMessageTable), #228). That
+ * wrapper no-ops while MM is the active game (see the header comment above),
+ * so MM text boxes never fire OoT text hooks. */
 void GameInteractor_ExecuteOnItemGive(int itemId) { (void)itemId; }
 int GameInteractor_ShouldItemGive(int itemId) { (void)itemId; return 1; }
 int GameInteractor_ShouldActorDraw(void* actor) { (void)actor; return 1; }

--- a/src/common/test_runner.cpp
+++ b/src/common/test_runner.cpp
@@ -29,6 +29,13 @@ int MM_RegisterResourceFactoriesHeadless(void);
 // enters this translation unit; called through this C entry point, mirroring
 // MM_RegisterResourceFactoriesHeadless. Returns 0 on pass, non-zero on fail.
 int MM_SceneExecute_RunHeadless(void);
+// VB-affinity regression: MM's GameInteractor_* calls resolve to OoT's
+// extern "C" wrappers in single-exe builds, and the two games' vanilla-
+// behavior ordinals alias each other. The wrappers gate on the active game;
+// these helpers (GameInteractor_Hooks.cpp) arm a veto hook to prove it.
+bool GameInteractor_Should(int32_t flag, uint32_t result, ...);
+void GameInteractor_TestArmVBVeto(int32_t flag);
+void GameInteractor_TestDisarmVBVeto(void);
 }
 
 // Lifecycle unit tests — included directly to avoid static library link ordering issues
@@ -497,6 +504,45 @@ TestResult Test_StartupEntrance(void) {
     return TEST_PASS;
 }
 
+TestResult Test_VBAffinity(void) {
+    printf("[TEST] vb-affinity: OoT VB hooks must not fire while MM is active\n");
+
+    // 206 is the aliased ordinal behind the Market -> Clock Tower crash: MM's
+    // VB_SETUP_TRANSITION and OoT's VB_PLAY_RAINBOW_BRIDGE_CS share it, so an
+    // OoT hook could veto MM's transition setup and leave transitionCtx.init
+    // NULL (called at games/mm/src/code/z_play.c TRANS_MODE_INSTANCE_INIT).
+    const int32_t kAliasedOrdinal = 206;
+
+    GameId prevGame = Context_GetCurrentGame();
+    GameInteractor_TestArmVBVeto(kAliasedOrdinal);
+
+    // With OoT active, dispatch must reach OoT's hook registry: veto applies.
+    Context_SetCurrentGame(GAME_OOT);
+    bool vetoed = GameInteractor_Should(kAliasedOrdinal, 1);
+
+    // With MM active, the affinity gate must return the vanilla default before
+    // any OoT hook runs.
+    Context_SetCurrentGame(GAME_MM);
+    bool mmTrueDefault = GameInteractor_Should(kAliasedOrdinal, 1);
+    bool mmFalseDefault = GameInteractor_Should(kAliasedOrdinal, 0);
+
+    GameInteractor_TestDisarmVBVeto();
+    Context_SetCurrentGame(prevGame);
+
+    if (vetoed != false) {
+        printf("[TEST] FAIL: OoT-active dispatch ignored the armed veto hook\n");
+        return TEST_FAIL;
+    }
+    if (mmTrueDefault != true || mmFalseDefault != false) {
+        printf("[TEST] FAIL: MM-active call did not get vanilla behavior (got %d/%d, want 1/0)\n",
+               (int)mmTrueDefault, (int)mmFalseDefault);
+        return TEST_FAIL;
+    }
+
+    printf("[TEST] PASS: MM-active VB calls stay vanilla; OoT-active hooks still fire\n");
+    return TEST_PASS;
+}
+
 TestResult Test_RoundtripIntegrity(void) {
     printf("[TEST] roundtrip-integrity: OoT SaveContext byte-integrity across roundtrip (issue #262)\n");
     int failures = TestRoundtripIntegrity_Run();
@@ -582,6 +628,7 @@ const TestDescriptor gTests[] = {
     {"switch-mm-oot", "Test game switch MM -> OoT", Test_SwitchMMOoT},
     {"midos-house", "Test Mido's House entrance (test mode)", Test_MidosHouse},
     {"startup-entrance", "Test startup entrance flow", Test_StartupEntrance},
+    {"vb-affinity", "OoT VB hooks stay quiet while MM is active", Test_VBAffinity},
     {"roundtrip", "Full round-trip with state verification", Test_Roundtrip},
     {"roundtrip-integrity", "OoT SaveContext byte-identical across OoT->MM->OoT (issue #262)", Test_RoundtripIntegrity},
     {"shared-roundtrip", "Shared flag/seed survive OoT->MM switch (issue #264)", Test_SharedStateRoundtrip},


### PR DESCRIPTION
Fixes the operator's 2026-07-17 crash (Windows artifact of PR #363's CI run: `0xc0000005`, RIP=0, "Market Day" dump).

## Diagnosis

The crash is on the **OoT→MM leg** (Market → Happy Mask Shop → Clock Tower), not the return leg. The log's `Cutscene_HandleConditionalTriggers: entrance: 49168` line is **MM's** `func_800EDDB0` (its log text borrows the OoT function's name); 0xC010 is MM's correct Clock Tower spawn — #356 is working. The Market actor dump is OoT's *suspended* PlayState, printed by OoT's crash callback.

Root cause: in single-exe builds MM's GameInteractor layer is not compiled, so MM's calls to the unprefixed extern-C `GameInteractor_*` wrappers resolve to **OoT's** definitions — and the two games' `GIVanillaBehavior` enums alias by ordinal (MM `VB_SETUP_TRANSITION` == OoT `VB_PLAY_RAINBOW_BRIDGE_CS` == 206; MM `VB_PLAY_TRANSITION_CS` == OoT `VB_PHANTOM_GANON_DEATH_SCENE` == 182, an unchecked `va_arg` hazard). PR #361's WHOLE_ARCHIVE change armed OoT's previously-elided TimeSaver handler for the first time; when MM asked "should I set up the screen transition?", OoT's rainbow-bridge cutscene-skip handler answered **no**, set OoT EventChkInf 0x4D (the log's `z_actor.c:4940` line, written into unified save storage holding MM's live save), queued an OoT BGM on drained audio, and MM skipped `Play_SetupTransition` — leaving `transitionCtx.init` NULL for the `TRANS_MODE_INSTANCE_INIT` fall-through call at `games/mm/src/code/z_play.c`.

Register forensics seal it: `RCX − RBX = 0x1AC08 = offsetof(PlayState, transitionCtx.instanceData)` under the MM build flags; RIP=0/RAX=0 is the call through the NULL `init`.

A build-object symbol sweep found **14 MM-referenced `GameInteractor_*` symbols cross-binding to OoT** (including per-frame `ExecuteOnActorUpdate`, `ExecuteOnFlagSet`, `ExecuteOnGameStateMainStart`) — the VB veto was just the first to crash. `z_scene_2SH.cpp`'s #344 spot-patch documented this exact aliasing but per-call-site `#ifdef`s don't scale to 357 call sites.

## Fix

- **`GameInteractor_Hooks.cpp`**: every extern-C wrapper no-ops (returning vanilla behavior) while MM is the active game, under `RSBS_SINGLE_EXECUTABLE` — closing the whole aliasing class. `GAME_NONE` (boot) and OoT-active behavior are unchanged; the registration-only `RegisterOnAssetAltChange` is deliberately ungated. This makes the cross-bound wrappers equivalent to the explicit MM stubs in `src/common/mm_stubs.c`.
- **`games/mm/src/code/z_play.c`**: breadcrumb guard — if transition setup was skipped and `transitionCtx.init` is NULL, log and disable the transition instead of calling address zero.
- **`src/common/mm_stubs.c`**: corrected the comment that treated OoT's wrapper definitions as valid providers for MM calls (the misunderstanding that let these 14 symbols cross-bind silently).
- **New `VBAffinity` CTest** (`redship --test vb-affinity`): arms a real veto hook on ordinal 206 and asserts it fires with OoT active and is invisible with MM active.

## Testing

- Full single-exe build passes.
- `ctest -LE integration`: 24/25 pass (the `prism` Not-Run is pre-existing in this environment); new `VBAffinity` test passes.
- Integration/boot tests left to CI (need ROM archives + display).

## Follow-ups filed from the same investigation

#364 (F10 switch never freezes state), #365 (OoT audio thread live during MM without initialized guard), #366 (clang-format CI is a no-op).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018VHEt9DjjSjXW3HwVnsHfb

---
_Generated by [Claude Code](https://claude.ai/code/session_018VHEt9DjjSjXW3HwVnsHfb)_

<!--- section:artifacts:start -->
### Build Artifacts
  - [rsbs-windows.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/8423670440.zip)
  - [rsbs-linux.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/8423563316.zip)
<!--- section:artifacts:end -->