### PR TITLE
Docs: phase-3 execution plan + roadmap corrections from the 07-19 review

### DIFF
--- a/docs/phase3-execution-prompt.md
+++ b/docs/phase3-execution-prompt.md
@@ -1,0 +1,120 @@
+ultracode — Execute Phase 3 of RedShipBlueShip: close out Phase 2's debt and land the "Basic Combo Randomizer" MVP.
+
+Read `docs/phase3-roadmap.md` (the phase plan), `CLAUDE.md` (build/test/conventions), and `gh issue view 381` (the Phase-2 review tracker) before planning. `gh` lives at `"C:/Program Files/GitHub CLI/gh.exe"` and is not on PATH.
+
+Phase 2 merged as `c8c47fa6` with fully green CI. That cleared the roadmap's hard blocker; everything downstream is unblocked.
+
+**The roadmap is good but predates a 2026-07-19 review and ODR sweep.** Six findings below were verified against source or the built binary after it was written. Four of them contradict the roadmap or an obvious plan. Trust these over the roadmap where they conflict, but re-verify anything you are about to build on — two claims in this very analysis were overturned by a second look.
+
+---
+
+## Six corrections that reshape the phase
+
+### 1. MM's randomizer is not in the shipping binary
+
+`games/mm/2s2h/Rando/` is a complete string-keyed randomizer — own pools, fill, logic tiers (`NoLogic.cpp` already implements the deferral Lane D wants), a 382-row item table, `Rando::GiveItem`, spoiler JSON. It is built as `2ship_rando` and linked. **The linker discards every object**, because no undefined symbol in the binary references it.
+
+Verified two ways:
+- Every non-`Rando/` file referencing `Rando::` is in an excluded TU: `BenPort.cpp` (`games/mm/CMakeLists.txt:202`), `BenGui/` (`:205`), `DeveloperTools/` (`:208`), `SaveManager/` (`:250`), or `Enhancements/**` — and `:335` states `2ship_enh`/`2ship_rando` deliberately do **not** get `WHOLE_ARCHIVE`. Filtering those leaves the empty set.
+- String probe of the real `build-cmake/redship.exe`: `"Enable Rando (Randomizes new files upon creation)"` **ABSENT**, while the control `"gEnhancements.Graphics.MotionBlur.Mode"` is **PRESENT**.
+
+Consequences: any Lane C plan that edits `StaticData/Items.cpp` / `itemPool` / `GiveItem.cpp` would compile, pass CI, and **do nothing**. `#384` (registrar collisions) therefore **does** gate Lane C, since getting `2ship_rando` into the link means either `WHOLE_ARCHIVE` (needs #384 cleared) or an explicit `MM_Rando_Init()` from `GameExports_SingleExe.cpp`. And the `rando` CTest label is three invocations of one **OoT** test (`CMake/SingleExecutable.cmake:278/291/292`) — there is zero MM-side rando coverage because there is no MM-side rando.
+
+**Wave 0 spike, before Lane C is scoped:** what is the smallest change that makes `2ship_rando` reachable, and what does it drag in?
+
+### 2. The cross-game seed does not propagate in single-exe
+
+The roadmap's §1 table says seed propagation and the `sourceIsRando` handshake are "wired both directions," citing `OTRGlobals.cpp:2756-2766` and `BenPort.cpp:2153-2226`. Both cited sites are in the **dead legacy path**:
+
+- `OTRGlobals.cpp:2866` is inside `OoT_FreezeState(ComboContext*)` (starts `:2850`)
+- `BenPort.cpp:2167/:2222` are inside `MM_InitFirstEntrySaveContext` / `MM_FreezeState(ComboContext*)` — and `BenPort.cpp` is excluded (`:202`)
+- `src/common/switch.cpp:171` states these are "legacy … only compiled in non-single-exe builds"; their only caller `Context_ProcessSwitch` has no callers
+
+The **live** path is `Combo_FreezeState(gameId, returnEntrance, saveCtx, size)` → `Context_FreezeState` → `gFrozenStates.FreezeState(...)`, carrying a `SaveContext` blob and nothing else. No `ComboContext`, so no seed, no `sourceIsRando`, no `sharedItems`, no `sharedFlags`.
+
+So Lane A is larger than scoped: **the `ComboContext` channel must cross the switch in the live path at all** before any item work means anything. Lane B's "seed propagation already exists; only generation-side determinism is missing" is false as written.
+
+### 3. `ComboContext` has no serialization headroom — this bites the moment Lane A lands
+
+`src/common/save.cpp:31` sets `kComboSize = sizeof(ComboContext)`, and `DeserializeHeader` (`:158-160`) does `if (h.comboSize != kComboSize) return false;`, commented *"ComboContext has no capacity headroom."* `Load()` returning false leaves `gComboCtx` untouched **and shows the user nothing.**
+
+The roadmap's own #1 risk mitigation — tag shared items with origin game — widens `sharedItems` and changes `sizeof(ComboContext)`. **Every existing `.redsave` then silently stops loading**, and again on every later shape change.
+
+Fix before Lane A's first commit and before the `v0.1.0-prealpha` tag (i.e. before the operator holds saves they care about): add reserved padding, convert the tier-1 check from exact-match-refuse to the same size-field-driven zero-extend the game tiers already use (`save.cpp:167-170`), bump `RSBS_SAVE_VERSION`. An afternoon now versus a migration path plus an operator sitting later.
+
+Note the **write** path is genuinely good — atomic temp-plus-rename (`:110-133`), CRC32 over payload, explicit refusal to write a half-empty file. Roadmap §7's "Fault A may corrupt saves" is wrong; the real Fault A exposure is the `OnExitGame` write not being *reached*, which is loss-of-latest-state, not corruption.
+
+### 4. `#370` does gate Lane A — settled from source
+
+The `.redsave` write executes **inside** the mutex #370 poisons: `SaveManager.cpp:1264` locks `saveMtx`, `:1353` fires `ExecuteHooks<OnSaveFile>` — where the handler registered at `:151` calls `RsbsSave_Save()` at `:164` — and `:1355` unlocks. The coupling is through hook dispatch, not through an include, so "the two SaveManagers are separable" is technically true and analytically irrelevant.
+
+Severity is narrower than it first looks (the leak needs a malformed-UTF8 OoT JSON meta save, on the randomizer branch at `:624`), but the fix is a `lock_guard` plus temp-rename — under an hour. Land it in Wave 0.
+
+**Forward-looking trap worth documenting before Lane A is written:** `saveMtx` is a plain `std::mutex` (`SaveManager.h:200`), so any Lane A code hanging off `OnSaveFile` that re-enters SaveManager self-deadlocks.
+
+### 5. #387's "fast link-only job" cannot exist — fix ccache instead
+
+Measured against a real run: **31.42 of build-linux's 32.7 minutes is compilation.** Stripping asset download, tests, and packaging saves ~1.1 minutes. The advertised ~5-minute link-only job is not achievable.
+
+The actual lever is `generate-builds.yml:227` — `save: ${{ github.ref_name == github.event.repository.default_branch }}` restores ccache on feature branches but **never saves** it, so a long-lived `claude/**` branch re-misses the same objects on every push. Fix the policy; drop the link-only job idea.
+
+(#387's *diagnosis* stands — this class is invisible on the operator's Windows-only box because Windows links `/FORCE:MULTIPLE`. Only the proposed remedy was wrong.)
+
+### 6. Four required items no plan covered
+
+- **The known-issues doc does not exist** (`docs/` has no `known-issues*`), and it is a hard `#321` gate alongside #310. Any plan that tags `v0.1.0-prealpha` after one operator sitting is describing a tag that cannot be cut. Write it **before** the sitting so the operator's findings append to it. Agent-doable, no ROMs.
+- **`.claude/worker-prompts.md` is stale and actively misleading.** Line 1 says "Wave 3"; the Rev 7 body still claims "eleven commits awaiting push (gh auth still absent)" — corrected on 2026-07-18, still wrong today. This is the file agents read to learn what wave they are in. Minimum fix: replace the body with a pointer to the tracker epic. Ten minutes.
+- **File the Phase 3 tracker epic** with lanes as sub-issues, shaped like #381 (categorized, with the *why* on each item). Without it every agent invents its own wave numbering.
+- **`gComboCtx.saveSlot` is dead plumbing too** — declared `context.h:103`, set to `-1` at `context.cpp:210`, otherwise referenced only in `src/common/tests/`. Same status as `sharedItems`/`sharedFlags` (both confirmed zero non-test references). Decide its fate during Lane A rather than carrying it.
+
+---
+
+## Execution shape
+
+### Wave 0 — unblock, in parallel (no lane touches another's files)
+
+| Lane | Work | Files |
+|---|---|---|
+| 0a | **#388** headless crash handler | `CrashHandler.cpp` |
+| 0b | **#370** `lock_guard` + temp-rename | `games/oot/soh/SaveManager.cpp` (sole owner) |
+| 0c | **ccache policy** (replaces #387's link job) | `.github/workflows/generate-builds.yml` |
+| 0d | **Spike:** smallest change making `2ship_rando` reachable | read-only, report |
+| 0e | Known-issues doc; worker-prompts.md pointer; tracker epic; #34/#177 out of milestone 4 | docs + `gh` |
+
+Do **#388 first or concurrently** — it is a throughput multiplier, not a correctness item. Every wave below is agent-driven and CI-only-observable, and right now a crash presents as a 180s timeout with no exit code, signal, or stack. It already cost a full Linux bisect this week.
+
+### Wave 1 — save/switch integrity (gates Lane A)
+
+`ComboContext` headroom + versioned migration **solo** (exclusive ownership of `src/common/context.h`, `context.cpp`, `save.cpp`, `unified_save.c`), then in parallel: **#364** (`rsbs/src/main.cpp`, `src/common/switch.cpp`), **#374** (`src/common/entrance.h`), **#371 + #378 together** (both edit `audio_load.c` — one agent, not two).
+
+### Wave 2 — MM binding correctness (parallel with Lane A; gates Lane C)
+
+**#382**, **#383 GameInteractor**, **#385**. Note #382 and #383 both need `games/mm/CMakeLists.txt` — give one sole ownership and have the other rebase, or land the filter change as one preparatory commit both branch from. A detailed #383 handoff prompt already exists; its key finding is that the `S2H` namespace pattern **does not** transfer to GameInteractor (sharing is architectural per `CMakeLists.txt:224` "use OoT's"), so an `extern "C"` shim is the likely shape.
+
+### Wave 3 — the MVP
+
+**Lane A0** (ComboContext shape) is the serial section — keep it to about a day. **Lane A1** then fans out to two agents on the genuinely disjoint `games/oot/soh/GameExports_SingleExe.cpp` and `games/mm/2s2h/GameExports_SingleExe.cpp`. Then B, then C.
+
+**Item-id representation — decide as an ADR merged before Lane A's first commit, not during.** It is a serialization-format decision, since it sets `sizeof(ComboContext)`. Do **not** bit-pack a 12-bit id plus 4-bit game tag into the existing `uint16_t`: a packed representation makes a raw integer read *almost* work, which is exactly how the #356 entrance-id leak behaved. Use an explicit tagged struct so a raw read fails **at compile time**. Size the array generously once (64+ entries) — the expensive part is re-versioning the format, not the bytes.
+
+### Deferred out of 3.0
+
+#386, #383's UIWidgets portion, #376 items 4-6, Lane D (logic), and **#369** — a whole-tree reformat conflicts with *every* open branch simultaneously, so run it in a quiet window between waves or slip it to 3.1 at near-zero cost, since `49444e30`/`b802120f` already established incremental enforcement.
+
+---
+
+## The governing constraint
+
+**Validation bandwidth, not engineering throughput.** Hosted CI is ROM-free by construction; the `int-*` tier is `workflow_dispatch`-only and never runs on a PR. Exactly one human, with real ROMs, on a Windows-only box (no Docker, no WSL), can confirm gameplay behavior. `docs/ci-gameplay-repro-postmortem.md` exists because an entire crash class shipped through fully green CI.
+
+Therefore: **every feature ships with a ROM-free lock in the `redship` CTest label, or it is not done.** Batch operator verdicts — design waves so one sitting covers maximum surface. Do not create lanes each needing their own hands-on session.
+
+Second constraint: each PR triggers ~32 min Linux + ~46 min Windows CI. Eight simultaneous PRs is eight concurrent builds; #177 (Windows CI time) is open. Stagger if a wave is wide.
+
+## Rules
+
+- Work branches `claude/<description>`; separate PRs per lane; squash-merge only on fully green CI.
+- Never merge red or partial CI. If blocked or uncertain, push the branch and report.
+- Do **not** use `-Wl,--allow-multiple-definition` or otherwise weaken the Linux link to match Windows. Linux `ld` is the project's only working ODR gate: #375's tripwire cannot fail (baseline never committed) **and** would not catch the COMDAT class anyway, since `nm`-based intersection skips weak/COMDAT symbols. There is a comment in `src/common/mm_stubs.c` explaining this.
+- If a fix is riskier than the bug, or an item proves latent rather than active, **say so and stop.** Several findings in this analysis changed shape under scrutiny, including the one a judge had already ranked first. A precise diagnosis with no patch is a good outcome.
+- Verify load-bearing claims against source or the built binary before building on them. The single most consequential fact here — that MM's randomizer is absent from the binary — was asserted by one agent, accepted by a judge, and only confirmed by probing `redship.exe` directly.

--- a/docs/phase3-roadmap.md
+++ b/docs/phase3-roadmap.md
@@ -1,0 +1,239 @@
+# Phase 3 roadmap — Basic Combo Randomizer
+
+> Written 2026-07-18. State verified against `main`, milestone 4, and the open
+> tracker on this date. Supersedes nothing; complements `.claude/worker-prompts.md`
+> (which stays the *worker* task file — this is the *phase* plan).
+>
+> **AMENDED 2026-07-19 — read §0.1 before planning off this document.** Six
+> claims below were checked against source and the built binary after a code
+> review and ODR sweep. Four are wrong. The execution plan derived from this
+> roadmap plus those corrections is `docs/phase3-execution-prompt.md`.
+
+## 0.1 Corrections (2026-07-19) — these override the body below
+
+Verified after Phase 2 merged (`c8c47fa6`). Each was checked against source or
+against `build-cmake/redship.exe`, not inferred.
+
+1. **MM's randomizer is not in the shipping binary.** §1's table implicitly
+   treats MM's rando as present. `games/mm/2s2h/Rando/` is complete (pools,
+   fill, logic tiers, 382-row item table, spoiler JSON) and is built as
+   `2ship_rando` and linked — but **no undefined symbol in the binary
+   references it**, so the linker discards every object. Every non-`Rando/`
+   caller of `Rando::` is in an excluded TU: `BenPort.cpp` (CMakeLists `:202`),
+   `BenGui/` (`:205`), `DeveloperTools/` (`:208`), `SaveManager/` (`:250`), or
+   `Enhancements/**` (`:335` — `2ship_enh`/`2ship_rando` deliberately do *not*
+   get `WHOLE_ARCHIVE`). Confirmed by string-probing the real exe: the Rando
+   menu string is absent while a MotionBlur control string is present.
+   **Consequence: #384 gates Lane C**, and the `rando` CTest label is three
+   invocations of one *OoT* test — there is no MM-side rando coverage.
+
+2. **The cross-game seed does not propagate in single-exe.** §1 says seed
+   propagation and the `sourceIsRando` handshake are "wired both directions."
+   Both cited sites are in the dead legacy path: `OTRGlobals.cpp:2866` is inside
+   `OoT_FreezeState(ComboContext*)`, `BenPort.cpp:2167/:2222` inside
+   `MM_InitFirstEntrySaveContext`/`MM_FreezeState` — and `BenPort.cpp` is
+   excluded. `switch.cpp:171` states these are "only compiled in non-single-exe
+   builds"; their sole caller `Context_ProcessSwitch` has no callers. The live
+   path (`Combo_FreezeState` → `Context_FreezeState` → `FreezeState`) carries a
+   `SaveContext` blob and **nothing else** — no `ComboContext`, so no seed, no
+   `sourceIsRando`, no `sharedItems`, no `sharedFlags`. **Lane A must first make
+   the `ComboContext` channel cross the switch at all.**
+
+3. **`ComboContext` has no serialization headroom, and Lane A necessarily
+   breaks it.** `save.cpp:31` sets `kComboSize = sizeof(ComboContext)`;
+   `DeserializeHeader:158-160` refuses any mismatch and `Load()` returns false
+   *silently*. §7's own mitigation (tag shared items with origin game) changes
+   `sizeof(ComboContext)`, so **every existing `.redsave` stops loading the
+   moment Lane A lands.** Fix before Lane A and before the `v0.1.0-prealpha`
+   tag: reserved padding, convert the tier-1 check to the size-field-driven
+   zero-extend the game tiers already use (`save.cpp:167-170`), bump
+   `RSBS_SAVE_VERSION`.
+
+4. **§7 is wrong that Fault A "may corrupt saves on exit."** The `.redsave`
+   write path is sound — atomic temp-plus-rename (`save.cpp:110-133`), CRC32
+   over payload, explicit refusal to write a half-empty file. The real exposure
+   is the `OnExitGame` write not being *reached*: loss of latest state, not
+   corruption. Different severity, different fix.
+
+5. **#370 gates Lane A.** The `.redsave` write executes inside the mutex #370
+   poisons — `SaveManager.cpp:1264` locks, `:1353` fires
+   `ExecuteHooks<OnSaveFile>` (the handler at `:151` calls `RsbsSave_Save()` at
+   `:164`), `:1355` unlocks. Coupling is via hook dispatch, not an include.
+   Also: `saveMtx` is a plain `std::mutex` (`SaveManager.h:200`), so any Lane A
+   code hanging off `OnSaveFile` that re-enters SaveManager self-deadlocks.
+
+6. **Two more dead-plumbing fields and two missing gates.**
+   `gComboCtx.saveSlot` (`context.h:103`) is dead exactly like
+   `sharedItems`/`sharedFlags` — zero non-test references. And §3 item 9's
+   **known-issues doc does not exist** (`docs/` has no `known-issues*`), so
+   `v0.1.0-prealpha` cannot be tagged until it is written;
+   `.claude/worker-prompts.md` is still stale in the exact way §0 item 1
+   describes, and it is what agents read to orient.
+
+Additionally, the #387 remedy is wrong as filed: measured, **31.42 of
+build-linux's 32.7 minutes is compilation**, so the proposed "~5 minute
+link-only job" cannot exist. The real lever is `generate-builds.yml:227`, where
+ccache restores on feature branches but never saves. #387's *diagnosis* stands.
+
+## 0. Tracker corrections (verified, apply before planning off these docs)
+
+Three load-bearing claims in the current docs are stale:
+
+1. **`.claude/worker-prompts.md` Rev 6/7 say "gh auth still absent."** It is
+   present and working (`gh auth status` → logged in, scopes `repo`/`workflow`).
+   The 22 commits it describes as "awaiting push" *are* pushed, and are open as
+   **PR #368** ("Phase 2: first full OoT↔MM gameplay round trip", 74 files,
+   +5367/−762). Nothing is stranded; it is waiting on CI.
+
+2. **Epic #321 (pre-alpha v0.1.0) reads as ~0/8 but is ~6/8.** #315 and #316 are
+   MERGED; #317, #318, #319, #320 are all CLOSED. The only real remaining gates
+   are **#310** (manual real-ROM QA) and the known-issues doc. Pre-alpha is much
+   closer than the epic body implies.
+
+3. **Milestone 4 is named "Basic Combo Randomizer" but contains no combo
+   randomizer work.** Its 17 closed issues are SOH shuffle ports (#235, #289–293),
+   Phase-1 cleanup (#270–272), and a PR-rebase chain (#253–258). Its 2 open issues
+   (#34 settings migration, #177 Windows CI time) are also not randomizer work.
+   **The milestone's headline deliverable is 0% started.** It has been used as a
+   catch-all bucket.
+
+## 1. Where the cross-game randomizer actually stands
+
+The foundation is *partially* real. Verified by source inspection:
+
+| Capability | State | Evidence |
+|---|---|---|
+| Cross-game switch (OoT↔MM round trip) | **Works** | `int-gameplay-roundtrip` 3-cycle soak passes; PR #368 |
+| Shared rando seed propagation | **Wired both directions** | `games/oot/soh/OTRGlobals.cpp:2756-2766`, `games/mm/2s2h/BenPort.cpp:2153-2226` |
+| `sourceIsRando` handshake | **Wired both directions** | same |
+| `gComboCtx.sharedItems[32]` | **Dead plumbing** | declared `src/common/context.h:102`; the *only* other references in the whole tree are in `src/common/tests/`. No game code reads or writes it. |
+| `gComboCtx.sharedFlags[64]` | **Dead plumbing** | declared `src/common/context.h:101`; zero non-test references. |
+| Cross-game entrance shuffle | **Not started** | `src/common/entrance.h` is a fixed 1:1 link table; header says "extensible for future entrance shuffling" |
+| Cross-game item placement | **Not started** | no item-namespace bridge, no foreign-item give path |
+
+**Read that table as: the pipe is laid and the seed flows through it, but nothing
+is on either end of the item channel.** Phase 3's first job is producers and
+consumers for `sharedItems`/`sharedFlags` — everything else in the phase depends
+on it.
+
+## 2. The real capacity constraint
+
+Not engineering throughput — **validation bandwidth.**
+
+Hosted CI is ROM-free by construction (`oot.o2r`/`mm.o2r` cannot exist there);
+the `int-*` tier is `workflow_dispatch`-only and never runs on a PR. Exactly one
+human with real ROMs can confirm gameplay behavior. `docs/ci-gameplay-repro-postmortem.md`
+exists because an entire crash class shipped through fully green CI.
+
+Planning consequences, which apply to every item below:
+
+- Every Phase 3 feature ships with a **ROM-free test lock in the `redship` CTest
+  label**, or it is not done. Not negotiable — it is the only automated tier.
+- **Operator verdicts are the scarce resource.** Batch them. Do not design lanes
+  that each need an independent hands-on session; design lanes that can be
+  verified together in one sitting.
+- Budget roughly **20% of the phase to correctness debt** carried out of Phase 2
+  (§3), not 0%. Phase 2's debt is unusually load-bearing: two of the items are
+  data-loss bugs.
+
+## 3. NOW — close out Phase 2 (blocking Phase 3)
+
+Nothing in Phase 3 should start before item 1 lands. Items 2–5 can run in
+parallel with early Phase 3 design work.
+
+| # | Item | Why it is here | Size |
+|---|---|---|---|
+| 1 | **Merge PR #368** — drive CI green, squash-merge | 22 commits of round-trip stabilization are not on `main`. Every other lane branches off stale code until this lands. **Hard blocker.** | S (CI-bound) |
+| 2 | **#370** SaveManager `saveMtx` never unlocked + truncate-before-write | Permanent deadlock on every subsequent save/load; **strictly worse than the crash it replaced**. Data loss. | S |
+| 3 | **#371** `sequenceMap`/`gSequenceMap` `malloc` → `calloc` | Uninitialized holes get dereferenced and `free()`d. Named candidate contributor to the tracked `0xC0000374` exit corruption (Fault A). One-word fix, outsized payoff. | S |
+| 4 | **#364** F10 hot-swap never freezes state | Phase 2 turned this from an obvious title-screen boot into **silent progress rollback** — the worst failure mode, because the user does not notice. `critical`. | M |
+| 5 | **Retire the stub-signature-drift class** | #372, #379's `MotionBlur_Override`, and the two dead FI stubs are the *same class* Phase 2 already eliminated twice (see `mm-stub-signature-drift` note, postmortem §8.3). The structural fix exists: a header-checked TU compiled against the real declaration, so drift becomes a compile error. **Highest leverage item in this list** — retires a recurring class instead of three instances. | M |
+| 6 | **Vacuous-gate category** — #375, #376 | Same class as the already-fixed #366. A gate that cannot fail is worse than no gate: it reads as coverage. Treat as one category, not two bugs. | M |
+| 7 | Remaining #381 correctness: #374, #373, #378, #377, #372 | Real repros, none blocking. Parallelizable. | S each |
+| 8 | Hygiene: #369 (format allowlist), #379, #380 | #369 is highly parallelizable, one directory per PR. | S each |
+| 9 | **#310 manual QA + known-issues doc → tag `v0.1.0-prealpha`** | The only remaining #321 gates. Closing this converts Phase 2 into a *shipped artifact*, which is what makes Phase 3 feedback possible. | M (operator-bound) |
+
+**Phase 2 closure criterion:** PR #368 merged, #381's correctness block closed,
+both vacuous gates able to fail, and `v0.1.0-prealpha` tagged from green `main`.
+
+## 4. NEXT — Phase 3.0 MVP ("Basic Combo Randomizer")
+
+### MVP definition
+
+> **One seed produces a paired OoT+MM world in which at least one item class
+> crosses games, the crossing survives a full round trip, and a spoiler log
+> describes it.**
+
+That is deliberately the smallest thing that earns the milestone's name. It is
+*not* OoTMM parity.
+
+### Lanes
+
+**Lane A — Make `sharedItems`/`sharedFlags` real.** *(prerequisite for everything)*
+Producers and consumers on both sides of the switch: OoT writes on suspend, MM
+reads on resume, and back. Define the shared-item id namespace up front — OoT's
+`RG_*` and MM's item ids are unrelated enumerations and *must not* be aliased by
+raw integer (this is the same class of bug as the entrance-id leak fixed in #356).
+Lock with a `redship`-label round-trip test asserting a written item survives
+suspend→switch→resume→switch→resume.
+Size: **M**. Risk: low. Fully ROM-free testable.
+
+**Lane B — Unified seed → paired world.** One seed deterministically derives both
+games' randomizer settings. Seed *propagation* already exists (§1); what is
+missing is generation-side determinism and a settings surface that presents the
+pair as one configuration rather than two. Lock with a same-seed-twice determinism
+test.
+Size: **M**. Risk: low-medium. Mostly ROM-free testable.
+
+**Lane C — Cross-game item placement (narrowed).** The headline. Ship it
+**one-directional and one item class** for the MVP — recommended: a small set of
+OoT progression items placeable in MM checks. Needs a foreign-item give path, and
+text/icon handling for an item the receiving game has no assets for (a generic
+"foreign item" presentation is acceptable and is what makes the narrowing viable).
+Size: **L**. Risk: **high** — this is the phase's big bet.
+
+**Lane D — Logic (DEFERRED to 3.1, deliberately).** Cross-game logic — not
+placing MM's Bow behind an OoT check that requires MM's Bow — is the hardest
+problem in the phase and does not fit an MVP. **Ship 3.0 with free-form placement
+plus a spoiler log**, which is a legitimate rando mode, and let the spoiler log
+carry the burden logic would otherwise carry. Adding logic later does not
+invalidate A/B/C.
+
+### Sequencing
+
+A → B in parallel with A's back half → C. D is out of scope.
+Gate C on Lane A being merged and locked; C without A is unverifiable.
+
+## 5. LATER — Phase 3.1+
+
+Directional, not committed:
+
+- **Cross-game logic + beatability check** (Lane D promoted)
+- **Cross-game item placement, both directions, full item pool**
+- **Cross-game entrance shuffle** — `entrance.h` was designed for it; the
+  1:1 link table generalizes to any-entrance→any-entrance
+- **`sharedFlags` semantics** — which world events are genuinely shared
+  (this needs a design decision, not just plumbing)
+- **#34 settings migration** — deferred here by design since Phase 2
+
+## 6. Milestone hygiene (recommended)
+
+- **Move #34 and #177 out of milestone 4.** Neither is combo-randomizer work.
+  #177 is CI infrastructure; #34 is settings migration explicitly deferred.
+  Leaving them there is what made the milestone read as "in progress" while its
+  actual deliverable sat at zero.
+- **File a Phase 3 tracker epic** with Lanes A–D as sub-issues, in the shape of
+  #381 (which is a good tracker: categorized, with the *why* on each item).
+- Keep `.claude/worker-prompts.md` as the worker task file and **rewrite it as
+  Wave 4** once PR #368 merges — its own §"Replanning" section requires this, and
+  it is the mechanism that stops the file going stale again.
+
+## 7. Risks
+
+| Risk | Impact | Mitigation |
+|---|---|---|
+| **Item-id namespace aliasing across games** | Repeat of the #356 entrance-leak crash class — an id from one game interpreted as an index in the other | Tag shared items with their origin game, exactly as the startup entrance was given game affinity in `7c6e7eec`. Decide this in Lane A, before any placement work. |
+| **Validation bandwidth** (single operator, ROM-gated) | Phase 3 features ship unverified; postmortem repeats | Every feature gets a `redship`-label lock; batch operator verdicts |
+| **Lane C scope creep toward OoTMM parity** | Phase never closes | The MVP definition in §4 is the contract; one direction, one item class |
+| **Phase 2 debt compounding** | Correctness debt in the save path corrupts rando saves, which are longer-lived | §3 items 2–4 before Lane A starts |
+| **Fault A (`0xC0000374` on exit) still open** | Every session ends dirty; may corrupt saves on exit | #371 is a named candidate; re-evaluate Fault A after it lands |


### PR DESCRIPTION
Adds `docs/phase3-execution-prompt.md` (the wave plan to execute) and amends `docs/phase3-roadmap.md` with a `§0.1` correcting six claims that a code review and ODR sweep falsified after the roadmap was written on 07-18.

The roadmap is sound as a *plan*; what changed is the *state* it described. Four corrections invalidate a plan someone would reasonably derive from the body:

1. **MM's randomizer is not in the shipping binary.** `2ship_rando` is built and linked, but no undefined symbol references it, so the linker discards every object — every non-`Rando/` caller of `Rando::` is in an excluded TU. Verified by string-probing `redship.exe` (Rando menu string **absent**, MotionBlur control string **present**). Makes **#384 a Lane C blocker**; the `rando` CTest label covers only OoT.
2. **The cross-game seed does not propagate in single-exe.** The cited sites are in the legacy `OoT_/MM_FreezeState` path — `switch.cpp:171` states it is non-single-exe-only, and its sole caller has no callers. The live path carries a `SaveContext` blob and no `ComboContext`. Lane A is larger than scoped.
3. **`ComboContext` has no serialization headroom.** `save.cpp:31` + `DeserializeHeader` exact-match-refuse, and the roadmap's own origin-tagging mitigation changes `sizeof(ComboContext)` — so landing Lane A silently stops every existing `.redsave` from loading. Must precede the `v0.1.0-prealpha` tag.
4. **§7's "Fault A may corrupt saves" is wrong.** That write path is atomic temp-plus-rename with a CRC32; the exposure is a *missed* write, not corruption.

Plus: #370 gates Lane A (the `.redsave` write runs inside the poisoned mutex via hook dispatch), and #387's proposed link-only CI job cannot exist — 31.42 of build-linux's 32.7 minutes is compilation, so the real lever is the ccache save policy at `generate-builds.yml:227`.

Docs-only; no code paths touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)