### PR TITLE
Force-include MM's prelude per source file so VS-generator builds get the C list

### DIFF
--- a/games/mm/CMakeLists.txt
+++ b/games/mm/CMakeLists.txt
@@ -676,38 +676,49 @@ if(SINGLE_EXECUTABLE_BUILD)
     # Use force-include instead of PCH to avoid .gch files being passed to linker
     # GCC/Clang use -include, MSVC uses /FI
     if(MSVC)
-        target_compile_options(${_t} PRIVATE
-            "$<$<COMPILE_LANGUAGE:CXX>:/FIlibultraship/bridge/consolevariablebridge.h>"
-            "$<$<COMPILE_LANGUAGE:CXX>:/FI${CMAKE_CURRENT_SOURCE_DIR}/2s2h/GameInteractor/GameInteractor.h>"
-            "$<$<COMPILE_LANGUAGE:CXX>:/FI${CMAKE_CURRENT_SOURCE_DIR}/2s2h/BenPort.h>"
-            "$<$<COMPILE_LANGUAGE:CXX>:/FI${CMAKE_CURRENT_SOURCE_DIR}/include/variables.h>"
-            "$<$<COMPILE_LANGUAGE:CXX>:/FI${CMAKE_CURRENT_SOURCE_DIR}/include/functions.h>"
-            "$<$<COMPILE_LANGUAGE:CXX>:/FI${CMAKE_CURRENT_SOURCE_DIR}/include/macros.h>"
-            "$<$<COMPILE_LANGUAGE:CXX>:/FI${CMAKE_CURRENT_SOURCE_DIR}/include/z64.h>"
-            "$<$<COMPILE_LANGUAGE:C>:/FI${CMAKE_CURRENT_SOURCE_DIR}/include/ultra64.h>"
-            "$<$<COMPILE_LANGUAGE:C>:/FI${CMAKE_CURRENT_SOURCE_DIR}/include/global.h>"
-            "$<$<COMPILE_LANGUAGE:C>:/FI${CMAKE_CURRENT_SOURCE_DIR}/include/z64.h>"
-            "$<$<COMPILE_LANGUAGE:C>:/FI${CMAKE_CURRENT_SOURCE_DIR}/include/macros.h>"
-            "$<$<COMPILE_LANGUAGE:C>:/FI${CMAKE_CURRENT_SOURCE_DIR}/include/functions.h>"
-            "$<$<COMPILE_LANGUAGE:C>:/FI${CMAKE_CURRENT_SOURCE_DIR}/include/variables.h>"
-        )
+        set(_fi "/FI")
     else()
-        target_compile_options(${_t} PRIVATE
-            "$<$<COMPILE_LANGUAGE:CXX>:-includelibultraship/bridge/consolevariablebridge.h>"
-            "$<$<COMPILE_LANGUAGE:CXX>:-include${CMAKE_CURRENT_SOURCE_DIR}/2s2h/GameInteractor/GameInteractor.h>"
-            "$<$<COMPILE_LANGUAGE:CXX>:-include${CMAKE_CURRENT_SOURCE_DIR}/2s2h/BenPort.h>"
-            "$<$<COMPILE_LANGUAGE:CXX>:-include${CMAKE_CURRENT_SOURCE_DIR}/include/variables.h>"
-            "$<$<COMPILE_LANGUAGE:CXX>:-include${CMAKE_CURRENT_SOURCE_DIR}/include/functions.h>"
-            "$<$<COMPILE_LANGUAGE:CXX>:-include${CMAKE_CURRENT_SOURCE_DIR}/include/macros.h>"
-            "$<$<COMPILE_LANGUAGE:CXX>:-include${CMAKE_CURRENT_SOURCE_DIR}/include/z64.h>"
-            "$<$<COMPILE_LANGUAGE:C>:-include${CMAKE_CURRENT_SOURCE_DIR}/include/ultra64.h>"
-            "$<$<COMPILE_LANGUAGE:C>:-include${CMAKE_CURRENT_SOURCE_DIR}/include/global.h>"
-            "$<$<COMPILE_LANGUAGE:C>:-include${CMAKE_CURRENT_SOURCE_DIR}/include/z64.h>"
-            "$<$<COMPILE_LANGUAGE:C>:-include${CMAKE_CURRENT_SOURCE_DIR}/include/macros.h>"
-            "$<$<COMPILE_LANGUAGE:C>:-include${CMAKE_CURRENT_SOURCE_DIR}/include/functions.h>"
-            "$<$<COMPILE_LANGUAGE:C>:-include${CMAKE_CURRENT_SOURCE_DIR}/include/variables.h>"
-        )
+        set(_fi "-include")
     endif()
+
+    set(_force_include_cxx
+        "${_fi}libultraship/bridge/consolevariablebridge.h"
+        "${_fi}${CMAKE_CURRENT_SOURCE_DIR}/2s2h/GameInteractor/GameInteractor.h"
+        "${_fi}${CMAKE_CURRENT_SOURCE_DIR}/2s2h/BenPort.h"
+        "${_fi}${CMAKE_CURRENT_SOURCE_DIR}/include/variables.h"
+        "${_fi}${CMAKE_CURRENT_SOURCE_DIR}/include/functions.h"
+        "${_fi}${CMAKE_CURRENT_SOURCE_DIR}/include/macros.h"
+        "${_fi}${CMAKE_CURRENT_SOURCE_DIR}/include/z64.h"
+    )
+    set(_force_include_c
+        "${_fi}${CMAKE_CURRENT_SOURCE_DIR}/include/ultra64.h"
+        "${_fi}${CMAKE_CURRENT_SOURCE_DIR}/include/global.h"
+        "${_fi}${CMAKE_CURRENT_SOURCE_DIR}/include/z64.h"
+        "${_fi}${CMAKE_CURRENT_SOURCE_DIR}/include/macros.h"
+        "${_fi}${CMAKE_CURRENT_SOURCE_DIR}/include/functions.h"
+        "${_fi}${CMAKE_CURRENT_SOURCE_DIR}/include/variables.h"
+    )
+
+    # Attach the prelude per source file rather than through
+    # $<COMPILE_LANGUAGE:...>. MSBuild models force-includes as a single
+    # target-level ForcedIncludeFiles property, so the Visual Studio generator
+    # resolves COMPILE_LANGUAGE once per target from its linker language, keeps
+    # that language's list and silently drops the other one. Every MM target
+    # links C++ libultraship, so the linker language is CXX and the .c sources
+    # were handed the C++ prelude - consolevariablebridge.h ahead of the z64.h
+    # that pulls in <stdbool.h> - failing with "C2061: syntax error: identifier
+    # 'CVarExists'" on its bool declaration. Ninja emits per-source flags and so
+    # never hit this, which is why CI stayed green while local Visual Studio
+    # generator builds broke. Per-source properties hand both generators the
+    # command lines Ninja was already producing.
+    get_target_property(_target_sources ${_t} SOURCES)
+    foreach(_src IN LISTS _target_sources)
+        if(_src MATCHES "\\.c$")
+            set_source_files_properties(${_src} PROPERTIES COMPILE_OPTIONS "${_force_include_c}")
+        elseif(_src MATCHES "\\.(cpp|cxx|cc)$")
+            set_source_files_properties(${_src} PROPERTIES COMPILE_OPTIONS "${_force_include_cxx}")
+        endif()
+    endforeach()
 else()
     target_precompile_headers(${PROJECT_NAME} PRIVATE
         "$<$<COMPILE_LANGUAGE:CXX>:<libultraship/bridge/consolevariablebridge.h$<ANGLE-R>>"


### PR DESCRIPTION
## Problem

Local Windows/MSVC builds fail across MM's C translation units with hundreds of:

```
libultraship/include/libultraship/bridge/consolevariablebridge.h(33,6):
  error C2061: syntax error: identifier 'CVarExists'
  error C2059: syntax error: ';'
  error C2059: syntax error: '<parameter-list>'
```

Confined to `2ship_src` and `2ship_port`; every OoT target is fine. CI's `build-windows` job passes on the same commit.

## Root cause

Not the MSVC toolset, and not the `/std:c` level — both were ruled out empirically:

- MSVC 19.44 does **not** predefine `bool` in any C mode, including `/std:clatest` where `__STDC_VERSION__` is `202312`. (`/std:c23` isn't even a valid flag — `D9002: ignoring unknown option`.)
- CMake emits `LanguageStandard_C=stdclatest` correctly under **both** generators.

The actual discriminator is the **generator**. MM attaches its force-include prelude with `$<COMPILE_LANGUAGE:C>` / `$<COMPILE_LANGUAGE:CXX>`-gated `/FI` options. MSBuild models force-includes as one *target-level* `ForcedIncludeFiles` property, so the Visual Studio generator resolves `COMPILE_LANGUAGE` once per target from the target's **linker language**, keeps that language's list, and silently drops the other.

Every MM target links C++ libultraship, so the linker language is CXX — even for `2ship_src`, which is 942 `.c` files and zero `.cpp`. All of its C sources were handed the **C++** prelude, which puts `consolevariablebridge.h` ahead of the `z64.h` that pulls in `<stdbool.h>`. Hence `bool` is not in scope at line 33.

Ninja emits per-source compile commands and applies both lists correctly — which is why CI stayed green while local builds following [`docs/BUILDING.md`](docs/BUILDING.md) (which documents `-G "Visual Studio 17 2022"`) broke.

Reduced to a 6-line CMake repro, the VS generator emits `ForcedIncludeFiles` = the CXX header only, applied to `a.c` as well; Ninja compiles the same project clean.

## Fix

Attach the prelude via per-source `COMPILE_OPTIONS` instead of the `COMPILE_LANGUAGE` genex. This is RSBS-side only — no libultraship submodule change.

Both generators now emit the command lines Ninja was already producing, so this is a **no-op for CI** and a fix for the Visual Studio generator.

## Verification

- `-G "Visual Studio 17 2022"`: `2ship_src` (1044 sources) and `2ship_port` both build clean — previously hundreds of C2061/C2059. Generated vcxproj shows per-file `ForcedIncludeFiles`, with no target-level entry leaking the C++ list.
- `-G Ninja`: configure + `2ship_src` build still succeed; 1232 `/FI` flags present, `.c` TUs get the correct six-header C prelude in order.

## Note for reviewers

CI only builds Windows with Ninja, so it structurally cannot catch this class of regression. Worth considering a VS-generator configure job to cover the path `docs/BUILDING.md` documents — deliberately left out of this PR to keep it focused.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!--- section:artifacts:start -->
### Build Artifacts
  - [rsbs-windows.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/8474249768.zip)
  - [rsbs-linux.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/8473965942.zip)
<!--- section:artifacts:end -->