### PR TITLE
Register CTests through redship_add_test() so adding a test is one appended line

### DIFF
--- a/CMake/CheckTestRegistration.cmake
+++ b/CMake/CheckTestRegistration.cmake
@@ -1,0 +1,234 @@
+# CMake/CheckTestRegistration.cmake
+#
+# Registration-completeness guard. Run as a CTest row in the tier it polices:
+#   cmake -DREDSHIP_EXE=<redship> -DMANIFEST=<manifest> -P CheckTestRegistration.cmake
+#
+# Fails when the two halves of test registration disagree:
+#   (1) a dispatch-table entry in test_runner.cpp with no CTest row  — a test
+#       that exists but is never scheduled;
+#   (2) a CTest row whose `--test <name>` is not in the dispatch table — a row
+#       that can only ever error out.
+#
+# The table side is read from the BINARY (`redship --test list`), not from the
+# source text, so it reflects what actually linked.
+#
+# This file is deliberately paranoid about its own inputs. A completeness guard
+# that silently checks nothing is worse than no guard: this repo has shipped two
+# of those already (#366's clang-format target pointed at a directory that did
+# not exist; #375's collision baseline was never committed, so it "could not
+# fail"). Every way this script could end up comparing empty sets against empty
+# sets is an explicit FATAL_ERROR below.
+
+if(NOT DEFINED REDSHIP_EXE)
+    message(FATAL_ERROR "CheckTestRegistration: -DREDSHIP_EXE=<path> is required")
+endif()
+if(NOT DEFINED MANIFEST)
+    message(FATAL_ERROR "CheckTestRegistration: -DMANIFEST=<path> is required")
+endif()
+if(NOT EXISTS "${REDSHIP_EXE}")
+    message(FATAL_ERROR "CheckTestRegistration: redship binary not found: ${REDSHIP_EXE}")
+endif()
+if(NOT EXISTS "${MANIFEST}")
+    message(FATAL_ERROR "CheckTestRegistration: manifest not found: ${MANIFEST}")
+endif()
+
+# ============================================================================
+# Side A — what CMake registered (manifest written by redship_finalize_tests)
+# ============================================================================
+
+file(STRINGS "${MANIFEST}" _manifest_lines)
+
+set(_reg_unit "")          # dispatch names driven by a --test row
+set(_reg_int "")           # dispatch names driven by an --integration-test row
+set(_exempt "")            # dispatch names declared row-less on purpose
+set(_row_for "")           # parallel to _reg_unit/_reg_int: owning CTest row
+set(_meta_rows "")         # rows that drive neither table (this guard itself)
+
+foreach(_line IN LISTS _manifest_lines)
+    if(_line MATCHES "^#")
+        continue()
+    elseif(_line MATCHES "^register\\|([^|]*)\\|([^|]*)\\|([^|]*)\\|(.*)$")
+        set(_ctest_name "${CMAKE_MATCH_2}")
+        set(_kind "${CMAKE_MATCH_3}")
+        set(_dispatch "${CMAKE_MATCH_4}")
+        if(_kind STREQUAL "unit")
+            list(APPEND _reg_unit "${_dispatch}")
+            list(APPEND _row_for "${_dispatch}=${_ctest_name}")
+        elseif(_kind STREQUAL "integration")
+            list(APPEND _reg_int "${_dispatch}")
+            list(APPEND _row_for "${_dispatch}=${_ctest_name}")
+        else()
+            list(APPEND _meta_rows "${_ctest_name}")
+        endif()
+    elseif(_line MATCHES "^exempt\\|([^|]*)\\|(.*)$")
+        list(APPEND _exempt "${CMAKE_MATCH_1}")
+    endif()
+endforeach()
+
+if(NOT _reg_unit)
+    message(FATAL_ERROR
+        "CheckTestRegistration: the manifest lists no --test rows at all (${MANIFEST}).\n"
+        "Either registration broke or the manifest format changed; either way this "
+        "guard would pass vacuously. Refusing.")
+endif()
+
+# ============================================================================
+# Side B — what the binary actually contains (`redship --test list`)
+# ============================================================================
+
+execute_process(
+    COMMAND "${REDSHIP_EXE}" --test list
+    OUTPUT_VARIABLE _out
+    ERROR_VARIABLE _err
+    RESULT_VARIABLE _rc
+)
+if(NOT _rc EQUAL 0)
+    message(FATAL_ERROR
+        "CheckTestRegistration: '${REDSHIP_EXE} --test list' exited ${_rc}.\n"
+        "stdout:\n${_out}\nstderr:\n${_err}")
+endif()
+
+string(REPLACE "\r\n" "\n" _out_n "${_out}")
+string(REPLACE ";" "\\;" _out_n "${_out_n}")
+string(REPLACE "\n" ";" _lines "${_out_n}")
+
+set(_section "")
+set(_saw_unit_header FALSE)
+set(_saw_special_header FALSE)
+set(_saw_int_header FALSE)
+set(_found_unit "")
+set(_found_special "")
+set(_found_integration "")
+
+foreach(_line IN LISTS _lines)
+    if(_line MATCHES "Available unit tests")
+        set(_section "unit")
+        set(_saw_unit_header TRUE)
+    elseif(_line MATCHES "^Special commands:")
+        set(_section "special")
+        set(_saw_special_header TRUE)
+    elseif(_line MATCHES "^Integration tests \\(")
+        set(_section "integration")
+        set(_saw_int_header TRUE)
+    elseif(_section AND _line MATCHES "^  ([A-Za-z0-9._-]+)[ \t]")
+        # Entry rows are "  <name><padding><description>". The parenthetical
+        # note under the integration header starts with '(' and is skipped by
+        # the character class.
+        list(APPEND _found_${_section} "${CMAKE_MATCH_1}")
+    endif()
+endforeach()
+
+# If TestRunner_ListTests' output format ever changes, the parse above can go
+# quiet and start comparing nothing to nothing. Treat a missing section marker
+# or an empty section as a hard failure of THIS guard, not as a pass.
+if(NOT _saw_unit_header OR NOT _saw_special_header OR NOT _saw_int_header)
+    message(FATAL_ERROR
+        "CheckTestRegistration: could not parse '--test list' output — expected the "
+        "'Available unit tests' / 'Special commands:' / 'Integration tests (' section "
+        "markers (found: unit=${_saw_unit_header} special=${_saw_special_header} "
+        "integration=${_saw_int_header}).\n"
+        "TestRunner_ListTests' format probably changed; update this parser.\n"
+        "Raw output:\n${_out}")
+endif()
+if(NOT _found_unit OR NOT _found_integration)
+    message(FATAL_ERROR
+        "CheckTestRegistration: parsed zero entries from a '--test list' section "
+        "(unit=${_found_unit} / integration=${_found_integration}). Refusing to pass vacuously.\n"
+        "Raw output:\n${_out}")
+endif()
+
+# ============================================================================
+# Compare
+# ============================================================================
+
+set(_problems "")
+
+# Split on the first '=' rather than interpolating the dispatch name into a
+# regex — an error path must not itself misfire on an unexpected name.
+function(_row_owning dispatch out_var)
+    foreach(_pair IN LISTS _row_for)
+        string(REGEX REPLACE "=.*$" "" _d "${_pair}")
+        if(_d STREQUAL "${dispatch}")
+            string(REGEX REPLACE "^[^=]*=" "" _owner "${_pair}")
+            set(${out_var} "${_owner}" PARENT_SCOPE)
+            return()
+        endif()
+    endforeach()
+    set(${out_var} "<none>" PARENT_SCOPE)
+endfunction()
+
+# (1) every dispatch-table entry needs a CTest row (or a declared exemption)
+set(_used_exempt "")
+foreach(_entry IN LISTS _found_unit)
+    if(_entry IN_LIST _reg_unit)
+        continue()
+    elseif(_entry IN_LIST _exempt)
+        list(APPEND _used_exempt "${_entry}")
+    else()
+        list(APPEND _problems
+            "dispatch entry '${_entry}' (test_runner.cpp gTests[]) has no CTest row -- \
+add redship_add_test(NAME <Row> COMMAND redship --test ${_entry}), or declare it \
+row-less with redship_test_exempt(${_entry} \"<why>\")")
+    endif()
+endforeach()
+
+foreach(_entry IN LISTS _found_integration)
+    if(NOT _entry IN_LIST _reg_int)
+        list(APPEND _problems
+            "integration entry '${_entry}' (test_runner.cpp gIntegrationTests[]) has no CTest row")
+    endif()
+endforeach()
+
+# (2) every registered row must resolve to a real dispatch entry.
+#     "all"/"list" are TestRunner_Run special commands, not table rows; they are
+#     read out of the same --test list output rather than hardcoded here.
+set(_valid_unit_targets ${_found_unit} ${_found_special})
+foreach(_dispatch IN LISTS _reg_unit)
+    if(NOT _dispatch IN_LIST _valid_unit_targets)
+        _row_owning("${_dispatch}" _owner)
+        list(APPEND _problems
+            "CTest row '${_owner}' runs '--test ${_dispatch}', which is not in the \
+dispatch table and would fail with \"Unknown test\"")
+    endif()
+endforeach()
+foreach(_dispatch IN LISTS _reg_int)
+    if(NOT _dispatch IN_LIST _found_integration)
+        _row_owning("${_dispatch}" _owner)
+        list(APPEND _problems
+            "CTest row '${_owner}' runs '--integration-test ${_dispatch}', which is not \
+in the integration dispatch table")
+    endif()
+endforeach()
+
+# (3) exemptions must stay honest — a stale one is a hard error, so this list
+#     cannot quietly become a rubber stamp (same rule as
+#     .github/clang-format-paths.txt).
+foreach(_e IN LISTS _exempt)
+    if(NOT _e IN_LIST _found_unit)
+        list(APPEND _problems
+            "stale exemption: redship_test_exempt(${_e}) names a dispatch entry that no \
+longer exists -- drop the exemption")
+    elseif(_e IN_LIST _reg_unit)
+        list(APPEND _problems
+            "needless exemption: '${_e}' now has its own CTest row -- drop the \
+redship_test_exempt(${_e}) line")
+    endif()
+endforeach()
+
+if(_problems)
+    list(LENGTH _problems _n)
+    string(REPLACE ";" "\n  * " _pretty "${_problems}")
+    message(FATAL_ERROR
+        "Test registration is incomplete (${_n} problem(s)):\n  * ${_pretty}\n\n"
+        "Registration lives in CMake/SingleExecutable.cmake (redship_add_test) and "
+        "src/common/test_runner.cpp (gTests[]/gIntegrationTests[]). Both sides must agree.")
+endif()
+
+list(LENGTH _found_unit _n_unit)
+list(LENGTH _reg_unit _n_reg)
+list(LENGTH _found_integration _n_int)
+list(LENGTH _used_exempt _n_ex)
+list(LENGTH _meta_rows _n_meta)
+message(STATUS
+    "Test registration complete: ${_n_unit} dispatch entries covered by ${_n_reg} "
+    "--test rows (${_n_ex} exempt), ${_n_int} integration entries, ${_n_meta} meta row(s).")

--- a/CMake/RedshipTests.cmake
+++ b/CMake/RedshipTests.cmake
@@ -1,0 +1,186 @@
+# CMake/RedshipTests.cmake
+# Test registration helpers for the single-executable build.
+#
+# Why this module exists (#376): registering one test used to take three edits,
+# one of which was a SHARED LINE. `add_test(NAME ...)` appends cleanly, but the
+# test's name also had to be appended to a single five-line
+# `set_tests_properties(<30 names> PROPERTIES TIMEOUT ... LABELS "redship")`
+# block. Every parallel lane that added a test rewrote those same lines, so
+# every lane after the first conflicted — four Wave 1 lanes and both Wave 2
+# lanes collided there over 2026-07-19/20.
+#
+# The conflict is worse than a rebase: GitHub builds `pull_request` checks
+# against `refs/pull/N/merge`, which it cannot create while a PR conflicts, so a
+# stale PR gets ZERO check runs rather than failing ones — indistinguishable
+# from an Actions outage until someone looks at the mergeability flag.
+#
+# `redship_add_test()` folds the properties into the registration, so a test is
+# one appended line and the shared name list is gone.
+
+include_guard(GLOBAL)
+
+# ============================================================================
+# redship_add_test(NAME <name> COMMAND <argv...>
+#                  [LABEL <label>...] [TIMEOUT <seconds>] [ENVIRONMENT <var=val>...])
+#
+# Registers a CTest row and its properties together.
+#
+# LABEL defaults to "redship" (the ROM-free tier hosted CI runs) and TIMEOUT
+# defaults to ${REDSHIP_TEST_TIMEOUT}, so a plain unit test needs neither.
+# ============================================================================
+function(redship_add_test)
+    cmake_parse_arguments(PARSE_ARGV 0 RSBS_T "" "NAME;TIMEOUT" "COMMAND;LABEL;ENVIRONMENT")
+
+    if(NOT RSBS_T_NAME)
+        message(FATAL_ERROR "redship_add_test: NAME is required")
+    endif()
+    if(NOT RSBS_T_COMMAND)
+        message(FATAL_ERROR "redship_add_test(${RSBS_T_NAME}): COMMAND is required")
+    endif()
+    # A typo'd keyword would otherwise be silently swallowed and the row would
+    # quietly get default properties — the exact failure class this module exists
+    # to remove.
+    if(RSBS_T_UNPARSED_ARGUMENTS)
+        message(FATAL_ERROR
+            "redship_add_test(${RSBS_T_NAME}): unrecognized argument(s): ${RSBS_T_UNPARSED_ARGUMENTS}")
+    endif()
+
+    if(NOT RSBS_T_LABEL)
+        set(RSBS_T_LABEL "redship")
+    endif()
+    if(NOT RSBS_T_TIMEOUT)
+        if(NOT DEFINED REDSHIP_TEST_TIMEOUT)
+            message(FATAL_ERROR
+                "redship_add_test(${RSBS_T_NAME}): no TIMEOUT given and REDSHIP_TEST_TIMEOUT is not set yet")
+        endif()
+        set(RSBS_T_TIMEOUT ${REDSHIP_TEST_TIMEOUT})
+    endif()
+
+    # A caller writing ENVIRONMENT "A=1;B=2" hands cmake_parse_arguments ONE
+    # argument, which it stores with the semicolons escaped ("A=1\;B=2") to keep
+    # it a single list element. Forwarded as-is, CTest receives one malformed
+    # variable named A whose value is "1;B=2" instead of two variables — a
+    # silent environment regression in a tier that only runs under xvfb. Undo the
+    # escaping so both spellings (one ;-joined string, or several separate
+    # arguments) produce the same list.
+    string(REPLACE "\\;" ";" _labels "${RSBS_T_LABEL}")
+    string(REPLACE "\\;" ";" _environment "${RSBS_T_ENVIRONMENT}")
+
+    add_test(NAME ${RSBS_T_NAME} COMMAND ${RSBS_T_COMMAND})
+    set_tests_properties(${RSBS_T_NAME} PROPERTIES
+        TIMEOUT "${RSBS_T_TIMEOUT}"
+        LABELS "${_labels}"
+    )
+    if(RSBS_T_ENVIRONMENT)
+        set_tests_properties(${RSBS_T_NAME} PROPERTIES ENVIRONMENT "${_environment}")
+    endif()
+
+    # Record which dispatch-table entry this row drives, for the completeness
+    # guard below. The CTest row name is NOT the dispatch name: RandoGen,
+    # RandoGenSongsDungeonRewards and RandoGenSongsAnywhere are three rows over
+    # the one "rando-gen" entry, differing only by ENVIRONMENT.
+    set(_kind "meta")
+    set(_dispatch "")
+    set(_take_next FALSE)
+    foreach(_arg IN LISTS RSBS_T_COMMAND)
+        if(_take_next)
+            set(_dispatch "${_arg}")
+            set(_take_next FALSE)
+        elseif(_arg STREQUAL "--test")
+            set(_kind "unit")
+            set(_take_next TRUE)
+        elseif(_arg STREQUAL "--integration-test")
+            set(_kind "integration")
+            set(_take_next TRUE)
+        endif()
+    endforeach()
+
+    # Manifest fields are '|'-separated and one-per-line, so flatten any
+    # multi-label value rather than letting its ';' split the line.
+    string(REPLACE ";" "," _manifest_labels "${_labels}")
+    set_property(GLOBAL APPEND PROPERTY REDSHIP_TEST_MANIFEST
+        "register|${_manifest_labels}|${RSBS_T_NAME}|${_kind}|${_dispatch}")
+endfunction()
+
+# ============================================================================
+# redship_test_exempt(<dispatch-name> <reason>)
+#
+# Declares a dispatch-table entry that deliberately has NO dedicated CTest row.
+# The guard hard-fails on a stale exemption (name gone from the table, or since
+# registered), so this list cannot rot into a rubber stamp — same rule the
+# clang-format path allowlist uses.
+# ============================================================================
+function(redship_test_exempt name reason)
+    set_property(GLOBAL APPEND PROPERTY REDSHIP_TEST_MANIFEST "exempt|${name}|${reason}")
+endfunction()
+
+# ============================================================================
+# redship_check_test_sources()
+#
+# Every src/common/tests/*.c must be #included by test_runner.cpp.
+#
+# These files are deliberately NOT separate translation units: each is pulled
+# into test_runner.cpp either inside an `extern "C"` block or at file scope,
+# and which one is load-bearing (test_roundtrip_integrity.c must compile as C++
+# or its Entrance_Init call binds to OoT's C-linkage randomizer symbol instead
+# of the combo entrance system). Compiling them as their own TUs as well would
+# define every symbol twice.
+#
+# So this globs to DETECT rather than to build: CONFIGURE_DEPENDS re-runs
+# configure when a file is added to the directory, and a file that is never
+# #included is a test that compiles into nothing and can never run.
+# ============================================================================
+function(redship_check_test_sources)
+    file(GLOB _test_sources CONFIGURE_DEPENDS "${CMAKE_SOURCE_DIR}/src/common/tests/*.c")
+
+    # A glob that matches nothing would make this check pass vacuously, which is
+    # the failure mode it exists to prevent.
+    list(LENGTH _test_sources _count)
+    if(_count EQUAL 0)
+        message(FATAL_ERROR
+            "redship_check_test_sources: src/common/tests/*.c matched no files. "
+            "If the test sources moved, update this glob — do not leave it matching nothing.")
+    endif()
+
+    file(READ "${CMAKE_SOURCE_DIR}/src/common/test_runner.cpp" _runner)
+    set(_orphans "")
+    foreach(_src IN LISTS _test_sources)
+        get_filename_component(_name "${_src}" NAME)
+        string(FIND "${_runner}" "#include \"tests/${_name}\"" _pos)
+        if(_pos EQUAL -1)
+            list(APPEND _orphans "${_name}")
+        endif()
+    endforeach()
+
+    if(_orphans)
+        string(REPLACE ";" "\n  - " _pretty "${_orphans}")
+        message(FATAL_ERROR
+            "Test source(s) in src/common/tests/ are not #included by "
+            "src/common/test_runner.cpp:\n  - ${_pretty}\n"
+            "They compile into nothing and can never run. Add "
+            "#include \"tests/<file>\" to test_runner.cpp (inside an extern \"C\" block "
+            "if the test only touches C-linkage symbols; at file scope if it drives "
+            "C++-linkage APIs).")
+    endif()
+
+    message(STATUS "Test sources: ${_count} file(s) in src/common/tests/, all #included")
+endfunction()
+
+# ============================================================================
+# redship_finalize_tests()
+#
+# Writes the manifest the completeness guard reads. Call AFTER every
+# redship_add_test()/redship_test_exempt() call.
+# ============================================================================
+function(redship_finalize_tests manifest_path)
+    get_property(_entries GLOBAL PROPERTY REDSHIP_TEST_MANIFEST)
+    if(NOT _entries)
+        message(FATAL_ERROR "redship_finalize_tests: no tests were registered")
+    endif()
+    string(REPLACE ";" "\n" _body "${_entries}")
+    file(WRITE "${manifest_path}"
+        "# Generated by redship_finalize_tests() — do not edit.\n"
+        "# register|<labels>|<ctest-name>|<kind>|<dispatch-name>\n"
+        "# exempt|<dispatch-name>|<reason>\n"
+        "${_body}\n")
+endfunction()

--- a/CMake/SingleExecutable.cmake
+++ b/CMake/SingleExecutable.cmake
@@ -210,19 +210,35 @@ endif()
 # CTest Integration
 # ============================================================================
 
+include(${CMAKE_CURRENT_LIST_DIR}/RedshipTests.cmake)
+
 if(BUILD_TESTING)
+    # Cache variables so a slow runner can raise these without editing the file.
+    # They must be set before the first redship_add_test(): a row that passes no
+    # TIMEOUT inherits REDSHIP_TEST_TIMEOUT.
+    set(REDSHIP_TEST_TIMEOUT 60 CACHE STRING "Test timeout in seconds")
+    set(REDSHIP_INTEGRATION_TEST_TIMEOUT 120 CACHE STRING "Integration test timeout in seconds")
+
+    # A test source that is never #included compiles into nothing and can never
+    # run. The glob notices the file; this asserts it is actually wired in.
+    redship_check_test_sources()
+
     # ========================================================================
     # Unit tests (no display required)
+    #
+    # redship_add_test() performs add_test + set_tests_properties together and
+    # defaults to LABELS "redship" / TIMEOUT ${REDSHIP_TEST_TIMEOUT}, so adding
+    # a test is ONE appended line — there is no shared name list to edit (#376).
     # ========================================================================
-    add_test(NAME BootOoT COMMAND redship --test boot-oot)
-    add_test(NAME BootMM COMMAND redship --test boot-mm)
-    add_test(NAME SwitchOoTMM COMMAND redship --test switch-oot-mm)
-    add_test(NAME SwitchMMOoT COMMAND redship --test switch-mm-oot)
+    redship_add_test(NAME BootOoT COMMAND redship --test boot-oot)
+    redship_add_test(NAME BootMM COMMAND redship --test boot-mm)
+    redship_add_test(NAME SwitchOoTMM COMMAND redship --test switch-oot-mm)
+    redship_add_test(NAME SwitchMMOoT COMMAND redship --test switch-mm-oot)
     # Startup-entrance flow incl. game-affinity regression: an MM-tagged
     # entrance (0xC010) must be invisible to OoT, whose entranceIndex is a
     # linear gEntranceTable index — the OOB-read crash behind the Market
     # cutscene 0xC0000005.
-    add_test(NAME StartupEntrance COMMAND redship --test startup-entrance)
+    redship_add_test(NAME StartupEntrance COMMAND redship --test startup-entrance)
     # Entrance-link dedup regression (#374): the default (mask shop) and test
     # (Mido's House) links both return through MM 0xC010, and both were
     # registered unconditionally. Entrance_CheckCrossGame resolves first-match,
@@ -230,31 +246,31 @@ if(BUILD_TESTING)
     # House, walk back into the Clock Tower, exit in Hyrule Market instead of
     # Kokiri Forest. Locks that a duplicate (sourceGame, sourceEntrance) is
     # rejected atomically and that each portal face routes to its own return.
-    add_test(NAME EntranceDedup COMMAND redship --test entrance-dedup)
+    redship_add_test(NAME EntranceDedup COMMAND redship --test entrance-dedup)
     # VB-affinity regression: MM's GameInteractor_* calls bind to OoT's
     # extern "C" wrappers in single-exe builds, and the two games' vanilla-
     # behavior ordinals alias (MM VB_SETUP_TRANSITION == OoT
     # VB_PLAY_RAINBOW_BRIDGE_CS == 206). The wrappers must return vanilla
     # behavior while MM is active — the Market -> Clock Tower NULL-call crash.
-    add_test(NAME VBAffinity COMMAND redship --test vb-affinity)
+    redship_add_test(NAME VBAffinity COMMAND redship --test vb-affinity)
     # MM HUD gfx-wrapper contract: the CosmeticEditor Override wrappers must
     # write commands and return the advanced display-list pointer. The old
     # void stubs in mm_stubs.c fed MM_Interface_DrawItemButtons a garbage
     # write pointer (WRITE AV at 0xA7, first HUD-visible MM frame — caught by
     # int-gameplay-roundtrip on the OoT->MM leg).
-    add_test(NAME CosmeticGfxStub COMMAND redship --test cosmetic-gfx-stub)
-    add_test(NAME Roundtrip COMMAND redship --test roundtrip)
-    add_test(NAME RoundtripIntegrity COMMAND redship --test roundtrip-integrity)
-    add_test(NAME SharedRoundtrip COMMAND redship --test shared-roundtrip)
-    add_test(NAME ArchiveHotswapLogic COMMAND redship --test archive-hotswap-logic)
+    redship_add_test(NAME CosmeticGfxStub COMMAND redship --test cosmetic-gfx-stub)
+    redship_add_test(NAME Roundtrip COMMAND redship --test roundtrip)
+    redship_add_test(NAME RoundtripIntegrity COMMAND redship --test roundtrip-integrity)
+    redship_add_test(NAME SharedRoundtrip COMMAND redship --test shared-roundtrip)
+    redship_add_test(NAME ArchiveHotswapLogic COMMAND redship --test archive-hotswap-logic)
     # Unified save (.redsave) headless tests — Phase 2 T6 (#35)
-    add_test(NAME SaveRoundtripTiers COMMAND redship --test save-roundtrip-tiers)
-    add_test(NAME SaveHeader COMMAND redship --test save-header)
-    add_test(NAME SaveHasDelete COMMAND redship --test save-has-delete)
-    add_test(NAME SaveVersionReject COMMAND redship --test save-version-reject)
-    add_test(NAME SaveSizeMismatch COMMAND redship --test save-size-mismatch)
-    add_test(NAME SaveLegacySize COMMAND redship --test save-legacy-size)
-    add_test(NAME SaveCrcCorrupt COMMAND redship --test save-crc-corrupt)
+    redship_add_test(NAME SaveRoundtripTiers COMMAND redship --test save-roundtrip-tiers)
+    redship_add_test(NAME SaveHeader COMMAND redship --test save-header)
+    redship_add_test(NAME SaveHasDelete COMMAND redship --test save-has-delete)
+    redship_add_test(NAME SaveVersionReject COMMAND redship --test save-version-reject)
+    redship_add_test(NAME SaveSizeMismatch COMMAND redship --test save-size-mismatch)
+    redship_add_test(NAME SaveLegacySize COMMAND redship --test save-legacy-size)
+    redship_add_test(NAME SaveCrcCorrupt COMMAND redship --test save-crc-corrupt)
     # Tier-1 (ComboContext) format headroom — Phase 3 Wave 1. The loader used to
     # demand comboSize == sizeof(ComboContext) exactly, so the moment Lane A
     # widens sharedItems to carry an origin-game tag, every existing .redsave
@@ -262,104 +278,100 @@ if(BUILD_TESTING)
     # a pre-headroom Tier-1 still loads and zero-extends, the record size is
     # fixed and padded so growth does not move it, and an oversized record is
     # refused rather than truncated.
-    add_test(NAME SaveComboLegacyRecord COMMAND redship --test save-combo-legacy-record)
-    add_test(NAME SaveComboRecordFixed COMMAND redship --test save-combo-record-fixed)
-    add_test(NAME SaveComboOversize COMMAND redship --test save-combo-oversize)
-    add_test(NAME Context COMMAND redship --test context)
+    redship_add_test(NAME SaveComboLegacyRecord COMMAND redship --test save-combo-legacy-record)
+    redship_add_test(NAME SaveComboRecordFixed COMMAND redship --test save-combo-record-fixed)
+    redship_add_test(NAME SaveComboOversize COMMAND redship --test save-combo-oversize)
+    redship_add_test(NAME Context COMMAND redship --test context)
     # F10 hot-swap freeze/consume contract (#364): the hotkey path must freeze
     # the DEPARTING game (or refuse the switch), and a consumed frozen state
     # must be retired so it can never be re-applied. Before the fix, one
     # entrance switch left a blob that every later F10 return silently rolled
     # the player back to.
-    add_test(NAME HotSwapFreeze COMMAND redship --test hotswap-freeze)
+    redship_add_test(NAME HotSwapFreeze COMMAND redship --test hotswap-freeze)
     # MM scene-command parse + execute regressions — display-free, no ROM
     # archives (#344). Parse checks the wire format; execute runs the commands
     # against a PlayState and asserts the spawn-path pointers/fields populate.
-    add_test(NAME MMSceneParse COMMAND redship --test mm-scene-parse)
-    add_test(NAME MMSceneExecute COMMAND redship --test mm-scene-execute)
+    redship_add_test(NAME MMSceneParse COMMAND redship --test mm-scene-parse)
+    redship_add_test(NAME MMSceneExecute COMMAND redship --test mm-scene-execute)
     # Sequence-map capacity bounds (#371, #378). The rest of AudioLoad_Init
     # needs a booted audio heap and real archives, but both bugs were
     # bound-arithmetic bugs, so the capacity computation was factored into pure
     # helpers this test calls directly — display-free, ROM-free.
-    add_test(NAME SeqMapBounds COMMAND redship --test seq-map-bounds)
+    redship_add_test(NAME SeqMapBounds COMMAND redship --test seq-map-bounds)
     # MM cross-game resume contracts (games/mm/2s2h/mm_resume_state_test.cpp):
     # a resume must re-arm the (by-design leaked) system arena for the cold
     # gamestate-chain boot, and Play_Init's startup-entrance consumption must
     # restore the frozen save the boot chain wiped — the cycle-2 re-entry
     # crash + save-continuity faults caught by the int-gameplay-roundtrip
     # soak (docs/ci-gameplay-repro-postmortem.md).
-    add_test(NAME MMResumeArena COMMAND redship --test mm-resume-arena)
-    add_test(NAME MMStartupRestore COMMAND redship --test mm-startup-restore)
-    add_test(NAME AllTests COMMAND redship --test all)
+    redship_add_test(NAME MMResumeArena COMMAND redship --test mm-resume-arena)
+    redship_add_test(NAME MMStartupRestore COMMAND redship --test mm-startup-restore)
+    redship_add_test(NAME AllTests COMMAND redship --test all)
 
-    # Set reasonable timeout and label our tests
-    set(REDSHIP_TEST_TIMEOUT 60 CACHE STRING "Test timeout in seconds")
-    set_tests_properties(
-        BootOoT BootMM SwitchOoTMM SwitchMMOoT StartupEntrance EntranceDedup VBAffinity CosmeticGfxStub Roundtrip RoundtripIntegrity SharedRoundtrip ArchiveHotswapLogic
-        SaveRoundtripTiers SaveHeader SaveHasDelete SaveVersionReject SaveSizeMismatch SaveLegacySize SaveCrcCorrupt
-        SaveComboLegacyRecord SaveComboRecordFixed SaveComboOversize
-        Context HotSwapFreeze MMSceneParse MMSceneExecute SeqMapBounds MMResumeArena MMStartupRestore AllTests
-        PROPERTIES
-        TIMEOUT ${REDSHIP_TEST_TIMEOUT}
-        LABELS "redship"
-    )
+    # Registration-completeness guard (#376). Diffs the dispatch table the
+    # binary actually links (`redship --test list`) against the rows registered
+    # above, and FAILS on a disagreement in either direction: a gTests[] entry
+    # with no row, or a row naming an entry that does not exist.
+    #
+    # It carries the "redship" label on purpose, so it runs in the tier it
+    # polices — CI's `ctest -L "^redship$"` picks it up with no workflow change.
+    # That makes this tier 31 rows: the 30 pre-existing tests, unchanged, plus
+    # this guard.
+    redship_add_test(NAME TestRegistrationComplete
+        COMMAND ${CMAKE_COMMAND}
+                -DREDSHIP_EXE=$<TARGET_FILE:redship>
+                -DMANIFEST=${CMAKE_BINARY_DIR}/redship-test-manifest.txt
+                -P ${CMAKE_CURRENT_LIST_DIR}/CheckTestRegistration.cmake)
+
+    # Dispatch-table entries that deliberately have no dedicated CTest row.
+    # Both predate this refactor and both still execute inside AllTests, which
+    # runs the whole table; they simply never got a row of their own. Listing
+    # them here is what lets the guard treat every OTHER row-less entry as an
+    # error. The guard hard-fails if one of these leaves gTests[] or later gains
+    # a row, so the list cannot rot into a rubber stamp.
+    redship_test_exempt(lifecycle "Game lifecycle unit tests — runs inside AllTests only")
+    redship_test_exempt(midos-house "Test-entrance (--test-entrance) path — runs inside AllTests only")
 
     # ========================================================================
     # Rando seed-generation test (requires a display for the Fast3dWindow
     # bring-up but NO game archives — CI runs it under xvfb-run; issue #337).
     # Not in the "redship" label because that tier runs display-free.
     # ========================================================================
-    add_test(NAME RandoGen COMMAND redship --test rando-gen)
-    set_tests_properties(
-        RandoGen
-        PROPERTIES
+    redship_add_test(NAME RandoGen COMMAND redship --test rando-gen
+        LABEL rando
         TIMEOUT 180
-        LABELS "rando"
-        ENVIRONMENT "SDL_AUDIODRIVER=dummy;RSBS_DISABLE_OTR_INIT=1"
-    )
+        ENVIRONMENT "SDL_AUDIODRIVER=dummy;RSBS_DISABLE_OTR_INIT=1")
 
     # Song shuffle modes. Stock (RandoGen above) already covers mode 1 — "Song
     # Locations" is the default — which is the mode that regressed when the
     # linker dropped ShuffleSongs.cpp.o from the static soh_rando archive and
     # left the fill with 12 songs and 0 song locations.
-    add_test(NAME RandoGenSongsDungeonRewards COMMAND redship --test rando-gen)
-    add_test(NAME RandoGenSongsAnywhere COMMAND redship --test rando-gen)
-    set_tests_properties(
-        RandoGenSongsDungeonRewards
-        PROPERTIES
+    redship_add_test(NAME RandoGenSongsDungeonRewards COMMAND redship --test rando-gen
+        LABEL rando
         TIMEOUT 180
-        LABELS "rando"
-        ENVIRONMENT "SDL_AUDIODRIVER=dummy;RSBS_DISABLE_OTR_INIT=1;RSBS_DIAG_CVARS=gRandoSettings.ShuffleSongs=2"
-    )
-    set_tests_properties(
-        RandoGenSongsAnywhere
-        PROPERTIES
+        ENVIRONMENT "SDL_AUDIODRIVER=dummy;RSBS_DISABLE_OTR_INIT=1;RSBS_DIAG_CVARS=gRandoSettings.ShuffleSongs=2")
+    redship_add_test(NAME RandoGenSongsAnywhere COMMAND redship --test rando-gen
+        LABEL rando
         TIMEOUT 180
-        LABELS "rando"
-        ENVIRONMENT "SDL_AUDIODRIVER=dummy;RSBS_DISABLE_OTR_INIT=1;RSBS_DIAG_CVARS=gRandoSettings.ShuffleSongs=3"
-    )
+        ENVIRONMENT "SDL_AUDIODRIVER=dummy;RSBS_DISABLE_OTR_INIT=1;RSBS_DIAG_CVARS=gRandoSettings.ShuffleSongs=3")
 
     # ========================================================================
     # Integration tests (requires display - use Xvfb in CI)
     # These tests actually boot the games and verify boot completion
     # ========================================================================
-    set(REDSHIP_INTEGRATION_TEST_TIMEOUT 120 CACHE STRING "Integration test timeout in seconds")
-
-    add_test(NAME IntBootOoT COMMAND redship --integration-test int-boot-oot)
-    add_test(NAME IntBootMM COMMAND redship --integration-test int-boot-mm)
-    add_test(NAME IntSwitchOoTHmsToMm
-             COMMAND redship --integration-test int-switch-oot-hms-to-mm)
-    add_test(NAME IntSwitchMmClockTownSouthToOoT
-             COMMAND redship --integration-test int-switch-mm-clocktown-south-to-oot)
-    add_test(NAME IntArchiveHotswapCycle
-             COMMAND redship --integration-test int-archive-hotswap-cycle)
-
-    set_tests_properties(
-        IntBootOoT IntBootMM IntSwitchOoTHmsToMm IntSwitchMmClockTownSouthToOoT IntArchiveHotswapCycle
-        PROPERTIES
-        TIMEOUT ${REDSHIP_INTEGRATION_TEST_TIMEOUT}
-        LABELS "integration"
-    )
+    redship_add_test(NAME IntBootOoT COMMAND redship --integration-test int-boot-oot
+        LABEL integration TIMEOUT ${REDSHIP_INTEGRATION_TEST_TIMEOUT})
+    redship_add_test(NAME IntBootMM COMMAND redship --integration-test int-boot-mm
+        LABEL integration TIMEOUT ${REDSHIP_INTEGRATION_TEST_TIMEOUT})
+    redship_add_test(NAME IntSwitchOoTHmsToMm
+        COMMAND redship --integration-test int-switch-oot-hms-to-mm
+        LABEL integration TIMEOUT ${REDSHIP_INTEGRATION_TEST_TIMEOUT})
+    redship_add_test(NAME IntSwitchMmClockTownSouthToOoT
+        COMMAND redship --integration-test int-switch-mm-clocktown-south-to-oot
+        LABEL integration TIMEOUT ${REDSHIP_INTEGRATION_TEST_TIMEOUT})
+    redship_add_test(NAME IntArchiveHotswapCycle
+        COMMAND redship --integration-test int-archive-hotswap-cycle
+        LABEL integration TIMEOUT ${REDSHIP_INTEGRATION_TEST_TIMEOUT})
 
     # Gameplay round-trip crash repro (docs/ci-gameplay-repro-postmortem.md):
     # the programmatic version of the operator's manual repro — debug save,
@@ -370,23 +382,23 @@ if(BUILD_TESTING)
     # CI). Scene/frame parameters come from RSBS_GP_* env vars, so a soak
     # matrix can sweep scenes without new CTest rows. The soak variant runs
     # three round trips before the warp.
-    add_test(NAME IntGameplayRoundtrip
-             COMMAND redship --integration-test int-gameplay-roundtrip)
-    set_tests_properties(
-        IntGameplayRoundtrip
-        PROPERTIES
-        TIMEOUT 300
-        LABELS "integration"
-    )
-    add_test(NAME IntGameplayRoundtripSoak
-             COMMAND redship --integration-test int-gameplay-roundtrip)
-    set_tests_properties(
-        IntGameplayRoundtripSoak
-        PROPERTIES
+    #
+    # These two carry their own timeouts rather than the shared integration
+    # value: the repro is far longer than a boot check, and the soak runs it
+    # three times over.
+    redship_add_test(NAME IntGameplayRoundtrip
+        COMMAND redship --integration-test int-gameplay-roundtrip
+        LABEL integration
+        TIMEOUT 300)
+    redship_add_test(NAME IntGameplayRoundtripSoak
+        COMMAND redship --integration-test int-gameplay-roundtrip
+        LABEL integration-soak
         TIMEOUT 900
-        LABELS "integration-soak"
-        ENVIRONMENT "RSBS_GP_CYCLES=3"
-    )
+        ENVIRONMENT "RSBS_GP_CYCLES=3")
+
+    # Must come after every redship_add_test()/redship_test_exempt() above —
+    # writes the manifest TestRegistrationComplete reads.
+    redship_finalize_tests(${CMAKE_BINARY_DIR}/redship-test-manifest.txt)
 endif()
 
 # ============================================================================


### PR DESCRIPTION
Adding a test to the ROM-free `redship` tier took three edits, one of them to a
shared line. This makes it one appended line in one file, and adds two guards so
the convenience cannot quietly cost coverage.

## The three collision points, and what replaced them

| # | Before | After |
|---|--------|-------|
| 1 | `SingleExecutable.cmake:18` — add the new `src/common/tests/*.c` to the explicit `REDSHIP_COMMON_SOURCES` list | **Did not exist.** See below. |
| 2 | `add_test(NAME ...)` **plus** appending the name to a shared 5-line `set_tests_properties(<30 names> ...)` block | One `redship_add_test(...)` line. The shared name list is deleted. |
| 3 | A `{"name", "desc", Func}` row in `test_runner.cpp` | Unchanged, deliberately. See "Dispatch table" below. |

**Point 1 was not real.** `REDSHIP_COMMON_SOURCES` contains no test files at all.
`src/common/tests/*.c` reach the binary by being `#include`d directly into
`test_runner.cpp`, each with a comment explaining why it sits inside an
`extern "C"` block or at file scope — and that placement is load-bearing
(`test_roundtrip_integrity.c` must compile as C++, or its `Entrance_Init` call
binds to OoT's C-linkage randomizer symbol instead of the combo entrance system).
Globbing those into `REDSHIP_COMMON_SOURCES` would compile all eight twice, once
via the include and once as their own TU, and fail the link on duplicate symbols.

So the glob was kept and pointed at the problem it actually solves — see guard 1.

**Point 2 is the one that hurt.** `add_test` rows append cleanly; the properties
block did not. All four Wave 1 lanes and both Wave 2 lanes collided on it over
2026-07-19/20. And a conflict there costs more than a rebase: GitHub builds
`pull_request` checks against `refs/pull/N/merge`, which it cannot create while a
PR conflicts, so a stale PR gets **zero** check runs rather than failing ones.
Both Wave 2 PRs sat with no CI at all and read as an Actions outage.

## (a) One-call registration

```cmake
redship_add_test(NAME <name> COMMAND <argv...>
                 [LABEL <label>...] [TIMEOUT <seconds>] [ENVIRONMENT <var=val>...])
```

`add_test` + `set_tests_properties` in one call, defaulting to `LABELS "redship"`
and `TIMEOUT ${REDSHIP_TEST_TIMEOUT}`. All 40 rows go through it with no
special-casing: the 3 `rando` rows carry `LABEL rando TIMEOUT 180 ENVIRONMENT ...`,
and the integration rows' previously hardcoded `TIMEOUT 300`/`900` are now just
the helper's `TIMEOUT` argument. Both timeout cache variables moved above the
first call site, since an omitted `TIMEOUT` reads `REDSHIP_TEST_TIMEOUT` at call
time; both still work as cache variables.

Unrecognized keywords are a `FATAL_ERROR` rather than being silently swallowed
into default properties — that would be the same failure class this replaces.

## (c) Registration-completeness guard

`TestRegistrationComplete` is a `redship`-labelled CTest row that diffs
`redship --test list` against the rows registered in CMake and **fails** — not
warns — when either side has an entry the other lacks:

- a `gTests[]` entry with no CTest row, or
- a CTest row whose `--test <name>` is not in the dispatch table.

It reads the table out of the **linked binary**, not the source text, so it
reflects what actually built. Rows are matched by their `--test` argument rather
than by CTest name, because the three `RandoGen*` rows share the one `rando-gen`
entry and differ only by `ENVIRONMENT`. Integration rows are checked the same way
against `gIntegrationTests[]`.

### It fails when registration is missing

Commenting out one registration and reconfiguring:

```
$ cmake -B build -S .          # SeqMapBounds registration removed
$ ctest ... TestRegistrationComplete
CMake Error at CMake/CheckTestRegistration.cmake:221 (message):
  Test registration is incomplete (1 problem(s)):
    * dispatch entry 'seq-map-bounds' (test_runner.cpp gTests[]) has no CTest row
      -- add redship_add_test(NAME <Row> COMMAND redship --test seq-map-bounds), or
      declare it row-less with redship_test_exempt(seq-map-bounds "<why>")
exit: 1
```

A typo'd dispatch name trips **both** directions at once, which is the real
"renamed a test" case:

```
  Test registration is incomplete (2 problem(s)):
    * dispatch entry 'seq-map-bounds' ... has no CTest row -- add redship_add_test(...)
    * CTest row 'SeqMapBounds' runs '--test seq-map-boundz', which is not in the
      dispatch table and would fail with "Unknown test"
```

### It refuses to pass vacuously

This repo has shipped two gates that looked like coverage and were not (#366
targeted a directory that did not exist; #375's baseline was never committed and
so could not fail). Every way this check could compare empty sets is a hard
error. If `TestRunner_ListTests`' output format changes:

```
  CheckTestRegistration: could not parse '--test list' output — expected
  section markers (found: unit=FALSE special=FALSE integration=FALSE).
  TestRunner_ListTests' format probably changed; update this parser.
```

Likewise: a glob matching no files, a section parsing to zero entries, a manifest
with no `--test` rows, or a missing binary.

`lifecycle` and `midos-house` have no dedicated row (both predate this change and
both run inside `AllTests`). They are declared with `redship_test_exempt()`, and a
**stale or newly-redundant exemption is itself a failure**, so the list cannot rot
into a rubber stamp — the same rule `.github/clang-format-paths.txt` uses:

```
    * stale exemption: redship_test_exempt(no-such-entry) names a dispatch entry
      that no longer exists -- drop the exemption
    * needless exemption: 'boot-oot' now has its own CTest row -- drop the
      redship_test_exempt(boot-oot) line
```

## (b) Globbing, repurposed

`redship_check_test_sources()` globs `src/common/tests/*.c` with
`CONFIGURE_DEPENDS` and fails configure if any file there is not `#include`d by
`test_runner.cpp` — a test source that compiles into nothing and can never run:

```
$ touch src/common/tests/test_orphan.c && cmake -B build -S .
CMake Error at CMake/RedshipTests.cmake:157 (message):
  Test source(s) in src/common/tests/ are not #included by
  src/common/test_runner.cpp:
    - test_orphan.c
  They compile into nothing and can never run.
```

`CONFIGURE_DEPENDS` means dropping a file into that directory re-runs configure
on the next build, so the check cannot be skipped by forgetting to reconfigure.
Clean runs print `Test sources: 8 file(s) in src/common/tests/, all #included`.

## (d) Dispatch table left alone

Row-appends conflict far less than shared lines, but there is a stronger reason
than that. `gTests[]` has a **documented ordering contract**: `archive-hotswap-logic`
must run last because it re-inits the entrance table, and the two MM resume tests
mutate process-global state so anything depending on live arena contents or a
populated `gSaveContext` must precede them. Constructor- or section-based
self-registration makes cross-TU initialization order unspecified, which would
silently break exactly those comments while looking tidier. Per-area tables would
keep order within a table but not between them. Not worth it for a row append.

## Test counts

| Label | Before | After |
|---|---|---|
| `redship` | 30 | **31** |
| `rando` | 3 | **3** |
| `integration` | 6 | 6 |
| `integration-soak` | 1 | 1 |

**`redship` is 31, not 30, and that is deliberate** — the 30 pre-existing tests
plus the new guard. Requirement (c) asks the guard to run in the tier it polices,
and CI runs only `-L "^redship$"` and `-L "^rando$"`, so any tier that runs the
guard gains a row; a separately-labelled guard would need a workflow step that can
be dropped, which is the vacuous-gate failure mode again. Nothing was removed: all
30 original names are present and unchanged.

That last point is verified mechanically. The generated `CTestTestfile.cmake` was
diffed against a build configured from pristine `main`; the entire delta is the
one added row, with all 40 pre-existing tests byte-identical in command, timeout,
labels and environment:

```
=> TestRegistrationComplete
=>     CMD   cmake -DREDSHIP_EXE=<BUILD>/redship -DMANIFEST=... -P CheckTestRegistration.cmake
=>     PROPS LABELS "redship" TIMEOUT "60"
```

That diff earned its keep: the first pass of the helper re-encoded the rando rows'
`ENVIRONMENT` from `"A=1;B=2"` to `[[A=1\;B=2]]`, because `cmake_parse_arguments`
escapes semicolons to keep one list element. `ctest --show-only=json-v1` confirmed
CTest then saw **one** malformed variable instead of two, silently dropping
`RSBS_DISABLE_OTR_INIT=1` in a tier that only runs under xvfb. The helper now
normalizes the escaping, and all three rando rows verify with the correct 2/3/3
variables.

## Verification status

Counts and properties above come from `ctest -N` against a real configure, and the
guard was exercised through all six of its failure modes. **The compile-and-run
leg is CI's**: a local Windows build is blocked by a pre-existing, unrelated
break — `bool CVarExists(...)` at `libultraship/include/libultraship/bridge/consolevariablebridge.h:33`
fails to parse in MM's C TUs under MSVC (`2ship_port`/`2ship_src`; OoT's targets
all build). That is in a submodule header and predates this branch, and this
change has zero compile surface — every hunk is inside the `CTest Integration`
section. The guard was therefore validated against a stand-in that reproduces
`TestRunner_ListTests`' output byte-for-byte, generated from the real
`gTests[]`/`gIntegrationTests[]` tables.

No file in `.github/clang-format-paths.txt` is touched (this is CMake only), so
the format gate is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!--- section:artifacts:start -->
### Build Artifacts
  - [rsbs-windows.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/8471294047.zip)
  - [rsbs-linux.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/8471044272.zip)
<!--- section:artifacts:end -->