### PR TITLE
A0: ADR 0002 origin-tagged shared items + ComboContext carve

### DIFF
--- a/CMake/SingleExecutable.cmake
+++ b/CMake/SingleExecutable.cmake
@@ -281,6 +281,11 @@ if(BUILD_TESTING)
     redship_add_test(NAME SaveComboLegacyRecord COMMAND redship --test save-combo-legacy-record)
     redship_add_test(NAME SaveComboRecordFixed COMMAND redship --test save-combo-record-fixed)
     redship_add_test(NAME SaveComboOversize COMMAND redship --test save-combo-oversize)
+    # Origin-tagged shared items (ADR 0002): the array carved out of reserved[]
+    # must round-trip byte-exact, and SaveComboLegacyRecord's crafted "legacy"
+    # length is pinned to the pre-carve prefix (RSBS_COMBO_CONTEXT_PRECARVE_SIZE)
+    # so the carve cannot silently widen what that test calls legacy.
+    redship_add_test(NAME SaveTaggedItems COMMAND redship --test save-tagged-items)
     redship_add_test(NAME Context COMMAND redship --test context)
     # F10 hot-swap freeze/consume contract (#364): the hotkey path must freeze
     # the DEPARTING game (or refuse the switch), and a consumed frozen state

--- a/docs/adr/0002-origin-tagged-shared-items.md
+++ b/docs/adr/0002-origin-tagged-shared-items.md
@@ -1,0 +1,192 @@
+# ADR 0002: Cross-game items are origin-tagged structs; the dead ComboContext fields retire in place
+
+- Status: **Accepted** (2026-07-20)
+- For: #392 (Phase 3.0 tracker), Lane A serial section (A0)
+- Depends on: the ComboContext serialization headroom shipped in #399
+  (`RSBS_COMBO_CONTEXT_RECORD_SIZE`, the growth contract in
+  `src/common/context.h`)
+
+Everything below is **final** for Phase 3: Lanes A1 (producers/consumers),
+B (unified seed), and C (foreign items) build on these decisions without
+re-litigating them.
+
+## Context
+
+Phase 3's MVP moves items between two randomizers that were never designed to
+meet: OoT items are `RandomizerGet` (`RG_*`,
+`games/oot/soh/Enhancements/randomizer/randomizerTypes.h`) and MM items are
+`RandoItemId` (`RI_*`, `games/mm/2s2h/Rando/Types.h`). Both are dense enums
+from 0 that fit comfortably in a `uint16_t` — which is exactly the danger: a
+raw `uint16_t` holding an `RG_*` value is indistinguishable from one holding an
+`RI_*` value, and an id from one game interpreted in the other is the #356
+entrance-id crash class all over again, this time written into save files.
+
+The carrier for cross-game state is `ComboContext` (`gComboCtx`,
+`src/common/context.h`), a process-global shared by both games in the single
+exe and serialized as the fixed 1024-byte Tier-1 record of every `.redsave`.
+Its growth contract (established with #399): new fields are carved from
+`reserved[]` or appended — never inserted — and **zero must be a valid "unset"
+for every new field**, because a shorter legacy record is loaded as a byte
+prefix and zero-extended.
+
+`ComboContext` also carries dead weight whose fate had to be decided before
+Lane A wires anything: `sharedItems[32]` (`uint16_t`, never wired),
+`sharedFlags[64]` (`uint32_t`, never wired), `saveSlot` (never assigned), and
+`sourceIsRando`/`sharedRandoSeed` (serialized, produced/consumed only by dead
+or excluded code paths). All of their offsets are shipped: bytes at those
+positions exist in every `.redsave` written since the format landed.
+
+`context.h` is compiled as both C and C++ (game C TUs like `z_play.c` on one
+side, `save.cpp`/`GameExports_SingleExe.cpp` on the other), so whatever type
+system enforces the tagging has to work identically in both languages.
+
+## Decision
+
+### 1. The shared item representation: a plain tagged struct, no bit-packing
+
+```c
+typedef struct {
+    uint8_t originGame;  // GameId that owns the id-space; GAME_NONE (0) = empty slot
+    uint8_t flags;       // RSBS_SHARED_ITEM_* bits; 0 = default (present, not redeemed)
+    uint16_t id;         // RG_* if originGame==GAME_OOT, RI_* if GAME_MM; 0 when empty
+} SharedItem;
+```
+
+- **4 bytes, fixed layout**, locked by static asserts in both language views
+  (`sizeof == 4`, member offsets 0/1/2). These bytes are `.redsave` format.
+- **No bit-packing.** A game tag packed into the high bits of a `uint16_t`
+  makes a raw integer read *almost* work — the precise failure mode of the
+  #356 entrance-id leak. As a struct, assigning a raw integer into a
+  `SharedItem` is ill-formed in **both** C and C++ (neither language converts
+  arithmetic types to struct types). The C++ view additionally carries
+  `static_assert(!std::is_convertible<int, SharedItem>)` /
+  `!std::is_assignable<SharedItem&, int>` probes so nobody can later add a
+  converting constructor; the C view needs no probe because C has no
+  user-defined conversions at all.
+- **No `enum class`, no constructors** — the type must be identical in the C
+  view. A plain struct is the whole mechanism.
+- **Zero means unset**, member by member: `originGame == GAME_NONE` marks an
+  empty slot, `flags == 0` is the default state, `id == 0` in both id-spaces is
+  the respective "none" enumerator (`RG_NONE`, `RI_UNKNOWN`). A zero-extended
+  legacy record therefore reads as "no shared items", which is correct.
+- **`flags` bit 0 is `RSBS_SHARED_ITEM_REDEEMED`**: set by the origin game's
+  consumer when it actually awards the item, so a round trip can never award
+  an entry twice (Lane C's redemption flow). Remaining bits are reserved;
+  any future bit must keep 0 == unset.
+- **Storage: `SharedItem sharedItemsTagged[64]`** (`RSBS_SHARED_ITEM_CAP`),
+  carved from the **front** of `reserved[640]`, which shrinks to
+  `reserved[384]`. Every previously shipped field keeps its offset; the array
+  begins exactly where `reserved` used to (offset 364, pinned — see below).
+  64 entries is deliberately generous, sized once; the MVP needs a handful.
+- **No count field.** A slot is occupied iff `originGame != GAME_NONE`. A
+  count would be a second source of truth that a zero-extended legacy record
+  could contradict.
+
+### 2. The dead fields: retire in place, never delete
+
+Offsets are shipped format; deletion or retyping would break the byte-prefix
+property every existing `.redsave` relies on, and renaming would break two
+test TUs outside A0's ownership (`test_roundtrip_integrity.c`,
+`test_shared_state_roundtrip.c`). So:
+
+- **`sharedItems[32]` — RETIRED IN PLACE.** Never wired, and its untagged
+  `uint16_t` shape is the aliasing hazard this ADR exists to prevent. The
+  bytes stay; nothing may ever wire it. `sharedItemsTagged` is its
+  replacement.
+- **`sharedFlags[64]` — KEPT.** Origin-neutral event bits have no id-space
+  aliasing problem; the shape is fine. Which bit means what is assigned by
+  Lane A1 and later; until something writes a bit, every word stays zero.
+- **`saveSlot` — RETIRED IN PLACE.** Dead plumbing; `ComboContext_Init` keeps
+  stamping -1 (shipped behavior, harmless), nothing may wire it.
+
+### 3. `sourceIsRando` / `sharedRandoSeed` are Lane B's carrier — explicitly
+
+Yes: the brief's default is confirmed. Both fields exist, serialize in every
+`.redsave`, and are dead (their only writers are the legacy `OoT_FreezeState`
+— compiled, zero callers — and MM's excluded `BenPort.cpp`). **Lane B revives
+them as-is**: written in the live path at OoT generation time (not at freeze
+time), read by MM's consumption path when Lane C makes it reachable. No new
+seed fields; no shape change. If B needs a settings digest beyond the seed, it
+carves that from `reserved[384]` under the same growth contract.
+
+### 4. Version knobs: neither moves
+
+- `RSBS_SAVE_VERSION` stays **2**. It bumps only with
+  `RSBS_COMBO_CONTEXT_RECORD_SIZE`, which is unchanged (the struct grew from
+  1004 bytes toward the same 1024-byte budget; the on-disk record length did
+  not move).
+- `COMBO_CONTEXT_VERSION` (inner content semantics, `context.cpp`) stays
+  **1**. The carve introduces no semantic that zero-as-unset does not already
+  carry; bump it only when old content must be *distinguished*, not merely
+  extended.
+
+### 5. The legacy-record test pin
+
+`Test_SaveComboLegacyRecord` used to derive its "legacy" Tier-1 length as
+`offsetof(ComboContext, reserved)`. The carve moves that offset forward past
+the new array — the test would stay green while silently redefining "legacy"
+to include the carved fields, no longer exercising the true shipped prefix.
+The pre-carve length is now a pinned constant,
+`RSBS_COMBO_CONTEXT_PRECARVE_SIZE` (**364**), tied to the live layout by
+static asserts (`offsetof(ComboContext, sharedItemsTagged) == 364`, and the
+tagged array contiguous with the remaining headroom). Any layout drift —
+compiler surprise or accidental field insertion — is a build break, not a
+silently weakened test.
+
+## Rationale
+
+1. **Make the wrong thing unrepresentable at compile time.** The failure mode
+   this phase fears most — an id from one game read in the other — compiles
+   clean under any integer encoding and corrupts saves months later. The
+   struct makes the untagged read a compile error in both languages, which is
+   the only enforcement layer that runs everywhere the type goes.
+2. **Zero-as-unset falls out of the shape.** `GAME_NONE == 0` was already the
+   sentinel game id; making it the occupancy marker means the growth
+   contract's zero-extension rule needs no special case.
+3. **Retire-in-place is the only move that respects shipped bytes.** The
+   prefix-load scheme means offsets are API. Reuse of `sharedItems`' bytes for
+   a differently-shaped field was considered and rejected — a legacy record
+   would alias old u16 ids into the new interpretation.
+4. **Reviving the seed fields costs nothing and unblocks B now.** They are
+   already the right shape (u32 seed + bool), already serialized, already
+   round-trip-locked by tests.
+
+## Consequences
+
+- `sizeof(ComboContext)` stays 1004 (≤ 1024 budget); ~20 bytes of record slack
+  plus `reserved[384]` remain for A1/B/C carves.
+- New coverage: `SaveTaggedItems` CTest (byte-exact round-trip of the tagged
+  array, unset slots stay unset) and the extended `SaveComboLegacyRecord`
+  (pre-carve record loads with every tagged slot reading unset).
+- Housekeeping landed with this ADR, as `context.h`'s owner: the dangling
+  legacy declarations `Context_ProcessSwitch` / `Context_IsSwitchInProgress`
+  are deleted (their implementations left `switch.cpp` earlier; see its header
+  comment), the stale `context.cpp` note claiming switch.cpp is
+  non-single-exe-only is corrected, and `docs/known-issues.md`'s dead-plumbing
+  entry now reflects this ADR.
+- Lane A1 wires producers (both suspend paths + the entrance-switch hook) and
+  consumers (both startup-entrance consumption points) against
+  `sharedItemsTagged` only. Lane C's give path stores foreign items here with
+  `originGame` set to the item's owner and redeems via
+  `RSBS_SHARED_ITEM_REDEEMED`. Raw `RG_*`/`RI_*` integers must not cross a
+  game boundary outside a `SharedItem`.
+
+## Alternatives considered
+
+- **Bit-packed `uint16_t` (tag in high bits).** Rejected: a packed id *almost*
+  works as a raw integer — the #356 failure mode — and 16 bits minus tag bits
+  leaves the id-space cramped for no benefit.
+- **C++ wrapper type (`enum class` id + explicit constructor).** Rejected: the
+  type must exist identically in the C view of `context.h`; a C++-only device
+  enforces nothing in the C TUs that touch `gComboCtx`.
+- **Widening `sharedItems` in place to the tagged shape.** Rejected: same
+  offset, different element layout — a legacy record's u16 ids would be
+  reinterpreted as tag/flag bytes. Retire-in-place plus a fresh carve keeps
+  old bytes meaning what they always meant.
+- **A unified cross-game item namespace (single enum spanning both games).**
+  Rejected for 3.0: requires a hand-maintained mapping table that drifts
+  against both upstream enums, and the origin tag still ends up encoded — just
+  implicitly, in ranges. The tag might as well be explicit bytes.
+- **Deleting the dead fields and bumping `RSBS_SAVE_VERSION`.** Rejected: it
+  orphans every existing `.redsave` (or demands a real migration path) to save
+  68 bytes that the 1024-byte fixed record doesn't even give back.

--- a/docs/known-issues.md
+++ b/docs/known-issues.md
@@ -1,7 +1,7 @@
 # Known issues
 
 **Applies to:** `v0.1.0-prealpha` and the `main` branch behind it.
-**Last updated:** 2026-07-19.
+**Last updated:** 2026-07-20.
 
 RedShipBlueShip is **pre-alpha**. It boots Ocarina of Time and Majora's Mask from
 one executable and can round-trip between them, and that is roughly where the
@@ -25,9 +25,14 @@ entrance-based switch between them.
 
 Specifically:
 
-- The `sharedItems` / `sharedFlags` fields in the cross-game context are declared
-  but have **no producers and no consumers** outside tests. Nothing is written to
-  them and nothing reads them.
+- The cross-game item storage exists but **nothing populates it during play**.
+  ADR 0002 (Phase 3 Lane A0) gave the cross-game context an origin-tagged item
+  array (`sharedItemsTagged`) and retired the never-wired `sharedItems` and
+  `saveSlot` fields in place; `sharedFlags` is kept with its bit semantics
+  still unassigned, and `sourceIsRando`/`sharedRandoSeed` are designated Lane
+  B's seed carrier. The producers and consumers — writing on suspend, reading
+  after a switch — are Lane A1, still open: outside tests, nothing is written
+  to any of these fields yet.
 - MM's randomizer code (`games/mm/2s2h/Rando/`) is compiled but **discarded by the
   linker** — no symbol in the shipping binary references it, so it is not in the
   executable at all.

--- a/src/common/context.cpp
+++ b/src/common/context.cpp
@@ -207,9 +207,14 @@ void ComboContext_Init(void) {
     gComboCtx.targetEntrance = 0;
     gComboCtx.sourceGame = GAME_NONE;
     gComboCtx.sourceEntrance = 0;
-    gComboCtx.saveSlot = -1;  // NOT WIRED — see context.h; nothing reads this yet
+    gComboCtx.saveSlot = -1;  // RETIRED IN PLACE (ADR 0002) — the -1 stamp is shipped behavior, kept as-is
     gComboCtx.sourceIsRando = false;
     gComboCtx.sharedRandoSeed = 0;
+    // sharedItemsTagged and the remaining reserved[] headroom are covered by
+    // the memset above: all-zero IS the initialized state (every slot unset,
+    // originGame == GAME_NONE). That equivalence is load-bearing — it is what
+    // makes a zero-extended legacy .redsave record indistinguishable from a
+    // fresh init (ADR 0002 growth contract).
 }
 
 void ComboContext_RequestSwitch(GameId target, uint16_t entrance) {
@@ -256,11 +261,13 @@ GameId Context_GetCurrentGame(void) {
     return gCurrentGame;
 }
 
-// Note: Context_ProcessSwitch() and Context_IsSwitchInProgress() are implemented
-// in switch.cpp. That translation unit is only linked when the legacy
-// OoT_/MM_FreezeState/ResumeFromContext symbols are also available, i.e. in
-// non-single-exe builds. Single-exe callers should not reference those
-// functions.
+// Note: the legacy Context_ProcessSwitch() / Context_IsSwitchInProgress() API
+// is gone entirely. switch.cpp removed the implementations (zero callers, and
+// they referenced OoT_/MM_FreezeState symbols from TUs excluded from the
+// single-exe link), and ADR 0002 removed the dangling declarations from
+// context.h. switch.cpp itself IS part of the single-exe build — it holds the
+// live hot-swap freeze/consume policy (Switch_PrepareHotSwap /
+// Combo_ConsumeFrozenState).
 
 // ============================================================================
 // C API implementation

--- a/src/common/context.h
+++ b/src/common/context.h
@@ -20,7 +20,21 @@
 #include "game.h"
 
 #ifdef __cplusplus
+// For the SharedItem raw-assignment static_asserts below. Included BEFORE the
+// extern "C" block on purpose: wrapping a std header in C linkage is ill-formed.
+#include <type_traits>
+#endif
+
+#ifdef __cplusplus
 extern "C" {
+#endif
+
+// Dual-language static_assert: context.h is compiled as both C and C++ (that
+// is also why the shared types below are plain structs — see SharedItem).
+#ifdef __cplusplus
+#define RSBS_CTX_STATIC_ASSERT(cond, msg) static_assert(cond, msg)
+#else
+#define RSBS_CTX_STATIC_ASSERT(cond, msg) _Static_assert(cond, msg)
 #endif
 
 /**
@@ -111,6 +125,58 @@ void Context_UpdateShadowCopy(GameId game, const void* saveContext, size_t size)
  */
 #define RSBS_COMBO_CONTEXT_RECORD_SIZE 1024u
 
+// ============================================================================
+// Origin-tagged shared items (ADR 0002)
+// ============================================================================
+
+/**
+ * Capacity of ComboContext.sharedItemsTagged. Sized generously ONCE (ADR 0002):
+ * 64 entries x 4 bytes take 256 of the original 640 headroom bytes. Growing it
+ * later would be legal under the growth contract (carve more of `reserved`)
+ * but is format churn we choose to avoid by not starting small.
+ */
+#define RSBS_SHARED_ITEM_CAP 64u
+
+/**
+ * SharedItem.flags bit: the ORIGIN game has redeemed (actually awarded) this
+ * entry. Lane C's give path records a foreign pickup with flags == 0; the
+ * origin game's consumer sets this bit when it hands the item to the player,
+ * so a round trip can never award the same entry twice. All other bits are
+ * reserved and must keep the "0 == unset" property when assigned, because a
+ * zero-extended legacy record reads every flag as 0.
+ */
+#define RSBS_SHARED_ITEM_REDEEMED 0x01u
+
+/**
+ * One cross-game item, tagged with the game whose id-space `id` belongs to.
+ *
+ * Why a struct and not a packed integer (ADR 0002): OoT's RandomizerGet (RG_*)
+ * and MM's RandoItemId (RI_*) are unrelated enumerations that must never alias
+ * by raw integer. A game tag bit-packed into a uint16_t would make an untagged
+ * read *almost* work — exactly how the #356 entrance-id leak behaved. As a
+ * plain struct, assigning a raw integer into a SharedItem is ill-formed in
+ * BOTH C and C++ (neither language converts arithmetic types to struct types),
+ * so an untagged id cannot cross this boundary by accident. The static_asserts
+ * below lock the layout — these bytes are .redsave format — and, on the C++
+ * side, prove the raw-assignment rejection.
+ *
+ * Zero means unset for every member (growth contract): a slot is occupied iff
+ * originGame != GAME_NONE. There is deliberately NO separate count field — a
+ * count would be a second source of truth that a zero-extended legacy record
+ * could contradict.
+ */
+typedef struct {
+    uint8_t originGame;  // GameId that owns the id-space; GAME_NONE (0) = empty slot
+    uint8_t flags;       // RSBS_SHARED_ITEM_* bits; 0 = default (present, not redeemed)
+    uint16_t id;         // RG_* if originGame==GAME_OOT, RI_* if GAME_MM; 0 when empty
+} SharedItem;
+
+RSBS_CTX_STATIC_ASSERT(sizeof(SharedItem) == 4,
+                       "SharedItem is serialized raw inside the .redsave Tier-1 record; its layout is format");
+RSBS_CTX_STATIC_ASSERT(offsetof(SharedItem, originGame) == 0 && offsetof(SharedItem, flags) == 1 &&
+                           offsetof(SharedItem, id) == 2,
+                       "SharedItem member offsets are .redsave format and must not move");
+
 typedef struct {
     char magic[8];        // "OoT+MM<3"
     uint32_t version;
@@ -119,39 +185,88 @@ typedef struct {
     uint16_t targetEntrance;
     GameId sourceGame;
     uint16_t sourceEntrance;
+    // KEPT (ADR 0002): origin-neutral event bits, so the shape has no id-space
+    // aliasing hazard. Still unwired; which bit means what is assigned by Lane
+    // A1 and later — until something writes a bit, every word stays zero.
     uint32_t sharedFlags[64];
-    // NOT WIRED: no non-test reader/writer exists yet. Lane A widens this into
-    // an origin-tagged form — OoT's RG_* ids and MM's item ids are unrelated
-    // enumerations that must never alias by raw integer.
+    // RETIRED IN PLACE (ADR 0002): never wired — zero non-test producers or
+    // consumers ever shipped, and the un-tagged uint16_t shape is exactly the
+    // raw-integer aliasing hazard the ADR exists to prevent. The bytes stay at
+    // this shipped offset because a legacy .redsave loads as a byte PREFIX of
+    // this layout. Do not wire; use sharedItemsTagged below instead.
     uint16_t sharedItems[32];
-    // NOT WIRED: dead plumbing. Set to -1 by ComboContext_Init and serialized,
-    // but nothing outside the tests reads it — do not assume the active slot
-    // index is available here until something actually assigns it.
+    // RETIRED IN PLACE (ADR 0002): dead plumbing. ComboContext_Init still sets
+    // -1 and it still serializes, but nothing ever assigned the active slot
+    // index. Kept at its shipped offset; do not wire.
     int32_t saveSlot;
 
-    // Cross-game rando state propagation
+    // Cross-game rando state propagation — Lane B's carrier (ADR 0002): set in
+    // the LIVE path at OoT generation time, read by MM's consumption path when
+    // Lane C makes it reachable.
     bool sourceIsRando;        // Source game is in randomizer mode
     uint32_t sharedRandoSeed;  // Shared seed for synchronization
 
-    // Headroom. Shrink this when appending a field so the struct stays inside
+    // Origin-tagged cross-game items (ADR 0002), carved from the FRONT of the
+    // original reserved[640] headroom so every field above keeps its shipped
+    // offset. All-zero = every slot unset (originGame == GAME_NONE), which is
+    // exactly what a zero-extended legacy record must read as.
+    SharedItem sharedItemsTagged[RSBS_SHARED_ITEM_CAP];
+
+    // Headroom. Carve new fields from the FRONT of this array (as
+    // sharedItemsTagged was) so the struct stays inside
     // RSBS_COMBO_CONTEXT_RECORD_SIZE; the on-disk record size does not change
     // either way, so old saves keep loading. Zeroed by ComboContext_Init, which
     // is what makes a zero-extended legacy record indistinguishable from a
-    // freshly-initialized one.
-    uint8_t reserved[640];
+    // freshly-initialized one — every field carved from here must keep "zero
+    // means unset".
+    uint8_t reserved[384];
 } ComboContext;
+
+/**
+ * The Tier-1 byte length PRE-CARVE builds (Phase 2 headroom fix #399 through
+ * the ADR 0002 carve) populated meaningfully: every field up to, but not
+ * including, the then-reserved[640] headroom. Test_SaveComboLegacyRecord
+ * crafts its "legacy" record at exactly this length.
+ *
+ * This is a pinned NUMBER, deliberately not offsetof(ComboContext, reserved):
+ * carving fields out of `reserved` moves that offsetof forward, which would
+ * silently redefine "legacy" to include the new fields and leave the true
+ * shipped pre-carve prefix untested. The static_asserts below tie the number
+ * to the live layout so neither can drift without a build break.
+ */
+#define RSBS_COMBO_CONTEXT_PRECARVE_SIZE 364u
 
 // Deliberately `<=`, not `==`: the on-disk record is padded to a fixed size, so
 // the struct only has to FIT the budget. An exact-match assert would turn a
 // harmless ABI padding difference into a build break for no benefit.
+RSBS_CTX_STATIC_ASSERT(sizeof(ComboContext) <= RSBS_COMBO_CONTEXT_RECORD_SIZE,
+                       "ComboContext outgrew its .redsave Tier-1 record budget; raise "
+                       "RSBS_COMBO_CONTEXT_RECORD_SIZE and RSBS_SAVE_VERSION together");
+// The carve must begin exactly where the pre-carve reserved[] began. If this
+// fires, either a field was INSERTED before sharedItemsTagged (which breaks
+// the byte-prefix property every shipped .redsave relies on) or the compiler
+// laid the struct out differently than every build that ever wrote a save.
+RSBS_CTX_STATIC_ASSERT(offsetof(ComboContext, sharedItemsTagged) == RSBS_COMBO_CONTEXT_PRECARVE_SIZE,
+                       "sharedItemsTagged must sit exactly at the pre-carve reserved[] offset; "
+                       "moving it orphans every shipped .redsave");
+RSBS_CTX_STATIC_ASSERT(offsetof(ComboContext, reserved) ==
+                           RSBS_COMBO_CONTEXT_PRECARVE_SIZE + RSBS_SHARED_ITEM_CAP * sizeof(SharedItem),
+                       "the tagged-item array and the remaining headroom must stay contiguous "
+                       "(no padding, no fields slipped between them)");
+
 #ifdef __cplusplus
-static_assert(sizeof(ComboContext) <= RSBS_COMBO_CONTEXT_RECORD_SIZE,
-              "ComboContext outgrew its .redsave Tier-1 record budget; raise "
-              "RSBS_COMBO_CONTEXT_RECORD_SIZE and RSBS_SAVE_VERSION together");
-#else
-_Static_assert(sizeof(ComboContext) <= RSBS_COMBO_CONTEXT_RECORD_SIZE,
-               "ComboContext outgrew its .redsave Tier-1 record budget; raise "
-               "RSBS_COMBO_CONTEXT_RECORD_SIZE and RSBS_SAVE_VERSION together");
+// The raw-assignment-fails proof (ADR 0002). In C this is a constraint
+// violation by construction — C has no arithmetic-to-struct conversions at all
+// — so only the C++ view needs an explicit probe (C++ could later grow a
+// converting constructor or assignment operator; these asserts forbid that).
+static_assert(!std::is_convertible<int, SharedItem>::value,
+              "a raw integer must never implicitly become a SharedItem — tag the origin game");
+static_assert(!std::is_assignable<SharedItem&, int>::value && !std::is_assignable<SharedItem&, unsigned>::value,
+              "a raw integer must never be assignable into a SharedItem — tag the origin game");
+static_assert(!std::is_assignable<SharedItem&, GameId>::value,
+              "a bare GameId is not a SharedItem either; populate the struct members explicitly");
+static_assert(std::is_trivially_copyable<ComboContext>::value,
+              "gComboCtx is serialized with memcpy; ComboContext must stay trivially copyable");
 #endif
 
 extern ComboContext gComboCtx;
@@ -181,16 +296,11 @@ void Context_RequestSwitch(GameId target, uint16_t entrance);
  */
 bool Context_HasPendingSwitch(void);
 
-/**
- * Process the pending game switch (called by main loop)
- * This coordinates freezing current game state and launching target game
- */
-void Context_ProcessSwitch(void);
-
-/**
- * Check if a switch is currently being processed
- */
-bool Context_IsSwitchInProgress(void);
+// Context_ProcessSwitch() / Context_IsSwitchInProgress() used to be declared
+// here. Their implementations were removed from switch.cpp (zero callers, and
+// they depended on TUs excluded from the single-exe link); the dangling
+// declarations were removed with ADR 0002. The live switch policy is
+// Switch_PrepareHotSwap / Combo_ConsumeFrozenState in switch.cpp.
 
 /**
  * Set the current game (used during initialization)

--- a/src/common/test_runner.cpp
+++ b/src/common/test_runner.cpp
@@ -870,6 +870,8 @@ const TestDescriptor gTests[] = {
     {"save-combo-legacy-record", "Pre-headroom Tier-1 still loads and zero-extends", Test_SaveComboLegacyRecord},
     {"save-combo-record-fixed", "Tier-1 written at a fixed padded size; headroom round-trips", Test_SaveComboRecordFixed},
     {"save-combo-oversize", "Load rejects an oversized Tier-1 record, no clobber", Test_SaveComboOversize},
+    {"save-tagged-items", "Origin-tagged shared items round-trip; empty slots stay unset (ADR 0002)",
+     Test_SaveTaggedItems},
     {"mm-scene-parse", "MM scene commands parse via the S2H factory (#344)", Test_MMSceneParse},
     {"seq-map-bounds", "Sequence-map capacity covers the id range + custom slack (#371, #378)", Test_SeqMapBounds},
     {"active-queue", "__osGetActiveQueue returns a walkable list, not a return register (#385)", Test_ActiveQueue},

--- a/src/common/tests/test_save_roundtrip.c
+++ b/src/common/tests/test_save_roundtrip.c
@@ -452,19 +452,24 @@ TestResult Test_SaveComboLegacyRecord(void) {
     }
     mgr.DeleteSave(0);
 
-    // The old ComboContext is exactly today's struct minus the reserved tail,
-    // so offsetof gives us the legacy record length with no hand-arithmetic and
-    // no duplicated struct definition to drift out of sync.
-    const uint32_t kLegacyComboSize = static_cast<uint32_t>(offsetof(ComboContext, reserved));
+    // The legacy record length is the PINNED pre-carve prefix, not
+    // offsetof(ComboContext, reserved): the ADR 0002 carve moved that offsetof
+    // forward past sharedItemsTagged, so deriving "legacy" from it would
+    // silently include the carved fields and stop exercising the true shipped
+    // pre-carve prefix. context.h static_asserts tie the constant to
+    // offsetof(ComboContext, sharedItemsTagged), so it cannot drift.
+    const uint32_t kLegacyComboSize = RSBS_COMBO_CONTEXT_PRECARVE_SIZE;
     SAVE_ASSERT(kLegacyComboSize < RSBS_COMBO_CONTEXT_RECORD_SIZE,
                 "legacy Tier-1 must be shorter than the record budget");
     SAVE_ASSERT(SaveTestWriteCraftedSlot(mgr.SlotPath(0), RSBS_SAVE_VERSION_MIN, kLegacyComboSize),
                 "could not write legacy-record slot file");
 
-    // Scribble the reserved tail so "zero-extended" is provably the loader's
-    // doing and not a leftover zero.
+    // Scribble everything past the legacy prefix — the carved tagged-item
+    // array AND the remaining reserved tail — so "zero-extended" is provably
+    // the loader's doing and not a leftover zero.
     ComboContext_Init();
     gComboCtx.saveSlot = 0x7FFFFFFF;
+    std::memset(gComboCtx.sharedItemsTagged, 0x5A, sizeof(gComboCtx.sharedItemsTagged));
     std::memset(gComboCtx.reserved, 0x5A, sizeof(gComboCtx.reserved));
 
     SAVE_ASSERT(mgr.Load(0), "Load refused a pre-headroom .redsave — the migration path is broken");
@@ -477,6 +482,14 @@ TestResult Test_SaveComboLegacyRecord(void) {
     for (size_t i = 0; i < 32; i++) {
         SAVE_ASSERT(gComboCtx.sharedItems[i] == static_cast<uint16_t>(0x2000u + i),
                     "legacy sharedItems not restored");
+    }
+    // The fields carved from the pre-carve headroom must read as UNSET, which
+    // for SharedItem means all-zero members — the growth contract's "zero
+    // means unset" made concrete.
+    for (size_t i = 0; i < RSBS_SHARED_ITEM_CAP; i++) {
+        SAVE_ASSERT(gComboCtx.sharedItemsTagged[i].originGame == GAME_NONE &&
+                        gComboCtx.sharedItemsTagged[i].flags == 0 && gComboCtx.sharedItemsTagged[i].id == 0,
+                    "tagged items from a pre-carve record must load as unset slots");
     }
     for (size_t i = 0; i < sizeof(gComboCtx.reserved); i++) {
         SAVE_ASSERT(gComboCtx.reserved[i] == 0, "Tier-1 tail beyond the legacy record not zero-extended");
@@ -554,5 +567,58 @@ TestResult Test_SaveComboOversize(void) {
 
     mgr.DeleteSave(0);
     printf("[TEST] PASS: oversized Tier-1 rejected, live state intact\n");
+    return TEST_PASS;
+}
+
+TestResult Test_SaveTaggedItems(void) {
+    printf("[TEST] save-tagged-items: origin-tagged shared items round-trip byte-exact (ADR 0002)\n");
+
+    rsbs::SaveManager& mgr = rsbs::SaveManager::Instance();
+    mgr.SetSaveDirectory(kSaveTestDir);
+
+    SaveTestSeed(0x7A66EDu);
+
+    // A representative spread: first slot, adjacent slot, and the LAST slot,
+    // covering both origin games and a set flags bit. Values are arbitrary
+    // in-range ids — the test asserts transport, not item semantics.
+    gComboCtx.sharedItemsTagged[0].originGame = GAME_OOT;
+    gComboCtx.sharedItemsTagged[0].flags = 0;
+    gComboCtx.sharedItemsTagged[0].id = 0x00A7;
+    gComboCtx.sharedItemsTagged[1].originGame = GAME_MM;
+    gComboCtx.sharedItemsTagged[1].flags = RSBS_SHARED_ITEM_REDEEMED;
+    gComboCtx.sharedItemsTagged[1].id = 0x0042;
+    gComboCtx.sharedItemsTagged[RSBS_SHARED_ITEM_CAP - 1].originGame = GAME_OOT;
+    gComboCtx.sharedItemsTagged[RSBS_SHARED_ITEM_CAP - 1].flags = 0;
+    gComboCtx.sharedItemsTagged[RSBS_SHARED_ITEM_CAP - 1].id = 0x0123;
+
+    SharedItem expected[RSBS_SHARED_ITEM_CAP];
+    std::memcpy(expected, gComboCtx.sharedItemsTagged, sizeof(expected));
+
+    mgr.DeleteSave(0);
+    SAVE_ASSERT(mgr.Save(0), "Save(0) failed");
+
+    // Wipe live state, then scribble the tagged array so a restored zero is
+    // provably the loader's doing.
+    ComboContext_Init();
+    std::memset(gComboCtx.sharedItemsTagged, 0x5A, sizeof(gComboCtx.sharedItemsTagged));
+
+    SAVE_ASSERT(mgr.Load(0), "Load(0) failed");
+
+    SAVE_ASSERT(std::memcmp(expected, gComboCtx.sharedItemsTagged, sizeof(expected)) == 0,
+                "tagged shared items not byte-identical after a .redsave round-trip");
+    // Spot-check through the TYPED view too, so a memcmp-passing-but-misread
+    // layout (e.g. an endianness or padding surprise) still fails loudly.
+    SAVE_ASSERT(gComboCtx.sharedItemsTagged[0].originGame == GAME_OOT, "slot 0 origin tag lost");
+    SAVE_ASSERT(gComboCtx.sharedItemsTagged[0].id == 0x00A7, "slot 0 id lost");
+    SAVE_ASSERT(gComboCtx.sharedItemsTagged[1].originGame == GAME_MM, "slot 1 origin tag lost");
+    SAVE_ASSERT(gComboCtx.sharedItemsTagged[1].flags == RSBS_SHARED_ITEM_REDEEMED, "slot 1 redeemed bit lost");
+    SAVE_ASSERT(gComboCtx.sharedItemsTagged[RSBS_SHARED_ITEM_CAP - 1].id == 0x0123, "last slot id lost");
+    // Untouched slots must come back as unset, not as scribble.
+    SAVE_ASSERT(gComboCtx.sharedItemsTagged[2].originGame == GAME_NONE && gComboCtx.sharedItemsTagged[2].flags == 0 &&
+                    gComboCtx.sharedItemsTagged[2].id == 0,
+                "an unpopulated slot must round-trip as unset");
+
+    mgr.DeleteSave(0);
+    printf("[TEST] PASS: tagged shared items survive Save/Load; empty slots stay unset\n");
     return TEST_PASS;
 }


### PR DESCRIPTION
Phase 3 Lane **A0** (serial section, #392): the shared item-id ADR and the ComboContext struct carve implementing it. A1 and B branch only after this merges; the decisions in the ADR are final for the phase.

## ADR 0002 (`docs/adr/0002-origin-tagged-shared-items.md`, Status: Accepted)

- **Item representation:** plain 4-byte tagged struct `SharedItem {u8 originGame; u8 flags; u16 id}` — identical in the C and C++ views of `context.h`. A raw `RG_*`/`RI_*` integer cannot become a `SharedItem` (ill-formed in both languages, empirically negative-compile-verified on MSVC in both modes; C++ view also carries `!is_convertible`/`!is_assignable` static_asserts so a converting constructor can never be added). **No bit-packing** — a packed id would *almost* work as a raw read, the #356 failure mode. Zero means unset member-by-member; occupancy is `originGame != GAME_NONE`; no count field. `flags` bit 0 = `RSBS_SHARED_ITEM_REDEEMED` for Lane C's redemption flow.
- **Storage:** `SharedItem sharedItemsTagged[64]` (`RSBS_SHARED_ITEM_CAP`, sized generously once), carved from the **front** of `reserved[640]` → `reserved[384]`. Every shipped field keeps its offset; `sizeof(ComboContext)` stays 1004 inside the fixed 1024-byte record. Neither `RSBS_SAVE_VERSION` (2) nor `COMBO_CONTEXT_VERSION` (1) moves.
- **Dead fields:** `sharedItems[32]` and `saveSlot` **retired in place** (bytes at shipped offsets, never to be wired — also keeps `test_roundtrip_integrity.c`/`test_shared_state_roundtrip.c` untouched); `sharedFlags[64]` **kept**, bit semantics assigned by A1+.
- **`sourceIsRando`/`sharedRandoSeed` are Lane B's carrier — confirmed, final.** B revives them in the live path at OoT generation time; no new seed fields.

## The legacy-record pin (test honesty)

`Test_SaveComboLegacyRecord` derived its "legacy" Tier-1 length from `offsetof(ComboContext, reserved)`; the carve moves that offset forward past the new array, so the test would have stayed green while silently including the carved fields in "legacy". The pre-carve length is now the pinned `RSBS_COMBO_CONTEXT_PRECARVE_SIZE` (364), tied to the live layout by static_asserts (`offsetof(sharedItemsTagged) == 364`; tagged array contiguous with remaining headroom), and the test asserts a pre-carve record loads with every tagged slot unset.

## Coverage added

- **New `SaveTaggedItems`** CTest (`--test save-tagged-items`, one `redship_add_test` row + `gTests[]` entry): byte-exact round-trip of the tagged array through Save/Load, redeemed-bit survival, unpopulated slots stay unset against a scribbled background.
- **Extended `SaveComboLegacyRecord`**: crafted record at the pinned 364-byte pre-carve prefix; scribbles both `sharedItemsTagged` and `reserved` before load; asserts all 64 tagged slots read as unset.
- Layout static_asserts in `context.h` (both language views): `sizeof(SharedItem)==4`, member offsets 0/1/2, the 364 pin, contiguity, `is_trivially_copyable<ComboContext>`.

## Housekeeping (as context.h's owner)

- Deleted the dangling `Context_ProcessSwitch` / `Context_IsSwitchInProgress` declarations (switch.cpp removed the implementations earlier and assigned the decl removal here).
- Corrected the stale `context.cpp` note claiming switch.cpp is only linked in non-single-exe builds.
- Updated `docs/known-issues.md`'s dead-plumbing entry to match the ADR.
- Noted, not changed (outside A0's file list): `switch.cpp`'s header comment still says the context.h declarations "are now dangling" — a two-line comment refresh for whoever next owns that file.

Verified locally (single-TU syntax checks only, no project build per venue rules): `context.h` compiles clean as C (`/std:clatest`) and C++20 under MSVC 19.44 including all static_asserts, raw-int assignment negative-compiles in both languages, and the modified test file compiles as a C++ TU.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!--- section:artifacts:start -->
### Build Artifacts
  - [rsbs-windows.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/8476918042.zip)
  - [rsbs-linux.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/8476671763.zip)
<!--- section:artifacts:end -->