### PR TITLE
Make F10 hot-swap freeze state and clear it on consume

### DIFF
--- a/CMake/SingleExecutable.cmake
+++ b/CMake/SingleExecutable.cmake
@@ -266,6 +266,12 @@ if(BUILD_TESTING)
     add_test(NAME SaveComboRecordFixed COMMAND redship --test save-combo-record-fixed)
     add_test(NAME SaveComboOversize COMMAND redship --test save-combo-oversize)
     add_test(NAME Context COMMAND redship --test context)
+    # F10 hot-swap freeze/consume contract (#364): the hotkey path must freeze
+    # the DEPARTING game (or refuse the switch), and a consumed frozen state
+    # must be retired so it can never be re-applied. Before the fix, one
+    # entrance switch left a blob that every later F10 return silently rolled
+    # the player back to.
+    add_test(NAME HotSwapFreeze COMMAND redship --test hotswap-freeze)
     # MM scene-command parse + execute regressions — display-free, no ROM
     # archives (#344). Parse checks the wire format; execute runs the commands
     # against a PlayState and asserts the spawn-path pointers/fields populate.
@@ -292,7 +298,7 @@ if(BUILD_TESTING)
         BootOoT BootMM SwitchOoTMM SwitchMMOoT StartupEntrance EntranceDedup VBAffinity CosmeticGfxStub Roundtrip RoundtripIntegrity SharedRoundtrip ArchiveHotswapLogic
         SaveRoundtripTiers SaveHeader SaveHasDelete SaveVersionReject SaveSizeMismatch SaveLegacySize SaveCrcCorrupt
         SaveComboLegacyRecord SaveComboRecordFixed SaveComboOversize
-        Context MMSceneParse MMSceneExecute SeqMapBounds MMResumeArena MMStartupRestore AllTests
+        Context HotSwapFreeze MMSceneParse MMSceneExecute SeqMapBounds MMResumeArena MMStartupRestore AllTests
         PROPERTIES
         TIMEOUT ${REDSHIP_TEST_TIMEOUT}
         LABELS "redship"

--- a/games/mm/src/code/z_play.c
+++ b/games/mm/src/code/z_play.c
@@ -55,9 +55,12 @@ extern uint16_t Combo_GetStartupEntrance(void);
 extern void Combo_ClearStartupEntrance(void);
 extern uint16_t Combo_GetStartupEntranceForGame(const char* gameId);
 extern bool Combo_HasStartupEntranceForGame(const char* gameId);
-// Frozen-state accessors - defined in src/common/context.cpp
-extern int Combo_HasFrozenState(const char* gameId);
-extern int Combo_RestoreState(const char* gameId, void* saveContext, size_t size);
+// Frozen-state consumption (src/common/switch.cpp): applies the frozen save
+// and retires it in the same step, so a blob can never be consumed twice.
+// Deliberately NOT the bare Combo_HasFrozenState/Combo_RestoreState pair that
+// used to be declared here — a restore without the retire is exactly the #364
+// silent-rollback bug, and leaving those in scope invites it back.
+extern int Combo_ConsumeFrozenState(const char* gameId, void* saveContext, size_t size);
 
 s32 MM_gDbgCamEnabled = false;
 u8 D_801D0D54 = false;
@@ -2275,9 +2278,14 @@ void MM_Play_ConsumeStartupEntrance(void) {
     // interpreted, so continuity for cycle-2+ round trips lives here. A first
     // MM entry has no frozen state — the restore is a no-op and the entrance
     // spawn proceeds on the bootstrap save.
-    if (Combo_HasFrozenState("mm")) {
-        Combo_RestoreState("mm", &gSaveContext, sizeof(gSaveContext));
-    }
+    // Consume (restore + retire) rather than merely restore. A blob that
+    // survives its own consumption is indistinguishable, on the NEXT return
+    // leg, from one that was just frozen — so any entry into MM that did not
+    // freeze first would silently re-apply this same snapshot and roll the
+    // player back (#364). Retiring it here makes "frozen state exists" mean
+    // "MM was left and has not been returned to", which is the only condition
+    // the restore is valid for. A first MM entry has no frozen state — no-op.
+    Combo_ConsumeFrozenState("mm", &gSaveContext, sizeof(gSaveContext));
     gSaveContext.save.entrance = startupEntrance;
     // On a first MM entry this Play_Init is reached through MM's
     // title-screen boot (TitleSetup_SetupTitleScreen), so the save

--- a/games/oot/soh/GameExports_SingleExe.cpp
+++ b/games/oot/soh/GameExports_SingleExe.cpp
@@ -938,6 +938,33 @@ void Combo_SignalReadyToSwitch(void);
 void Combo_RequestGameSwitch(void);
 bool Combo_IsGameSwitchRequested(void);
 void Combo_ClearGameSwitchRequest(void);
+// Hot-swap freeze policy (src/common/switch.cpp). The launcher drives the F10
+// freeze, but only this side can supply the SaveContext, so the glue below
+// bridges the two.
+int Switch_PrepareHotSwap(GameId departing, const void* saveContext, size_t size);
+}
+
+/**
+ * Freeze the departing game for an F10 hot swap (#364).
+ *
+ * The launcher (rsbs/src/main.cpp) decides that a hot swap is happening, but
+ * `gSaveContext` is only addressable from a game translation unit — hence this
+ * one-line bridge. It is the F10 twin of the freeze `Combo_CheckEntranceSwitch`
+ * performs below for the entrance path; without it, F10 departures produced no
+ * blob at all while the launcher still restored whatever blob an *earlier*
+ * entrance switch had left behind.
+ *
+ * As in `Combo_CheckEntranceSwitch`, `sizeof(gSaveContext)` here is OoT's
+ * layout even when MM is the departing game. That over-reads relative to MM's
+ * smaller struct but stays in bounds: the underlying unified storage
+ * (src/common/unified_save.c) is OOT_SAVE_CONTEXT_SIZE for both games, and
+ * Context_FreezeState clamps to the per-game blob capacity.
+ *
+ * @return 1 if a fresh blob was recorded, 0 if the launcher must refuse the
+ *         switch instead of proceeding into a stale restore.
+ */
+extern "C" int Combo_FreezeActiveGameForHotSwap(GameId departing) {
+    return Switch_PrepareHotSwap(departing, &gSaveContext, sizeof(gSaveContext));
 }
 
 static bool sLastF10State = false;

--- a/games/oot/src/code/z_play.c
+++ b/games/oot/src/code/z_play.c
@@ -27,8 +27,12 @@ extern uint16_t Combo_GetStartupEntrance(void);
 extern void Combo_ClearStartupEntrance(void);
 extern uint16_t Combo_GetStartupEntranceForGame(const char* gameId);
 extern bool Combo_HasStartupEntranceForGame(const char* gameId);
-extern int Combo_HasFrozenState(const char* gameId);
-extern int Combo_RestoreState(const char* gameId, void* saveContext, size_t size);
+// Frozen-state consumption (src/common/switch.cpp): applies the frozen save
+// and retires it in the same step, so a blob can never be consumed twice.
+// Deliberately NOT the bare Combo_HasFrozenState/Combo_RestoreState pair that
+// used to be declared here — a restore without the retire is exactly the #364
+// silent-rollback bug, and leaving those in scope invites it back.
+extern int Combo_ConsumeFrozenState(const char* gameId, void* saveContext, size_t size);
 
 // Cross-game combo support - entrance switch checking
 extern uint16_t Combo_CheckEntranceSwitch(uint16_t entranceIndex);
@@ -427,9 +431,15 @@ void OoT_Play_Init(GameState* thisx) {
                 // interpreted; without it, OoT continuity (age, rupees,
                 // inventory) silently reset on every return trip. A first
                 // OoT boot has no frozen state — the restore is a no-op.
-                if (Combo_HasFrozenState("oot")) {
-                    Combo_RestoreState("oot", &gSaveContext, sizeof(gSaveContext));
-                }
+                // Consume (restore + retire) rather than merely restore. A blob
+                // that survives its own consumption is indistinguishable, on the
+                // NEXT return leg, from one that was just frozen — so any entry
+                // into OoT that did not freeze first would silently re-apply
+                // this same snapshot and roll the player back (#364). Retiring
+                // it here makes "frozen state exists" mean "OoT was left and has
+                // not been returned to", which is the only condition the restore
+                // is valid for. A first OoT boot has no frozen state — no-op.
+                Combo_ConsumeFrozenState("oot", &gSaveContext, sizeof(gSaveContext));
                 fprintf(stderr, "[OoT] consumption: restored, linkAge=%d\n", (int)gSaveContext.linkAge);
                 fflush(stderr);
                 gSaveContext.entranceIndex = startupEntrance;

--- a/rsbs/src/main.cpp
+++ b/rsbs/src/main.cpp
@@ -89,6 +89,12 @@ extern "C" {
     // Whether the shared bring-up found an OoT game archive and ran OoT's
     // asset-dependent init (games/oot/soh/OTRGlobals.cpp, #330).
     int OoT_GameAssetsInitialized(void);
+    // Freezes the departing game's SaveContext for an F10 hot swap and records
+    // a return entrance for it (#364). Defined in
+    // games/oot/soh/GameExports_SingleExe.cpp because only a game TU can
+    // address gSaveContext; the policy itself is in src/common/switch.cpp.
+    // Returns 0 when the freeze could not be performed — refuse the switch.
+    int Combo_FreezeActiveGameForHotSwap(GameId departing);
     // In-app mm.o2r generation, offered at the start prompt when MM is
     // selected without a game archive (#317). Defined in
     // games/mm/2s2h/GameExports_SingleExe.cpp. Success is observed by
@@ -570,6 +576,34 @@ int main(int argc, char** argv) {
                 continue;
             }
 
+            // F10 hot swap: freeze the DEPARTING game before we leave (#364).
+            //
+            // The entrance path freezes inside Combo_CheckEntranceSwitch, so by
+            // the time we get here the departing game's blob is fresh. The F10
+            // path had no such hook and froze nothing — yet the startup-entrance
+            // branch below still consults Context_HasFrozenState(nextGame). Once
+            // any entrance switch had populated a blob, every subsequent F10
+            // return re-applied that stale snapshot: the player was rolled back
+            // to whatever they had at the FIRST departure, with no error, no
+            // title screen, and no visible symptom. Freezing here is what makes
+            // the blob the launcher restores actually belong to this trip.
+            //
+            // If the freeze cannot be performed we refuse the switch outright
+            // and keep the current game running, exactly like the archive checks
+            // above. Switching anyway would hand the player a silent rollback,
+            // which is strictly worse than a hotkey that appears not to work.
+            if (!isEntranceSwitch) {
+                GameId departingGame = GameRunner_GetActive(&runner);
+                if (!Combo_FreezeActiveGameForHotSwap(departingGame)) {
+                    Combo_ClearGameSwitchRequest();
+                    Entrance_ClearPendingSwitch();
+                    printf("Hot swap to %s refused: could not freeze %s state — continuing %s.\n",
+                           Game_ToString(nextGame), Game_ToString(departingGame),
+                           Game_ToString(GameRunner_GetActive(&runner)));
+                    continue;
+                }
+            }
+
             GameOps* nextOps = GameRunner_GetOps(&runner, nextGame);
             printf("\n=== Switching to %s ===\n",
                    nextOps ? nextOps->name : "Unknown");
@@ -592,6 +626,14 @@ int main(int argc, char** argv) {
             // boots as a brand-new file at its title screen and the frozen
             // save is never consumed. A first-time hotkey entry (no frozen
             // state) keeps the plain title-screen boot.
+            //
+            // The blob this branch restores is now guaranteed to be current:
+            // the hot-swap freeze above runs on every F10 departure, and the
+            // target's Play_Init retires the blob as it consumes it
+            // (Combo_ConsumeFrozenState). So a frozen state existing here means
+            // "the player left this game and has not returned since", which is
+            // exactly the condition the restore is for — not "this game was
+            // left at some point in the past" (#364).
             if (isEntranceSwitch && targetEntrance != 0) {
                 Entrance_SetStartupEntrance(targetEntrance, nextGame);
             } else if (!isEntranceSwitch && Context_HasFrozenState(nextGame)) {

--- a/src/common/switch.cpp
+++ b/src/common/switch.cpp
@@ -1,172 +1,143 @@
 /**
  * @file switch.cpp
- * @brief Game switching logic for cross-game transitions
+ * @brief Freeze/consume policy for cross-game switches (single-exe build).
  *
- * Coordinates the process of switching between OoT and MM:
- * 1. Freeze current game state (save context + return entrance)
- * 2. Update gCurrentGame to target
- * 3. Resume target game from frozen state (or fresh start if first switch)
+ * There are two ways to leave a game:
  *
- * The freeze/resume functions are implemented in each game's port layer:
- * - OoT: games/oot/soh/OTRGlobals.cpp
- * - MM:  games/mm/2s2h/BenPort.cpp
+ * 1. **Entrance switch** — the player walks through a linked door. The freeze
+ *    happens inside `Combo_CheckEntranceSwitch`
+ *    (games/oot/soh/GameExports_SingleExe.cpp), which has the departing game's
+ *    live SaveContext and a link-derived return entrance.
+ *
+ * 2. **Hot swap (F10)** — the player presses the debug hotkey. There is no
+ *    entrance link and no game-side hook, so the launcher has to drive the
+ *    freeze itself. `Switch_PrepareHotSwap` below is that driver.
+ *
+ * Both paths end at the same restore point: the target's `Play_Init` consumes
+ * the tagged startup entrance and re-applies the frozen save via
+ * `Combo_ConsumeFrozenState`, which retires the blob as it hands it over.
+ *
+ * The freeze and the consume are deliberately symmetric. If a blob is ever
+ * created without a matching consume, or consumed without being retired, the
+ * next return leg re-applies a stale snapshot and silently rolls the player's
+ * progress back (issue #364).
+ *
+ * NOTE: the legacy `Context_ProcessSwitch` / `OoT_FreezeState` /
+ * `MM_FreezeState` / `*_ResumeFromContext` path that used to live here has
+ * been removed. It had zero callers, and two of the four symbols it referenced
+ * (`MM_FreezeState`, `MM_ResumeFromContext`) live in games/mm/2s2h/BenPort.cpp,
+ * which is excluded from the single-exe build — so this translation unit could
+ * only stay linkable as long as nothing pulled it in. Its declarations in
+ * context.h are now dangling; removing them is a context.h change and belongs
+ * to whoever owns that file.
  */
 
 #include "context.h"
 #include "entrance.h"
 #include <cstdio>
-
-// ============================================================================
-// Game-specific freeze/resume functions (implemented in game port layers)
-// ============================================================================
+#include <cstddef>
 
 extern "C" {
 
 /**
- * Freeze OoT game state before switching away
- * Saves the current SaveContext and any other necessary state
+ * Where a hot-swapped game should spawn when the player comes back to it.
+ *
+ * An F10 switch has no entrance link to derive a return from, so we use the
+ * same arrival spawn the *entrance* portal would have produced for that game.
+ * That keeps both departure paths landing the player in the same place, and —
+ * more importantly — guarantees an id that is in range for the target's
+ * entrance table. A bogus id here reaches `gSaveContext.entranceIndex`, which
+ * is a direct linear index into `gEntranceTable`, i.e. an out-of-bounds read
+ * (this is the #356 class).
+ *
+ * @return the return entrance, or 0 for a game with no defined portal — the
+ *         caller must treat that as "cannot hot swap", not as entrance 0x0000.
  */
-void OoT_FreezeState(ComboContext* ctx);
-
-/**
- * Resume OoT from a frozen state or start fresh
- * Called when switching back to OoT (or starting OoT from MM)
- */
-void OoT_ResumeFromContext(ComboContext* ctx);
-
-/**
- * Freeze MM game state before switching away
- * Saves the current SaveContext and any other necessary state
- */
-void MM_FreezeState(ComboContext* ctx);
-
-/**
- * Resume MM from a frozen state or start fresh
- * Called when switching back to MM (or starting MM from OoT)
- */
-void MM_ResumeFromContext(ComboContext* ctx);
-
-} // extern "C"
-
-// ============================================================================
-// Internal state
-// ============================================================================
-
-namespace {
-
-/**
- * Track whether a switch is currently in progress
- * Prevents re-entrancy during the switch process
- */
-bool gSwitchInProgress = false;
-
-/**
- * Freeze the current game's state
- */
-void FreezeCurrentGame(void) {
-    if (gCurrentGame == GAME_NONE) {
-        return;
+uint16_t Switch_GetHotSwapReturnEntrance(GameId departing) {
+    switch (departing) {
+        case GAME_OOT:
+            return OOT_ENTR_MARKET_FROM_MASK_SHOP;
+        case GAME_MM:
+            return MM_ENTR_SOUTH_CLOCK_TOWN_0;
+        default:
+            return 0;
     }
-
-    // Record source game info in combo context
-    gComboCtx.sourceGame = gCurrentGame;
-    gComboCtx.sourceEntrance = Entrance_GetSwitchReturnEntrance();
-
-    // Call game-specific freeze function
-    if (gCurrentGame == GAME_OOT) {
-        OoT_FreezeState(&gComboCtx);
-    } else if (gCurrentGame == GAME_MM) {
-        MM_FreezeState(&gComboCtx);
-    }
-
-    fprintf(stderr, "[Switch] Froze %s state, return entrance: 0x%04X\n",
-            Game_ToString(gCurrentGame), gComboCtx.sourceEntrance);
 }
 
 /**
- * Resume the target game
+ * Freeze the departing game for an F10 hot swap.
+ *
+ * Before this existed the F10 path froze nothing at all, while
+ * rsbs/src/main.cpp still consulted `Context_HasFrozenState(target)` to decide
+ * whether to set a startup entrance. Once any entrance switch had populated a
+ * blob, every later F10 return re-applied that same ancient snapshot and the
+ * player lost everything earned since — silently, because the restore looks
+ * exactly like a successful resume (issue #364).
+ *
+ * @param departing   the game being left (must be a real game)
+ * @param saveContext the departing game's live SaveContext storage
+ * @param size        bytes available at @p saveContext; Context_FreezeState
+ *                    clamps this to the per-game blob capacity
+ * @return 1 if a fresh blob is now recorded, 0 if the caller must refuse the
+ *         switch rather than proceed into a stale restore
  */
-void ResumeTargetGame(GameId target) {
-    fprintf(stderr, "[Switch] Resuming %s at entrance 0x%04X\n",
-            Game_ToString(target), gComboCtx.targetEntrance);
-
-    // Set the startup entrance for the target game
-    Entrance_SetStartupEntrance(gComboCtx.targetEntrance);
-
-    // Call game-specific resume function
-    if (target == GAME_OOT) {
-        OoT_ResumeFromContext(&gComboCtx);
-    } else if (target == GAME_MM) {
-        MM_ResumeFromContext(&gComboCtx);
+int Switch_PrepareHotSwap(GameId departing, const void* saveContext, size_t size) {
+    if (departing != GAME_OOT && departing != GAME_MM) {
+        fprintf(stderr, "[Switch] Hot swap refused: no active game to freeze\n");
+        return 0;
+    }
+    if (saveContext == NULL || size == 0) {
+        fprintf(stderr, "[Switch] Hot swap refused: %s has no SaveContext to freeze\n", Game_ToString(departing));
+        return 0;
     }
 
-    // Update current game
-    gCurrentGame = target;
-}
+    uint16_t returnEntrance = Switch_GetHotSwapReturnEntrance(departing);
 
-} // anonymous namespace
+    Context_FreezeState(departing, returnEntrance, saveContext, size);
 
-// ============================================================================
-// Public API
-// ============================================================================
-
-extern "C" {
-
-void Context_ProcessSwitch(void) {
-    // Check if a switch was requested
-    if (!Context_HasPendingSwitch()) {
-        return;
+    if (!Context_HasFrozenState(departing)) {
+        fprintf(stderr, "[Switch] Hot swap refused: freeze of %s did not take\n", Game_ToString(departing));
+        return 0;
     }
 
-    // Prevent re-entrancy
-    if (gSwitchInProgress) {
-        fprintf(stderr, "[Switch] Warning: Switch already in progress\n");
-        return;
-    }
-    gSwitchInProgress = true;
-
-    GameId target = gComboCtx.targetGame;
-    uint16_t targetEntrance = gComboCtx.targetEntrance;
-
-    fprintf(stderr, "[Switch] Processing switch: %s -> %s (entrance 0x%04X)\n",
-            Game_ToString(gCurrentGame),
-            Game_ToString(target),
-            targetEntrance);
-
-    // Validate target
-    if (target == GAME_NONE || target == gCurrentGame) {
-        fprintf(stderr, "[Switch] Invalid target game, aborting\n");
-        ComboContext_ClearSwitch();
-        gSwitchInProgress = false;
-        return;
-    }
-
-    // Step 1: Freeze current game state
-    FreezeCurrentGame();
-
-    // Step 2: Resume target game
-    ResumeTargetGame(target);
-
-    // Step 3: Clear the switch request
-    ComboContext_ClearSwitch();
-    Entrance_ClearPendingSwitch();
-
-    fprintf(stderr, "[Switch] Switch complete, now in %s\n",
-            Game_ToString(gCurrentGame));
-
-    gSwitchInProgress = false;
+    fprintf(stderr, "[Switch] Hot swap froze %s, return entrance 0x%04X\n", Game_ToString(departing), returnEntrance);
+    return 1;
 }
 
 /**
- * Get whether a switch is currently in progress
+ * Apply a game's frozen save and retire it in the same step.
+ *
+ * Called from each game's startup-entrance consumption point
+ * (games/oot/src/code/z_play.c, games/mm/src/code/z_play.c) — the first place
+ * after the boot chain's SaveContext wipes and before the save is interpreted.
+ *
+ * Retiring the blob here is what makes a frozen state single-use. A blob that
+ * survives its own consumption is indistinguishable, at the next return leg,
+ * from a blob that was just created — so a game re-entered without a fresh
+ * freeze would silently rewind to it. The clear runs even when the restore
+ * reports failure: a blob that could not be applied must not linger to be
+ * retried against different state later.
+ *
+ * @return 1 if a frozen save was applied, 0 if there was none (first entry).
  */
-bool Context_IsSwitchInProgress(void) {
-    return gSwitchInProgress;
+int Combo_ConsumeFrozenState(const char* gameId, void* saveContext, size_t size) {
+    if (gameId == NULL || saveContext == NULL || size == 0) {
+        return 0;
+    }
+    if (!Combo_HasFrozenState(gameId)) {
+        return 0;
+    }
+
+    int restored = Combo_RestoreState(gameId, saveContext, size);
+    Combo_ClearFrozenState(gameId);
+
+    fprintf(stderr, "[Switch] Consumed frozen %s state (restored=%d), blob retired\n", gameId, restored);
+    return restored;
 }
 
 } // extern "C"
 
-// Context_SetCurrentGame / Context_GetCurrentGame live in context.cpp so that
-// call sites in main.cpp / GameExports_SingleExe.cpp don't pull switch.cpp.o
-// (and its references to the legacy OoT_/MM_FreezeState/ResumeFromContext
-// symbols, which are only compiled in non-single-exe builds) into the link.
+// Context_SetCurrentGame / Context_GetCurrentGame live in context.cpp rather
+// than here. That split predates this file having any live code; it is kept
+// because context.cpp is the lower-level TU and nothing about the switch
+// policy above needs to be in the same object as the current-game tracker.

--- a/src/common/test_runner.cpp
+++ b/src/common/test_runner.cpp
@@ -75,6 +75,13 @@ extern "C" {
 #include "tests/test_shared_state_roundtrip.c"
 }
 
+// Hot-swap (F10) freeze/consume contract (issue #364). Included inside its own
+// extern "C" block: it only touches C-linkage Context_/Combo_/Switch_ symbols,
+// so it has no reason to be compiled as C++ and bind anything by mangled name.
+extern "C" {
+#include "tests/test_hotswap_freeze.c"
+}
+
 // Archive hot-swap regression test (issue #263). Included at FILE SCOPE (not
 // inside an extern "C" block): it is compiled as C++ and uses the C++-linkage
 // Entrance_* API for setup. Its cross-TU ArchiveHotswap_* helpers are wrapped
@@ -736,6 +743,12 @@ TestResult Test_RoundtripIntegrity(void) {
     return (failures == 0) ? TEST_PASS : TEST_FAIL;
 }
 
+TestResult Test_HotSwapFreeze(void) {
+    printf("[TEST] hotswap-freeze: F10 freeze + single-use frozen state (issue #364)\n");
+    int failures = TestHotSwapFreeze_Run();
+    return (failures == 0) ? TEST_PASS : TEST_FAIL;
+}
+
 TestResult Test_Lifecycle(void) {
     printf("[TEST] lifecycle: Game lifecycle unit tests\n");
     int failures = TestLifecycle_RunAll();
@@ -822,6 +835,10 @@ const TestDescriptor gTests[] = {
     {"roundtrip-integrity", "OoT SaveContext byte-identical across OoT->MM->OoT (issue #262)", Test_RoundtripIntegrity},
     {"shared-roundtrip", "Shared flag/seed survive OoT->MM switch (issue #264)", Test_SharedStateRoundtrip},
     {"context", "Test context/state management", Test_Context},
+    // Clears all frozen states on entry and exit, so it must not run between a
+    // test that freezes and one that expects that freeze to still be there.
+    {"hotswap-freeze", "F10 hot swap freezes the departing game; frozen state is single-use (#364)",
+     Test_HotSwapFreeze},
     {"lifecycle", "Game lifecycle unit tests", Test_Lifecycle},
     // Unified save (.redsave) headless coverage (issue #35, Phase 2 T6).
     {"save-roundtrip-tiers", "Unified .redsave preserves ComboContext + both SaveContexts (#35)", Test_SaveRoundtripTiers},

--- a/src/common/tests/test_hotswap_freeze.c
+++ b/src/common/tests/test_hotswap_freeze.c
@@ -1,0 +1,144 @@
+/**
+ * @file test_hotswap_freeze.c
+ * @brief Hot-swap (F10) freeze/consume contract — issue #364
+ *
+ * Locks the two halves of the #364 fix:
+ *
+ *   1. A hot swap freezes the DEPARTING game with a valid return entrance, or
+ *      it refuses. It never leaves the launcher to restore someone else's blob.
+ *   2. A frozen blob is single-use. Consuming it retires it, so it can never be
+ *      re-applied on a later entry.
+ *
+ * The bug this replaces was silent. F10 froze nothing, but rsbs/src/main.cpp
+ * still keyed the return-leg restore off Context_HasFrozenState(target), and
+ * nothing ever cleared that flag. So after one entrance switch, every later F10
+ * return re-applied the FIRST departure's snapshot — the player kept playing,
+ * kept collecting, and kept losing it, with no error and no visible symptom.
+ * Assertion 5 below is the direct regression: freeze fresh progress, consume,
+ * and require the NEW bytes rather than the old ones.
+ *
+ * Headless: no SDL, no game boot, no ROM archives. It drives the exact
+ * production entry points — Switch_PrepareHotSwap (what the launcher calls via
+ * Combo_FreezeActiveGameForHotSwap) and Combo_ConsumeFrozenState (what both
+ * games' Play_Init startup-entrance consumption calls).
+ *
+ * #included into test_runner.cpp inside its extern "C" block: every symbol used
+ * here is genuine C linkage (Context_*, Combo_*, Switch_*), and the entrance
+ * ids are plain macros.
+ *
+ * The "../entrance.h" include below resolves to nothing in practice —
+ * test_runner.cpp already includes entrance.h at FILE scope, so the guard is
+ * set by the time we get here. That ordering matters: entrance.h's second half
+ * declares C++-linkage Entrance_* functions, and pulling it in for the first
+ * time from inside an extern "C" block would give those C linkage and collide
+ * with OoT's randomizer Entrance_Init. Do not move this file's inclusion above
+ * test_runner.cpp's own includes.
+ */
+
+#include "../context.h"
+#include "../entrance.h"
+#include "../test_runner.h"
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+
+/* Freeze/consume policy under test (src/common/switch.cpp). Declared locally
+ * for the same reason the game TUs declare it locally: context.h is owned
+ * elsewhere this wave, so the switch policy has no header of its own yet. */
+int Switch_PrepareHotSwap(GameId departing, const void* saveContext, size_t size);
+uint16_t Switch_GetHotSwapReturnEntrance(GameId departing);
+int Combo_ConsumeFrozenState(const char* gameId, void* saveContext, size_t size);
+
+#define HSF_ASSERT(cond)                                                                                               \
+    do {                                                                                                               \
+        if (!(cond)) {                                                                                                 \
+            printf("  FAIL: %s:%d: %s\n", __FILE__, __LINE__, #cond);                                                  \
+            return 1;                                                                                                  \
+        }                                                                                                              \
+    } while (0)
+
+/* A slice of a SaveContext is enough: Context_FreezeState/RestoreState clamp to
+ * min(size, per-game capacity), so a short buffer round-trips exactly. */
+#define HSF_BUF 512
+
+static int TestHotSwapFreeze_Run(void) {
+    uint8_t live[HSF_BUF];
+    uint8_t scratch[HSF_BUF];
+
+    Context_InitFrozenStates();
+    Context_ClearAllFrozenStates();
+
+    /* ---- 1. Refusals produce nothing ------------------------------------
+     * The launcher treats a 0 return as "keep running the current game". That
+     * only stays safe if a refused freeze leaves no blob behind for a later
+     * return leg to pick up. */
+    memset(live, 0xA1, sizeof(live));
+    HSF_ASSERT(Switch_PrepareHotSwap(GAME_NONE, live, sizeof(live)) == 0);
+    HSF_ASSERT(Switch_PrepareHotSwap(GAME_OOT, NULL, sizeof(live)) == 0);
+    HSF_ASSERT(Switch_PrepareHotSwap(GAME_OOT, live, 0) == 0);
+    HSF_ASSERT(Context_HasFrozenState(GAME_OOT) == 0);
+    HSF_ASSERT(Context_HasFrozenState(GAME_MM) == 0);
+
+    /* ---- 2. A hot swap freezes the departing game ------------------------
+     * The return entrance must be the game's own portal arrival. It lands in
+     * gSaveContext.entranceIndex, a direct linear index into the entrance
+     * table, so an id from the WRONG game reads out of bounds (#356 class). */
+    HSF_ASSERT(Switch_PrepareHotSwap(GAME_OOT, live, sizeof(live)) == 1);
+    HSF_ASSERT(Context_HasFrozenState(GAME_OOT) == 1);
+    HSF_ASSERT(Context_GetFrozenReturnEntrance(GAME_OOT) == OOT_ENTR_MARKET_FROM_MASK_SHOP);
+    HSF_ASSERT(Switch_GetHotSwapReturnEntrance(GAME_MM) == MM_ENTR_SOUTH_CLOCK_TOWN_0);
+    HSF_ASSERT(Switch_GetHotSwapReturnEntrance(GAME_NONE) == 0);
+    /* Freezing one side must not fabricate state for the other. */
+    HSF_ASSERT(Context_HasFrozenState(GAME_MM) == 0);
+
+    /* ---- 3. The return leg consumes it ----------------------------------- */
+    memset(scratch, 0x00, sizeof(scratch));
+    HSF_ASSERT(Combo_ConsumeFrozenState("oot", scratch, sizeof(scratch)) == 1);
+    HSF_ASSERT(scratch[0] == 0xA1);
+    HSF_ASSERT(scratch[HSF_BUF - 1] == 0xA1);
+    /* ...and retires it in the same step. */
+    HSF_ASSERT(Context_HasFrozenState(GAME_OOT) == 0);
+
+    /* ---- 4. A consumed blob cannot be re-applied -------------------------
+     * The second consume must report "nothing" and must not write. This is the
+     * property that makes Context_HasFrozenState(target) in main.cpp mean "left
+     * and not yet returned to" instead of "left at some point, ever". */
+    memset(scratch, 0x3C, sizeof(scratch));
+    HSF_ASSERT(Combo_ConsumeFrozenState("oot", scratch, sizeof(scratch)) == 0);
+    HSF_ASSERT(scratch[0] == 0x3C);
+    HSF_ASSERT(scratch[HSF_BUF - 1] == 0x3C);
+
+    /* ---- 5. The #364 regression: the next trip carries the NEW state ------
+     * Play on after the first round trip, hot swap again, come back. Before the
+     * fix the return leg re-applied the step-2 snapshot (0xA1) and the 0xB2
+     * progress vanished without a trace. */
+    memset(live, 0xB2, sizeof(live));
+    HSF_ASSERT(Switch_PrepareHotSwap(GAME_OOT, live, sizeof(live)) == 1);
+    memset(scratch, 0x00, sizeof(scratch));
+    HSF_ASSERT(Combo_ConsumeFrozenState("oot", scratch, sizeof(scratch)) == 1);
+    HSF_ASSERT(scratch[0] != 0xA1); /* the silent rollback */
+    HSF_ASSERT(scratch[0] == 0xB2);
+    HSF_ASSERT(scratch[HSF_BUF - 1] == 0xB2);
+    HSF_ASSERT(Context_HasFrozenState(GAME_OOT) == 0);
+
+    /* ---- 6. The MM side behaves identically -------------------------------
+     * F10 from MM freezes MM, not OoT. The launcher's departing-game lookup and
+     * the freeze target have to agree or the two blobs cross over. */
+    memset(live, 0xC3, sizeof(live));
+    HSF_ASSERT(Switch_PrepareHotSwap(GAME_MM, live, sizeof(live)) == 1);
+    HSF_ASSERT(Context_HasFrozenState(GAME_MM) == 1);
+    HSF_ASSERT(Context_HasFrozenState(GAME_OOT) == 0);
+    HSF_ASSERT(Context_GetFrozenReturnEntrance(GAME_MM) == MM_ENTR_SOUTH_CLOCK_TOWN_0);
+    memset(scratch, 0x00, sizeof(scratch));
+    HSF_ASSERT(Combo_ConsumeFrozenState("mm", scratch, sizeof(scratch)) == 1);
+    HSF_ASSERT(scratch[0] == 0xC3);
+    HSF_ASSERT(Context_HasFrozenState(GAME_MM) == 0);
+    HSF_ASSERT(Combo_ConsumeFrozenState("mm", scratch, sizeof(scratch)) == 0);
+
+    printf("[TEST] PASS: hot swap freezes the departing game or refuses; "
+           "a consumed frozen state is retired and cannot be re-applied\n");
+
+    /* Leave global state clean for any subsequent test. */
+    Context_ClearAllFrozenStates();
+    return 0;
+}


### PR DESCRIPTION
## What was broken

The F10 hot-swap hotkey never froze anything, and nothing ever cleared frozen state.

- `Combo_CheckHotSwap` (`games/oot/soh/GameExports_SingleExe.cpp`) only called `Combo_RequestGameSwitch()`.
- The `OoT_FreezeState` / `MM_FreezeState` path it nominally reached is dead in single-exe: `Context_ProcessSwitch` had zero callers, and `MM_FreezeState` / `MM_ResumeFromContext` live in `BenPort.cpp`, which is excluded from the build. The only live freeze was `Combo_FreezeState` inside `Combo_CheckEntranceSwitch` — the *entrance* path.
- `Context_ClearFrozenState` had zero live callers outside a test, so `Context_HasFrozenState` stayed true forever once set.

But `rsbs/src/main.cpp` keyed the F10 return leg off exactly that flag. So the blob written by the **first** entrance switch stayed valid indefinitely:

> Walk into the Happy Mask Shop (OoT freezes at 50 rupees, no Bow) -> play MM -> walk the Clock Tower back -> earn 150 rupees and the Bow -> F10 to MM -> F10 back to OoT. `Play_Init` re-applies the original snapshot. No error, no title screen, no symptom.

Phase 2 converted this from an obvious bad boot into **silent progress loss**.

I re-verified all four claims from the issue against source before changing anything. All held.

## Mechanism

**Half 1 - freeze on departure.** The launcher now calls `Combo_FreezeActiveGameForHotSwap` before any non-entrance switch. That glue lives in OoT's `GameExports_SingleExe.cpp` because only a game TU can address `gSaveContext` (reusing the documented "OoT layout over unified storage, clamped by `Context_FreezeState`" pattern the entrance path already relies on). It forwards to `Switch_PrepareHotSwap`, which records the departing game's blob plus the return entrance that game's own portal would have produced. A return entrance from the wrong game lands in `gSaveContext.entranceIndex`, a direct linear index into `gEntranceTable` — the #356 out-of-bounds class — so the mapping is explicit per game, and a game with no portal yields 0, which the launcher treats as **refuse the switch and keep running the current game**, shaped like the existing archive refusals. A hotkey that appears not to work beats a silent rollback.

**Half 2 - retire on consume.** Both games' startup-entrance consumption points (`games/oot/src/code/z_play.c`, `games/mm/src/code/z_play.c`) now call `Combo_ConsumeFrozenState`, which restores and clears in one step, instead of the bare `Combo_HasFrozenState` / `Combo_RestoreState` pair. This makes a blob single-use, so `Context_HasFrozenState` now means *"this game was left and has not been returned to"* rather than *"this game was left at some point, ever"* — the precondition `main.cpp` was already assuming. The clear runs even when the restore reports failure: a blob that could not be applied must not linger to be retried against different state later. The old bare declarations are removed from both files so a restore-without-retire cannot creep back in.

## Note on `switch.cpp`

The policy lives in `src/common/switch.cpp`, and its dead legacy body had to go for that file to link at all. `switch.cpp.o` was previously pulled in by nothing — that is the *only* reason its references to the excluded `MM_FreezeState` / `MM_ResumeFromContext` did not break the Linux link. Giving the file live callers required deleting them.

**For the reviewer / context.h owner:** `Context_ProcessSwitch` and `Context_IsSwitchInProgress` are now declared in `context.h` with no definition anywhere. Both have zero callers, so this does not break the link, but the declarations should be removed. I did not touch `context.h` — another agent owns it this wave.

## Verification

New ROM-free CTest **`HotSwapFreeze`** in the `redship` label (`src/common/tests/test_hotswap_freeze.c`, `--test hotswap-freeze`). Headless, no SDL, no archives; drives the production entry points directly. It asserts:

1. Refusals (`GAME_NONE`, null buffer, zero size) return 0 **and leave no blob behind** for a later return leg to pick up.
2. A hot swap freezes the departing game with that game's own return entrance, and does not fabricate state for the other side.
3. Consuming restores the bytes **and retires the blob**.
4. A second consume reports nothing and does not write — the property that makes `Context_HasFrozenState(target)` in `main.cpp` meaningful.
5. **The direct #364 regression:** freeze `0xA1`, consume, play on, freeze `0xB2`, consume — the second trip must carry `0xB2`. Before the fix it carried `0xA1`, which *is* the silent rollback.
6. The MM side behaves identically, so the two blobs cannot cross over.

Existing coverage that touches this area still holds: `MMStartupRestore` consumes once per section and clears explicitly; `ArchiveHotswapLogic`, `Roundtrip`, and `RoundtripIntegrity` drive `Combo_RestoreState` directly and are unaffected.

Not built locally — three other agents are on this machine. CI builds it. `clang-format 14` was not available in this worktree, so the three format-gated files were hand-checked instead (max added line 88 cols, limit 120, no tabs).

Closes #364.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!--- section:artifacts:start -->
### Build Artifacts
  - [rsbs-windows.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/8453234570.zip)
  - [rsbs-linux.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/8453089151.zip)
<!--- section:artifacts:end -->