### PR TITLE
calloc the sequence maps and bound-check custom sequences before registering

### DIFF
--- a/CMake/SingleExecutable.cmake
+++ b/CMake/SingleExecutable.cmake
@@ -249,6 +249,11 @@ if(BUILD_TESTING)
     # against a PlayState and asserts the spawn-path pointers/fields populate.
     add_test(NAME MMSceneParse COMMAND redship --test mm-scene-parse)
     add_test(NAME MMSceneExecute COMMAND redship --test mm-scene-execute)
+    # Sequence-map capacity bounds (#371, #378). The rest of AudioLoad_Init
+    # needs a booted audio heap and real archives, but both bugs were
+    # bound-arithmetic bugs, so the capacity computation was factored into pure
+    # helpers this test calls directly — display-free, ROM-free.
+    add_test(NAME SeqMapBounds COMMAND redship --test seq-map-bounds)
     # MM cross-game resume contracts (games/mm/2s2h/mm_resume_state_test.cpp):
     # a resume must re-arm the (by-design leaked) system arena for the cold
     # gamestate-chain boot, and Play_Init's startup-entrance consumption must
@@ -264,7 +269,7 @@ if(BUILD_TESTING)
     set_tests_properties(
         BootOoT BootMM SwitchOoTMM SwitchMMOoT StartupEntrance VBAffinity CosmeticGfxStub Roundtrip RoundtripIntegrity SharedRoundtrip ArchiveHotswapLogic
         SaveRoundtripTiers SaveHeader SaveHasDelete SaveVersionReject SaveSizeMismatch SaveLegacySize SaveCrcCorrupt
-        Context MMSceneParse MMSceneExecute MMResumeArena MMStartupRestore AllTests
+        Context MMSceneParse MMSceneExecute SeqMapBounds MMResumeArena MMStartupRestore AllTests
         PROPERTIES
         TIMEOUT ${REDSHIP_TEST_TIMEOUT}
         LABELS "redship"

--- a/games/mm/src/audio/lib/load.c
+++ b/games/mm/src/audio/lib/load.c
@@ -117,6 +117,37 @@ s32 gAudioCtxInitalized = false;
 
 char** gSequenceMap;
 size_t gSequenceMapSize;
+
+// RSBS (#371/#378): headroom for custom songs whose assigned seqNum is NOT
+// consecutive — AudioLoad_Init walks `while (AudioCollection_HasSequenceNum(n))
+// n++` for a free slot and AudioCollection holds more than sequences, so N
+// custom files can consume more than N ids. OoT's map carried this slack as an
+// unexplained `+ 0xF`; MM's had NONE, which made the unguarded custom-song
+// write below an out-of-bounds heap store rather than merely a lost song.
+#define SEQUENCE_MAP_SLACK 0xF
+
+/**
+ * RSBS (#371/#378): slot count the sequence map must be allocated with.
+ * Mirror of OoT_AudioLoad_SequenceMapCapacity (games/oot/src/code/audio_load.c)
+ * — separate symbol, per the project's MM_-prefix ODR rule. Pure, so the
+ * arithmetic is verifiable ROM-free (CTest `SeqMapBounds`).
+ *
+ * Sizing by the authentic FILE COUNT was actively wrong for MM: ids run
+ * 0x00-0x7F but 0x7A is absent (games/mm/include/sequence.h), so the count is
+ * 127 while the highest legal id is 0x7F == 127. The `id >= gSequenceMapSize`
+ * guard therefore rejected NA_BGM_END_CREDITS_SECOND_HALF outright whenever no
+ * custom songs were installed. Reserve the full authentic id range instead.
+ */
+size_t MM_AudioLoad_SequenceMapCapacity(size_t authenticFileCount, size_t customCount) {
+    size_t authentic = (size_t)MAX_AUTHENTIC_SEQID;
+
+    if (authenticFileCount > authentic) {
+        authentic = authenticFileCount;
+    }
+
+    return authentic + customCount + SEQUENCE_MAP_SLACK;
+}
+
 u8 MM_seqCachePolicyMap[MAX_AUTHENTIC_SEQID];
 char** gFontMap;
 size_t gFontMapSize;
@@ -1266,8 +1297,15 @@ void MM_AudioLoad_Init(void* heap, size_t heapSize) {
     char** seqList = ResourceMgr_ListFiles("audio/sequences*", &seqListSize);
 #endif
     char** customSeqList = ResourceMgr_ListFiles("custom/music/*", &customSeqListSize);
-    gSequenceMapSize = (size_t)(seqListSize + customSeqListSize);
-    gSequenceMap = malloc(gSequenceMapSize * sizeof(char*));
+    gSequenceMapSize = MM_AudioLoad_SequenceMapCapacity((size_t)seqListSize, (size_t)customSeqListSize);
+    // RSBS #371: calloc, not malloc. The bounds guard below `continue`s past
+    // rejected entries, leaving those indices — and the slack — untouched.
+    // Under malloc they hold indeterminate heap bytes, and no consumer
+    // null-checks (load.c:631/:791/:1601, seqplayer.c:1302/:1436 hand the slot
+    // straight to ResourceMgr_LoadSeqByName); BenPort.cpp's OTRAudio_Exit also
+    // free()s every slot. The adjacent gFontMap/fontLoadStatus allocations
+    // below already calloc; this was the inconsistent one.
+    gSequenceMap = calloc(gSequenceMapSize, sizeof(char*));
     gAudioCtx.seqLoadStatus = calloc(gSequenceMapSize, sizeof(u8));
 
     memset(&gAudioCtx.seqLoadStatus[seqListSize], LOAD_STATUS_PERMANENT, customSeqListSize);
@@ -1371,6 +1409,23 @@ void MM_AudioLoad_Init(void* heap, size_t heapSize) {
 
         while (AudioCollection_HasSequenceNum(seqNum)) {
             seqNum++;
+        }
+
+        // RSBS #378: bound BEFORE registering, against the real allocation.
+        //
+        // MM had NO guard here at all — `gSequenceMap[seqNum] = strdup(...)`
+        // ran unconditionally against an array sized to the file count, while
+        // the HasSequenceNum skip above walks seqNum past AudioCollection's
+        // non-sequence entries. With custom songs installed that is an
+        // out-of-bounds heap WRITE, not just a lost song. (OoT's equivalent
+        // guard existed but ran after registration; both are fixed the same
+        // way.) Checking before AudioCollection_AddToCollection also keeps a
+        // dropped song out of the Audio Editor, which resolves a selection
+        // through gSequenceMap[seqNum] with no null check.
+        if ((size_t)seqNum >= gSequenceMapSize) {
+            fprintf(stderr, "[MM] AudioLoad: custom sequence %s overflows gSequenceMap (seqNum %d >= %u); skipping\n",
+                    customSeqList[j], seqNum, (unsigned)gSequenceMapSize);
+            continue;
         }
 
         AudioCollection_AddToCollection(customSeqList[j], seqNum);

--- a/games/oot/src/code/audio_load.c
+++ b/games/oot/src/code/audio_load.c
@@ -85,6 +85,48 @@ s32 gAudioContextInitalized = false;
 
 char** sequenceMap;
 size_t sequenceMapSize;
+
+// RSBS (#371/#378): headroom for custom songs whose assigned seqNum is NOT
+// consecutive. AudioLoad_Init walks `while (AudioCollection_HasSequenceNum(n))
+// n++` to find a free slot, and AudioCollection holds more than sequences
+// (instruments at 130-135, sfx in the 2000s/6000s/...), so N custom files can
+// consume more than N ids. This slack was previously an unexplained `+ 0xF`
+// baked into the sequenceMap malloc only — the published sequenceMapSize did
+// not include it, which is exactly how #378's guard came to reject ids the
+// array could actually hold.
+#define SEQUENCE_MAP_SLACK 0xF
+
+/**
+ * RSBS (#371/#378): slot count the sequence map must be allocated with.
+ *
+ * Factored out of AudioLoad_Init as a pure function so the arithmetic is
+ * verifiable ROM-free (CTest `SeqMapBounds`) — everything else in this
+ * function needs a booted audio heap and real archives.
+ *
+ * Two corrections over the old `seqListSize + customSeqListSize`:
+ *
+ *  1. Authentic sequence ids are a SPARSE id space, not a count. Sizing by the
+ *     number of files in the archive makes the `id >= size` guard reject a
+ *     legal id whenever the id space has a hole (MM's is missing 0x7A, so its
+ *     file count is 127 while its highest valid id is 127 — the top sequence
+ *     was being dropped). Always reserve the full authentic id range.
+ *  2. Custom ids are not consecutive — see SEQUENCE_MAP_SLACK above.
+ *
+ * Callers assign the result to sequenceMapSize, so the published size IS the
+ * allocation. Every consumer (audio_heap.c:56, OTRGlobals.cpp:1318, and the
+ * bounds guards below) reads it as "how many slots exist", which is what it
+ * now means.
+ */
+size_t OoT_AudioLoad_SequenceMapCapacity(size_t authenticFileCount, size_t customCount) {
+    size_t authentic = (size_t)MAX_AUTHENTIC_SEQID;
+
+    if (authenticFileCount > authentic) {
+        authentic = authenticFileCount;
+    }
+
+    return authentic + customCount + SEQUENCE_MAP_SLACK;
+}
+
 // A map of authentic sequence IDs to their cache policies, for use with sequence swapping.
 u8 OoT_seqCachePolicyMap[MAX_AUTHENTIC_SEQID];
 size_t fontMapSize;
@@ -1352,10 +1394,20 @@ void OoT_AudioLoad_Init(void* heap, size_t heapSize) {
     char** seqList = ResourceMgr_ListFiles("audio/sequences*", &seqListSize);
 #endif
     char** customSeqList = ResourceMgr_ListFiles("custom/music/*", &customSeqListSize);
-    sequenceMapSize = (size_t)(seqListSize + customSeqListSize);
-    sequenceMap = malloc((sequenceMapSize + 0xF) * sizeof(char*));
+    sequenceMapSize = OoT_AudioLoad_SequenceMapCapacity((size_t)seqListSize, (size_t)customSeqListSize);
+    // RSBS #371: calloc, not malloc. The bounds guards below `continue` past
+    // rejected entries, so every skipped index — and every slot in the slack —
+    // stays untouched. Under malloc those hold indeterminate heap bytes, and
+    // no consumer null-checks (audio_load.c:593/:748/:1702, audio_seqplayer.c
+    // :1071/:1186 all hand the slot straight to ResourceMgr_LoadSeqByName).
+    // The adjacent fontMap/fontLoadStatus allocations below already calloc;
+    // these were the inconsistent ones.
+    sequenceMap = calloc(sequenceMapSize, sizeof(char*));
 
-    gAudioContext.seqLoadStatus = malloc(sequenceMapSize);
+    gAudioContext.seqLoadStatus = calloc(sequenceMapSize, sizeof(u8));
+    // The memset is the real initializer here (LOAD_STATUS_PERMANENT), so this
+    // array was never actually exposed to the uninitialized-hole bug; calloc
+    // keeps the pair uniform and covers the array if the memset ever narrows.
     memset(gAudioContext.seqLoadStatus, 5, sequenceMapSize);
     for (size_t i = 0; i < seqListSize; i++) {
         SequenceData sDat = ResourceMgr_LoadSeqByName(seqList[i]);
@@ -1476,17 +1528,31 @@ void OoT_AudioLoad_Init(void* heap, size_t heapSize) {
             seqNum++;
         }
 
+        // RSBS #378: bound BEFORE registering, against the real allocation.
+        //
+        // This guard used to run after AudioCollection_AddToCollection and
+        // after `sDat->seqNumber = seqNum`, so a song we then dropped from
+        // sequenceMap stayed in the collection — live and selectable in the
+        // Audio Editor, where picking it drives AudioEditor_GetReplacementSeq
+        // into an empty sequenceMap slot with no null check. Registering a
+        // song and then refusing to give it a map slot is never a coherent
+        // state; skip it entirely instead.
+        //
+        // The bound is sequenceMapSize, which is now the allocated slot count
+        // (see OoT_AudioLoad_SequenceMapCapacity) rather than the file count.
+        // The old comparison against a file count was wrong in the other
+        // direction: the HasSequenceNum skip above can legitimately push
+        // seqNum past the number of custom files, which is what the slack is
+        // for, so it rejected songs the array had room for.
+        if ((size_t)seqNum >= sequenceMapSize) {
+            fprintf(stderr, "[OoT] AudioLoad: custom sequence %s overflows sequenceMap (seqNum %d >= %u); skipping\n",
+                    customSeqList[j], seqNum, (unsigned)sequenceMapSize);
+            continue;
+        }
+
         AudioCollection_AddToCollection(customSeqList[j], seqNum);
 
         sDat->seqNumber = seqNum;
-        printf("%d\n", seqNum);
-        if ((size_t)sDat->seqNumber >= sequenceMapSize) {
-            fprintf(stderr,
-                    "[OoT] AudioLoad: custom sequence %s overflows sequenceMap (seqNumber %d >= %u); skipping\n",
-                    customSeqList[j], seqNum, (unsigned)sequenceMapSize);
-            seqNum++;
-            continue;
-        }
         sequenceMap[sDat->seqNumber] = strdup(customSeqList[j]);
         seqNum++;
     }

--- a/src/common/test_runner.cpp
+++ b/src/common/test_runner.cpp
@@ -89,6 +89,13 @@ extern "C" {
 // over a synthetic scene buffer — no ROM archives or display needed.
 #include "tests/test_mm_scene_parse.c"
 
+// Sequence-map capacity bounds (#371, #378). Included at FILE SCOPE: it calls
+// the two C-linkage capacity helpers in games/oot/src/code/audio_load.c and
+// games/mm/src/audio/lib/load.c, which it declares itself in an extern "C"
+// block (including either game's z64audio.h here would collide on
+// MAX_AUTHENTIC_SEQID). Pure arithmetic — no audio subsystem, no archives.
+#include "tests/test_seq_map_bounds.c"
+
 // MM scene-command EXECUTE regression (issue #344). Unlike the parse test, the
 // body runs the parsed commands against a PlayState, so it needs MM's global.h
 // — which lives in an MM TU (games/mm/2s2h/mm_scene_execute_test.cpp) to keep
@@ -680,6 +687,7 @@ const TestDescriptor gTests[] = {
     {"save-legacy-size", "Unified save Load zero-extends shorter legacy tiers (#35)", Test_SaveLegacySize},
     {"save-crc-corrupt", "Unified save Load rejects corrupt payload, no clobber (#35)", Test_SaveCrcCorrupt},
     {"mm-scene-parse", "MM scene commands parse via the S2H factory (#344)", Test_MMSceneParse},
+    {"seq-map-bounds", "Sequence-map capacity covers the id range + custom slack (#371, #378)", Test_SeqMapBounds},
     {"mm-scene-execute", "MM scene commands execute against a PlayState (#344)", Test_MMSceneExecute},
     // The two MM resume-contract tests below mutate process-global state
     // (mm-resume-arena re-inits the MM system arena + heaps; mm-startup-restore

--- a/src/common/tests/test_seq_map_bounds.c
+++ b/src/common/tests/test_seq_map_bounds.c
@@ -1,0 +1,110 @@
+/**
+ * Sequence-map capacity bounds regression test (issues #371, #378).
+ *
+ * The rest of AudioLoad_Init needs a booted audio heap and real archives, so
+ * it is unreachable from the ROM-free CTest tier. The BOUND, however, is pure
+ * arithmetic, and both bugs this test locks were bound-arithmetic bugs — so
+ * the capacity computation was factored into two pure functions
+ * (OoT_AudioLoad_SequenceMapCapacity, MM_AudioLoad_SequenceMapCapacity) that
+ * this test can call directly with no audio subsystem at all.
+ *
+ * What it locks:
+ *
+ *   1. Capacity covers the full AUTHENTIC ID RANGE, not the authentic file
+ *      count. MM's sequence ids run 0x00-0x7F with 0x7A absent, so the archive
+ *      yields 127 files while the highest legal id is 127 — sizing by count
+ *      made `id >= gSequenceMapSize` reject the top sequence.
+ *   2. Capacity leaves slack past (files + custom). Custom songs are assigned
+ *      via `while (AudioCollection_HasSequenceNum(n)) n++`, which skips
+ *      AudioCollection's non-sequence entries, so N custom files can consume
+ *      more than N ids. #378's reported repro — 21 custom songs landing at
+ *      seqNum 136 against a size of 131 — is asserted verbatim below.
+ *   3. Capacity never drops below the file count, so a mod adding more
+ *      sequence files than the authentic range still gets a slot per file.
+ *
+ * MAX_AUTHENTIC_SEQID is spelled as a literal here rather than included: the
+ * two games define the same macro with different values (110 / 128), and
+ * restating the contract independently is the point of a regression lock.
+ *
+ * Included at FILE SCOPE by test_runner.cpp (compiled as C++), like the other
+ * files in this directory; the declarations below carry C linkage explicitly
+ * because both definitions live in C translation units.
+ */
+
+#include <cstddef>
+#include <cstdio>
+
+extern "C" {
+size_t OoT_AudioLoad_SequenceMapCapacity(size_t authenticFileCount, size_t customCount);
+size_t MM_AudioLoad_SequenceMapCapacity(size_t authenticFileCount, size_t customCount);
+}
+
+#define SEQMAP_OOT_MAX_AUTHENTIC_SEQID 110
+#define SEQMAP_MM_MAX_AUTHENTIC_SEQID 128
+#define SEQMAP_EXPECTED_SLACK 0xF
+
+#define SEQMAP_CHECK(cond, msg)                        \
+    do {                                               \
+        if (!(cond)) {                                 \
+            printf("[TEST] FAIL: %s\n", (msg));        \
+            return TEST_FAIL;                          \
+        }                                              \
+    } while (0)
+
+TestResult Test_SeqMapBounds(void) {
+    printf("[TEST] seq-map-bounds: sequence-map capacity covers the id range + custom slack (#371, #378)\n");
+
+    // (1) The sparse-id-space regression. MM: 127 files on disk, no custom
+    // songs, highest legal id 127. Sizing by file count yields 127 slots and
+    // the `id >= size` guard drops NA_BGM_END_CREDITS_SECOND_HALF.
+    size_t mmSparse = MM_AudioLoad_SequenceMapCapacity(SEQMAP_MM_MAX_AUTHENTIC_SEQID - 1, 0);
+    SEQMAP_CHECK(mmSparse > (size_t)(SEQMAP_MM_MAX_AUTHENTIC_SEQID - 1),
+                 "MM capacity does not cover id 0x7F when the 0x7A hole shrinks the file count");
+    SEQMAP_CHECK(mmSparse >= (size_t)SEQMAP_MM_MAX_AUTHENTIC_SEQID,
+                 "MM capacity is below MAX_AUTHENTIC_SEQID");
+
+    size_t ootSparse = OoT_AudioLoad_SequenceMapCapacity(0, 0);
+    SEQMAP_CHECK(ootSparse >= (size_t)SEQMAP_OOT_MAX_AUTHENTIC_SEQID,
+                 "OoT capacity is below MAX_AUTHENTIC_SEQID on an empty archive");
+
+    // (2) #378's reported repro, verbatim: OoT with 110 authentic files and 21
+    // custom songs. The HasSequenceNum skip walks past AudioCollection's
+    // instrument entries at 130-135, so the 21st song is assigned seqNum 136
+    // while the old size was 110 + 21 == 131. 136 must be in bounds.
+    size_t ootRepro = OoT_AudioLoad_SequenceMapCapacity(SEQMAP_OOT_MAX_AUTHENTIC_SEQID, 21);
+    SEQMAP_CHECK(ootRepro > 136, "OoT capacity rejects seqNum 136 (the 21-custom-song repro from #378)");
+    SEQMAP_CHECK(ootRepro >= (size_t)(SEQMAP_OOT_MAX_AUTHENTIC_SEQID + 21 + SEQMAP_EXPECTED_SLACK),
+                 "OoT capacity does not carry the non-consecutive-id slack");
+
+    // The same shape must hold on the MM side, which previously had no slack
+    // at all — there the overflow was an out-of-bounds heap write.
+    size_t mmRepro = MM_AudioLoad_SequenceMapCapacity(SEQMAP_MM_MAX_AUTHENTIC_SEQID - 1, 21);
+    SEQMAP_CHECK(mmRepro >= (size_t)(SEQMAP_MM_MAX_AUTHENTIC_SEQID + 21 + SEQMAP_EXPECTED_SLACK),
+                 "MM capacity does not carry the non-consecutive-id slack");
+
+    // (3) Every custom file gets a slot: capacity grows one-for-one with the
+    // custom count, so the map cannot be starved by installing more songs.
+    for (size_t custom = 0; custom < 64; custom++) {
+        size_t oot = OoT_AudioLoad_SequenceMapCapacity(SEQMAP_OOT_MAX_AUTHENTIC_SEQID, custom);
+        size_t mm = MM_AudioLoad_SequenceMapCapacity(SEQMAP_MM_MAX_AUTHENTIC_SEQID, custom);
+
+        SEQMAP_CHECK(oot >= (size_t)SEQMAP_OOT_MAX_AUTHENTIC_SEQID + custom,
+                     "OoT capacity does not grow with the custom-song count");
+        SEQMAP_CHECK(mm >= (size_t)SEQMAP_MM_MAX_AUTHENTIC_SEQID + custom,
+                     "MM capacity does not grow with the custom-song count");
+    }
+
+    // (4) A mod shipping more sequence files than the authentic range must
+    // still get a slot per file — clamping to MAX_AUTHENTIC_SEQID would
+    // reintroduce the overflow from the other side.
+    size_t ootModded = OoT_AudioLoad_SequenceMapCapacity(4096, 8);
+    SEQMAP_CHECK(ootModded >= 4096 + 8, "OoT capacity clamps below an oversized authentic file count");
+
+    size_t mmModded = MM_AudioLoad_SequenceMapCapacity(4096, 8);
+    SEQMAP_CHECK(mmModded >= 4096 + 8, "MM capacity clamps below an oversized authentic file count");
+
+    printf("[TEST] PASS: sequence-map capacity bounds hold for both games\n");
+    return TEST_PASS;
+}
+
+#undef SEQMAP_CHECK


### PR DESCRIPTION
## What was broken

Three bound-arithmetic faults on the same array in both games' `AudioLoad_Init`. They share a block and a root cause, so they are fixed together.

**#371 — uninitialized holes.** `sequenceMap` / `gSequenceMap` were `malloc`'d, but the bounds guards `continue` past rejected entries and the arrays carry slack, so skipped slots held indeterminate heap bytes. Nothing null-checks them — `audio_load.c:593/:748/:1702`, `mm/load.c:631/:791/:1601`, `seqplayer.c:1302/:1436` all hand the slot straight to `ResourceMgr_LoadSeqByName`.

**#378 — the custom-song guard ran too late, against the wrong bound.** On the OoT side `AudioCollection_AddToCollection` and `sDat->seqNumber = seqNum` both ran *before* the guard, so a song we then refused a map slot stayed registered — live and selectable in the Audio Editor, which resolves a selection through `sequenceMap[seqNum]` with no null check. The bound was also wrong in the other direction: it compared against the file count while the array was over-allocated by `0xF`, rejecting ids the array had room for.

**MM had no guard here at all** — found while implementing #378. `gSequenceMap[seqNum] = strdup(...)` ran unconditionally against an array with *no* slack, while the `while (AudioCollection_HasSequenceNum(seqNum)) seqNum++` skip walks past AudioCollection's non-sequence entries. With custom songs installed that is an out-of-bounds heap **write**, not a lost song — strictly worse than the OoT bug the issue describes.

**The sizing question in #371, assessed: it is a real active bug, and the fix is small.** The guards compared an *id* against a *file count*. MM's ids run `0x00`-`0x7F` with `0x7A` absent, so the count is 127 while the highest legal id is `0x7F` == 127 — `id >= gSequenceMapSize` rejected `NA_BGM_END_CREDITS_SECOND_HALF` outright whenever no custom songs were installed. Fixed here rather than deferred.

## Mechanism

The capacity arithmetic moves into a pure per-game helper — `OoT_AudioLoad_SequenceMapCapacity` / `MM_AudioLoad_SequenceMapCapacity`, separate symbols per the `MM_`-prefix ODR rule — returning `max(fileCount, MAX_AUTHENTIC_SEQID) + customCount + SLACK`.

Callers assign that to `sequenceMapSize`, so **the published size IS the allocation**. The divergence between a hidden `+ 0xF` in the malloc and a smaller advertised size was the root of #378; collapsing the two removes the class, not just the instance. Every existing consumer (`audio_heap.c:56`, `mm/heap.c:75`, both shutdown free loops) already reads that global as "how many slots exist", which is now what it means.

`malloc` → `calloc` then makes a skipped slot `NULL`, the state every consumer already assumes.

## Verification

**New CTest `SeqMapBounds`, label `redship`** (`src/common/tests/test_seq_map_bounds.c`).

A test at this level looked infeasible at first — these run inside audio init, behind a booted audio heap and real archives. But all three bugs are *bound-arithmetic* bugs, and that arithmetic factors out cleanly, so the lock is real rather than cosmetic. The test calls both helpers directly with no audio subsystem at all and asserts:

1. the sparse-id-space case (127 files, highest legal id 127 — the `0x7A` hole);
2. **#378's reported repro verbatim** — 110 authentic + 21 custom, song landing at `seqNum` 136 against the old size of 131, now in bounds;
3. one slot per custom file across 0-63 custom songs, both games;
4. an oversized modded file count is not clamped down to `MAX_AUTHENTIC_SEQID`.

What it does **not** cover: that `AudioLoad_Init` actually calls the helper, and the guard ordering itself. Both need a booted audio subsystem. Reviewed by inspection.

## Two premise corrections

Neither changes the fix, but both are worth recording since #371 cites them as impact:

- **`gAudioContext.seqLoadStatus` (`audio_load.c:1358`) was never exposed to the uninitialized-hole bug.** The very next line `memset`s the whole array to `LOAD_STATUS_PERMANENT`. It is converted to `calloc` here for uniformity, not because it was broken.
- **The link to the tracked `0xC0000374` exit heap corruption is not supportable in the single-exe binary.** Both `free()` loops #371 names are compiled out of `redship`: `OTRGlobals.cpp:1318` is inside `#if 0`, and `BenPort.cpp` is excluded at `games/mm/CMakeLists.txt:202`. The `free()` of an indeterminate pointer is real in *standalone* SoH/2Ship builds, and `calloc` fixes it there. It is not a Fault A contributor.

## Scope note

Beyond the two files in the lane, this touches `src/common/test_runner.cpp` (registry + include) and `CMake/SingleExecutable.cmake` (`add_test` + label), which is unavoidable for any new CTest. Both are append-only edits; conflicts with a parallel Wave 1 lane adding its own test would be trivial.

`clang-format` could not be run locally (not installed on this box). Both allowlisted files were hand-checked against the clang-format 14 config — no line exceeds 120 columns, and the one construct that would have wrapped ambiguously (a long ternary) was rewritten as an `if`. If the format gate still trips, it will be a whitespace-only follow-up.

Closes #371.
Closes #378.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!--- section:artifacts:start -->
### Build Artifacts
  - [rsbs-windows.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/8452645346.zip)
  - [rsbs-linux.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/8452507633.zip)
<!--- section:artifacts:end -->