### PR TITLE
Give MM's fault.c/stubs.c non-void stubs real returns, revive FindFaultedThread

### DIFF
--- a/games/mm/src/boot/fault.c
+++ b/games/mm/src/boot/fault.c
@@ -271,6 +271,15 @@ uintptr_t MM_Fault_ConvertAddress(uintptr_t addr) {
 
     return 0;
 #endif
+    /* #403: the walk above is disabled along with the rest of the fault-client
+     * machinery it depends on (sFaultInstance and MM_Fault_AddAddrConvClient
+     * are themselves #if 0'd, so no address-converter client can ever be
+     * registered). This function's only two call sites, MM_Fault_DrawStackTrace
+     * and MM_Fault_LogStackTrace below, are themselves #if 0'd too, so this is
+     * unreachable either way today. 0 is the documented "could not convert"
+     * answer, and it is exactly what the disabled walk above would produce for
+     * an empty client list if it were ever revived — not a placeholder. */
+    return 0;
 }
 
 void MM_Fault_Sleep(u32 msec) {
@@ -333,6 +342,15 @@ u32 MM_Fault_WaitForInputImpl(void) {
         }
     }
 #endif
+    /* #403: disabled along with the input-polling machinery it needs
+     * (sFaultInstance, MM_Fault_UpdatePadImpl). Its only potential caller,
+     * MM_Fault_WaitForInput just below, has its own call to this commented
+     * out (`// MM_Fault_WaitForInputImpl();`), so this function has zero live
+     * callers today. 0 (false) is what the disabled body itself returns on
+     * its ordinary exit (auto-scroll countdown elapsing, or A / DPad-Right) —
+     * chosen so falling off the end is explicit rather than a garbage
+     * register, not because this value is otherwise load-bearing. */
+    return 0;
 }
 
 void MM_Fault_WaitForInput(void) {
@@ -552,8 +570,32 @@ void osSyncPrintfThreadContext(OSThread* thread) {
  * Iterates through the active thread queue for a user thread with either
  * the CPU break or Fault flag set.
  */
+/* #403: this body used to be entirely inside #if 0 (both returns included),
+ * so the function fell off the end unconditionally and handed its caller a
+ * return register instead of a thread pointer — see the do/while in
+ * MM_Fault_ThreadEntry below. Reviving it is possible now, and only now:
+ * __osGetActiveQueue() used to be an empty non-void stub with the same defect
+ * (games/oot/soh/stubs.c, before #401), returning garbage. #401 gave it a
+ * real, unprefixed (shared-across-both-games) implementation
+ * (rsbs/src/libultra/os/getactivequeue.c) backed by __osActiveQueue storage
+ * (rsbs/src/libultra/os/threadqueue.c). That storage is an empty list whose
+ * head IS the OS_PRIORITY_THREADTAIL tail sentinel — exactly the contract
+ * this loop already assumed — so the walk below terminates on its first
+ * iteration and returns NULL: an honest answer, since this port never creates
+ * a real libultra thread for anything to be "faulted" in.
+ *
+ * OS_PRIORITY_THREADTAIL and the __osGetActiveQueue() declaration are
+ * normally supplied by PR/os_thread.h, but that header's meaningful content —
+ * including this exact declaration (os_thread.h:86) and this exact macro
+ * (os_thread.h:73) — is itself wrapped in an #if 0 that predates this fix and
+ * is out of scope to unwrap here, so both are restated locally. */
+extern OSThread* __osGetActiveQueue(void);
+
+#ifndef OS_PRIORITY_THREADTAIL
+#define OS_PRIORITY_THREADTAIL (-1)
+#endif
+
 OSThread* MM_Fault_FindFaultedThread(void) {
-#if 0
     OSThread* iter = __osGetActiveQueue();
 
     while (iter->priority != OS_PRIORITY_THREADTAIL) {
@@ -565,7 +607,6 @@ OSThread* MM_Fault_FindFaultedThread(void) {
     }
 
     return NULL;
-#endif
 }
 void MM_Fault_Wait5Seconds(void) {
 #if 0
@@ -1015,6 +1056,12 @@ void MM_Fault_UpdatePad(void) {
 //#define FAULT_MSG_FAULT ((OSMesg)2)
 //#define FAULT_MSG_UNK ((OSMesg)3)
 
+/* #403: retry cap for the do/while fixed below (see the comment at its new
+ * "break"). Generous relative to a 1-second-ish poll loop, finite on purpose —
+ * the whole point of this fix is that "keep spinning" is not an acceptable
+ * answer for a crash handler. */
+#define MM_FAULT_FIND_THREAD_MAX_RETRIES 60
+
 void MM_Fault_ThreadEntry(void* arg) {
 #if 0
     OSMesg msg;
@@ -1026,6 +1073,8 @@ void MM_Fault_ThreadEntry(void* arg) {
     MM_osSetEventMesg(OS_EVENT_FAULT, &sFaultInstance->queue, FAULT_MSG_FAULT);
 
     while (true) {
+        s32 findRetries = 0;
+
         do {
             // Wait for a thread to hit a fault
             MM_osRecvMesg(&sFaultInstance->queue, &msg, OS_MESG_BLOCK);
@@ -1054,6 +1103,24 @@ void MM_Fault_ThreadEntry(void* arg) {
             if (faultedThread == NULL) {
                 faultedThread = MM_Fault_FindFaultedThread();
                 osSyncPrintf("FindFaultedThread()=%08x\n", faultedThread);
+
+                /* #403: bounded retry. A fault/CPU-break message was received,
+                 * so something really did fault — but __osGetCurrFaultedThread()
+                 * and MM_Fault_FindFaultedThread() can only ever answer "no
+                 * thread" in this port (see their definitions): no real
+                 * libultra thread is ever created here, so a persistently-NULL
+                 * result is not a transient race to keep waiting out, it is
+                 * the permanent answer. Before this fix this do/while had no
+                 * exit at all, so the crash handler itself spun forever —
+                 * turning a crash into a hang, which is worse than reporting
+                 * nothing. Give up loudly once retries are exhausted instead;
+                 * whoever wires up a real MM_Fault_Init / ThreadEntry later
+                 * inherits this already fixed. */
+                if ((faultedThread == NULL) && (++findRetries >= MM_FAULT_FIND_THREAD_MAX_RETRIES)) {
+                    MM_Fault_AddHungupAndCrashImpl("MM_Fault_ThreadEntry",
+                                                   "MM_Fault_FindFaultedThread() found none after max retries");
+                    break;
+                }
             }
         } while (faultedThread == NULL);
 

--- a/games/mm/src/code/stubs.c
+++ b/games/mm/src/code/stubs.c
@@ -101,11 +101,29 @@ void* osRomBase;
 
 __osHwInt __osHwIntTable[1];
 
+/* NOTE (#403): every stub below with a return type returns an explicit value.
+ * Falling off the end of a non-void function is UB — in practice the caller
+ * reads whatever happened to be in the return register — and this file had 22
+ * such bodies (the same defect class #385/#401 retired from
+ * games/oot/soh/stubs.c). Mirrored against #401's table where an OoT twin
+ * exists (games/oot/soh/stubs.c); derived from the libultra contract, and
+ * noted as such, where none does. Most of these have zero live callers in the
+ * single-exe build — their real N64 implementations live under
+ * games/mm/src/libultra/**, which is unconditionally excluded
+ * (games/mm/CMakeLists.txt), and the callers that would reach them are
+ * excluded right along with them — but a defined value is supplied anyway so
+ * the contract is honest if that ever changes, matching #401's precedent of
+ * never picking "whatever is cheapest to write". */
+
 OSIntMask MM_osSetIntMask(OSIntMask a) {
     return 0;
 }
 
 s32 MM_osProbeRumblePak(OSMesgQueue* ctrlrqueue, OSPfs* pfs, u32 channel) {
+    /* Twin: OoT's osProbeRumblePak (games/oot/soh/stubs.c). Rumble is driven by
+     * libultraship/SDL, not a probed Rumble Pak; PFS_ERR_NOPACK — not 0 — so
+     * the N64 probe path stays out of it. */
+    return PFS_ERR_NOPACK;
 }
 
 s32 MM_osSetRumble(OSPfs* pfs, u32 vibrate) {
@@ -121,6 +139,10 @@ u32 MM___osSetFpcCsr(u32 a0) {
 }
 
 OSIntMask MM___osDisableInt(void) {
+    /* Twin: OoT's __osDisableInt. There are no RCP interrupts to mask; 0 is
+     * the "previous mask" the paired no-op MM___osRestoreInt below is handed
+     * back. */
+    return 0;
 }
 
 void MM___osRestoreInt(OSIntMask a0) {
@@ -135,6 +157,9 @@ void MM_Audio_osWritebackDCache(void* mem, s32 size) {
 }
 
 OSPiHandle* MM_osDriveRomInit() {
+    /* Twin: OoT's OoT_osDriveRomInit. There is no cart PI handle in the port;
+     * NULL is the libultra "no device" return. */
+    return NULL;
 }
 
 void MM_osSetUpMempakWrite(s32 channel, OSPifRam* buf) {
@@ -231,24 +256,44 @@ void MM_gSPInvalidateTexCache(Gfx* pkt, uintptr_t texAddr) {
 void __osDispatchThread(void) {
 }
 
+/* No OoT twin for the six COP0-register accessors below (OoT's soh/stubs.c
+ * never needed them). Derived from the libultra contract: each reads a MIPS
+ * COP0 register that does not exist on this platform, so 0 ("no cause set" /
+ * "no compare value programmed" / "no config bits" / "no status bits") is the
+ * honest absent-hardware answer. All six are dead in the single-exe build
+ * today regardless — their one real caller, games/mm/src/libultra/os/initialize.c
+ * (MM___osInitialize_common), is unconditionally excluded
+ * (games/mm/CMakeLists.txt filters src/libultra/os/*), so this file's own
+ * empty no-op MM___osInitialize_common (below) runs instead and never calls
+ * them. Notably, __osGetCause's real caller guards `if (__osGetCause() &
+ * CAUSE_IP5) { while (true) {} }` — an infinite loop if a garbage return had
+ * that bit set — but that guard is excluded dead code too, so today's stray
+ * garbage return was never live enough to hang anything. */
 u32 __osGetCause(void) {
+    return 0;
 }
 void __osSetCause(u32 p) {
 }
 u32 __osGetCompare(void) {
+    return 0;
 }
 void __osSetCompare(u32 value) {
 }
 u32 __osGetConfig(void) {
+    return 0;
 }
 void __osSetConfig(u32 p) {
 }
 u32 __osGetSR(void) {
+    return 0;
 }
 void __osSetSR(u32 value) {
 }
 
 u32 __osGetWatchLo(void) {
+    /* Paired with the no-op __osSetWatchLo just below; 0 == no watchpoint
+     * address programmed. */
+    return 0;
 }
 void __osSetWatchLo(u32 value) {
 }
@@ -258,10 +303,28 @@ void __osEnqueueAndYield(OSThread** param_1) {
 void __osEnqueueThread(OSThread** param_1, OSThread* param_2) {
 }
 OSThread* __osPopThread(OSThread** param_1) {
+    /* No OoT twin; derived. Dequeues and returns the head of a libultra thread
+     * queue. No OSThread is ever created in this port (MM_osCreateThread and
+     * OoT's osCreateThread are both no-ops), so every queue this could be
+     * called on is empty — NULL ("nothing to pop") is the honest answer, the
+     * same reasoning rsbs/src/libultra/os/threadqueue.c uses for
+     * __osRunningThread. Dead today regardless: this file's only in-tree
+     * caller (games/mm/src/libultra/os/startthread.c) is excluded
+     * (games/mm/CMakeLists.txt filters src/libultra/os/*), and rsbs's own
+     * message-queue reference implementations that call it
+     * (src/libultra/os/{jam,recv,send}mesg.c) are commented out of
+     * rsbs/CMakeLists.txt in favor of libultraship's runtime queues. */
+    return NULL;
 }
 void osMapTLBRdb(void) {
 }
 u32 __osProbeTLB(void* param_1) {
+    /* No OoT twin; derived. Probes the TLB for a mapping of the given address.
+     * There is no MMU/TLB in this port; 0 ("no matching entry") is the
+     * contract-correct absent-hardware answer. Dead today regardless: its one
+     * caller, games/mm/src/libultra/os/virtualtophysical.c, is excluded
+     * (games/mm/CMakeLists.txt filters src/libultra/os/*). */
+    return 0;
 }
 s32 MM_osAiSetFrequency(u32 frequency) {
     // this is based off the math from the original method
@@ -302,10 +365,23 @@ s32 MM_osAiSetFrequency(u32 frequency) {
     return 32006;
 }
 s32 MM_osContStartQuery(OSMesgQueue* mq) {
+    /* Twin: OoT's OoT_osContStartQuery. 0 == query issued. LIVE: the real
+     * implementation (games/mm/src/libultra/io/contquery.c) is excluded
+     * (games/mm/CMakeLists.txt filters src/libultra/io/*), so this stub is
+     * what games/mm/src/boot/O2/padsetup.c:13 actually calls —
+     * `if (MM_osContStartQuery(mq) != 0) { return 1; }` aborts controller
+     * setup on non-zero, exactly the padsetup.c hazard #401 documented for
+     * OoT's twin. */
+    return 0;
 }
 void MM_osCreateThread(OSThread* thread, OSId id, void* entry, void* arg, void* sp, OSPri p) {
 }
 OSPri MM_osGetThreadPri(OSThread* t) {
+    /* Twin: OoT's OoT_osGetThreadPri. OS_PRIORITY_IDLE, not the tail priority
+     * (-1): callers (games/mm/src/boot/yaz0.c, .../io/pimgr.c, .../io/vimgr.c)
+     * save-and-restore this around a priority bump, never compare it against
+     * the thread-list terminator. */
+    return OS_PRIORITY_IDLE;
 }
 void MM_osContGetQuery(OSContStatus* data) {
 }
@@ -328,6 +404,13 @@ void MM___osCleanupThread(void) {
 void MM_osDestroyThread(OSThread* thread) {
 }
 s32 MM_osContSetCh(u8 ch) {
+    /* Twin: OoT's OoT_osContSetCh. 0 == channel count accepted, per libultra.
+     * LIVE: the real implementation (games/mm/src/libultra/io/contsetch.c) is
+     * excluded (games/mm/CMakeLists.txt filters src/libultra/io/*), so this
+     * stub is what games/mm/src/code/padmgr.c:813 actually calls (return
+     * value currently discarded there, but the contract is honest either
+     * way). */
+    return 0;
 }
 void MM_osViSetYScale(f32 scale) {
 }
@@ -336,8 +419,23 @@ void MM_osViSetXScale(f32 value) {
 void MM_osSpTaskYield(void) {
 }
 void* MM_osViGetCurrentFramebuffer(void) {
+    /* No OoT twin; derived. This port's real
+     * implementation (games/mm/src/libultra/io/vigetcurrframebuf.c) reads
+     * __osViCurr->buffer, excluded along with the rest of src/libultra/io/*.
+     * games/mm/src/code/sched.c's two live callers only ever compare this
+     * against MM_osViGetNextFramebuffer() and a task's target buffer pointer
+     * — never dereference it — so NULL ("no framebuffer pointer tracked") is
+     * safe: at worst the comparisons resolve differently than on real
+     * hardware, never a crash. */
+    return NULL;
 }
 OSPiHandle* osFlashInit(void) {
+    /* No OoT twin (OoT has no flash cart to emulate). Same "no device"
+     * contract as MM_osDriveRomInit above: NULL. Its one live caller,
+     * games/mm/src/code/sys_flashrom.c's SysFlashrom_InitFlash, discards the
+     * return value outright — flash "presence" is instead faked entirely by
+     * osFlashReadId below, which SysFlashrom_CheckFlashType reads. */
+    return NULL;
 }
 void osFlashReadId(u32* t, u32* v) {
     // We're faking these so the flashrom system will continue to work
@@ -345,12 +443,37 @@ void osFlashReadId(u32* t, u32* v) {
     *v = 0x00C20000; // FLASH_VERSION_MX_PROTO_A
 }
 s32 osFlashSectorErase(u32 page) {
+    /* No OoT twin. FLASH_STATUS_ERASE_OK (0, PR/os_flash.h) — the real
+     * implementation's success code, not just "0 as a habit". Its only
+     * caller, SysFlashrom_EraseSector, is itself only reachable from
+     * SysFlashrom_AttemptWrite / SysFlashrom_WriteData (non-async), which
+     * games/mm/2s2h/SaveManager/SaveManager.cpp's save path never calls —
+     * saves go through SaveManager_SysFlashrom_WriteData instead (see the
+     * "2S2H [Port] Redirect" region in sys_flashrom.c). Dead today, but a
+     * real success code keeps SysFlashrom_AttemptWrite's retry-then-give-up
+     * logic honest if that ever changes. */
+    return FLASH_STATUS_ERASE_OK;
 }
 s32 osFlashWriteBuffer(OSIoMesg* mb, s32 priority, void* dramAddr, OSMesgQueue* mq) {
+    /* No OoT twin. The real implementation returns MM_osEPiStartDma()'s result
+     * verbatim (DMA accepted); 0 mirrors that success convention. Same
+     * redirected-around, currently-unreachable path as osFlashSectorErase
+     * above. */
+    return 0;
 }
 s32 osFlashWriteArray(u32 pageNum) {
+    /* No OoT twin. FLASH_STATUS_WRITE_OK (0, PR/os_flash.h) — the real
+     * implementation's success code. Same unreachable path as
+     * osFlashSectorErase above. */
+    return FLASH_STATUS_WRITE_OK;
 }
 s32 osFlashReadArray(OSIoMesg* mb, s32 priority, u32 pageNum, void* dramAddr, u32 pageCount, OSMesgQueue* mq) {
+    /* No OoT twin. Same DMA-accepted convention as osFlashWriteBuffer above.
+     * Its caller, SysFlashrom_ReadData, redirects to
+     * SaveManager_SysFlashrom_ReadData before ever reaching this call (see the
+     * "2S2H [Port] Redirect" region in sys_flashrom.c), so this is
+     * unreachable today. */
+    return 0;
 }
 void osFlashChange(u32 flashNum) {
 }
@@ -359,6 +482,11 @@ void osFlashAllEraseThrough(void) {
 void osFlashSectorEraseThrough(u32 pageNum) {
 }
 s32 osFlashCheckEraseEnd(void) {
+    /* No OoT twin. FLASH_STATUS_ERASE_OK (0, PR/os_flash.h): "not busy, erase
+     * completed cleanly" — never FLASH_STATUS_ERASE_BUSY (2), since nothing
+     * here ever starts an asynchronous erase to be busy on. Zero live callers
+     * found in-tree; kept contract-correct in case a future caller polls it. */
+    return FLASH_STATUS_ERASE_OK;
 }
 void MM_osSetThreadPri(OSThread* thread, OSPri p) {
 }
@@ -386,8 +514,19 @@ void MM_guS2DInitBg(uObjBg* bg) {
     }
 }
 void* MM_osViGetNextFramebuffer() {
+    /* No OoT twin; derived. Same reasoning as MM_osViGetCurrentFramebuffer
+     * above: the real implementation (games/mm/src/libultra/io/vigetnextframebuf.c)
+     * is excluded, and its live consumer (games/mm/src/code/sched.c) only
+     * pointer-compares the result, never dereferences it. NULL is safe. */
+    return NULL;
 }
 OSYieldResult MM_osSpTaskYielded(OSTask* task) {
+    /* Twin: OoT's OoT_osSpTaskYielded. 0, i.e. NOT OS_TASK_YIELDED (1 << 0,
+     * PR/sptask.h). MM_osSpTaskYield above is a no-op, so no task ever
+     * yields; returning the OS_TASK_YIELDED bit (which garbage would set half
+     * the time) would make the graphics thread re-submit a task that was
+     * never interrupted. */
+    return 0;
 }
 void MM_osViBlack(u8 active) {
 }


### PR DESCRIPTION
## What was broken

`games/mm/src/boot/fault.c:555`'s `MM_Fault_FindFaultedThread` had its
entire body, both return statements included, inside `#if 0` — the
function fell off the end unconditionally, handing its caller a return
register instead of a thread pointer. Its only reference is a
`do/while (faultedThread == NULL)` loop in `MM_Fault_ThreadEntry`
(`:1054-1058` pre-edit) with no exit — so a persistently-NULL result would
spin the crash handler forever, and a non-NULL garbage result would store a
wild pointer later dereferenced while building the crash report.

`games/mm/src/code/stubs.c` had 22 more non-void functions with empty
bodies — the same defect class #385/#401 retired from
`games/oot/soh/stubs.c`.

## Severity framing (latent on MM's own facts)

Unlike OoT's twin (#385/#401), where the consumer was live, **nothing here
can spin today**: `MM_Fault_ThreadEntry`'s entire body is `#if 0` (so is
`MM_Fault_Init`, so `MM_osCreateThread` — itself an empty stub — is never
even asked to start the fault thread). `#403` undersold this by calling
only 3 stubs.c functions out; the tree has ~24 (22 in stubs.c + 2 more in
fault.c). This PR is **not** claiming #385/#401 called OoT's twin latent —
they didn't, OoT's consumer was live. The value of this PR is retiring the
defect class before `ThreadEntry` is ever wired up for real, so whoever
does that inherits contract-correct returns and a bounded retry loop
instead of an infinite one.

## fault.c

1. **`MM_Fault_FindFaultedThread` revived.** Possible now, and only now:
   `__osGetActiveQueue()` used to be OoT's own empty non-void stub
   (pre-#401); #401 gave it a real, unprefixed (shared-across-both-games)
   implementation (`rsbs/src/libultra/os/getactivequeue.c`) backed by an
   `__osActiveQueue` tail-sentinel (`rsbs/src/libultra/os/threadqueue.c`).
   That storage is an empty list whose head *is* the
   `OS_PRIORITY_THREADTAIL` sentinel, so the revived walk terminates on its
   first iteration and returns `NULL` — honest, since this port never
   creates a real libultra thread. `OS_PRIORITY_THREADTAIL` and the
   `__osGetActiveQueue()` declaration are normally supplied by
   `PR/os_thread.h`, but that header's meaningful content (including this
   exact declaration and macro) is itself wrapped in an `#if 0` predating
   this fix, so both are restated locally.
2. **The `do/while` loop fixed in place** (still disabled — its enclosing
   function is `#if 0`): bounded retry (60 attempts) then a loud abort via
   `MM_Fault_AddHungupAndCrashImpl`, instead of no exit condition at all.
3. **`MM_Fault_ConvertAddress` and `MM_Fault_WaitForInputImpl`** — both
   non-void with fully-`#if 0` bodies and zero live callers (verified: both
   callers of `ConvertAddress` are themselves `#if 0`'d;
   `WaitForInputImpl`'s only potential caller has its call commented out).
   Each now returns an explicit, documented value.

## stubs.c — the return-value table

Mirrored against #401's table where an OoT twin exists; derived from the
libultra contract (and noted as such) where none does.

| Function | Value | Reasoning |
|---|---|---|
| `MM_osProbeRumblePak` | `PFS_ERR_NOPACK` | Twin: OoT's `osProbeRumblePak`. |
| `MM___osDisableInt` | `0` | Twin: OoT's `__osDisableInt`. |
| `MM_osDriveRomInit` | `NULL` | Twin: OoT's `OoT_osDriveRomInit`. |
| `__osGetCause` | `0` | No twin. Dead: caller (`initialize.c`) excluded. |
| `__osGetCompare` | `0` | No twin. Dead: caller excluded. |
| `__osGetConfig` | `0` | No twin. Dead: caller excluded. |
| `__osGetSR` | `0` | No twin. Dead: caller excluded. |
| `__osGetWatchLo` | `0` | No twin. Dead: caller excluded. |
| `__osPopThread` | `NULL` | No twin (derived). No real OSThread ever created; dead today (caller excluded, rsbs's own callers commented out of its CMakeLists). |
| `__osProbeTLB` | `0` | No twin. Dead: caller excluded. |
| `MM_osContStartQuery` | `0` | Twin: OoT's `OoT_osContStartQuery`. **Live**: real impl excluded, so `padsetup.c:13`'s `if (...) != 0) return 1;` actually runs this stub — same abort-controller-setup hazard #401 flagged for OoT. |
| `MM_osGetThreadPri` | `OS_PRIORITY_IDLE` | Twin: OoT's `OoT_osGetThreadPri`. Live callers (`yaz0.c`, `pimgr.c`, `vimgr.c`) save/restore only. |
| `MM_osContSetCh` | `0` | Twin: OoT's `OoT_osContSetCh`. Live via `padmgr.c:813` (real impl excluded). |
| `MM_osViGetCurrentFramebuffer` | `NULL` | No twin (derived). Live callers (`sched.c`) only pointer-compare, never deref. |
| `osFlashInit` | `NULL` | No twin (derived). Only caller discards the value. |
| `osFlashSectorErase` | `FLASH_STATUS_ERASE_OK` (0) | No twin. Dead: only reachable via a path the 2S2H SaveManager redirect bypasses. |
| `osFlashWriteBuffer` | `0` | No twin. Mirrors `MM_osEPiStartDma`'s DMA-accepted convention. |
| `osFlashWriteArray` | `FLASH_STATUS_WRITE_OK` (0) | No twin. Same dead path as `osFlashSectorErase`. |
| `osFlashReadArray` | `0` | No twin. Same DMA-accepted convention; dead via the SaveManager redirect. |
| `osFlashCheckEraseEnd` | `FLASH_STATUS_ERASE_OK` (0) | No twin. Zero live callers found in-tree. |
| `MM_osViGetNextFramebuffer` | `NULL` | No twin (derived). Same reasoning as `GetCurrentFramebuffer`. |
| `MM_osSpTaskYielded` | `0` | Twin: OoT's `OoT_osSpTaskYielded`. Not `OS_TASK_YIELDED`. |

Every value's reasoning (including exactly which caller is live vs.
excluded, and why) is documented inline as a comment on its function.

## Escalation hunk (deferred)

The per-source `-Werror=return-type` / `/we4716 /we4715` `COMPILE_OPTIONS`
lock lives in `games/mm/CMakeLists.txt`, owned by the G1 lane while it's
actively landing its GameInteractor shim in parallel. Per the phase-3
lane-ownership plan, that hunk is a small follow-up PR after G1 merges (or
an escalation comment on #392 if G1 is still in flight after ~30 min of
polling). Tracking that as a separate step; this PR is fully self-contained
without it.

## Out of scope (explicitly)

No renames or symbol dedup of the unprefixed shared-namespace stubs
(`__osGetCause`, `osFlashInit`, `__osPopThread`, ...) — that's G2/#375's
job. Adding returns here is safe; deduping symbols is a different, riskier
change.

Part of #403 (closing once this merges and the escalation-hunk status is
noted).

<!--- section:artifacts:start -->
### Build Artifacts
  - [rsbs-windows.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/8476988469.zip)
  - [rsbs-linux.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/8476748356.zip)
<!--- section:artifacts:end -->