### PR TITLE
CI harness gates: fail on ROM-runner archive drift, run the integration-soak gate (#376 items 1-3)

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -176,6 +176,11 @@ jobs:
 
     - name: Check for game archives
       id: check-archives
+      env:
+        # Empty on hosted runners; a JSON runs-on value when the operator has
+        # pointed this job at a ROM-equipped runner. Its presence is the signal
+        # that archives are *expected* to exist here.
+        ROM_RUNNER: ${{ vars.RSBS_ROM_RUNNER }}
       run: |
         # Integration tests require game ROM-derived archives (oot.o2r, mm.o2r)
         # These cannot be distributed — they must be generated from original ROMs
@@ -189,6 +194,18 @@ jobs:
         done
         echo "has_oot=$has_oot" >> $GITHUB_OUTPUT
         echo "has_mm=$has_mm" >> $GITHUB_OUTPUT
+        # When RSBS_ROM_RUNNER is configured the operator has deliberately routed
+        # this job to a ROM-equipped runner *expecting* the integration and
+        # crash-repro tier to run. A missing archive there means the staging path
+        # moved or OTR generation failed — and because every int-* step is
+        # if:-gated on these outputs, the whole tier would skip while the run
+        # still reports green. That is the exact false-confidence #376 item 3
+        # describes ("a fully-skipped run looks green"). Fail loudly instead: a
+        # gate that is configured but cannot fail is not a gate.
+        if [ -n "$ROM_RUNNER" ] && { [ "$has_oot" = "false" ] || [ "$has_mm" = "false" ]; }; then
+          echo "::error::RSBS_ROM_RUNNER is set but game archives are missing (oot=$has_oot mm=$has_mm). The integration/crash-repro tier would skip silently on a runner configured to run it. Ensure oot.o2r and mm.o2r are staged in build-cmake, build-cmake/soh (oot) / build-cmake/2s2h (mm), or the repo root."
+          exit 1
+        fi
         if [ "$has_oot" = "false" ] && [ "$has_mm" = "false" ]; then
           echo "::notice::Game archives not found — integration tests will be skipped (requires original ROMs)"
         fi
@@ -334,6 +351,23 @@ jobs:
         GP_FRAMES: ${{ inputs.gp_frames || '120' }}
         GP_CYCLES: ${{ inputs.gp_cycles || '1' }}
         GP_WARP_ENTRANCES: ${{ inputs.gp_warp_entrances || '0x00B1' }}
+
+    # Multi-cycle soak of the same round trip (RSBS_GP_CYCLES=3, supplied by the
+    # IntGameplayRoundtripSoak CTest row's ENVIRONMENT). The single-cycle step
+    # above cannot reach the cycle-2/cycle-3 re-entry crash class that the MM
+    # resume-arena and startup-restore contracts exist to guard — the comment in
+    # CMake/SingleExecutable.cmake already names "the int-gameplay-roundtrip
+    # soak" as what catches it. That soak had a CTest row (label
+    # `integration-soak`) but was referenced by no job, so it never actually
+    # ran (#376 item 1). Drive it through ctest here so the label is a live,
+    # enforced gate; --no-tests=error fails loudly if the row/label ever
+    # regresses, mirroring the redship and rando tiers. The row carries its own
+    # TIMEOUT 900, so ctest — not an outer `timeout` — bounds a wedge.
+    - name: Integration Test - Gameplay Roundtrip Soak (3 cycles)
+      if: steps.check-archives.outputs.has_oot == 'true' && steps.check-archives.outputs.has_mm == 'true'
+      run: ctest --test-dir build-cmake --output-on-failure --label-regex "^integration-soak$" --no-tests=error
+      env:
+        DISPLAY: :99
 
     # Crash-signal plumbing: libultraship's CrashHandler writes its dump
     # (registers, backtrace, scene/actor state from the game callbacks) as a


### PR DESCRIPTION
Addresses the CI-harness items 1-3 of #376. Each premise was re-verified against the current tree first (items 4-6 are deferred per #392).

## Premise verdicts

| # | Claim | Verdict |
|---|---|---|
| 1 | Integration CTest rows are never run by any workflow; `integration-soak` referenced by no job | **Partially real** — see below |
| 2 | Unit-test step missing `--no-tests=error` | **Stale (already fixed)** |
| 3 | `check-archives` cannot fail, so a fully-skipped run looks green | **Still real** |

### Item 2 — stale
`integration-tests.yml:169` already passes `--no-tests=error`, with a comment on `:165-168` that explicitly cites #376. No change needed.

### Item 3 — fixed
`check-archives` now hard-fails (`::error::` + `exit 1`) when `RSBS_ROM_RUNNER` is set but `oot.o2r`/`mm.o2r` are absent. That variable is the operator's signal that this job was deliberately routed to a ROM-equipped runner *expecting* the integration + crash-repro tier to run; a missing archive there means staging drifted and every `int-*` step would skip while the run still reported green. Hosted runners (no `RSBS_ROM_RUNNER`) keep the prior skip-with-notice behavior.

### Item 1 — partially real, fixed the dead part
- The `integration`-labeled rows (`IntBootOoT`, switches, hotswap, `IntGameplayRoundtrip`) run today via the direct `--integration-test` steps, and since #404 their row↔dispatch mapping is correctness-guarded by `TestRegistrationComplete` (`CheckTestRegistration.cmake:175-201`). The bit-rot concern is covered — left as-is.
- `IntGameplayRoundtripSoak` (label `integration-soak`) was genuinely dead: referenced by **no** job, so the 3-cycle soak never ran — even though `SingleExecutable.cmake` names "the int-gameplay-roundtrip soak" as what catches the cycle-2/cycle-3 re-entry crash class. Now driven via `ctest -L "^integration-soak$" --no-tests=error` on the archive-gated ROM runner, making the label a live, enforced gate.

## Verification note
`integration-tests.yml` is `workflow_dispatch`-only and the new failure/soak paths are ROM-runner-gated, so hosted PR CI cannot exercise them directly. The PR still triggers `generate-builds` (this file is not path-ignored), which builds and runs the `redship`/`rando` tiers to confirm the tree is green. The workflow YAML was validated with a parser locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!--- section:artifacts:start -->
### Build Artifacts
  - [rsbs-windows.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/8476811902.zip)
  - [rsbs-linux.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/8476555538.zip)
<!--- section:artifacts:end -->