### PR TITLE
Reword TestRegistrationComplete guard comment to not state a stale count

### DIFF
--- a/CMake/SingleExecutable.cmake
+++ b/CMake/SingleExecutable.cmake
@@ -325,7 +325,7 @@ if(BUILD_TESTING)
     #
     # It carries the "redship" label on purpose, so it runs in the tier it
     # polices — CI's `ctest -L "^redship$"` picks it up with no workflow change.
-    # That makes this tier 31 rows: the 30 pre-existing tests, unchanged, plus
+    # That makes this tier every redship_add_test row above, unchanged, plus
     # this guard.
     redship_add_test(NAME TestRegistrationComplete
         COMMAND ${CMAKE_COMMAND}


### PR DESCRIPTION
## What

The comment above the `TestRegistrationComplete` guard in `CMake/SingleExecutable.cmake` claimed:

> That makes this tier 31 rows: the 30 pre-existing tests, unchanged, plus this guard.

That count went stale once `#401` (ActiveQueue) and `#402` (MMCullingBinding) added two more `redship_add_test` rows — the real count is now 33.

## Change

Rather than bump the number (which would just go stale again the next time a test is added), the comment now describes the tier's composition without a hardcoded count:

> That makes this tier every redship_add_test row above, unchanged, plus this guard.

Comment-only change; no behavior impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01VxAKNQWKtsG33XeT3iwjjG)_

<!--- section:artifacts:start -->
### Build Artifacts
  - [rsbs-windows.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/8476795438.zip)
  - [rsbs-linux.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/8476318128.zip)
<!--- section:artifacts:end -->