### PR TITLE
Fail fast on headless crashes instead of blocking in SDL_ShowSimpleMessageBox

### DIFF
--- a/CMake/SingleExecutable.cmake
+++ b/CMake/SingleExecutable.cmake
@@ -18,6 +18,9 @@ message(STATUS "=== Single Executable Architecture Enabled ===")
 set(REDSHIP_COMMON_SOURCES
     ${CMAKE_SOURCE_DIR}/src/common/game.c
     ${CMAKE_SOURCE_DIR}/src/common/archive_check.cpp
+    # Unattended-safe crash handling: replaces libultraship's modal crash
+    # dialog with stderr + immediate non-zero exit on headless runs (#388)
+    ${CMAKE_SOURCE_DIR}/src/common/headless_crash.cpp
     # Bundled ZAPD subprocess driver shared by both games' in-app extraction (#325)
     ${CMAKE_SOURCE_DIR}/src/common/zapd_subprocess.cpp
     ${CMAKE_SOURCE_DIR}/src/common/context.cpp
@@ -51,6 +54,7 @@ endif()
 set(REDSHIP_COMMON_HEADERS
     ${CMAKE_SOURCE_DIR}/src/common/game.h
     ${CMAKE_SOURCE_DIR}/src/common/archive_check.h
+    ${CMAKE_SOURCE_DIR}/src/common/headless_crash.h
     ${CMAKE_SOURCE_DIR}/src/common/zapd_subprocess.h
     ${CMAKE_SOURCE_DIR}/src/common/context.h
     ${CMAKE_SOURCE_DIR}/src/common/entrance.h

--- a/rsbs/src/main.cpp
+++ b/rsbs/src/main.cpp
@@ -30,6 +30,7 @@
 #include "test_runner.h"
 #include "integration_test_hooks.h"
 #include "archive_check.h"
+#include "headless_crash.h"
 
 #include <ship/Context.h>
 #include <ship/resource/ResourceManager.h>
@@ -100,7 +101,12 @@ extern "C" {
 }
 
 // ============================================================================
-// Signal handler for crash diagnostics
+// Startup crash handler for crash diagnostics
+//
+// Covers the window before the Ship::Context singleton exists, which is the
+// only stretch src/common/headless_crash.cpp cannot reach (it needs a context
+// to claim libultraship's handler from). Once HeadlessCrash_ClaimAndInstall
+// runs below, these are superseded.
 // ============================================================================
 
 #ifndef _WIN32
@@ -136,8 +142,6 @@ static void InstallCrashHandler(void) {
 }
 #else
 #include <windows.h>
-#include <io.h>
-#include <ship/debug/CrashHandler.h>
 
 static LONG WINAPI CrashHandler(EXCEPTION_POINTERS* exceptionInfo) {
     fprintf(stderr, "\n[CRASH] Windows exception: 0x%08X\n",
@@ -150,116 +154,7 @@ static void InstallCrashHandler(void) {
     SetUnhandledExceptionFilter(CrashHandler);
 }
 
-// Map the fatal Windows exception codes to the POSIX signal numbers the
-// integration tier documents (docs/ci-gameplay-repro-postmortem.md §7:
-// exit >= 128 means "crashed", signal = code - 128), so CI and the agent
-// loop read Windows crashes the same way they read Linux ones.
-static int MapExceptionToSignal(DWORD code) {
-    switch (code) {
-        case EXCEPTION_ACCESS_VIOLATION:
-        case EXCEPTION_IN_PAGE_ERROR:
-        case EXCEPTION_STACK_OVERFLOW:
-            return 11; // SIGSEGV
-        case EXCEPTION_ILLEGAL_INSTRUCTION:
-        case EXCEPTION_PRIV_INSTRUCTION:
-            return 4; // SIGILL
-        case EXCEPTION_INT_DIVIDE_BY_ZERO:
-        case EXCEPTION_INT_OVERFLOW:
-        case EXCEPTION_FLT_DIVIDE_BY_ZERO:
-        case EXCEPTION_FLT_INVALID_OPERATION:
-        case EXCEPTION_FLT_OVERFLOW:
-        case EXCEPTION_FLT_UNDERFLOW:
-        case EXCEPTION_FLT_INEXACT_RESULT:
-        case EXCEPTION_FLT_DENORMAL_OPERAND:
-        case EXCEPTION_FLT_STACK_CHECK:
-            return 8; // SIGFPE
-        default:
-            return 6; // SIGABRT-equivalent bucket
-    }
-}
-
-/**
- * Integration-mode unhandled-exception filter (Windows).
- *
- * libultraship's CrashHandler constructor takes over the process filter
- * during shared bring-up, and its seh_filter ends in a MODAL MessageBoxA —
- * on an unattended runner a crashed test hangs until the CTest timeout,
- * and the register/backtrace dump is lost if nobody clicks. In integration
- * mode we take the filter back after game init and do what the POSIX side
- * documents:
- *   1. raw _write of the exception code to stderr (stdio can be unusable
- *      in a crash context — this breadcrumb must always escape),
- *   2. best-effort gameplay phase dump,
- *   3. libultraship's own PrintStack (identical registers + traceback dump
- *      into the rotating log, including the flush) minus the MessageBox,
- *   4. TerminateProcess(128 + signal).
- * Release (non-test) behavior is unchanged: this filter is only installed
- * when TestRunner_IsIntegrationTestMode().
- */
-static LONG WINAPI IntegrationCrashFilter(EXCEPTION_POINTERS* exceptionInfo) {
-    DWORD code = exceptionInfo->ExceptionRecord->ExceptionCode;
-    char buf[256];
-    int n = snprintf(buf, sizeof(buf), "\n[CRASH] Windows exception: 0x%08lX (integration mode)\n",
-                     (unsigned long)code);
-    if (n > 0) {
-        _write(2, buf, (unsigned int)n);
-    }
-
-    // ASLR-independent fault location: exe-relative offset survives across
-    // runs and resolves to a function via the linker map (redship.map), even
-    // without PDBs. For access violations also say read-vs-write and the
-    // faulting address — a small faulting address is a near-NULL field deref
-    // and its value is the field offset.
-    {
-        uintptr_t rip = (uintptr_t)exceptionInfo->ExceptionRecord->ExceptionAddress;
-        uintptr_t base = (uintptr_t)GetModuleHandleA(NULL);
-        n = snprintf(buf, sizeof(buf), "[CRASH] addr=%p exe_base=%p exe_offset=0x%zX\n", (void*)rip, (void*)base,
-                     (size_t)(rip >= base ? rip - base : rip));
-        if (n > 0) {
-            _write(2, buf, (unsigned int)n);
-        }
-        if (code == EXCEPTION_ACCESS_VIOLATION && exceptionInfo->ExceptionRecord->NumberParameters >= 2) {
-            const ULONG_PTR* info = exceptionInfo->ExceptionRecord->ExceptionInformation;
-            n = snprintf(buf, sizeof(buf), "[CRASH] access violation: %s at 0x%zX\n",
-                         info[0] == 1 ? "WRITE" : (info[0] == 8 ? "EXEC" : "READ"), (size_t)info[1]);
-            if (n > 0) {
-                _write(2, buf, (unsigned int)n);
-            }
-        }
-    }
-
-    if (IntegrationTest_GetMode() == INT_TEST_GAMEPLAY_ROUNDTRIP) {
-        IntegrationTest_LogGameplayState("signal");
-    }
-
-    // Same dump path libultraship's own filter uses (registers + traceback
-    // appended as a CRITICAL record to the log, then flushed) — just without
-    // the modal MessageBox that would hang an unattended run.
-    auto ctx = Ship::Context::GetInstance();
-    if (ctx != nullptr && ctx->GetCrashHandler() != nullptr) {
-        ctx->GetCrashHandler()->PrintStack(exceptionInfo->ContextRecord);
-    }
-
-    TerminateProcess(GetCurrentProcess(), (UINT)(128 + MapExceptionToSignal(code)));
-    return EXCEPTION_EXECUTE_HANDLER; // unreachable
-}
 #endif
-
-/**
- * Re-take the crash handling after game init. libultraship's CrashHandler
- * constructor (shared Ship::Context bring-up) replaces whatever filter main()
- * installed at startup; in integration mode we need the unattended-safe
- * filter above to be the active one. No-op outside integration mode and on
- * POSIX (there libultraship's sigaction handlers already write the dump and
- * exit non-zero without human interaction, which is all the tier needs).
- */
-static void ReinstallCrashHandlerForIntegration(void) {
-#ifdef _WIN32
-    if (TestRunner_IsIntegrationTestMode()) {
-        SetUnhandledExceptionFilter(IntegrationCrashFilter);
-    }
-#endif
-}
 
 // ============================================================================
 // Command line parsing
@@ -438,6 +333,19 @@ int main(int argc, char** argv) {
     fprintf(stderr, "[RSBS] Ship::Context singleton created successfully at %p\n", (void*)shipContext.get());
     fflush(stderr);
 
+    // Claim crash handling BEFORE any game init runs (#388).
+    //
+    // Ship::CrashHandler ends every fatal fault in a modal dialog
+    // (SDL_ShowSimpleMessageBox on Linux, MessageBoxA on Windows). With nobody
+    // to click OK the process never returns from it, so on a runner a crash
+    // presents as a CTest timeout with no exit code, no signal and no
+    // traceback — which is how three "rando-gen hangs" hid a boot SIGSEGV and
+    // cost a Linux bisect. This must happen here rather than after game init:
+    // the #388 fault fired *inside* init (InitOTRForMMFirstBoot ->
+    // ShipInit::InitAll), so a post-init reinstall would have missed it.
+    // Interactive sessions are untouched and still get the dialog.
+    HeadlessCrash_ClaimAndInstall();
+
     // ========================================================================
     // Set up GameRunner with composable lifecycle
     // ========================================================================
@@ -571,11 +479,13 @@ int main(int argc, char** argv) {
     // cross-game entrance hooks dispatch against the right game (issue #170).
     Context_SetCurrentGame(selectedGame);
 
-    // Game init created the shared Ship::Context, whose CrashHandler stole
-    // the process exception filter (and on Windows ends crashes in a modal
-    // MessageBox). In integration mode, take it back so a crashed test dumps
-    // and exits instead of hanging an unattended runner.
-    ReinstallCrashHandlerForIntegration();
+    // Belt and braces: re-assert the unattended-safe handlers after game init.
+    // The claim above already makes Ship::Context::InitCrashHandler a no-op
+    // for both games, so nothing should have taken the handlers back — but
+    // this costs nothing and the failure mode it guards against (a silent
+    // re-registration turning every crash into a timeout again) is expensive
+    // and hard to spot.
+    HeadlessCrash_ClaimAndInstall();
 
     // Note: the previous MM-test detour (init OoT then SwitchTo MM) was
     // removed with #271 — MM integration tests now boot MM directly above.

--- a/src/common/archive_check.cpp
+++ b/src/common/archive_check.cpp
@@ -8,6 +8,7 @@
  */
 
 #include "archive_check.h"
+#include "headless_crash.h"
 
 #include <cstdio>
 #include <filesystem>
@@ -144,7 +145,7 @@ extern "C" void ArchiveCheck_ReportMissingPortArchive(GameId game, bool showDial
     fprintf(stderr, "\n[RSBS] === %s ===\n%s\n", title, msg.c_str());
     fflush(stderr);
 
-    if (showDialog) {
+    if (showDialog && !HeadlessCrash_IsHeadless()) {
         SDL_ShowSimpleMessageBox(SDL_MESSAGEBOX_ERROR, title, msg.c_str(), nullptr);
     }
 }
@@ -175,9 +176,12 @@ extern "C" void ArchiveCheck_ReportMissing(GameId game, bool showDialog) {
     fprintf(stderr, "\n[RSBS] === %s ===\n%s\n", title.c_str(), msg.c_str());
     fflush(stderr);
 
-    if (showDialog) {
-        // Works before SDL_Init/window creation; on headless systems it fails
-        // silently and the stderr text above is the fallback.
+    if (showDialog && !HeadlessCrash_IsHeadless()) {
+        // Works before SDL_Init/window creation. On a headless session it does
+        // NOT reliably fail silently — with a display server reachable but
+        // unattended it blocks waiting for a click — so the headless gate,
+        // not the SDL fallback, is what keeps CI from hanging here (#388).
+        // The stderr text above is the output that always survives.
         SDL_ShowSimpleMessageBox(SDL_MESSAGEBOX_ERROR, title.c_str(), msg.c_str(), nullptr);
     }
 }

--- a/src/common/headless_crash.cpp
+++ b/src/common/headless_crash.cpp
@@ -1,0 +1,343 @@
+/**
+ * @file headless_crash.cpp
+ * @brief Unattended-safe crash handling for the single executable (issue #388)
+ *
+ * See headless_crash.h for the rationale. The short version: libultraship's
+ * crash handlers end in a modal dialog, and a modal dialog on a runner is an
+ * infinite loop. Here a fatal fault instead produces a few lines on stderr and
+ * an immediate non-zero exit.
+ *
+ * Everything on the fault path is written with raw write(2)/_write, not
+ * printf: stdio locks can already be held by the thread we just interrupted,
+ * and a crash handler that deadlocks on a mutex is the same 180-second
+ * timeout by a different route.
+ */
+
+#include "headless_crash.h"
+
+// C headers, not their <c*> spellings: the fault path uses size_t/uintptr_t
+// unqualified, and only the C forms are guaranteed to declare them in the
+// global namespace.
+#include <stddef.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include <ship/Context.h>
+
+#include "integration_test_hooks.h"
+#include "test_runner.h"
+
+#ifdef _WIN32
+#include <windows.h>
+#include <io.h>
+#include <ship/debug/CrashHandler.h>
+#if defined(_MSC_VER)
+// GetUserObjectInformationW (window-station visibility probe) lives in user32.
+#pragma comment(lib, "user32.lib")
+#endif
+#else
+#include <execinfo.h>
+#include <signal.h>
+#include <unistd.h>
+#endif
+
+namespace {
+
+// --------------------------------------------------------------------------
+// Async-signal-safe output primitives
+// --------------------------------------------------------------------------
+
+void RawWrite(const char* str, size_t len) {
+#ifdef _WIN32
+    _write(2, str, (unsigned int)len);
+#else
+    // Deliberately ignoring the result: there is nothing useful to do about a
+    // short write from inside a crash handler, and we are about to _exit.
+    ssize_t ignored = write(2, str, len);
+    (void)ignored;
+#endif
+}
+
+void RawWrite(const char* str) {
+    RawWrite(str, strlen(str));
+}
+
+// Unsigned -> text without snprintf, which is not async-signal-safe.
+void RawWriteNum(unsigned long long value, int base) {
+    char buf[24];
+    int i = (int)sizeof(buf);
+    buf[--i] = '\0';
+    if (value == 0) {
+        buf[--i] = '0';
+    }
+    while (value != 0 && i > 0) {
+        unsigned digit = (unsigned)(value % (unsigned)base);
+        buf[--i] = (char)(digit < 10 ? '0' + digit : 'a' + (digit - 10));
+        value /= (unsigned)base;
+    }
+    RawWrite(&buf[i]);
+}
+
+// --------------------------------------------------------------------------
+// Headless detection
+// --------------------------------------------------------------------------
+
+bool EnvSet(const char* name) {
+    const char* value = getenv(name);
+    return value != nullptr && value[0] != '\0';
+}
+
+bool sForcedHeadless = false;
+
+bool DetectHeadless() {
+    // Explicit override wins in both directions. RSBS_HEADLESS=0 is the escape
+    // hatch for a desktop user whose environment trips one of the heuristics.
+    const char* forced = getenv("RSBS_HEADLESS");
+    if (forced != nullptr && forced[0] != '\0') {
+        return strcmp(forced, "0") != 0;
+    }
+
+    // An entry point that knows it is unattended (the unit-test harness) said
+    // so explicitly.
+    if (sForcedHeadless) {
+        return true;
+    }
+
+    // Any test mode is unattended by construction — a test that waits for a
+    // human is a test that times out.
+    if (TestRunner_IsIntegrationTestMode()) {
+        return true;
+    }
+
+    if (EnvSet("CI") || EnvSet("GITHUB_ACTIONS")) {
+        return true;
+    }
+
+#ifdef _WIN32
+    // The authoritative Windows question is not "is stderr a tty" (CI
+    // redirects it) but "does this process have a desktop to draw on".
+    // A non-visible window station — a service, or a session-0 job — makes
+    // MessageBoxA unanswerable.
+    HWINSTA station = GetProcessWindowStation();
+    USEROBJECTFLAGS flags;
+    DWORD needed = 0;
+    if (station != nullptr &&
+        GetUserObjectInformationW(station, UOI_FLAGS, &flags, (DWORD)sizeof(flags), &needed)) {
+        if ((flags.dwFlags & WSF_VISIBLE) == 0) {
+            return true;
+        }
+    }
+    return false;
+#else
+    // No display server at all: SDL cannot open a window, and its message box
+    // fallback is what blocks in an X11 poll().
+    return !EnvSet("DISPLAY") && !EnvSet("WAYLAND_DISPLAY");
+#endif
+}
+
+// --------------------------------------------------------------------------
+// Fault handlers
+// --------------------------------------------------------------------------
+
+#ifndef _WIN32
+
+const char* SignalName(int sig) {
+    switch (sig) {
+        case SIGSEGV:
+            return "SIGSEGV (invalid access to storage)";
+        case SIGBUS:
+            return "SIGBUS (bad memory access)";
+        case SIGILL:
+            return "SIGILL (illegal instruction)";
+        case SIGFPE:
+            return "SIGFPE (erroneous arithmetic operation)";
+        case SIGABRT:
+            return "SIGABRT (abort)";
+        default:
+            return "unknown fatal signal";
+    }
+}
+
+void HeadlessSignalHandler(int sig, siginfo_t* info, void* /*ucontext*/) {
+    // Re-arm as SIG_DFL first. If anything below faults a second time the
+    // process dies on the spot rather than recursing through this handler.
+    signal(sig, SIG_DFL);
+
+    RawWrite("\n[CRASH] ");
+    RawWrite(SignalName(sig));
+    RawWrite(" (signal ");
+    RawWriteNum((unsigned long long)sig, 10);
+    RawWrite(")\n");
+
+    if (info != nullptr && (sig == SIGSEGV || sig == SIGBUS)) {
+        RawWrite("[CRASH] fault address: 0x");
+        RawWriteNum((unsigned long long)(uintptr_t)info->si_addr, 16);
+        // A small faulting address is a near-null dereference, and its value
+        // is the struct field offset — worth reading literally.
+        RawWrite("\n");
+    }
+
+    // backtrace_symbols_fd is the async-signal-safe member of the backtrace
+    // family: it formats into the fd without allocating, unlike
+    // backtrace_symbols. Symbols are mangled, but the frame addresses alone
+    // resolve through addr2line, and that is infinitely more than a timeout
+    // gives us today.
+    void* frames[64];
+    int count = backtrace(frames, (int)(sizeof(frames) / sizeof(frames[0])));
+    RawWrite("[CRASH] traceback (");
+    RawWriteNum((unsigned long long)count, 10);
+    RawWrite(" frames):\n");
+    backtrace_symbols_fd(frames, count, 2);
+
+    // Best effort, and deliberately last: this touches game state and is not
+    // async-signal-safe, so it runs only after the breadcrumbs above have
+    // already escaped to stderr.
+    if (IntegrationTest_GetMode() == INT_TEST_GAMEPLAY_ROUNDTRIP) {
+        IntegrationTest_LogGameplayState("signal");
+    }
+
+    RawWrite("[CRASH] exiting immediately (headless session; no crash dialog)\n");
+
+    // 128 + signal is the convention the integration tier documents
+    // (docs/ci-gameplay-repro-postmortem.md 7) so CI can tell "crashed" from
+    // "test failed". _exit, not exit: static destructors on a corrupted heap
+    // are how a crash turns back into a hang.
+    _exit(128 + sig);
+}
+
+void InstallHandlers() {
+    // Warm up backtrace() now. Its first call dlopens libgcc and allocates;
+    // doing that lazily from inside a SIGSEGV handler can deadlock on the
+    // loader lock.
+    void* warmup[4];
+    (void)backtrace(warmup, 4);
+
+    struct sigaction action;
+    memset(&action, 0, sizeof(action));
+    action.sa_flags = SA_SIGINFO;
+    action.sa_sigaction = HeadlessSignalHandler;
+    sigemptyset(&action.sa_mask);
+
+    sigaction(SIGSEGV, &action, nullptr);
+    sigaction(SIGBUS, &action, nullptr);
+    sigaction(SIGILL, &action, nullptr);
+    sigaction(SIGFPE, &action, nullptr);
+    sigaction(SIGABRT, &action, nullptr);
+}
+
+#else // _WIN32
+
+// Map the fatal Windows exception codes onto the POSIX signal numbers the
+// integration tier documents, so a Windows crash reads the same way a Linux
+// one does (exit >= 128 means crashed, signal = code - 128).
+int MapExceptionToSignal(DWORD code) {
+    switch (code) {
+        case EXCEPTION_ACCESS_VIOLATION:
+        case EXCEPTION_IN_PAGE_ERROR:
+        case EXCEPTION_STACK_OVERFLOW:
+            return 11; // SIGSEGV
+        case EXCEPTION_ILLEGAL_INSTRUCTION:
+        case EXCEPTION_PRIV_INSTRUCTION:
+            return 4; // SIGILL
+        case EXCEPTION_INT_DIVIDE_BY_ZERO:
+        case EXCEPTION_INT_OVERFLOW:
+        case EXCEPTION_FLT_DIVIDE_BY_ZERO:
+        case EXCEPTION_FLT_INVALID_OPERATION:
+        case EXCEPTION_FLT_OVERFLOW:
+        case EXCEPTION_FLT_UNDERFLOW:
+        case EXCEPTION_FLT_INEXACT_RESULT:
+        case EXCEPTION_FLT_DENORMAL_OPERAND:
+        case EXCEPTION_FLT_STACK_CHECK:
+            return 8; // SIGFPE
+        default:
+            return 6; // SIGABRT-equivalent bucket
+    }
+}
+
+LONG WINAPI HeadlessExceptionFilter(EXCEPTION_POINTERS* exceptionInfo) {
+    const DWORD code = exceptionInfo->ExceptionRecord->ExceptionCode;
+
+    RawWrite("\n[CRASH] Windows exception: 0x");
+    RawWriteNum((unsigned long long)code, 16);
+    RawWrite("\n");
+
+    // ASLR-independent fault location: an exe-relative offset survives across
+    // runs and resolves to a function through the linker map (redship.map)
+    // even without PDBs.
+    {
+        uintptr_t rip = (uintptr_t)exceptionInfo->ExceptionRecord->ExceptionAddress;
+        uintptr_t base = (uintptr_t)GetModuleHandleA(nullptr);
+        RawWrite("[CRASH] addr=0x");
+        RawWriteNum((unsigned long long)rip, 16);
+        RawWrite(" exe_base=0x");
+        RawWriteNum((unsigned long long)base, 16);
+        RawWrite(" exe_offset=0x");
+        RawWriteNum((unsigned long long)(rip >= base ? rip - base : rip), 16);
+        RawWrite("\n");
+    }
+
+    if (code == EXCEPTION_ACCESS_VIOLATION && exceptionInfo->ExceptionRecord->NumberParameters >= 2) {
+        const ULONG_PTR* info = exceptionInfo->ExceptionRecord->ExceptionInformation;
+        RawWrite("[CRASH] access violation: ");
+        RawWrite(info[0] == 1 ? "WRITE" : (info[0] == 8 ? "EXEC" : "READ"));
+        RawWrite(" at 0x");
+        RawWriteNum((unsigned long long)info[1], 16);
+        RawWrite("\n");
+    }
+
+    if (IntegrationTest_GetMode() == INT_TEST_GAMEPLAY_ROUNDTRIP) {
+        IntegrationTest_LogGameplayState("signal");
+    }
+
+    // The same registers + traceback dump libultraship's own filter produces
+    // (appended to the rotating log as a CRITICAL record, then flushed) —
+    // just without the modal MessageBoxA that follows it upstream.
+    auto ctx = Ship::Context::GetInstance();
+    if (ctx != nullptr && ctx->GetCrashHandler() != nullptr) {
+        ctx->GetCrashHandler()->PrintStack(exceptionInfo->ContextRecord);
+    }
+
+    RawWrite("[CRASH] exiting immediately (headless session; no crash dialog)\n");
+
+    TerminateProcess(GetCurrentProcess(), (UINT)(128 + MapExceptionToSignal(code)));
+    return EXCEPTION_EXECUTE_HANDLER; // unreachable
+}
+
+void InstallHandlers() {
+    SetUnhandledExceptionFilter(HeadlessExceptionFilter);
+}
+
+#endif // _WIN32
+
+} // namespace
+
+extern "C" void HeadlessCrash_ForceHeadless(void) {
+    sForcedHeadless = true;
+}
+
+extern "C" int HeadlessCrash_IsHeadless(void) {
+    // Cached: getenv is not async-signal-safe, and the verdict must not be
+    // able to differ between install time and fault time.
+    static const bool sHeadless = DetectHeadless();
+    return sHeadless ? 1 : 0;
+}
+
+extern "C" void HeadlessCrash_ClaimAndInstall(void) {
+    // Construct libultraship's CrashHandler now, on our terms. It is
+    // idempotent, so the later calls from OoT's OTRGlobals and MM's BenPort
+    // find it already built and skip their sigaction/SetUnhandledExceptionFilter
+    // registration entirely. Without this the window between game init and
+    // any later re-install is unprotected — and that window is exactly where
+    // the #388 boot SIGSEGV fired.
+    auto ctx = Ship::Context::GetInstance();
+    if (ctx != nullptr) {
+        (void)ctx->InitCrashHandler();
+    }
+
+    if (!HeadlessCrash_IsHeadless()) {
+        return; // Desktop user: keep upstream's dialog and rich log dump.
+    }
+
+    InstallHandlers();
+}

--- a/src/common/headless_crash.h
+++ b/src/common/headless_crash.h
@@ -1,0 +1,87 @@
+/**
+ * @file headless_crash.h
+ * @brief Unattended-safe crash handling for the single executable (issue #388)
+ *
+ * libultraship's Ship::CrashHandler ends every fatal fault in a MODAL dialog:
+ * SDL_ShowSimpleMessageBox on Linux, MessageBoxA on Windows. With nobody to
+ * click OK the process never leaves that call, so on a CI runner a crash does
+ * not present as a crash — it presents as a CTest timeout, with no exit code,
+ * no signal number and no traceback. Three "rando-gen hangs" were really a
+ * SIGSEGV at boot; correcting that misread cost a full Linux bisect.
+ *
+ * Worse on Linux: the message box is called BEFORE PrintCommon(), so the crash
+ * dump libultraship assembled is never even flushed to the log. The dialog
+ * suppresses the very output it exists to advertise.
+ *
+ * This module takes crash handling back whenever the session is unattended,
+ * and replaces the dialog with "write it to stderr, exit non-zero, now".
+ *
+ * The handler cannot be installed once at startup and left alone: the
+ * Ship::CrashHandler constructor (sigaction / SetUnhandledExceptionFilter)
+ * runs later, during shared context bring-up, and would overwrite it. See
+ * HeadlessCrash_ClaimAndInstall for how that ordering is closed.
+ */
+
+#ifndef RSBS_HEADLESS_CRASH_H
+#define RSBS_HEADLESS_CRASH_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief Whether this process is running without anyone to answer a dialog.
+ *
+ * True when any of the following holds:
+ *   - RSBS_HEADLESS is set to something other than "0"
+ *   - the process is in unit-test or integration-test mode
+ *   - CI is set in the environment
+ *   - (POSIX) neither DISPLAY nor WAYLAND_DISPLAY is set
+ *   - (Windows) the process window station is not visible, i.e. no
+ *     interactive desktop to draw a message box on
+ *
+ * RSBS_HEADLESS=0 forces "interactive" and is the escape hatch for anyone who
+ * wants libultraship's original dialog behavior back in an odd environment.
+ *
+ * Evaluated once and cached: the answer must not change between install time
+ * and a signal arriving, and getenv is not async-signal-safe.
+ */
+int HeadlessCrash_IsHeadless(void);
+
+/**
+ * @brief Declare this session unattended regardless of the environment.
+ *
+ * For entry points that know there is no human even when the heuristics would
+ * say otherwise — chiefly the unit-test harness, which runs under a live
+ * DISPLAY (rando-gen needs Xvfb for Fast3dWindow bring-up) and so would
+ * otherwise look like a desktop session. Must be called before the first
+ * HeadlessCrash_IsHeadless query, since that answer is cached.
+ */
+void HeadlessCrash_ForceHeadless(void);
+
+/**
+ * @brief Claim crash handling from libultraship and install the fast-fail path.
+ *
+ * Call immediately after creating the Ship::Context singleton and BEFORE any
+ * game init runs. Two things happen:
+ *
+ *  1. Ship::Context::InitCrashHandler() is called here. It is idempotent —
+ *     it returns early once mCrashHandler is non-null — so the later calls
+ *     from OoT's OTRGlobals and MM's BenPort become no-ops and cannot
+ *     re-register libultraship's blocking handlers behind our back. This is
+ *     what makes the fix cover a crash DURING game init, which is where the
+ *     #388 SIGSEGV (InitOTRForMMFirstBoot -> ShipInit::InitAll) actually fired.
+ *
+ *  2. If the session is headless, our own handlers replace libultraship's.
+ *     Interactive sessions are left completely alone: a desktop user still
+ *     gets the crash dialog and the rich log dump.
+ *
+ * Safe to call more than once.
+ */
+void HeadlessCrash_ClaimAndInstall(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // RSBS_HEADLESS_CRASH_H

--- a/src/common/test_runner.cpp
+++ b/src/common/test_runner.cpp
@@ -7,6 +7,7 @@
 #include "context.h"
 #include "entrance.h"
 #include "integration_test_hooks.h"
+#include "headless_crash.h"
 #include "rsbs_version.h"
 #include <cstdio>
 #include <cstring>
@@ -146,7 +147,21 @@ static std::shared_ptr<Ship::Context> CreateHarnessStyleContext(void) {
 #else
     setenv("SHIP_HOME", kBootTestHome, 1);
 #endif
-    return Ship::Context::CreateUninitializedInstance(RSBS_WINDOW_TITLE, "soh", "shipofharkinian.json");
+    auto ctx = Ship::Context::CreateUninitializedInstance(RSBS_WINDOW_TITLE, "soh", "shipofharkinian.json");
+
+    // Take crash handling before any bring-up runs (#388). A unit test is
+    // unattended by definition even though it runs under a live DISPLAY
+    // (rando-gen needs Xvfb), so say so explicitly rather than letting the
+    // DISPLAY heuristic conclude "desktop session". Without this, a fault
+    // inside the bring-up below ends in libultraship's modal
+    // SDL_ShowSimpleMessageBox and the test burns its full CTest timeout
+    // instead of reporting a crash.
+    HeadlessCrash_ForceHeadless();
+    if (ctx) {
+        HeadlessCrash_ClaimAndInstall();
+    }
+
+    return ctx;
 }
 
 TestResult Test_BootOoT(void) {


### PR DESCRIPTION
## What was broken

libultraship's `Ship::CrashHandler` ends every fatal fault in a **modal dialog** — `SDL_ShowSimpleMessageBox` on Linux, `MessageBoxA` on Windows. With nobody to click OK the process never returns from that call, so under CI a crash does not present as a crash: it presents as a CTest timeout, with no exit code, no signal number, and no traceback.

Worse on Linux — the message box is called *before* `PrintCommon()`, so the dump the handler just assembled never reaches the log. The dialog suppresses the exact output it exists to advertise.

This is not hypothetical. Three `rando-gen` tests sitting at exactly their 180s timeout were really a SIGSEGV during `InitOTRForMMFirstBoot` → `ShipInit::InitAll()`. Correcting that misread cost a full Linux bisect (#383, #388).

**The premise held, and was worse than stated on two counts:**
- The Linux ordering bug (dialog before the log flush) is not mentioned in the issue.
- Windows had only a *partial* fix already: `IntegrationCrashFilter` in `main.cpp` was installed only in integration-test mode and only *after* game init. Unit tests — which is where `rando-gen` actually lives — were fully exposed to the modal `MessageBoxA`.

## Mechanism

The blocking call lives in the **libultraship submodule, which this PR does not touch.** The fix uses the one seam available in-repo:

`Ship::Context::InitCrashHandler()` is public and idempotent — it returns early once `mCrashHandler` is non-null. Calling it ourselves right after the `Ship::Context` singleton is created means the later calls from OoT's `OTRGlobals` and MM's `BenPort` find it already built and **skip their `sigaction` / `SetUnhandledExceptionFilter` registration entirely**. Our handlers install on top and cannot be silently displaced.

Claiming it at *singleton creation* rather than after game init is the load-bearing detail: the #388 fault fired **inside** init, so a post-init reinstall would have missed the very crash that motivated this.

## How it's fixed

New `src/common/headless_crash.{h,cpp}`:

- **Headless predicate** (cached — `getenv` is not async-signal-safe, and the verdict must not differ between install time and fault time): `RSBS_HEADLESS` set to non-`"0"`; any test mode; `CI` or `GITHUB_ACTIONS` set; no `DISPLAY` and no `WAYLAND_DISPLAY` (POSIX); non-visible window station (Windows). `RSBS_HEADLESS=0` forces interactive as an escape hatch.
- **POSIX handler**: signal name + number, fault address, `backtrace_symbols_fd` traceback, then `_exit(128 + sig)`. `backtrace()` is warmed at install time so its first call does not allocate under the loader lock from inside a SIGSEGV. Handler re-arms `SIG_DFL` first so a double fault dies rather than recursing.
- **Windows handler**: the existing `IntegrationCrashFilter` logic moves here (exception code, ASLR-independent exe-relative offset, read/write/exec + faulting address, libultraship's own `PrintStack` log dump), minus the `MessageBoxA`, then `TerminateProcess(128 + signal)`. Now covers unit tests too, not just integration mode.
- All fault-path output uses raw `write(2)` / `_write`, never printf: stdio locks can already be held by the thread we interrupted, and a crash handler that deadlocks on a mutex is the same 180s timeout by another route.
- Exit code `128 + signal` on both platforms, matching the convention the integration tier already documents.

**Interactive sessions are untouched** — a desktop user still gets the dialog and the rich log dump.

Wired in at both entry points: `rsbs/src/main.cpp` (after singleton creation, plus a cheap belt-and-braces re-assert after game init) and `src/common/test_runner.cpp`'s `CreateHarnessStyleContext` funnel. The test harness declares itself headless explicitly, because `rando-gen` runs under Xvfb for Fast3dWindow bring-up and would otherwise look like a desktop session to the `DISPLAY` heuristic.

Also gates `archive_check.cpp`'s two "archive missing" dialogs on the same predicate. Those already print to stderr first, but the dialog blocks identically when a display server is reachable but unattended — the old comment's assumption that it "fails silently on headless systems" only holds when there is no display server at all.

## How I verified

Static verification only — per the wave rules I did not build locally (no compiler on this box either, so no local syntax check). CI is the verification gate here.

Reasoning that was checked against the source rather than assumed:
- `Context::InitCrashHandler`'s early return (`libultraship/src/ship/Context.cpp:255-258`) is what makes the claim-first approach work — confirmed by reading it.
- Its two in-repo callers (`games/oot/soh/OTRGlobals.cpp:908`, `games/mm/2s2h/BenPort.cpp:258`) call it bare and register no callback there, so pre-empting them loses nothing. `CrashHandlerRegisterCallback` (OoT/MM `main.c`) operates on the existing object and in fact becomes *more* reliable, since the handler is now guaranteed to exist by the time it runs.
- `rando-gen` is a `--test` unit test whose context comes from `CreateHarnessStyleContext`, not from `main()` — which is why the test-runner funnel needed wiring separately. This is the specific gap that would have left #388's own repro unfixed.

**What CI needs to confirm:** that both platforms compile and that the existing suite stays green. Behavior under an actual crash is not exercised by any current test.

Closes #388.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!--- section:artifacts:start -->
### Build Artifacts
  - [rsbs-windows.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/8452367724.zip)
  - [rsbs-linux.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/8452247231.zip)
<!--- section:artifacts:end -->