### PR TITLE
Give the non-void stubs in soh/stubs.c real returns and supply __osActiveQueue

### DIFF
--- a/CMake/SingleExecutable.cmake
+++ b/CMake/SingleExecutable.cmake
@@ -298,6 +298,12 @@ if(BUILD_TESTING)
     # bound-arithmetic bugs, so the capacity computation was factored into pure
     # helpers this test calls directly — display-free, ROM-free.
     redship_add_test(NAME SeqMapBounds COMMAND redship --test seq-map-bounds)
+    # Active-thread-queue contract (#385). soh/stubs.c's empty-bodied
+    # __osGetActiveQueue returned the return register, and both games' fault
+    # handlers walk that as a thread list — so the crash handler was itself
+    # liable to crash. Locks non-NULL, bounded termination at the priority == -1
+    # sentinel, and call-to-call stability.
+    redship_add_test(NAME ActiveQueue COMMAND redship --test active-queue)
     # MM cross-game resume contracts (games/mm/2s2h/mm_resume_state_test.cpp):
     # a resume must re-arm the (by-design leaked) system arena for the cold
     # gamestate-chain boot, and Play_Init's startup-entrance consumption must

--- a/games/oot/CMakeLists.txt
+++ b/games/oot/CMakeLists.txt
@@ -134,6 +134,27 @@ list(FILTER soh__Enhancements EXCLUDE REGEX "soh/Enhancements/randomizer/.*")
 # Remove Enhancements from soh__ (will be soh_port lib)
 list(FILTER soh__ EXCLUDE REGEX "soh/Enhancements/.*")
 
+# Falling off the end of a non-void function is a hard error in soh/stubs.c
+# (#385). That file is the port's shim layer: ~90 stubbed libultra entry points,
+# where the failure mode of a missing return is silent — the caller reads the
+# return register. It shipped 24 such bodies. One of them, __osGetActiveQueue,
+# handed a garbage pointer to the crash handler's thread walk
+# (games/oot/src/code/fault.c:537), so the fault handler was itself liable to
+# fault; another, _Printf, was returning the register as sprintf's character
+# count. MSVC does not error on this by default (C4716/C4715 are warnings in C)
+# and SUPPRESS_WARNINGS is ON, which is why it survived to phase 3.
+#
+# Scoped to this one file on purpose: the vendored decomp tree under src/ has
+# its own instances of this pattern and is compiled with ${WARNING_OVERRIDE}
+# (/w or -w), so a target-wide escalation would break the build and would fight
+# upstream. Same shape as the /we4013 precedent that retired the
+# implicit-declaration class in games/mm/CMakeLists.txt.
+if(MSVC)
+    set_source_files_properties(soh/stubs.c PROPERTIES COMPILE_OPTIONS "/we4716;/we4715")
+else()
+    set_source_files_properties(soh/stubs.c PROPERTIES COMPILE_OPTIONS "-Werror=return-type")
+endif()
+
 # Add specific files that don't match the pattern
 list(APPEND soh__Enhancements ${CMAKE_CURRENT_SOURCE_DIR}/soh/Enhancements/savestates_extern.inc)
 list(APPEND soh__Enhancements ${CMAKE_CURRENT_SOURCE_DIR}/soh/Enhancements/speechsynthesizer/DarwinSpeechSynthesizer.mm)

--- a/games/oot/soh/stubs.c
+++ b/games/oot/soh/stubs.c
@@ -36,10 +36,26 @@ f32 qNaN0x10000 = 0x7F810000;
 //	__gSPTextureRectangle(pkt, xl, yl, xh, yh, tile, s, t, dsdx, dtdy);
 // }
 
+/* NOTE (#385): every stub below with a return type returns an explicit value.
+ * Falling off the end of a non-void function is UB — in practice the caller
+ * reads whatever happened to be in the return register — and this file had 23
+ * such bodies. One of them, __osGetActiveQueue, fed a *garbage pointer* to the
+ * crash handler's thread walk (games/oot/src/code/fault.c:537), so the fault
+ * handler was itself liable to fault. soh/stubs.c is compiled with
+ * -Werror=return-type / /we4716 (games/oot/CMakeLists.txt) so the class cannot
+ * come back, mirroring the /we4013 precedent that retired implicit
+ * declarations. Values are the real libultra success/absent codes, never
+ * whatever is cheapest to write. */
+
 OSId OoT_osGetThreadId(OSThread* thread) {
+    /* The port runs no libultra threads; 0 is the id of the (absent) one. */
+    return 0;
 }
 
 OSPri OoT_osGetThreadPri(OSThread* thread) {
+    /* OS_PRIORITY_IDLE. Not the tail priority (-1): callers compare against
+     * that to detect the end of a thread list, never to describe a thread. */
+    return OS_PRIORITY_IDLE;
 }
 
 void OoT_osSetThreadPri(OSThread* thread, OSPri pri) {
@@ -48,34 +64,53 @@ void OoT_osSetThreadPri(OSThread* thread, OSPri pri) {
 void OoT_osCreatePiManager(OSPri pri, OSMesgQueue* cmdQ, OSMesg* cmdBuf, s32 cmdMsgCnt) {
 }
 
+/* Controller Pak (PFS) family. There is no memory pak on a PC, so every entry
+ * point reports PFS_ERR_NOPACK — the code libultra returns when nothing is
+ * plugged in, and the one callers already handle. Deliberately NOT 0: success
+ * would tell the game a pak exists and send it on to read/write it. This also
+ * preserves the pre-#385 de-facto behaviour, where the garbage in the return
+ * register was almost always non-zero and so read as "some error". */
+
 s32 OoT_osPfsFreeBlocks(OSPfs* pfs, s32* leftoverBytes) {
+    return PFS_ERR_NOPACK;
 }
 
 s32 OoT_osEPiWriteIo(OSPiHandle* handle, u32 devAddr, u32 data) {
+    /* PI writes are emulated away; report the write as accepted. */
+    return 0;
 }
 
 s32 OoT_osPfsReadWriteFile(OSPfs* pfs, s32 fileNo, u8 flag, s32 offset, ptrdiff_t size, u8* data) {
+    return PFS_ERR_NOPACK;
 }
 
 s32 OoT_osPfsDeleteFile(OSPfs* pfs, u16 companyCode, u32 gameCode, u8* gameName, u8* extName) {
+    return PFS_ERR_NOPACK;
 }
 
 s32 OoT_osPfsFileState(OSPfs* pfs, s32 fileNo, OSPfsState* state) {
+    return PFS_ERR_NOPACK;
 }
 
 s32 OoT_osPfsInitPak(OSMesgQueue* mq, OSPfs* pfs, s32 channel) {
+    return PFS_ERR_NOPACK;
 }
 
 s32 __osPfsCheckRamArea(OSPfs* pfs) {
+    return PFS_ERR_NOPACK;
 }
 
 s32 OoT_osPfsChecker(OSPfs* pfs) {
+    return PFS_ERR_NOPACK;
 }
 
 s32 OoT_osPfsFindFile(OSPfs* pfs, u16 companyCode, u32 gameCode, u8* gameName, u8* extName, s32* fileNo) {
+    return PFS_ERR_NOPACK;
 }
 
-s32 OoT_osPfsAllocateFile(OSPfs* pfs, u16 companyCode, u32 gameCode, u8* gameName, u8* extName, s32 length, s32* fileNo) {
+s32 OoT_osPfsAllocateFile(OSPfs* pfs, u16 companyCode, u32 gameCode, u8* gameName, u8* extName, s32 length,
+                          s32* fileNo) {
+    return PFS_ERR_NOPACK;
 }
 
 OSIntMask osSetIntMask(OSIntMask a) {
@@ -87,6 +122,10 @@ s32 OoT_osAfterPreNMI(void) {
 }
 
 s32 osProbeRumblePak(OSMesgQueue* ctrlrqueue, OSPfs* pfs, u32 channel) {
+    /* Rumble is driven by libultraship/SDL, not by a probed Rumble Pak. Report
+     * "no pack" so the N64 probe path stays out of it; osSetRumble below is the
+     * entry point that actually works. */
+    return PFS_ERR_NOPACK;
 }
 
 s32 osSetRumble(OSPfs* pfs, u32 vibrate) {
@@ -109,6 +148,10 @@ void OoT_osDestroyThread(OSThread* thread) {
  * below. libultraship provides identical no-ops for the whole family. */
 
 s32 OoT_osContStartQuery(OSMesgQueue* mq) {
+    /* 0 == query issued, matching games/oot/src/libultra/io/contquery.c. The
+     * caller in padsetup.c is `if (osContStartQuery(mq) != 0) return -1;`, so
+     * the old garbage return could abort controller setup at random. */
+    return 0;
 }
 
 void OoT_osContGetQuery(OSContStatus* data) {
@@ -122,15 +165,29 @@ void __osSetFpcCsr(u32 a0) {
 }
 
 s32 __osDisableInt(void) {
+    /* There are no RCP interrupts to mask; 0 is the "previous mask" that the
+     * paired no-op __osRestoreInt below will be handed back. */
+    return 0;
 }
 
 void __osRestoreInt(s32 a0) {
 }
 
-OSThread* __osGetActiveQueue(void) {
-}
+/* __osGetActiveQueue removed (#385) — the real implementation now resolves from
+ * rsbs/src/libultra/os/getactivequeue.c, whose __osActiveQueue storage lives in
+ * rsbs/src/libultra/os/threadqueue.c. It was never a duplicate-symbol error
+ * because __osActiveQueue had no definition anywhere in the link, which made
+ * getactivequeue.o unpullable and let this file's empty body win by default.
+ * That body returned the return register, and fault.c walked it as a thread
+ * list. The rsbs version returns a real tail-sentinel head, so the walk
+ * terminates immediately instead of dereferencing garbage. */
 
 OSThread* __osGetCurrFaultedThread(void) {
+    /* No libultra exception handler runs, so there is never a faulted thread on
+     * record. NULL is the documented "none" and both fault handlers check for
+     * it — games/mm/src/boot/fault.c:1051 falls back to Fault_FindFaultedThread
+     * on NULL, which is exactly the intended path here. */
+    return NULL;
 }
 
 u32 osMemSize = 1024 * 1024 * 1024;
@@ -209,21 +266,32 @@ void Audio_SetBGM(u32 bgmId) {
 }
 
 s32 OoT_osContSetCh(u8 ch) {
+    /* 0 == channel count accepted, per libultra. */
+    return 0;
 }
 
 u32 OoT_osDpGetStatus(void) {
+    /* No RDP status register to read; all status bits clear. */
+    return 0;
 }
 
 void OoT_osDpSetStatus(u32 status) {
 }
 
 u32 __osSpGetStatus() {
+    /* No RSP status register to read; all status bits clear. Callers poll this
+     * for DMA_BUSY / IO_BUSY, so 0 ("idle") is the value that lets them
+     * proceed — garbage could have read as permanently busy. */
+    return 0;
 }
 
 void __osSpSetStatus(u32 status) {
 }
 
 OSPiHandle* OoT_osDriveRomInit() {
+    /* There is no cart PI handle in the port. NULL is the libultra "no device"
+     * return; the old garbage pointer would have been dereferenced as one. */
+    return NULL;
 }
 
 void __osInitialize_common(void) {
@@ -240,9 +308,26 @@ void __osCleanupThread(void) {
 
 s32 _Printf(PrintCallback a, void* arg, const char* fmt, va_list ap) {
     unsigned char buffer[4096];
+    int written;
+    size_t len;
 
-    vsnprintf(buffer, sizeof(buffer), fmt, ap);
-    a(arg, buffer, strlen(buffer));
+    /* #385: this one had a body, so it survived the empty-body sweep, but it
+     * still fell off the end — and _Printf's return value is not decorative.
+     * games/oot/src/libultra/libc/sprintf.c returns it verbatim as sprintf's
+     * character count, so every sprintf() in the port was handing its caller
+     * the return register. libultra contracts _Printf to return the number of
+     * characters emitted, or -1 on failure. */
+    written = vsnprintf((char*)buffer, sizeof(buffer), fmt, ap);
+    if (written < 0) {
+        return -1;
+    }
+
+    /* vsnprintf reports what it WOULD have written; report what actually
+     * landed in the buffer, so a truncating format does not claim more
+     * characters than the callback ever saw. */
+    len = strlen((const char*)buffer);
+    a(arg, buffer, (s32)len);
+    return (s32)len;
 }
 
 void OoT_osSpTaskLoad(OSTask* task) {
@@ -266,9 +351,17 @@ void OoT_osSpTaskYield(void) {
 }
 
 s32 OoT_osStopTimer(OSTimer* timer) {
+    /* 0 == the timer was not on the active list, which is always true here:
+     * OoT_osSetTimer is not wired up either. */
+    return 0;
 }
 
 OSYieldResult OoT_osSpTaskYielded(OSTask* task) {
+    /* 0, i.e. NOT OS_TASK_YIELDED. OoT_osSpTaskYield above is a no-op, so no
+     * task ever yields; returning the OS_TASK_YIELDED bit (which garbage would
+     * set half the time) makes the graphics thread re-submit a task that was
+     * never interrupted. */
+    return 0;
 }
 
 void OoT_osViExtendVStart(u32 arg0) {

--- a/rsbs/CMakeLists.txt
+++ b/rsbs/CMakeLists.txt
@@ -19,6 +19,11 @@ add_library(rsbs STATIC
     src/libultra/os/getthreadpri.c
     src/libultra/os/destroythread.c
     src/libultra/os/dequeuethread.c
+    # Storage for __osActiveQueue / __osRunningThread (#385). Both games'
+    # defining TUs are excluded from the single-exe build, so without this the
+    # objects above are unlinkable and soh/stubs.c's empty-bodied
+    # __osGetActiveQueue won the symbol instead.
+    src/libultra/os/threadqueue.c
 
     # libultra/os - message queue functions (reference implementations)
     # Note: Runtime implementations provided by libultraship

--- a/rsbs/src/libultra/os/threadqueue.c
+++ b/rsbs/src/libultra/os/threadqueue.c
@@ -1,0 +1,64 @@
+/**
+ * @file threadqueue.c
+ * @brief Storage for the libultra active-thread list (issue #385)
+ *
+ * WHY THIS FILE EXISTS
+ *
+ * `__osActiveQueue` and `__osRunningThread` are defined upstream in
+ * games/oot/src/libultra/os/createthread.c and games/mm/src/libultra/os/thread.c.
+ * Both translation units are excluded from the single-executable build
+ * unconditionally (games/oot/CMakeLists.txt filters src/libultra/os/,
+ * games/mm/CMakeLists.txt likewise), and libultraship supplies neither symbol.
+ *
+ * That left the whole list *undefined anywhere in the link*, which in turn made
+ * rsbs's getactivequeue.o unpullable: it defines only `__osGetActiveQueue` and
+ * references `__osActiveQueue`, so any link that reached for it would have
+ * failed with `undefined reference to __osActiveQueue`. In practice the linker
+ * never got there — soh_port's stubs.o is dragged in unconditionally (osMemSize,
+ * OoT_osDestroyThread) and its empty `OSThread* __osGetActiveQueue(void) { }`
+ * body won the symbol first. The fault handler then read a *return register*
+ * as a thread pointer and walked it. See issue #385.
+ *
+ * Defining the storage here makes getactivequeue.o (and destroythread.o,
+ * getthreadid.o, getthreadpri.o) linkable, which is the precondition for
+ * deleting the stub.
+ *
+ * WHY A SENTINEL AND NOT NULL
+ *
+ * The consumers do not null-check. games/oot/src/code/fault.c walks
+ *
+ *     OSThread* iter = __osGetActiveQueue();
+ *     while (iter->priority != -1) { ...; iter = iter->tlnext; }
+ *
+ * and rsbs/src/libultra/os/destroythread.c has the same `priority != -1` loop.
+ * The N64 termination condition is a tail node with priority
+ * OS_PRIORITY_THREADTAIL (-1), not a NULL pointer — so `__osActiveQueue = NULL`
+ * would trade a garbage-pointer dereference for a null dereference in exactly
+ * the same crash handler. The empty list is therefore the sentinel itself:
+ * every walk terminates on the first iteration and yields "no faulted thread",
+ * which is the truthful answer for a port that runs no libultra threads.
+ */
+
+#include "rsbs/libultra_os.h"
+#include <stddef.h>
+
+/* libultraship's thread.h stops at OS_PRIORITY_IDLE; the tail priority is part
+ * of the internal (osint.h) contract that both games' fault handlers encode as
+ * a bare -1. Spelled once here so the sentinel and the walk agree by name. */
+#ifndef OS_PRIORITY_THREADTAIL
+#define OS_PRIORITY_THREADTAIL (-1)
+#endif
+
+/* Positional partial initialisation (next, priority); every remaining member is
+ * zero-initialised by C's aggregate rules. Kept positional rather than
+ * designated so the C11 requirement stays as low as possible across MSVC/GCC. */
+static OSThread sThreadTail = { NULL, OS_PRIORITY_THREADTAIL };
+
+/* An empty active list: the head *is* the tail sentinel. */
+OSThread* __osActiveQueue = &sThreadTail;
+
+/* No libultra thread is ever dispatched in the port. NULL is the correct value
+ * and is what osGetThreadId/osGetThreadPri already special-case ("current
+ * thread"); it exists so those objects and destroythread.o are linkable rather
+ * than dead weight that would break the link the moment anything reached them. */
+OSThread* __osRunningThread = NULL;

--- a/src/common/test_runner.cpp
+++ b/src/common/test_runner.cpp
@@ -104,6 +104,12 @@ extern "C" {
 // MAX_AUTHENTIC_SEQID). Pure arithmetic — no audio subsystem, no archives.
 #include "tests/test_seq_map_bounds.c"
 
+// Active-thread-queue contract (issue #385). soh/stubs.c's empty-bodied
+// __osGetActiveQueue fed a return register to the crash handler's thread walk
+// (fault.c:537). Included at FILE SCOPE like the rest; declares the C-linkage
+// symbols it needs itself. No subsystem, no archives.
+#include "tests/test_active_queue.c"
+
 // MM scene-command EXECUTE regression (issue #344). Unlike the parse test, the
 // body runs the parsed commands against a PlayState, so it needs MM's global.h
 // — which lives in an MM TU (games/mm/2s2h/mm_scene_execute_test.cpp) to keep
@@ -855,6 +861,7 @@ const TestDescriptor gTests[] = {
     {"save-combo-oversize", "Load rejects an oversized Tier-1 record, no clobber", Test_SaveComboOversize},
     {"mm-scene-parse", "MM scene commands parse via the S2H factory (#344)", Test_MMSceneParse},
     {"seq-map-bounds", "Sequence-map capacity covers the id range + custom slack (#371, #378)", Test_SeqMapBounds},
+    {"active-queue", "__osGetActiveQueue returns a walkable list, not a return register (#385)", Test_ActiveQueue},
     {"mm-scene-execute", "MM scene commands execute against a PlayState (#344)", Test_MMSceneExecute},
     // The two MM resume-contract tests below mutate process-global state
     // (mm-resume-arena re-inits the MM system arena + heaps; mm-startup-restore

--- a/src/common/tests/test_active_queue.c
+++ b/src/common/tests/test_active_queue.c
@@ -1,0 +1,133 @@
+/**
+ * Active-thread-queue contract lock (issue #385).
+ *
+ * WHAT BROKE
+ *
+ * games/oot/soh/stubs.c defined
+ *
+ *     OSThread* __osGetActiveQueue(void) { }
+ *
+ * — a non-void function with an empty body. Falling off the end is UB; in
+ * practice the caller reads whatever was left in the return register. The real
+ * implementation (rsbs/src/libultra/os/getactivequeue.c) could not win the
+ * symbol, because it references __osActiveQueue and *nothing in the link
+ * defined it*: both games' defining TUs (games/oot/src/libultra/os/createthread.c,
+ * games/mm/src/libultra/os/thread.c) are excluded, and libultraship supplies
+ * neither. So getactivequeue.o was unpullable and stubs.o — dragged in
+ * unconditionally via osMemSize / OoT_osDestroyThread — always won.
+ *
+ * WHY IT MATTERS ENOUGH TO LOCK
+ *
+ * The consumer is the crash handler. games/oot/src/code/fault.c:537 does
+ *
+ *     OSThread* iter = __osGetActiveQueue();
+ *     while (iter->priority != -1) { ...; iter = iter->tlnext; }
+ *
+ * (games/mm/src/boot/fault.c:557 is identical). So the fault handler — the one
+ * piece of machinery whose entire job is to produce a usable diagnostic when
+ * something else has already gone wrong — dereferenced a garbage pointer and
+ * was liable to fault itself, destroying exactly the crash report this project's
+ * debugging loop depends on.
+ *
+ * WHAT THIS TEST ASSERTS — the three properties fault.c actually needs:
+ *
+ *   1. NON-NULL. `iter->priority` is read before any null check, so NULL is not
+ *      an acceptable answer either. This is why the fix is a tail sentinel and
+ *      not `__osActiveQueue = NULL` — that would have swapped a garbage
+ *      dereference for a null dereference in the same line of the same handler.
+ *   2. TERMINATION. The walk reaches a node with priority == -1
+ *      (OS_PRIORITY_THREADTAIL) within a bounded number of steps. Run with a
+ *      hard step cap so a cyclic or garbage list fails the test instead of
+ *      hanging the CTest tier.
+ *   3. STABILITY. Two consecutive calls agree. A value genuinely read out of
+ *      global storage is invariant; a return register is not required to be.
+ *
+ * Also locks the two neighbours from the same sweep whose contracts are
+ * likewise consumed by fault.c and by controller setup.
+ *
+ * ROM-free and display-free: these are pure symbol contracts with no
+ * subsystem behind them, which is the whole reason they can be locked at all.
+ *
+ * Included at FILE SCOPE by test_runner.cpp (compiled as C++), like the other
+ * files in this directory; the declarations below carry C linkage explicitly
+ * because the definitions live in C translation units.
+ */
+
+/* Only the two headers that carry the types used below, not the libultra.h
+ * umbrella: this file is #included into test_runner.cpp's C++ translation unit,
+ * and gbi.h/rcp.h drag in a large macro surface that has no business there. */
+#include <cstdio>
+#include <libultraship/libultra/thread.h>
+#include <libultraship/libultra/message.h>
+
+extern "C" {
+OSThread* __osGetActiveQueue(void);
+OSThread* __osGetCurrFaultedThread(void);
+s32 __osDisableInt(void);
+s32 OoT_osContStartQuery(OSMesgQueue* mq);
+}
+
+/* The termination sentinel. Spelled as a bare -1 here on purpose: that is the
+ * literal fault.c compares against, and restating the constant independently
+ * of any header is the point of a regression lock. */
+#define ACTIVEQ_THREADTAIL_PRIORITY (-1)
+
+/* Generous relative to the real N64 thread count (single digits) and to the
+ * port's (zero), but finite — the failure mode being locked out is an
+ * unterminated walk, and a test that hangs is a test that reports nothing. */
+#define ACTIVEQ_MAX_WALK 64
+
+#define ACTIVEQ_CHECK(cond, msg)                \
+    do {                                        \
+        if (!(cond)) {                          \
+            printf("[TEST] FAIL: %s\n", (msg)); \
+            return TEST_FAIL;                   \
+        }                                       \
+    } while (0)
+
+TestResult Test_ActiveQueue(void) {
+    printf("[TEST] active-queue: __osGetActiveQueue returns a walkable list, not a return register (#385)\n");
+
+    OSThread* head = __osGetActiveQueue();
+
+    // (1) fault.c dereferences the result immediately, with no null check.
+    ACTIVEQ_CHECK(head != NULL, "__osGetActiveQueue() returned NULL; fault.c dereferences it unconditionally");
+
+    // (3) Stability. Checked before the walk so that a non-deterministic value
+    // is reported as such rather than as a walk failure.
+    OSThread* again = __osGetActiveQueue();
+    ACTIVEQ_CHECK(again == head, "__osGetActiveQueue() returned two different values for two consecutive calls");
+
+    // (2) Termination. This is fault.c's loop verbatim, plus a step cap.
+    OSThread* iter = head;
+    int steps = 0;
+    while (iter->priority != ACTIVEQ_THREADTAIL_PRIORITY) {
+        ACTIVEQ_CHECK(iter->tlnext != NULL, "active-queue walk hit a NULL tlnext before the priority == -1 tail");
+        iter = iter->tlnext;
+        steps++;
+        ACTIVEQ_CHECK(steps < ACTIVEQ_MAX_WALK, "active-queue walk did not terminate; list is cyclic or garbage");
+    }
+
+    printf("[TEST]   walk terminated at the tail sentinel after %d step(s)\n", steps);
+
+    // The port creates no libultra threads, so the list should be empty — the
+    // head IS the sentinel. Asserted separately from termination so that a
+    // future real thread list fails here loudly (a deliberate contract change)
+    // rather than silently.
+    ACTIVEQ_CHECK(steps == 0, "expected an empty active queue (head == tail sentinel) in the port");
+
+    // fault.c's other input. Both handlers branch on NULL to fall back to
+    // Fault_FindFaultedThread; a garbage pointer would be walked as a thread.
+    ACTIVEQ_CHECK(__osGetCurrFaultedThread() == NULL, "__osGetCurrFaultedThread() must report NULL, not a register");
+
+    // Same file, same defect class, and the value is load-bearing: the mask is
+    // handed straight back to the no-op __osRestoreInt.
+    ACTIVEQ_CHECK(__osDisableInt() == 0, "__osDisableInt() must return a defined interrupt mask");
+
+    // padsetup.c aborts controller setup on a non-zero return, so garbage here
+    // could fail controller init at random.
+    ACTIVEQ_CHECK(OoT_osContStartQuery(NULL) == 0, "OoT_osContStartQuery() must report success (0)");
+
+    printf("[TEST] PASS: active-queue\n");
+    return TEST_PASS;
+}


### PR DESCRIPTION
## What was broken

`games/oot/soh/stubs.c` had **24** functions with a return type and no `return` statement. Falling off the end of a non-void function is UB; in practice the caller reads whatever was left in the return register. MSVC treats C4716/C4715 as warnings in C, and `SUPPRESS_WARNINGS` is ON, so none of it was ever reported. Issue #385 named 4; a sweep of the file found 23 empty bodies plus one non-empty body (`_Printf`) that still fell off the end.

The worst instance is `__osGetActiveQueue`. Both games' crash handlers do:

```c
OSThread* iter = __osGetActiveQueue();
while (iter->priority != -1) { ...; iter = iter->tlnext; }
```

(`games/oot/src/code/fault.c:537`, `games/mm/src/boot/fault.c:557`). So the fault handler — whose entire job is to produce a usable diagnostic once something else has already gone wrong — dereferenced a return register as a thread list and was liable to fault itself.

## Mechanism

A real implementation already exists at `rsbs/src/libultra/os/getactivequeue.c`, but it could not win the symbol. It references `__osActiveQueue`, which **nothing in the link defined**: the two defining TUs (`games/oot/src/libultra/os/createthread.c`, `games/mm/src/libultra/os/thread.c`) are both excluded unconditionally, and libultraship supplies neither. That made `getactivequeue.o` unpullable — it exports no other symbol, so lazy archive extraction never reached for it — while `soh_port`'s `stubs.o` is dragged in unconditionally via `osMemSize` / `OoT_osDestroyThread` and always won.

Not a duplicate-definition bug; a **missing-storage** bug wearing one as a disguise. Confirmed: `__osGetActiveQueue` now has exactly one definition in the tree, and `libultraship` defines none of `__osActiveQueue` / `__osRunningThread` / `__osGetActiveQueue` / `__osDispatchThread`, so the new storage cannot collide.

## Fix

**1. `rsbs/src/libultra/os/threadqueue.c` (new)** defines `__osActiveQueue` and `__osRunningThread`.

`__osActiveQueue` points at a tail sentinel with priority `OS_PRIORITY_THREADTAIL` (-1), **not NULL**. The consumers do not null-check, so `NULL` would trade a garbage dereference for a null dereference on the same line of the same handler. An empty list whose head *is* the sentinel makes every walk terminate on the first iteration and answer "no faulted thread" — true for a port that runs no libultra threads. This also makes `destroythread.o` / `getthreadid.o` / `getthreadpri.o` linkable instead of dead weight that would break the link the moment anything reached them.

**2. The stub is deleted**, so the rsbs implementation resolves — the same treatment the `osWritebackDCache` / `osInvalICache` / `osInvalDCache` group got in #368.

**3. The remaining 23 got explicit returns** chosen against each function's real libultra contract, not whatever was cheapest:

| Group | Return | Why |
|---|---|---|
| Controller Pak (`osPfs*`, `__osPfsCheckRamArea`, `osProbeRumblePak`) | `PFS_ERR_NOPACK` | `0` would tell the game a pak exists and send it on to read it. Also preserves the old de-facto behaviour, where non-zero garbage read as "some error". |
| `osContStartQuery`, `osContSetCh`, `osStopTimer`, `osEPiWriteIo` | `0` | Success, per real libultra. `padsetup.c` aborts controller setup on non-zero, so garbage could fail init at random. |
| `osDpGetStatus`, `__osSpGetStatus` | `0` | Idle. Garbage could read as permanently busy. |
| `osSpTaskYielded` | `0` | Not `OS_TASK_YIELDED` — `osSpTaskYield` is a no-op, so re-submitting a task that never yielded is wrong. |
| `osDriveRomInit`, `__osGetCurrFaultedThread` | `NULL` | Documented "no device"/"none"; both fault handlers already branch on NULL. |
| `__osDisableInt` | `0` | Handed straight back to the no-op `__osRestoreInt`. |
| `osGetThreadId` / `osGetThreadPri` | `0` / `OS_PRIORITY_IDLE` | Not the tail priority — callers compare against `-1` to detect end-of-list. |

**4. `_Printf`** — the 24th, which has a body and still fell off the end. `games/oot/src/libultra/libc/sprintf.c` returns `_Printf`'s value verbatim as `sprintf`'s character count, so **every `sprintf()` in the port was handing its caller the return register**. It now returns the number of characters that actually reached the callback (not vsnprintf's would-have-written count, so a truncating format cannot over-report).

**5. Class lockout.** `soh/stubs.c` alone is compiled with `-Werror=return-type` (`/we4716 /we4715` on MSVC), mirroring the `/we4013` precedent that retired the implicit-declaration class. Scoped to this one file deliberately: the vendored decomp tree under `src/` has its own instances and is compiled with `${WARNING_OVERRIDE}` (`/w` or `-w`), so a target-wide escalation would break the build and fight upstream. Source-level `COMPILE_OPTIONS` is emitted after target-level flags, so the escalation wins over `${WARNING_OVERRIDE}` if that ever reaches this file.

## Verification

New ROM-free `redship`-label CTest **`ActiveQueue`** (`--test active-queue`, `src/common/tests/test_active_queue.c`) asserts the three properties `fault.c` actually needs:

1. **Non-NULL** — `iter->priority` is read before any null check.
2. **Bounded termination** — the walk (fault.c's loop verbatim) reaches the `priority == -1` tail within a hard step cap, so a cyclic or garbage list *fails* rather than hanging the tier.
3. **Stability** — two consecutive calls agree; a value read from global storage is invariant, a return register need not be.

Plus `__osGetCurrFaultedThread() == NULL`, `__osDisableInt() == 0`, `OoT_osContStartQuery() == 0`.

Not built locally by design (parallel agent contention) — CI is the build gate. The `-Werror=return-type` escalation is the one thing I could not pre-verify; if it fires, it has found a real 25th instance, which is the point. No file touched is in `.github/clang-format-paths.txt`, so the format gate is unaffected.

## Behavior changes

Real, and all in the safe direction: `sprintf`'s return value is now correct rather than garbage; controller/pak/RSP-status paths now take their deterministic branch instead of a random one. Nothing that previously "worked" depended on a defined value here, because there wasn't one.

## Out of lane

`games/mm/src/code/stubs.c` has the same defect class untouched — `MM___osDisableInt`, `MM_osContStartQuery`, `MM_osGetThreadPri` all have empty non-void bodies. Not in this lane; worth a follow-up issue with the same `-Werror=return-type` treatment.

## Shared-file note

Adds one entry each to `CMake/SingleExecutable.cmake` and `src/common/test_runner.cpp`, which a parallel Wave 2 lane may also be touching. Both edits are additive and adjacent to the `seq-map-bounds` entries, so conflict resolution is trivial.

Closes #385.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!--- section:artifacts:start -->
### Build Artifacts
  - [rsbs-windows.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/8475085518.zip)
  - [rsbs-linux.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/8474816957.zip)
<!--- section:artifacts:end -->