### PR TITLE
Give ComboContext serialization headroom before Lane A changes its shape

### DIFF
--- a/CMake/SingleExecutable.cmake
+++ b/CMake/SingleExecutable.cmake
@@ -255,6 +255,16 @@ if(BUILD_TESTING)
     add_test(NAME SaveSizeMismatch COMMAND redship --test save-size-mismatch)
     add_test(NAME SaveLegacySize COMMAND redship --test save-legacy-size)
     add_test(NAME SaveCrcCorrupt COMMAND redship --test save-crc-corrupt)
+    # Tier-1 (ComboContext) format headroom — Phase 3 Wave 1. The loader used to
+    # demand comboSize == sizeof(ComboContext) exactly, so the moment Lane A
+    # widens sharedItems to carry an origin-game tag, every existing .redsave
+    # would stop loading with no message to the user. These lock the migration:
+    # a pre-headroom Tier-1 still loads and zero-extends, the record size is
+    # fixed and padded so growth does not move it, and an oversized record is
+    # refused rather than truncated.
+    add_test(NAME SaveComboLegacyRecord COMMAND redship --test save-combo-legacy-record)
+    add_test(NAME SaveComboRecordFixed COMMAND redship --test save-combo-record-fixed)
+    add_test(NAME SaveComboOversize COMMAND redship --test save-combo-oversize)
     add_test(NAME Context COMMAND redship --test context)
     # MM scene-command parse + execute regressions — display-free, no ROM
     # archives (#344). Parse checks the wire format; execute runs the commands
@@ -281,6 +291,7 @@ if(BUILD_TESTING)
     set_tests_properties(
         BootOoT BootMM SwitchOoTMM SwitchMMOoT StartupEntrance EntranceDedup VBAffinity CosmeticGfxStub Roundtrip RoundtripIntegrity SharedRoundtrip ArchiveHotswapLogic
         SaveRoundtripTiers SaveHeader SaveHasDelete SaveVersionReject SaveSizeMismatch SaveLegacySize SaveCrcCorrupt
+        SaveComboLegacyRecord SaveComboRecordFixed SaveComboOversize
         Context MMSceneParse MMSceneExecute SeqMapBounds MMResumeArena MMStartupRestore AllTests
         PROPERTIES
         TIMEOUT ${REDSHIP_TEST_TIMEOUT}

--- a/src/common/context.cpp
+++ b/src/common/context.cpp
@@ -207,7 +207,7 @@ void ComboContext_Init(void) {
     gComboCtx.targetEntrance = 0;
     gComboCtx.sourceGame = GAME_NONE;
     gComboCtx.sourceEntrance = 0;
-    gComboCtx.saveSlot = -1;
+    gComboCtx.saveSlot = -1;  // NOT WIRED — see context.h; nothing reads this yet
     gComboCtx.sourceIsRando = false;
     gComboCtx.sharedRandoSeed = 0;
 }

--- a/src/common/context.h
+++ b/src/common/context.h
@@ -90,6 +90,27 @@ void Context_UpdateShadowCopy(GameId game, const void* saveContext, size_t size)
 
 #define COMBO_CONTEXT_MAGIC "OoT+MM<3"
 
+/**
+ * FIXED on-disk size of the .redsave Tier-1 (ComboContext) record.
+ *
+ * The serialized record is decoupled from sizeof(ComboContext) on purpose.
+ * save.cpp always writes exactly this many bytes — the live struct followed by
+ * zero padding — and Load reads the size the header stored, zero-extending a
+ * shorter record. That is the same size-field-driven scheme the OoT/MM tiers
+ * already use, and it is what lets ComboContext GROW without invalidating every
+ * existing .redsave.
+ *
+ * The growth contract, which Lane A (origin-tagged sharedItems) depends on:
+ *   - New fields are APPENDED (or carved out of `reserved`), never inserted
+ *     between existing members. Every already-shipped field must keep its
+ *     offset, because a short legacy record is loaded as a byte PREFIX of the
+ *     current layout.
+ *   - sizeof(ComboContext) must stay within this budget. Exceeding it is a
+ *     compile-time error (static_assert below), not a silent format break: the
+ *     fix is to raise both this constant and RSBS_SAVE_VERSION together.
+ */
+#define RSBS_COMBO_CONTEXT_RECORD_SIZE 1024u
+
 typedef struct {
     char magic[8];        // "OoT+MM<3"
     uint32_t version;
@@ -99,13 +120,39 @@ typedef struct {
     GameId sourceGame;
     uint16_t sourceEntrance;
     uint32_t sharedFlags[64];
+    // NOT WIRED: no non-test reader/writer exists yet. Lane A widens this into
+    // an origin-tagged form — OoT's RG_* ids and MM's item ids are unrelated
+    // enumerations that must never alias by raw integer.
     uint16_t sharedItems[32];
+    // NOT WIRED: dead plumbing. Set to -1 by ComboContext_Init and serialized,
+    // but nothing outside the tests reads it — do not assume the active slot
+    // index is available here until something actually assigns it.
     int32_t saveSlot;
 
     // Cross-game rando state propagation
     bool sourceIsRando;        // Source game is in randomizer mode
     uint32_t sharedRandoSeed;  // Shared seed for synchronization
+
+    // Headroom. Shrink this when appending a field so the struct stays inside
+    // RSBS_COMBO_CONTEXT_RECORD_SIZE; the on-disk record size does not change
+    // either way, so old saves keep loading. Zeroed by ComboContext_Init, which
+    // is what makes a zero-extended legacy record indistinguishable from a
+    // freshly-initialized one.
+    uint8_t reserved[640];
 } ComboContext;
+
+// Deliberately `<=`, not `==`: the on-disk record is padded to a fixed size, so
+// the struct only has to FIT the budget. An exact-match assert would turn a
+// harmless ABI padding difference into a build break for no benefit.
+#ifdef __cplusplus
+static_assert(sizeof(ComboContext) <= RSBS_COMBO_CONTEXT_RECORD_SIZE,
+              "ComboContext outgrew its .redsave Tier-1 record budget; raise "
+              "RSBS_COMBO_CONTEXT_RECORD_SIZE and RSBS_SAVE_VERSION together");
+#else
+_Static_assert(sizeof(ComboContext) <= RSBS_COMBO_CONTEXT_RECORD_SIZE,
+               "ComboContext outgrew its .redsave Tier-1 record budget; raise "
+               "RSBS_COMBO_CONTEXT_RECORD_SIZE and RSBS_SAVE_VERSION together");
+#endif
 
 extern ComboContext gComboCtx;
 extern GameId gCurrentGame;

--- a/src/common/save.cpp
+++ b/src/common/save.cpp
@@ -23,17 +23,35 @@ namespace rsbs {
 
 namespace {
 
-// Tier sizes as this build writes them. The game-tier constants are the blob
-// CAPACITIES from game.h — the same values the context-layer shadow buffers
-// are allocated at, so reading the shadows here is always in-bounds. On Load
-// the header's stored sizes drive the reads instead: older files with shorter
-// game tiers are accepted and zero-extended (see DeserializeHeader).
-constexpr uint32_t kComboSize = static_cast<uint32_t>(sizeof(ComboContext));
+// Tier sizes as this build writes them. All three are CAPACITIES, not exact
+// struct sizes: the game-tier constants come from game.h (the same values the
+// context-layer shadow buffers are allocated at, so reading the shadows here is
+// always in-bounds), and the Tier-1 constant is the fixed record size from
+// context.h, which is >= sizeof(ComboContext) by static_assert. On Load the
+// header's stored sizes drive the reads instead: older files with shorter tiers
+// are accepted and zero-extended (see DeserializeHeader).
+constexpr uint32_t kComboSize = RSBS_COMBO_CONTEXT_RECORD_SIZE;
 constexpr uint32_t kOoTSize = static_cast<uint32_t>(OOT_SAVE_CONTEXT_SIZE);
 constexpr uint32_t kMMSize = static_cast<uint32_t>(MM_SAVE_CONTEXT_SIZE);
 
+static_assert(sizeof(ComboContext) <= kComboSize,
+              "ComboContext must fit the fixed Tier-1 record");
+
 bool SlotInRange(int slot) {
     return slot >= 0 && slot < RSBS_SAVE_MAX_SLOTS;
+}
+
+// A rejected Load used to return false and tell the user NOTHING — the save
+// simply did not come back. Every refusal now names itself on stderr so a
+// format break is diagnosable from a log instead of a bug report that reads
+// "my save vanished".
+void SaveLogReject(bool verbose, const char* reason, unsigned long long got,
+                   unsigned long long expected) {
+    if (!verbose) {
+        return;
+    }
+    std::fprintf(stderr, "[RsbsSave] refusing slot file: %s (got %llu, expected %llu)\n",
+                 reason, got, expected);
 }
 
 }  // namespace
@@ -85,8 +103,13 @@ bool SaveManager::Save(int slot) {
     // write, in write order: ComboContext, OoT blob, MM blob.
     std::vector<uint8_t> payload;
     payload.reserve(kComboSize + kOoTSize + kMMSize);
+    // Tier-1 goes out at the FIXED record size: the live struct, then zeros to
+    // the budget. The padding is what gives ComboContext room to grow later
+    // without the serialized size — and therefore every existing save file's
+    // validity — moving.
     const uint8_t* comboBytes = reinterpret_cast<const uint8_t*>(&gComboCtx);
-    payload.insert(payload.end(), comboBytes, comboBytes + kComboSize);
+    payload.insert(payload.end(), comboBytes, comboBytes + sizeof(ComboContext));
+    payload.insert(payload.end(), kComboSize - sizeof(ComboContext), uint8_t{0});
     payload.insert(payload.end(), static_cast<const uint8_t*>(ootShadow),
                    static_cast<const uint8_t*>(ootShadow) + kOoTSize);
     payload.insert(payload.end(), static_cast<const uint8_t*>(mmShadow),
@@ -135,37 +158,54 @@ bool SaveManager::Save(int slot) {
     return true;
 }
 
-bool SaveManager::DeserializeHeader(std::istream& in, RsbsSaveHeader& outHeader) const {
+bool SaveManager::DeserializeHeader(std::istream& in, RsbsSaveHeader& outHeader,
+                                    bool verbose) const {
     RsbsSaveHeader h;
     in.read(reinterpret_cast<char*>(&h), sizeof(h));
     if (!in || in.gcount() != static_cast<std::streamsize>(sizeof(h))) {
+        SaveLogReject(verbose, "short header read", static_cast<unsigned long long>(in.gcount()),
+                      sizeof(h));
         return false;
     }
 
     if (std::memcmp(h.magic, RSBS_SAVE_MAGIC, sizeof(h.magic)) != 0) {
+        SaveLogReject(verbose, "bad magic (not a .redsave)", 0, 0);
         return false;
     }
-    if (h.version != RSBS_SAVE_VERSION) {
-        return false;  // older/newer layout — refuse rather than guess
+    // A version WINDOW, not an equality test. Bumping RSBS_SAVE_VERSION against
+    // an equality test is precisely how a format change orphans every existing
+    // save; older versions inside the window are prefix-compatible and load.
+    if (h.version < RSBS_SAVE_VERSION_MIN || h.version > RSBS_SAVE_VERSION) {
+        SaveLogReject(verbose, "unsupported format version", h.version, RSBS_SAVE_VERSION);
+        return false;
     }
     if (h.endian != RSBS_SAVE_ENDIAN_LE) {
+        SaveLogReject(verbose, "wrong byte order", h.endian, RSBS_SAVE_ENDIAN_LE);
         return false;
     }
     if (h.headerSize != sizeof(RsbsSaveHeader)) {
+        SaveLogReject(verbose, "unexpected header size", h.headerSize, sizeof(RsbsSaveHeader));
         return false;
     }
-    // Tier-1 must match exactly: ComboContext has no capacity headroom, and a
-    // different size means a different struct layout.
-    if (h.comboSize != kComboSize) {
+    // ALL THREE tiers are size-field-driven. A STORED size smaller than this
+    // build's capacity is a file from an older build — for the game tiers, one
+    // written before the capacities covered the ports' full runtime structs
+    // (OoT was the N64 0x1428); for Tier-1, one written before ComboContext got
+    // a fixed record size, or by any build whose ComboContext simply had fewer
+    // trailing fields. Either way the stored bytes are a PREFIX of the current
+    // layout, so Load accepts them and zero-extends. Larger than capacity means
+    // a newer/foreign layout that cannot fit our buffers: refuse rather than
+    // truncate, because truncating Tier-1 would silently drop cross-game state.
+    if (h.comboSize == 0 || h.comboSize > kComboSize) {
+        SaveLogReject(verbose, "Tier-1 (ComboContext) size out of range", h.comboSize, kComboSize);
         return false;
     }
-    // Game tiers are size-field-driven: a STORED size smaller than this
-    // build's blob capacity is a file from an older build (e.g. the OoT tier
-    // was the N64 0x1428 before the capacity covered SoH's full runtime
-    // struct) — its bytes are a prefix of the same layout, so Load accepts it
-    // and zero-extends. Larger than capacity means a newer/foreign layout that
-    // cannot fit the shadow buffers: refuse rather than truncate.
-    if (h.ootSize == 0 || h.ootSize > kOoTSize || h.mmSize == 0 || h.mmSize > kMMSize) {
+    if (h.ootSize == 0 || h.ootSize > kOoTSize) {
+        SaveLogReject(verbose, "Tier-2 (OoT) size out of range", h.ootSize, kOoTSize);
+        return false;
+    }
+    if (h.mmSize == 0 || h.mmSize > kMMSize) {
+        SaveLogReject(verbose, "Tier-3 (MM) size out of range", h.mmSize, kMMSize);
         return false;
     }
 
@@ -180,11 +220,12 @@ bool SaveManager::Load(int slot) {
 
     std::ifstream in(SlotPath(slot), std::ios::binary);
     if (!in) {
+        std::fprintf(stderr, "[RsbsSave] cannot open slot %d for load\n", slot);
         return false;
     }
 
     RsbsSaveHeader header;
-    if (!DeserializeHeader(in, header)) {
+    if (!DeserializeHeader(in, header, /*verbose=*/true)) {
         return false;
     }
 
@@ -193,38 +234,50 @@ bool SaveManager::Load(int slot) {
     // not clobber live state. Reads are driven by the header's STORED tier
     // sizes; the blobs are allocated at full capacity and zero-filled so a
     // shorter tier from an older build is zero-extended.
-    ComboContext combo;
+    //
+    // Tier-1 gets the same treatment via a full-record staging buffer: the
+    // struct is copied out of the FRONT of it, so fields appended since the file
+    // was written read as zero — exactly the value ComboContext_Init gives them
+    // — instead of whatever was on the stack.
+    std::vector<uint8_t> comboRecord(kComboSize, 0);
     std::vector<uint8_t> ootBlob(kOoTSize, 0);
     std::vector<uint8_t> mmBlob(kMMSize, 0);
 
-    in.read(reinterpret_cast<char*>(&combo), kComboSize);
-    if (!in || in.gcount() != static_cast<std::streamsize>(kComboSize)) {
+    in.read(reinterpret_cast<char*>(comboRecord.data()), header.comboSize);
+    if (!in || in.gcount() != static_cast<std::streamsize>(header.comboSize)) {
+        std::fprintf(stderr, "[RsbsSave] slot %d truncated in Tier-1\n", slot);
         return false;
     }
     in.read(reinterpret_cast<char*>(ootBlob.data()), header.ootSize);
     if (!in || in.gcount() != static_cast<std::streamsize>(header.ootSize)) {
+        std::fprintf(stderr, "[RsbsSave] slot %d truncated in Tier-2 (OoT)\n", slot);
         return false;
     }
     in.read(reinterpret_cast<char*>(mmBlob.data()), header.mmSize);
     if (!in || in.gcount() != static_cast<std::streamsize>(header.mmSize)) {
+        std::fprintf(stderr, "[RsbsSave] slot %d truncated in Tier-3 (MM)\n", slot);
         return false;
     }
+
+    ComboContext combo;
+    std::memcpy(&combo, comboRecord.data(), sizeof(ComboContext));
 
     // CRC over Tiers 1..3 exactly as stored (not the zero-extended tails), in
     // the same contiguous order they were written.
     std::vector<uint8_t> payload;
-    payload.reserve(kComboSize + header.ootSize + header.mmSize);
-    const uint8_t* comboBytes = reinterpret_cast<const uint8_t*>(&combo);
-    payload.insert(payload.end(), comboBytes, comboBytes + kComboSize);
+    payload.reserve(header.comboSize + header.ootSize + header.mmSize);
+    payload.insert(payload.end(), comboRecord.begin(), comboRecord.begin() + header.comboSize);
     payload.insert(payload.end(), ootBlob.begin(), ootBlob.begin() + header.ootSize);
     payload.insert(payload.end(), mmBlob.begin(), mmBlob.begin() + header.mmSize);
     if (Crc32(payload.data(), payload.size()) != header.crc32) {
+        std::fprintf(stderr, "[RsbsSave] slot %d failed CRC — file is corrupt, load refused\n", slot);
         return false;
     }
 
     // Inner ComboContext magic guards against a structurally-valid file whose
     // Tier-1 contents are not actually a ComboContext.
     if (std::memcmp(combo.magic, COMBO_CONTEXT_MAGIC, sizeof(combo.magic)) != 0) {
+        std::fprintf(stderr, "[RsbsSave] slot %d Tier-1 is not a ComboContext, load refused\n", slot);
         return false;
     }
 
@@ -246,7 +299,7 @@ bool SaveManager::HasSave(int slot) const {
         return false;
     }
     RsbsSaveHeader header;
-    return DeserializeHeader(in, header);
+    return DeserializeHeader(in, header, /*verbose=*/false);
 }
 
 void SaveManager::DeleteSave(int slot) {
@@ -338,7 +391,7 @@ SlotMeta SaveManager::ReadMeta(int slot) const {
     meta.exists = true;
 
     RsbsSaveHeader header;
-    if (!DeserializeHeader(in, header)) {
+    if (!DeserializeHeader(in, header, /*verbose=*/false)) {
         return meta;  // exists=true, valid=false
     }
     meta.valid = true;
@@ -350,12 +403,17 @@ SlotMeta SaveManager::ReadMeta(int slot) const {
     // ReadMeta is called for every slot every menu frame, and CRC over ~200KB
     // each time would dominate the file-select draw. Load() still CRC-checks
     // when the user actually picks a slot.
-    ComboContext combo;
-    in.read(reinterpret_cast<char*>(&combo), kComboSize);
-    if (!in || in.gcount() != static_cast<std::streamsize>(kComboSize)) {
+    // Same zero-filled staging + prefix-copy as Load: a legacy short Tier-1
+    // must still yield a readable sourceGame, or the file-select panel would
+    // label every pre-headroom slot as belonging to no game.
+    std::vector<uint8_t> comboRecord(kComboSize, 0);
+    in.read(reinterpret_cast<char*>(comboRecord.data()), header.comboSize);
+    if (!in || in.gcount() != static_cast<std::streamsize>(header.comboSize)) {
         meta.valid = false;
         return meta;
     }
+    ComboContext combo;
+    std::memcpy(&combo, comboRecord.data(), sizeof(ComboContext));
     if (std::memcmp(combo.magic, COMBO_CONTEXT_MAGIC, sizeof(combo.magic)) == 0) {
         meta.lastGame = combo.sourceGame;
     }

--- a/src/common/save.h
+++ b/src/common/save.h
@@ -22,12 +22,17 @@
  *   the header records endian=1 and Load asserts it so a future big-endian port
  *   fails loudly instead of silently corrupting.
  * - The header stores each tier's byte length, so the file is self-describing:
- *   Load reads the STORED sizes, not this build's constants. A game tier that
- *   is shorter than the current blob capacity (a file written by an older
- *   build, e.g. before the OoT tier grew from the N64 0x1428 to the full SoH
- *   runtime size) is accepted and zero-extended to capacity; a tier LARGER
- *   than this build's capacity, an unknown version, or a comboSize that does
- *   not match sizeof(ComboContext) is rejected (fail-safe, no partial load).
+ *   Load reads the STORED sizes, not this build's constants. This applies to
+ *   ALL THREE tiers, Tier-1 included. A tier that is shorter than this build's
+ *   size is a file from an older build — its bytes are a prefix of the same
+ *   layout, so it is accepted and zero-extended. A tier LARGER than this
+ *   build's capacity, or a version outside [RSBS_SAVE_VERSION_MIN,
+ *   RSBS_SAVE_VERSION], is rejected (fail-safe, no partial load) AND logged.
+ * - Tier-1 is written at a FIXED RSBS_COMBO_CONTEXT_RECORD_SIZE (struct plus
+ *   zero padding), so appending fields to ComboContext — which Lane A's
+ *   origin-tagged sharedItems requires — does not change the serialized size
+ *   at all and does not orphan existing saves. See context.h for the growth
+ *   contract that keeps the prefix property true.
  */
 
 #ifndef RSBS_COMMON_SAVE_H
@@ -40,7 +45,13 @@
 
 // On-disk constants (visible to both C and C++).
 #define RSBS_SAVE_MAGIC      "REDSHIP1"  // 8 bytes, NOT NUL-terminated on disk
-#define RSBS_SAVE_VERSION    1u          // bump on any layout change
+#define RSBS_SAVE_VERSION    2u          // version THIS build writes
+// Oldest version this build can still read. v1 files predate the fixed-size
+// Tier-1 record: their comboSize is the raw sizeof(ComboContext) of the build
+// that wrote them, which is a prefix of the current layout and therefore
+// zero-extends cleanly. Widen this window rather than bumping VERSION alone —
+// bumping alone is what silently orphans every existing .redsave.
+#define RSBS_SAVE_VERSION_MIN 1u
 #define RSBS_SAVE_ENDIAN_LE  1
 #define RSBS_SAVE_MAX_SLOTS  3           // matches each game's MaxFiles
 
@@ -99,7 +110,7 @@ struct RsbsSaveHeader {
     uint8_t  endian;      // RSBS_SAVE_ENDIAN_LE (1)
     uint8_t  slot;        // 0..RSBS_SAVE_MAX_SLOTS-1
     uint16_t headerSize;  // sizeof(RsbsSaveHeader) == 32 (forward-compat probe)
-    uint32_t comboSize;   // Tier-1 bytes == sizeof(ComboContext)
+    uint32_t comboSize;   // Tier-1 bytes as stored (RSBS_COMBO_CONTEXT_RECORD_SIZE at write time)
     uint32_t ootSize;     // Tier-2 bytes as stored (== OOT_SAVE_CONTEXT_SIZE at write time)
     uint32_t mmSize;      // Tier-3 bytes as stored (== MM_SAVE_CONTEXT_SIZE at write time)
     uint32_t crc32;       // CRC32 over Tiers 1..3 (the payload after the header)
@@ -155,12 +166,18 @@ public:
 private:
     SaveManager() = default;
 
-    // Validates magic / version / endian / headerSize, that comboSize matches
-    // this build's ComboContext, and that the stored game-tier sizes fit the
-    // current blob capacities (stored sizes may be SMALLER — older builds wrote
-    // shorter blobs — but never larger). Returns true and fills outHeader only
-    // on a fully valid header; never mutates live state.
-    bool DeserializeHeader(std::istream& in, RsbsSaveHeader& outHeader) const;
+    // Validates magic / version / endian / headerSize and that all three
+    // stored tier sizes fit this build's capacities. Stored sizes may be
+    // SMALLER (older builds wrote shorter tiers; Load zero-extends) but never
+    // larger. Returns true and fills outHeader only on a fully valid header;
+    // never mutates live state.
+    //
+    // `verbose` gates the rejection logging. Load() passes true — a user-
+    // initiated load that silently does nothing is the failure mode this whole
+    // path exists to prevent. HasSave/ReadMeta pass false: ReadMeta runs for
+    // every slot on every file-select frame, so logging there would be a
+    // per-frame spam loop, not a diagnostic.
+    bool DeserializeHeader(std::istream& in, RsbsSaveHeader& outHeader, bool verbose) const;
 
     std::string mSaveDir = "Save";
 

--- a/src/common/test_runner.cpp
+++ b/src/common/test_runner.cpp
@@ -831,6 +831,11 @@ const TestDescriptor gTests[] = {
     {"save-size-mismatch", "Unified save Load rejects oversized tier, no clobber (#35)", Test_SaveSizeMismatch},
     {"save-legacy-size", "Unified save Load zero-extends shorter legacy tiers (#35)", Test_SaveLegacySize},
     {"save-crc-corrupt", "Unified save Load rejects corrupt payload, no clobber (#35)", Test_SaveCrcCorrupt},
+    // Tier-1 format-headroom locks: the migration path Lane A's widened
+    // sharedItems rides on. Without these, "ComboContext can grow" is a claim.
+    {"save-combo-legacy-record", "Pre-headroom Tier-1 still loads and zero-extends", Test_SaveComboLegacyRecord},
+    {"save-combo-record-fixed", "Tier-1 written at a fixed padded size; headroom round-trips", Test_SaveComboRecordFixed},
+    {"save-combo-oversize", "Load rejects an oversized Tier-1 record, no clobber", Test_SaveComboOversize},
     {"mm-scene-parse", "MM scene commands parse via the S2H factory (#344)", Test_MMSceneParse},
     {"seq-map-bounds", "Sequence-map capacity covers the id range + custom slack (#371, #378)", Test_SeqMapBounds},
     {"mm-scene-execute", "MM scene commands execute against a PlayState (#344)", Test_MMSceneExecute},

--- a/src/common/tests/test_save_roundtrip.c
+++ b/src/common/tests/test_save_roundtrip.c
@@ -185,7 +185,9 @@ TestResult Test_SaveHeader(void) {
     SAVE_ASSERT(h.endian == RSBS_SAVE_ENDIAN_LE, "bad endian");
     SAVE_ASSERT(h.slot == 0, "bad slot");
     SAVE_ASSERT(h.headerSize == sizeof(rsbs::RsbsSaveHeader), "bad headerSize");
-    SAVE_ASSERT(h.comboSize == sizeof(ComboContext), "bad comboSize");
+    // The FIXED record size, deliberately not sizeof(ComboContext): the record
+    // is padded so appending a field cannot move it.
+    SAVE_ASSERT(h.comboSize == RSBS_COMBO_CONTEXT_RECORD_SIZE, "bad comboSize");
     SAVE_ASSERT(h.ootSize == OOT_SAVE_CONTEXT_SIZE, "bad ootSize");
     SAVE_ASSERT(h.mmSize == MM_SAVE_CONTEXT_SIZE, "bad mmSize");
 
@@ -381,5 +383,176 @@ TestResult Test_SaveCrcCorrupt(void) {
 
     mgr.DeleteSave(0);
     printf("[TEST] PASS: corrupt payload rejected, live state intact\n");
+    return TEST_PASS;
+}
+
+// ============================================================================
+// Tier-1 (ComboContext) format-headroom locks — Phase 3 Wave 1.
+//
+// Lane A widens gComboCtx.sharedItems to carry an origin-game tag, which
+// changes sizeof(ComboContext). Before this lane, DeserializeHeader demanded
+// `h.comboSize == sizeof(ComboContext)` exactly, so that change would have made
+// every already-written .redsave stop loading — silently, because Load's only
+// failure signal was a `false` nobody surfaced. These three tests are the
+// migration path: without them the headroom is an untested claim.
+// ============================================================================
+
+namespace {
+
+// Writes a hand-crafted slot file with an arbitrary version and Tier-1 record
+// length, taking the Tier-1 bytes from the front of the CURRENT gComboCtx.
+// Truncating gComboCtx at `comboSize` is byte-for-byte what an older build
+// wrote, as long as fields are only ever appended — which is the growth
+// contract documented in context.h.
+bool SaveTestWriteCraftedSlot(const std::string& path, uint32_t version, uint32_t comboSize) {
+    std::vector<uint8_t> payload;
+    const uint8_t* comboBytes = reinterpret_cast<const uint8_t*>(&gComboCtx);
+    payload.insert(payload.end(), comboBytes, comboBytes + comboSize);
+    for (size_t i = 0; i < OOT_SAVE_CONTEXT_SIZE; i++) {
+        payload.push_back(SaveTestOoTByte(i));
+    }
+    for (size_t i = 0; i < MM_SAVE_CONTEXT_SIZE; i++) {
+        payload.push_back(SaveTestMMByte(i));
+    }
+
+    rsbs::RsbsSaveHeader h;
+    std::memset(&h, 0, sizeof(h));
+    std::memcpy(h.magic, RSBS_SAVE_MAGIC, sizeof(h.magic));
+    h.version = version;
+    h.endian = RSBS_SAVE_ENDIAN_LE;
+    h.slot = 0;
+    h.headerSize = sizeof(rsbs::RsbsSaveHeader);
+    h.comboSize = comboSize;
+    h.ootSize = static_cast<uint32_t>(OOT_SAVE_CONTEXT_SIZE);
+    h.mmSize = static_cast<uint32_t>(MM_SAVE_CONTEXT_SIZE);
+    h.crc32 = rsbs::SaveManager::Crc32(payload.data(), payload.size());
+
+    std::filesystem::create_directories(kSaveTestDir);
+    std::ofstream out(path, std::ios::binary | std::ios::trunc);
+    if (!out) {
+        return false;
+    }
+    out.write(reinterpret_cast<const char*>(&h), sizeof(h));
+    out.write(reinterpret_cast<const char*>(payload.data()), static_cast<std::streamsize>(payload.size()));
+    return static_cast<bool>(out);
+}
+
+}  // namespace
+
+TestResult Test_SaveComboLegacyRecord(void) {
+    printf("[TEST] save-combo-legacy-record: a pre-headroom .redsave still loads and zero-extends\n");
+
+    rsbs::SaveManager& mgr = rsbs::SaveManager::Instance();
+    mgr.SetSaveDirectory(kSaveTestDir);
+
+    const uint32_t tag = 0x0DDBA11u;
+    SaveTestSeed(tag);
+    for (size_t i = 0; i < 32; i++) {
+        gComboCtx.sharedItems[i] = static_cast<uint16_t>(0x2000u + i);
+    }
+    mgr.DeleteSave(0);
+
+    // The old ComboContext is exactly today's struct minus the reserved tail,
+    // so offsetof gives us the legacy record length with no hand-arithmetic and
+    // no duplicated struct definition to drift out of sync.
+    const uint32_t kLegacyComboSize = static_cast<uint32_t>(offsetof(ComboContext, reserved));
+    SAVE_ASSERT(kLegacyComboSize < RSBS_COMBO_CONTEXT_RECORD_SIZE,
+                "legacy Tier-1 must be shorter than the record budget");
+    SAVE_ASSERT(SaveTestWriteCraftedSlot(mgr.SlotPath(0), RSBS_SAVE_VERSION_MIN, kLegacyComboSize),
+                "could not write legacy-record slot file");
+
+    // Scribble the reserved tail so "zero-extended" is provably the loader's
+    // doing and not a leftover zero.
+    ComboContext_Init();
+    gComboCtx.saveSlot = 0x7FFFFFFF;
+    std::memset(gComboCtx.reserved, 0x5A, sizeof(gComboCtx.reserved));
+
+    SAVE_ASSERT(mgr.Load(0), "Load refused a pre-headroom .redsave — the migration path is broken");
+
+    SAVE_ASSERT(gComboCtx.saveSlot == static_cast<int32_t>(tag), "legacy saveSlot not restored");
+    SAVE_ASSERT(gComboCtx.sharedFlags[5] == tag, "legacy sharedFlags not restored");
+    SAVE_ASSERT(gComboCtx.sharedRandoSeed == (tag ^ 0xA5A5A5A5u), "legacy sharedRandoSeed not restored");
+    SAVE_ASSERT(gComboCtx.sourceIsRando, "legacy sourceIsRando not restored");
+    SAVE_ASSERT(gComboCtx.sourceGame == GAME_OOT, "legacy sourceGame not restored");
+    for (size_t i = 0; i < 32; i++) {
+        SAVE_ASSERT(gComboCtx.sharedItems[i] == static_cast<uint16_t>(0x2000u + i),
+                    "legacy sharedItems not restored");
+    }
+    for (size_t i = 0; i < sizeof(gComboCtx.reserved); i++) {
+        SAVE_ASSERT(gComboCtx.reserved[i] == 0, "Tier-1 tail beyond the legacy record not zero-extended");
+    }
+    SAVE_ASSERT(SaveTestOoTShadowMatchesPattern(), "OoT blob not restored from legacy-record file");
+    SAVE_ASSERT(SaveTestMMShadowMatchesPattern(), "MM blob not restored from legacy-record file");
+
+    mgr.DeleteSave(0);
+    printf("[TEST] PASS: pre-headroom Tier-1 loads, added fields read as zero\n");
+    return TEST_PASS;
+}
+
+TestResult Test_SaveComboRecordFixed(void) {
+    printf("[TEST] save-combo-record-fixed: Tier-1 is written at a fixed padded size and carries the tail\n");
+
+    rsbs::SaveManager& mgr = rsbs::SaveManager::Instance();
+    mgr.SetSaveDirectory(kSaveTestDir);
+    SaveTestSeed(0xFEEDFACEu);
+
+    // Stand in for a field Lane A will carve out of `reserved`: if these bytes
+    // survive a Save/Load, so will the real field.
+    for (size_t i = 0; i < sizeof(gComboCtx.reserved); i++) {
+        gComboCtx.reserved[i] = static_cast<uint8_t>(0x30u + i * 7u);
+    }
+
+    mgr.DeleteSave(0);
+    SAVE_ASSERT(mgr.Save(0), "Save(0) failed");
+
+    // The written Tier-1 length must be the budget, NOT sizeof(ComboContext) —
+    // that decoupling is what keeps the on-disk size stable when the struct
+    // grows. Total file length proves the padding is actually on disk.
+    const uintmax_t expected = sizeof(rsbs::RsbsSaveHeader) + RSBS_COMBO_CONTEXT_RECORD_SIZE +
+                               OOT_SAVE_CONTEXT_SIZE + MM_SAVE_CONTEXT_SIZE;
+    SAVE_ASSERT(std::filesystem::file_size(mgr.SlotPath(0)) == expected,
+                "slot file length does not match a fixed-size padded Tier-1");
+    SAVE_ASSERT(sizeof(ComboContext) <= RSBS_COMBO_CONTEXT_RECORD_SIZE,
+                "ComboContext no longer fits its record budget");
+
+    ComboContext_Init();
+    gComboCtx.saveSlot = 0x7FFFFFFF;
+
+    SAVE_ASSERT(mgr.Load(0), "Load(0) failed");
+    for (size_t i = 0; i < sizeof(gComboCtx.reserved); i++) {
+        SAVE_ASSERT(gComboCtx.reserved[i] == static_cast<uint8_t>(0x30u + i * 7u),
+                    "reserved headroom not round-tripped — a future field would be lost");
+    }
+
+    mgr.DeleteSave(0);
+    printf("[TEST] PASS: Tier-1 record size is fixed and its headroom round-trips\n");
+    return TEST_PASS;
+}
+
+TestResult Test_SaveComboOversize(void) {
+    printf("[TEST] save-combo-oversize: Load refuses a Tier-1 larger than this build can hold\n");
+
+    rsbs::SaveManager& mgr = rsbs::SaveManager::Instance();
+    mgr.SetSaveDirectory(kSaveTestDir);
+    SaveTestSeed(0x13571357u);
+    mgr.DeleteSave(0);
+    SAVE_ASSERT(mgr.Save(0), "Save(0) failed");
+
+    // A Tier-1 record from a future, wider format. Accepting it would mean
+    // silently truncating cross-game state; the only safe answer is to refuse
+    // (loudly — Load logs the reason).
+    SAVE_ASSERT(SaveTestPatchU32(mgr.SlotPath(0), offsetof(rsbs::RsbsSaveHeader, comboSize),
+                                 RSBS_COMBO_CONTEXT_RECORD_SIZE + 4u),
+                "could not patch comboSize");
+
+    SaveTestSeed(0x2468ACE0u);
+    gComboCtx.saveSlot = 0x0BADF00D;
+
+    SAVE_ASSERT(!mgr.Load(0), "Load accepted an oversized Tier-1 record");
+    SAVE_ASSERT(gComboCtx.saveSlot == 0x0BADF00D, "rejected Load clobbered ComboContext");
+    SAVE_ASSERT(SaveTestOoTShadowMatchesPattern(), "rejected Load clobbered OoT shadow");
+
+    mgr.DeleteSave(0);
+    printf("[TEST] PASS: oversized Tier-1 rejected, live state intact\n");
     return TEST_PASS;
 }


### PR DESCRIPTION
## What was broken

`src/common/save.cpp` set `kComboSize = sizeof(ComboContext)` and `DeserializeHeader` did `if (h.comboSize != kComboSize) return false;`, commented "ComboContext has no capacity headroom." `Load()` returning false left `gComboCtx` untouched **and showed the user nothing**.

Phase 3 Lane A must widen `gComboCtx.sharedItems` to carry an origin-game tag — OoT's `RG_*` ids and MM's item ids are unrelated enumerations that must never alias by raw integer (same class as the #356 entrance-id leak crash). That changes `sizeof(ComboContext)`. The moment it lands, every existing `.redsave` silently stops loading, and again on every later shape change. This is risk item 3 on the #392 tracker, explicitly flagged to be fixed *before* Lane A's first commit and before the `v0.1.0-prealpha` tag.

## Mechanism

**Tier-1 is now a fixed 1024-byte on-disk record** (`RSBS_COMBO_CONTEXT_RECORD_SIZE`). `Save` writes the live struct then zero padding, so the serialized size is decoupled from `sizeof(ComboContext)` and does not move when the struct grows. `Load` reads the header's *stored* size into a zero-filled staging buffer and copies the struct out of the front of it: a shorter record from an older build is a byte prefix, and fields appended since then read as zero — exactly what `ComboContext_Init` would have given them. This is the same size-field-driven zero-extend the OoT/MM tiers already use (`save.cpp:167-170` on main); Tier-1 just stops being the exception.

The growth contract that keeps the prefix property true is documented on the struct in `context.h`: **append, never insert**.

**The version check becomes a window**, `[RSBS_SAVE_VERSION_MIN, RSBS_SAVE_VERSION]` = 1..2, rather than an equality test. Bumping the version against an equality test is itself a way to orphan every existing save, so the bump and the window land together.

**Exceeding the budget is a compile error.** A 640-byte `reserved` tail plus a `static_assert` that the struct fits the record. The assert is `<=`, not `==`: the record is padded so the struct only has to fit, and an exact-match assert would turn a harmless ABI padding difference into a build break for no benefit.

**Every refusal logs.** A load that quietly does nothing is the failure this path exists to prevent. Gated on a `verbose` flag only `Load()` sets — `ReadMeta` runs for every slot on every file-select frame, so logging there would be a per-frame spam loop, not a diagnostic.

Also documents `sharedItems` and `saveSlot` as **NOT WIRED** (zero non-test references) so the next reader does not assume the active slot index is available there. Neither is deleted — Lane A may want them, and deleting `sharedItems` would break the prefix property for existing files.

## Verification

Three new ROM-free tests in the `redship` CTest label (hosted CI is ROM-free by construction, so this is the tier that actually gates):

- **`SaveComboLegacyRecord`** — the migration lock. Writes a version-1 file whose Tier-1 is truncated at `offsetof(ComboContext, reserved)`, which is byte-for-byte the pre-headroom struct with no duplicated definition to drift, then proves the new loader reads it: every legacy field restored, and the added tail zero-extended over a deliberate `0x5A` scribble.
- **`SaveComboRecordFixed`** — the reverse direction. Asserts the written Tier-1 length is the budget and *not* `sizeof(ComboContext)`, that the file is physically padded (exact `file_size` check), and that bytes written into the headroom survive a Save→Load round trip — i.e. a field Lane A carves out of `reserved` will not be dropped.
- **`SaveComboOversize`** — a Tier-1 record wider than this build can hold is refused rather than truncated, and live state is untouched.

Existing `SaveHeader` updated to expect the fixed record size. `SaveLegacySize`, `SaveVersionReject`, `SaveSizeMismatch`, and `SaveCrcCorrupt` are unchanged and still pass by construction (the patched version `0xFFFF` is still outside the window; a smaller Tier-1 is still accepted on the same prefix rule).

Not built locally by design — three other Wave 1 agents are on the machine. CI builds this.

## Note for the reviewer

`Closes` is deliberately omitted: #392 is the Phase 3 tracker, not this lane's issue, and this is one checklist item on it. Part of #392 (risk item 3), gating Lane A.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!--- section:artifacts:start -->
### Build Artifacts
  - [rsbs-windows.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/8452943596.zip)
  - [rsbs-linux.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/8452774761.zip)
<!--- section:artifacts:end -->