### PR TITLE
Reject duplicate entrance-link registrations instead of silently shadowing

### DIFF
--- a/CMake/SingleExecutable.cmake
+++ b/CMake/SingleExecutable.cmake
@@ -219,6 +219,14 @@ if(BUILD_TESTING)
     # linear gEntranceTable index — the OOB-read crash behind the Market
     # cutscene 0xC0000005.
     add_test(NAME StartupEntrance COMMAND redship --test startup-entrance)
+    # Entrance-link dedup regression (#374): the default (mask shop) and test
+    # (Mido's House) links both return through MM 0xC010, and both were
+    # registered unconditionally. Entrance_CheckCrossGame resolves first-match,
+    # so the default silently shadowed the test link — enter MM from Mido's
+    # House, walk back into the Clock Tower, exit in Hyrule Market instead of
+    # Kokiri Forest. Locks that a duplicate (sourceGame, sourceEntrance) is
+    # rejected atomically and that each portal face routes to its own return.
+    add_test(NAME EntranceDedup COMMAND redship --test entrance-dedup)
     # VB-affinity regression: MM's GameInteractor_* calls bind to OoT's
     # extern "C" wrappers in single-exe builds, and the two games' vanilla-
     # behavior ordinals alias (MM VB_SETUP_TRANSITION == OoT
@@ -262,7 +270,7 @@ if(BUILD_TESTING)
     # Set reasonable timeout and label our tests
     set(REDSHIP_TEST_TIMEOUT 60 CACHE STRING "Test timeout in seconds")
     set_tests_properties(
-        BootOoT BootMM SwitchOoTMM SwitchMMOoT StartupEntrance VBAffinity CosmeticGfxStub Roundtrip RoundtripIntegrity SharedRoundtrip ArchiveHotswapLogic
+        BootOoT BootMM SwitchOoTMM SwitchMMOoT StartupEntrance EntranceDedup VBAffinity CosmeticGfxStub Roundtrip RoundtripIntegrity SharedRoundtrip ArchiveHotswapLogic
         SaveRoundtripTiers SaveHeader SaveHasDelete SaveVersionReject SaveSizeMismatch SaveLegacySize SaveCrcCorrupt
         Context MMSceneParse MMSceneExecute MMResumeArena MMStartupRestore AllTests
         PROPERTIES

--- a/rsbs/src/main.cpp
+++ b/rsbs/src/main.cpp
@@ -393,12 +393,16 @@ int main(int argc, char** argv) {
     ComboContext_Init();
     Entrance_Init();
 
-    // Register entrance links
-    Entrance_RegisterDefaultLinks();
-    // Also register test links (Mido's House) for easy testing
-    Entrance_RegisterTestLinks();
-    if (HasTestEntranceFlag(argc, argv)) {
-        printf("Test entrance links also registered (Mido's House <-> Clock Tower)\n");
+    // Register the one cross-game portal. The mask-shop door and Mido's House
+    // are two OoT-side faces of the SAME portal (both return through MM
+    // 0xC010), so they are mutually exclusive — registering both left the test
+    // link's return leg dead and exited Mido's House into Hyrule Market
+    // (#374). --test-entrance now selects the face instead of stacking on.
+    const bool useTestPortal = HasTestEntranceFlag(argc, argv);
+    Entrance_RegisterPortalLinks(useTestPortal);
+    if (useTestPortal) {
+        printf("Test entrance link registered (Mido's House <-> Clock Tower); "
+               "the default mask-shop link is NOT registered\n");
     }
 
     // ========================================================================

--- a/src/common/entrance.cpp
+++ b/src/common/entrance.cpp
@@ -7,6 +7,7 @@
  */
 
 #include "entrance.h"
+#include <cstdio>
 #include <cstring>
 #include <vector>
 #include <algorithm>
@@ -52,7 +53,7 @@ void Entrance_Init(void) {
     sGameSwitchRequested = false;
 }
 
-void Entrance_RegisterDefaultLinks(void) {
+bool Entrance_RegisterDefaultLinks(void) {
     // PRODUCTION: the mask-shop door and the Clock Tower door are the two
     // faces of one portal (see entrance.h):
     //   OoT enters Happy Mask Shop (0x0530)   -> MM spawns in South Clock
@@ -62,25 +63,101 @@ void Entrance_RegisterDefaultLinks(void) {
     // Argument roles: entrance2 = OoT->MM arrival, return2 = MM->OoT trigger.
     // The arrival (0xD800) is deliberately NOT a trigger — MM's own cycle
     // resets target it (Song of Time, save-warp, title attract demo).
-    Entrance_RegisterBidirectionalLink(
+    return Entrance_RegisterBidirectionalLink(
         GAME_OOT, OOT_ENTR_HAPPY_MASK_SHOP, OOT_ENTR_MARKET_FROM_MASK_SHOP,
         GAME_MM, MM_ENTR_SOUTH_CLOCK_TOWN_0, MM_ENTR_CLOCK_TOWER_INTERIOR_1
     );
 }
 
-void Entrance_RegisterTestLinks(void) {
+bool Entrance_RegisterTestLinks(void) {
     // TEST MODE: Mido's House <-> the same MM portal (closer to spawn for
     // quick testing). Same arrival/trigger split as the production link.
-    Entrance_RegisterBidirectionalLink(
+    //
+    // NOTE: this reuses the SAME MM-side trigger (0xC010) as the production
+    // link, so the two are mutually exclusive — see
+    // Entrance_RegisterPortalLinks. Registering both is now rejected rather
+    // than silently shadowed (#374).
+    return Entrance_RegisterBidirectionalLink(
         GAME_OOT, OOT_ENTR_MIDOS_HOUSE, OOT_ENTR_KOKIRI_FROM_MIDOS,
         GAME_MM, MM_ENTR_SOUTH_CLOCK_TOWN_0, MM_ENTR_CLOCK_TOWER_INTERIOR_1
     );
 }
 
-void Entrance_RegisterBidirectionalLink(
+bool Entrance_RegisterPortalLinks(bool useTestPortal) {
+    // There is exactly ONE cross-game portal, and its MM face is the Clock
+    // Tower door (0xC010). Its OoT face is selectable: the Happy Mask Shop
+    // door in production, or Mido's House when --test-entrance is passed
+    // (closer to the OoT spawn, so a switch can be exercised in seconds).
+    //
+    // These are alternatives, never additions. Both OoT doors want to own the
+    // single MM-side return leg, and only one link can — which is exactly the
+    // bug in #374, where main.cpp registered both unconditionally and the
+    // default won the first-match lookup, so entering MM from Mido's House
+    // spat you out in Hyrule Market instead of Kokiri Forest.
+    //
+    // Giving the test link its own MM entrance is not an option: every other
+    // MM id is a real door somewhere else in Termina, so a "distinct" test
+    // trigger would either hijack an unrelated MM transition or index out of
+    // MM's entrance table. Selecting one OoT face is the only honest model.
+    return useTestPortal ? Entrance_RegisterTestLinks() : Entrance_RegisterDefaultLinks();
+}
+
+bool Entrance_HasLinkFor(GameId game, uint16_t entrance) {
+    return std::any_of(gEntranceLinks.begin(), gEntranceLinks.end(),
+        [game, entrance](const CrossGameEntranceLink& link) {
+            return link.sourceGame == game && link.sourceEntrance == entrance;
+        });
+}
+
+bool Entrance_RegisterBidirectionalLink(
     GameId game1, uint16_t entrance1, uint16_t return1,
     GameId game2, uint16_t entrance2, uint16_t return2
 ) {
+    // Entrance_CheckCrossGame resolves by FIRST match on
+    // (sourceGame, sourceEntrance), so a second link on an already-claimed key
+    // is not an override — it is dead weight that silently changes nothing,
+    // while the caller believes it registered a route. #374 is precisely that:
+    // the default and test links both claimed MM 0xC010, the default won, and
+    // the test link's return leg mis-routed with no diagnostic anywhere.
+    //
+    // Reject the whole call ATOMICALLY. Validating both legs before pushing
+    // either matters: a half-registered link (forward accepted, reverse
+    // rejected) is a one-way portal — you switch games and can never come
+    // back, which is strictly worse than the collision it replaced.
+    struct {
+        GameId game;
+        uint16_t entrance;
+        const char* leg;
+    } const legs[] = {
+        { game1, entrance1, "forward" },
+        { game2, return2, "reverse" },
+    };
+
+    for (const auto& leg : legs) {
+        if (Entrance_HasLinkFor(leg.game, leg.entrance)) {
+            fprintf(stderr,
+                "[ENTRANCE] REJECTED duplicate registration: the %s leg's source "
+                "(%s entrance 0x%04X) is already claimed by an existing link. "
+                "Nothing was registered. Two links cannot share a source door — "
+                "the lookup resolves first-match, so the later one would be dead "
+                "(issue #374).\n",
+                leg.leg, Game_ToString(leg.game), leg.entrance);
+            return false;
+        }
+    }
+
+    // Also reject a self-collision inside this single call: if the forward
+    // source and the reverse source are the same key, the reverse leg would be
+    // born dead. Neither loop iteration above can see it, since nothing has
+    // been pushed yet.
+    if (game1 == game2 && entrance1 == return2) {
+        fprintf(stderr,
+            "[ENTRANCE] REJECTED self-colliding link: forward and reverse legs "
+            "share source (%s entrance 0x%04X). Nothing was registered.\n",
+            Game_ToString(game1), entrance1);
+        return false;
+    }
+
     // Forward link: game1:entrance1 -> game2:entrance2
     CrossGameEntranceLink forward = {
         .sourceGame = game1,
@@ -100,6 +177,8 @@ void Entrance_RegisterBidirectionalLink(
         .returnEntrance = entrance2
     };
     gEntranceLinks.push_back(reverse);
+
+    return true;
 }
 
 void Entrance_ClearLinks(void) {

--- a/src/common/entrance.h
+++ b/src/common/entrance.h
@@ -128,22 +128,51 @@ void Entrance_Init(void);
  * - OoT Happy Mask Shop door <-> MM Clock Tower door
  *   (arrival in MM is the South Clock Town tower-exit spawn; see the portal
  *   note above the MM entrance constants)
+ *
+ * @return false if a link already claims one of the source doors.
  */
-void Entrance_RegisterDefaultLinks(void);
+bool Entrance_RegisterDefaultLinks(void);
 
 /**
  * Register test links (for easier testing):
  * - OoT Mido's House <-> the same MM portal (SCT arrival / tower-door trigger)
+ *
+ * MUTUALLY EXCLUSIVE with Entrance_RegisterDefaultLinks: both claim the same
+ * MM-side trigger (0xC010), so registering both is rejected (#374). Prefer
+ * Entrance_RegisterPortalLinks, which picks exactly one.
+ *
+ * @return false if a link already claims one of the source doors.
  */
-void Entrance_RegisterTestLinks(void);
+bool Entrance_RegisterTestLinks(void);
 
 /**
- * Register a bidirectional link between game entrances
+ * Register the one cross-game portal, choosing its OoT-side face.
+ *
+ * @param useTestPortal true  -> Mido's House  (the --test-entrance face)
+ *                      false -> Happy Mask Shop (production)
+ * @return false if registration was rejected (a link already claims a door).
  */
-void Entrance_RegisterBidirectionalLink(
+bool Entrance_RegisterPortalLinks(bool useTestPortal);
+
+/**
+ * Register a bidirectional link between game entrances.
+ *
+ * Rejects the registration (loudly, on stderr) and returns false if either
+ * leg's source (game, entrance) is already claimed by a registered link, or
+ * if the two legs of this call collide with each other. Rejection is atomic:
+ * on false, NOTHING was added — never a one-way half-link.
+ *
+ * @return true if both legs were registered.
+ */
+bool Entrance_RegisterBidirectionalLink(
     GameId game1, uint16_t entrance1, uint16_t return1,
     GameId game2, uint16_t entrance2, uint16_t return2
 );
+
+/**
+ * Whether some registered link already resolves from (game, entrance).
+ */
+bool Entrance_HasLinkFor(GameId game, uint16_t entrance);
 
 /**
  * Clear all registered entrance links

--- a/src/common/test_runner.cpp
+++ b/src/common/test_runner.cpp
@@ -419,6 +419,135 @@ TestResult Test_Roundtrip(void) {
     return TEST_PASS;
 }
 
+// Regression lock for #374: two links must never share a source door.
+//
+// The default (mask shop) and test (Mido's House) links both return through MM
+// 0xC010. Both used to be registered unconditionally, and because
+// Entrance_CheckCrossGame resolves by first match, the default silently won:
+// entering MM from Mido's House and walking back into the Clock Tower dumped
+// you in Hyrule Market (0x01D1) instead of Kokiri Forest (0x0443). Nothing
+// reported the shadowing.
+//
+// ROM-free: pure table logic, no archives, no display.
+TestResult Test_EntranceDedup(void) {
+    printf("[TEST] entrance-dedup: duplicate links rejected; each portal face routes home\n");
+
+    // --- Leg 1: the production portal registers, and routes both ways. ------
+    Entrance_Init();
+    if (!Entrance_RegisterPortalLinks(false)) {
+        printf("[TEST] FAIL: default portal registration was rejected on an empty table\n");
+        return TEST_FAIL;
+    }
+    if (Entrance_GetLinkCount() != 2) {
+        printf("[TEST] FAIL: expected 2 links after default registration, got %zu\n",
+               Entrance_GetLinkCount());
+        return TEST_FAIL;
+    }
+
+    Entrance_CheckCrossGame(GAME_MM, MM_ENTR_CLOCK_TOWER_INTERIOR_1);
+    if (!Entrance_IsCrossGameSwitch() ||
+        Entrance_GetSwitchTargetGame() != GAME_OOT ||
+        Entrance_GetSwitchTargetEntrance() != OOT_ENTR_MARKET_FROM_MASK_SHOP) {
+        printf("[TEST] FAIL: default return leg should land at Market 0x%04X, got 0x%04X\n",
+               OOT_ENTR_MARKET_FROM_MASK_SHOP, Entrance_GetSwitchTargetEntrance());
+        return TEST_FAIL;
+    }
+    Entrance_ClearPendingSwitch();
+
+    // --- Leg 2: stacking the test link on top must be REJECTED, atomically. -
+    // This is the exact call pair main.cpp used to make unconditionally.
+    if (Entrance_RegisterTestLinks()) {
+        printf("[TEST] FAIL: test links were accepted despite MM 0x%04X already being claimed\n",
+               MM_ENTR_CLOCK_TOWER_INTERIOR_1);
+        return TEST_FAIL;
+    }
+    // Atomicity: a rejected call must not leave its forward leg behind. A
+    // half-registered link is a one-way portal — worse than the collision.
+    if (Entrance_GetLinkCount() != 2) {
+        printf("[TEST] FAIL: rejected registration mutated the table (%zu links, expected 2)\n",
+               Entrance_GetLinkCount());
+        return TEST_FAIL;
+    }
+    if (Entrance_HasLinkFor(GAME_OOT, OOT_ENTR_MIDOS_HOUSE)) {
+        printf("[TEST] FAIL: rejected registration left a dangling forward leg for Mido's House\n");
+        return TEST_FAIL;
+    }
+
+    // --- Leg 3: the test portal, registered alone, returns to Kokiri. -------
+    // Under the old first-match shadowing this produced 0x01D1 (the #374 bug).
+    Entrance_Init();
+    if (!Entrance_RegisterPortalLinks(true)) {
+        printf("[TEST] FAIL: test portal registration was rejected on an empty table\n");
+        return TEST_FAIL;
+    }
+    if (Entrance_HasLinkFor(GAME_OOT, OOT_ENTR_HAPPY_MASK_SHOP)) {
+        printf("[TEST] FAIL: test portal must not also register the mask-shop face\n");
+        return TEST_FAIL;
+    }
+
+    Entrance_CheckCrossGame(GAME_OOT, OOT_ENTR_MIDOS_HOUSE);
+    if (!Entrance_IsCrossGameSwitch() ||
+        Entrance_GetSwitchTargetEntrance() != MM_ENTR_SOUTH_CLOCK_TOWN_0 ||
+        Entrance_GetSwitchReturnEntrance() != OOT_ENTR_KOKIRI_FROM_MIDOS) {
+        printf("[TEST] FAIL: Mido's outbound leg wrong (target 0x%04X, return 0x%04X)\n",
+               Entrance_GetSwitchTargetEntrance(), Entrance_GetSwitchReturnEntrance());
+        return TEST_FAIL;
+    }
+    Entrance_ClearPendingSwitch();
+
+    Entrance_CheckCrossGame(GAME_MM, MM_ENTR_CLOCK_TOWER_INTERIOR_1);
+    if (!Entrance_IsCrossGameSwitch() ||
+        Entrance_GetSwitchTargetGame() != GAME_OOT ||
+        Entrance_GetSwitchTargetEntrance() != OOT_ENTR_KOKIRI_FROM_MIDOS) {
+        printf("[TEST] FAIL: test return leg should land at Kokiri 0x%04X, got 0x%04X "
+               "(0x%04X means the default link shadowed it — #374)\n",
+               OOT_ENTR_KOKIRI_FROM_MIDOS, Entrance_GetSwitchTargetEntrance(),
+               OOT_ENTR_MARKET_FROM_MASK_SHOP);
+        return TEST_FAIL;
+    }
+    Entrance_ClearPendingSwitch();
+
+    // --- Leg 4: rejection is keyed per-leg, not per-call. -------------------
+    // A link whose OoT face is fresh but whose MM face is taken must still be
+    // rejected — the MM trigger is the scarce resource.
+    if (Entrance_RegisterBidirectionalLink(
+            GAME_OOT, OOT_ENTR_HAPPY_MASK_SHOP, OOT_ENTR_MARKET_FROM_MASK_SHOP,
+            GAME_MM, MM_ENTR_SOUTH_CLOCK_TOWN_0, MM_ENTR_CLOCK_TOWER_INTERIOR_1)) {
+        printf("[TEST] FAIL: accepted a link reusing the claimed MM trigger 0x%04X\n",
+               MM_ENTR_CLOCK_TOWER_INTERIOR_1);
+        return TEST_FAIL;
+    }
+
+    // A link colliding with itself (forward source == reverse source) is dead
+    // on arrival and must be rejected too.
+    if (Entrance_RegisterBidirectionalLink(
+            GAME_OOT, 0x0EDD, 0x0EDE,
+            GAME_OOT, 0x0EDF, 0x0EDD)) {
+        printf("[TEST] FAIL: accepted a self-colliding link\n");
+        return TEST_FAIL;
+    }
+
+    // A genuinely distinct pair still registers — the guard rejects duplicates,
+    // not everything.
+    const size_t before = Entrance_GetLinkCount();
+    if (!Entrance_RegisterBidirectionalLink(
+            GAME_OOT, 0x0EE0, 0x0EE1,
+            GAME_MM, 0x0EE2, 0x0EE3)) {
+        printf("[TEST] FAIL: rejected a link with no source collision\n");
+        return TEST_FAIL;
+    }
+    if (Entrance_GetLinkCount() != before + 2) {
+        printf("[TEST] FAIL: accepted registration did not add both legs\n");
+        return TEST_FAIL;
+    }
+
+    // Restore the default table for tests that run after this one.
+    Entrance_Init();
+    Entrance_RegisterDefaultLinks();
+    printf("[TEST] PASS: duplicate source doors rejected atomically; each face routes home\n");
+    return TEST_PASS;
+}
+
 TestResult Test_MidosHouse(void) {
     printf("[TEST] midos-house: Test Mido's House entrance (test mode)\n");
 
@@ -663,6 +792,7 @@ const TestDescriptor gTests[] = {
     {"switch-oot-mm", "Test game switch OoT -> MM", Test_SwitchOoTMM},
     {"switch-mm-oot", "Test game switch MM -> OoT", Test_SwitchMMOoT},
     {"midos-house", "Test Mido's House entrance (test mode)", Test_MidosHouse},
+    {"entrance-dedup", "Duplicate entrance links rejected; each portal face routes home (#374)", Test_EntranceDedup},
     {"startup-entrance", "Test startup entrance flow", Test_StartupEntrance},
     {"vb-affinity", "OoT VB hooks stay quiet while MM is active", Test_VBAffinity},
     {"cosmetic-gfx-stub", "MM HUD gfx wrappers write commands and advance the display list", Test_CosmeticGfxStub},


### PR DESCRIPTION
## What was broken

`Entrance_RegisterDefaultLinks` and `Entrance_RegisterTestLinks` both pass `MM_ENTR_CLOCK_TOWER_INTERIOR_1` (`0xC010`) as `return2`, which `Entrance_RegisterBidirectionalLink` turns into a reverse link keyed on `(GAME_MM, 0xC010)`. `rsbs/src/main.cpp` registered **both** unconditionally — `HasTestEntranceFlag` gated only a `printf`, not the registration.

`Entrance_CheckCrossGame` uses `std::find_if`, so the **default** link always won the lookup and the test link's return leg was dead:

> Enter MM via Mido's House (OoT frozen with `returnEntrance = OOT_ENTR_KOKIRI_FROM_MIDOS` `0x0443`). Walk into the Clock Tower to return. The lookup hits the default reverse link first, so you spawn at `OOT_ENTR_MARKET_FROM_MASK_SHOP` (`0x01D1`) — you entered from Kokiri Forest and exit in Hyrule Market.

No diagnostic was emitted anywhere. Premise confirmed exactly as filed.

## Mechanism

The link table resolves by **first match** on `(sourceGame, sourceEntrance)`. A second link on an already-claimed key is therefore not an override — it is dead weight that silently changes nothing while the caller believes it registered a route.

## Fix

Symptom and root cause, since the root cause is the silent shadowing itself.

**1. `Entrance_RegisterBidirectionalLink` rejects duplicates loudly (`stderr`) and returns `bool`.**

It validates **both** legs' source keys *before* pushing either. Up-front validation is what makes rejection **atomic**, and that matters: a half-registered link (forward accepted, reverse rejected) is a one-way portal — you switch games and can never come back, strictly worse than the collision it replaced. It also rejects a call whose own two legs share a source, which no scan of existing links can catch since nothing has been pushed yet.

`Entrance_RegisterDefaultLinks` / `Entrance_RegisterTestLinks` propagate the `bool`.

**2. `Entrance_RegisterPortalLinks(bool useTestPortal)` — the two OoT faces become mutually exclusive.**

Of the issue's three options I took "register test links only when the flag is set", in its stronger form: `--test-entrance` now *selects* the portal's OoT face rather than stacking a second link on it. Gating alone would not have been enough — with the flag set, both would still register and now hit the new rejection.

I explicitly rejected "give the test link its own distinct MM entrance": every other MM id is a real door somewhere in Termina, so a fabricated "distinct" trigger would either hijack an unrelated MM transition or index out of MM's entrance table. There is one portal; its MM face is the Clock Tower door; its OoT face is either the mask shop or Mido's House. Selecting one is the only honest model, and it matches the existing `// TEST MODE:` comment's intent.

## ⚠️ `rsbs/src/main.cpp` — cross-lane, needs reconciliation

**`rsbs/src/main.cpp` is owned by another agent this wave.** My change there is confined to the six lines at `:397-402` and reduces to a single registration statement:

```cpp
const bool useTestPortal = HasTestEntranceFlag(argc, argv);
Entrance_RegisterPortalLinks(useTestPortal);
```

All policy lives in `src/common/entrance.cpp` specifically so this footprint stays one statement. If the other lane's diff conflicts here, take theirs and re-apply this two-liner — nothing else in main.cpp is touched.

## Verification

New CTest **`EntranceDedup`** (`redship` label, `redship --test entrance-dedup`). ROM-free and display-free — pure entrance-table logic, so it runs in the hosted CI tier. Four legs:

1. The production portal registers on an empty table and its MM return leg lands at Market `0x01D1`.
2. Stacking `Entrance_RegisterTestLinks()` on top — the exact call pair main.cpp used to make — is **rejected**, the table still holds exactly 2 links, and no dangling forward leg for Mido's House survives (atomicity).
3. The test portal registered *alone* routes Mido's House → SCT `0xD800` with return `0x0443`, and MM `0xC010` → **`0x0443`**, not `0x01D1`. This assertion is the direct lock on the reported failure; it fails on the old code.
4. Rejection is keyed per-leg, not per-call: a link with a fresh OoT face but the claimed MM trigger is rejected; a self-colliding link is rejected; a genuinely distinct pair still registers and adds both legs.

Not built locally (four agents share the machine) — CI builds. No files touched are in `.github/clang-format-paths.txt`, so no format run was required.

Closes #374.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!--- section:artifacts:start -->
### Build Artifacts
  - [rsbs-windows.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/8452634428.zip)
  - [rsbs-linux.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/8452453918.zip)
<!--- section:artifacts:end -->