### PR TITLE
CI: save ccache on feature branches so long-lived branches stop re-missing

### DIFF
--- a/.github/workflows/generate-builds.yml
+++ b/.github/workflows/generate-builds.yml
@@ -76,7 +76,11 @@ jobs:
       if: steps.rsbs-otr-cache.outputs.cache-hit != 'true'
       uses: hendrikmuhs/ccache-action@v1.2
       with:
-        save: ${{ github.ref_name == github.event.repository.default_branch }}
+        # Save on every branch (same rationale as build-linux's ccache step).
+        # This step only runs when the port-archive cache missed, and it uses
+        # the action's default 500M cap, so its quota footprint is small and
+        # infrequent.
+        save: true
         key: ${{ runner.os }}-otr-ccache-${{ github.ref }}
         restore-keys: |
           ${{ runner.os }}-otr-ccache-${{ github.ref }}
@@ -224,7 +228,22 @@ jobs:
     - name: Configure ccache
       uses: hendrikmuhs/ccache-action@v1.2
       with:
-        save: ${{ github.ref_name == github.event.repository.default_branch }}
+        # Save on every branch, not just main. Compilation is 31.42 of this
+        # job's 32.7 minutes, so a cache miss is essentially the whole job.
+        # Under the old main-only policy a PR restored main's cache but never
+        # wrote one back, so every push to a long-lived claude/** branch
+        # re-compiled that branch's own touched files from scratch — the same
+        # misses, forever. With save on, push N+1 restores push N's cache
+        # (the key below is ref-scoped and the action appends a timestamp, so
+        # restore-keys prefix-matches the newest entry for this ref).
+        #
+        # This cannot poison main's cache: GitHub scopes a cache to the ref
+        # that wrote it. A PR run writes to refs/pull/<n>/merge, which only
+        # that PR can read; main still restores only main-written entries.
+        # The real cost is quota — see the sccache step below, which stays
+        # main-only because its per-run save is ~2.3GB. This one is capped at
+        # 1.5G and PR-scoped caches are released when the PR closes.
+        save: true
         # The action's default 500M cap is too small for the full OoT+MM build
         # (~8180 objects): measured 2026-06-11 at 89.66% full with 15 cleanups
         # and a 73.24% hit rate. The working set is ~1.0-1.2G compressed.
@@ -348,6 +367,13 @@ jobs:
         # 2026-06-01). Main merges several times a day, so the main-keyed
         # cache restored via restore-keys is nearly fresh for every PR; a PR's
         # repeated pushes only re-compile files the PR itself touched.
+        #
+        # Deliberately NOT changed when build-linux's ccache moved to
+        # save-on-every-branch: this step is the one with direct measured
+        # evidence of blowing the quota, its per-run save is ~2.3GB (vs 1.5G
+        # capped on Linux), and Windows already runs at a 99.8% hit rate off
+        # main's cache, so there is little left for a branch-scoped cache to
+        # win. Revisit only with fresh hit-rate numbers.
         save: ${{ github.ref_name == github.event.repository.default_branch }}
         key: ${{ runner.os }}-sccache-${{ github.ref }}
         restore-keys: |

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -162,7 +162,11 @@ jobs:
         CXX: g++-11
 
     - name: Run unit tests
-      run: ctest --test-dir build-cmake --output-on-failure --label-regex "^redship$"
+      # --no-tests=error: without it, a regression that drops the "redship" label
+      # (renamed target, dropped add_test, CMake option flip) makes ctest print
+      # "No tests were found" and exit 0 — a green run that tested nothing. Both
+      # sibling invocations already carry it; this one was the odd one out (#376).
+      run: ctest --test-dir build-cmake --output-on-failure --label-regex "^redship$" --no-tests=error
 
     # Seed generation needs the windowed bring-up (hence xvfb-run) but no game
     # archives, so it runs unconditionally — unlike the archive-gated int-*


### PR DESCRIPTION
## What was broken

`build-linux` **restored** a ccache but never **saved** one unless the run was on the default branch:

```yaml
save: ${{ github.ref_name == github.event.repository.default_branch }}
```

Compilation is **31.42 of that job's 32.7 minutes**. A restore on a feature branch can only come from main's cache, which by definition does not contain the branch's own touched objects — and since nothing was ever written back, push 1 and push 20 of a long-lived `claude/**` branch missed on exactly the same files. The most expensive part of CI was being paid over and over for no reason.

Separately (#376), `integration-tests.yml:165` was missing `--no-tests=error` that both sibling ctest invocations (`:171`, `generate-builds.yml:274`) carry.

## Mechanism

The keys were already shaped correctly — ref-scoped with a main fallback:

```yaml
key: ${{ runner.os }}-ccache-${{ github.ref }}
restore-keys: |
  ${{ runner.os }}-ccache-${{ github.ref }}
  ${{ runner.os }}-ccache-refs/heads/main
  ${{ runner.os }}-ccache
```

`hendrikmuhs/ccache-action` appends a timestamp to the save key, so `restore-keys` prefix-matches the newest entry for the ref, and the main-keyed line is the cold-start fallback. **Only the write was missing.** So the fix is `save: true` on `build-linux` and `generate-rsbs-otr`, not a new key scheme.

**This cannot poison the default-branch cache.** GitHub scopes a cache entry to the ref that created it: a PR run writes `refs/pull/<n>/merge`, readable only by that PR and never by main. Branch-scoped write with a default-branch restore fallback is exactly the documented mechanism, and it was already half-configured here.

## What was deliberately left alone

`build-windows`' sccache **stays main-only**. It is the step with direct measured evidence of exhausting the 10GB Actions quota — 2026-06-11: per-PR ~2.3GB saves LRU-evicted main's caches, dropping the hit rate to 65.89% and builds to ~26 min. Its per-run save is ~2.3GB against Linux's 1.5G cap, and it already runs at a 99.8% hit rate off main, so a branch-scoped cache has little left to win. A comment now records why the two policies diverge, so the next reader does not "fix" the inconsistency.

`build-macos` is `if: false` and was left untouched.

## Relationship to #387

This **supersedes #387's proposed remedy while its diagnosis stands**. The diagnosis — CI feedback is slow and the cost is concentrated in `build-linux` — is correct and is what this PR acts on. The proposed "link-only job" remedy does not work: since 31.42 of 32.7 minutes is compilation, stripping assets, tests, and packaging saves ~1.1 minutes, so the advertised ~5-minute job cannot exist. Caching the compilation is the lever that actually moves the number.

## Verification

No local build (a full build is ~25 min and would thrash the machine; CI builds this). Verified statically:

- Both workflows parse as YAML.
- Resolved `save:` per job is what was intended:
  ```
  generate-rsbs-otr | Configure ccache  | save = True
  build-macos       | Configure ccache  | save = '${{ ... default_branch }}'   (if: false)
  build-linux       | Configure ccache  | save = True
  build-windows     | Configure sccache | save = '${{ ... default_branch }}'
  ```
- No touched file is in `.github/clang-format-paths.txt` (yaml only), so the format gate is unaffected.

The real signal arrives empirically: this PR's **second** push should show a materially higher Linux ccache hit rate in the action's post-build stats than its first. That is the thing to look at before trusting the change.

Refs #387, #376 — closing neither, as both contain further items beyond what is fixed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!--- section:artifacts:start -->
### Build Artifacts
  - [rsbs-windows.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/8452315751.zip)
  - [rsbs-linux.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/8452143346.zip)
<!--- section:artifacts:end -->