### PR TITLE
G1: GameInteractor extern-C shim — MM hook registration off the shared 4-byte instance (#395, #372, #383)

### DIFF
--- a/.github/clang-format-paths.txt
+++ b/.github/clang-format-paths.txt
@@ -31,6 +31,7 @@ games/mm/2s2h/Enhancements/FrameInterpolation/FrameInterpolation.h
 games/mm/2s2h/GameExports_SingleExe.cpp
 games/mm/2s2h/ShipInit.hpp
 games/mm/2s2h/mm_culling_test.cpp
+games/mm/2s2h/mm_gi_shim_test.cpp
 games/mm/2s2h/mm_resume_state_test.cpp
 games/mm/2s2h/z_scene_2SH.cpp
 games/mm/src/audio/lib/dcache.c

--- a/CMake/SingleExecutable.cmake
+++ b/CMake/SingleExecutable.cmake
@@ -314,6 +314,10 @@ if(BUILD_TESTING)
     # Actor::projectedPos 8 bytes earlier than MM's Actor puts it, and only one
     # definition survived the link, so there was no ODR error to catch it.
     redship_add_test(NAME MMCullingBinding COMMAND redship --test mm-culling-binding)
+    # MM GameInteractor shim (#395): MM-side hook registration must go through
+    # the MM-owned extern "C" shim; registering through MM's 104-byte view of
+    # the shared class writes ~92 bytes past OoT's 4-byte allocation.
+    redship_add_test(NAME MMGIShim COMMAND redship --test mm-gi-shim)
     redship_add_test(NAME MMResumeArena COMMAND redship --test mm-resume-arena)
     redship_add_test(NAME MMStartupRestore COMMAND redship --test mm-startup-restore)
     redship_add_test(NAME AllTests COMMAND redship --test all)

--- a/CMake/SingleExecutable.cmake
+++ b/CMake/SingleExecutable.cmake
@@ -315,8 +315,8 @@ if(BUILD_TESTING)
     # definition survived the link, so there was no ODR error to catch it.
     redship_add_test(NAME MMCullingBinding COMMAND redship --test mm-culling-binding)
     # MM GameInteractor shim (#395): MM-side hook registration must go through
-    # the MM-owned extern "C" shim; registering through MM's 104-byte view of
-    # the shared class writes ~92 bytes past OoT's 4-byte allocation.
+    # the MM-owned extern "C" shim; registering through MM's larger view of
+    # the shared class writes ~60-92 bytes past OoT's 4-byte allocation.
     redship_add_test(NAME MMGIShim COMMAND redship --test mm-gi-shim)
     redship_add_test(NAME MMResumeArena COMMAND redship --test mm-resume-arena)
     redship_add_test(NAME MMStartupRestore COMMAND redship --test mm-startup-restore)

--- a/games/mm/2s2h/GameExports_SingleExe.cpp
+++ b/games/mm/2s2h/GameExports_SingleExe.cpp
@@ -575,6 +575,42 @@ static void MM_RegisterIntegrationTestHooks(void) {
 }
 
 // ============================================================================
+// TEMPORARY #395 diagnostics — REMOVE with the shim migration commit.
+// ============================================================================
+// Mirror of the OoT_GI_ProbeRegisterOnMainStart* helpers in
+// games/oot/soh/Enhancements/game-interactor/GameInteractor_Hooks.cpp, but
+// compiled in THIS translation unit — the same TU, headers and flags as the
+// four live RegisterGameHook call sites above. The mm-gi-shim diagnostic test
+// runs both variants against oversized zeroed buffers and reports which byte
+// offsets each one writes:
+//  - Direct measures what the four call sites above actually execute
+//    (inlining included) — expected to write MM's nextHookId offset (96),
+//    i.e. the #395 out-of-bounds write, since inlined bodies bypass the
+//    linker's COMDAT fold entirely.
+//  - OutOfLine measures the linker-selected COMDAT copy as seen from MM.
+extern "C" uint32_t MM_GI_DiagRegisterOnMainStartDirect(void* storage, void (*fn)(void)) {
+    return static_cast<GameInteractor*>(storage)->RegisterGameHook<GameInteractor::OnGameStateMainStart>(fn);
+}
+
+extern "C" uint32_t MM_GI_DiagRegisterOnMainStartOutOfLine(void* storage, void (*fn)(void)) {
+    auto reg = &GameInteractor::RegisterGameHook<GameInteractor::OnGameStateMainStart>;
+    GameInteractor* gi = static_cast<GameInteractor*>(storage);
+#ifdef __cpp_lib_source_location
+    return (gi->*reg)(fn, std::source_location::current());
+#else
+    return (gi->*reg)(fn);
+#endif
+}
+
+extern "C" size_t MM_GI_DiagInstanceSize(void) {
+    return sizeof(GameInteractor);
+}
+
+extern "C" size_t MM_GI_DiagNextHookIdOffset(void) {
+    return offsetof(GameInteractor, nextHookId);
+}
+
+// ============================================================================
 // Gameplay round-trip repro (INT_TEST_GAMEPLAY_ROUNDTRIP) — MM frame driver
 // ============================================================================
 

--- a/games/mm/2s2h/GameExports_SingleExe.cpp
+++ b/games/mm/2s2h/GameExports_SingleExe.cpp
@@ -19,6 +19,7 @@
 
 #ifdef RSBS_SINGLE_EXECUTABLE
 
+#include <cstddef> // offsetof for the #395 layout facts; ptrdiff_t
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
@@ -37,6 +38,7 @@
 #include <ship/resource/ResourceLoader.h>
 #include <ship/resource/archive/ArchiveManager.h>
 #include "GameInteractor/GameInteractor.h"
+#include "mm_game_hooks.h" // MM-owned hook/event shim (#395) — implemented below
 #include <ship/resource/File.h>
 #include <libultraship/bridge/consolevariablebridge.h>
 
@@ -224,6 +226,99 @@ extern "C" bool Combo_ArchivePathIsMM(const char* path) {
     return path != nullptr && IsMMArchivePath(path);
 }
 
+// ============================================================================
+// MM-owned GameInteractor shim (#395) — API in games/mm/include/mm_game_hooks.h
+// ============================================================================
+// MM must never register hooks through the shared C++ GameInteractor: the one
+// allocation is OoT's (sizeof 4, nextHookId at offset 0) while this TU
+// compiles the class at sizeof 104 / nextHookId offset 96 (MSVC; 72 / 64 on
+// Linux GCC), so a registration compiled from MM's body writes ~60-92 bytes
+// past the end of the block. (The PR #415 diagnostic showed Linux happened to
+// fold these calls to OoT's body — a link-order accident, not a contract.)
+// Hooks registered here are dispatched from MM's own frame loop
+// (games/mm/src/code/game.c -> MM_GameHooks_ExecuteOnGameStateMainStart), so
+// they run on MM frames only — the semantics MM's upstream executor had. The
+// cross-bound OoT wrapper path stayed gated off while MM is active (#367),
+// which is also why these hooks never enter OoT's registry: no MM handler can
+// alias an OoT hook type or VB ordinal from here.
+
+namespace {
+
+struct MMGameHookEntry {
+    uint32_t id;
+    void (*fn)(void);
+};
+
+std::vector<MMGameHookEntry> sMMHooksOnGameStateMainStart;
+std::vector<uint32_t> sMMHooksPendingUnregister;
+uint32_t sMMNextGameHookId = 1;
+
+// MM-owned storage for the GIEvent queue MM code used to reach as
+// GameInteractor::Instance->events / ->currentEvent — MM-only data members at
+// offsets entirely past the shared 4-byte allocation, i.e. the same #395 OOB on
+// the data path. Lane C's Rando/enh migration reads and writes these instead
+// (contract in mm_game_hooks.h and on #392).
+std::vector<GIEvent> sMMEventQueue;
+GIEvent sMMCurrentEvent = GIEventNone{};
+
+} // namespace
+
+extern "C" uint32_t MM_GameHooks_RegisterOnGameStateMainStart(void (*fn)(void)) {
+    if (fn == nullptr) {
+        return 0;
+    }
+    uint32_t id = sMMNextGameHookId++;
+    sMMHooksOnGameStateMainStart.push_back({ id, fn });
+    return id;
+}
+
+extern "C" void MM_GameHooks_UnregisterOnGameStateMainStart(uint32_t hookId) {
+    if (hookId == 0) {
+        return;
+    }
+    // Deferred like the C++ registry's UnregisterGameHook: a hook may
+    // unregister itself (or a peer) while the dispatch walk is in progress.
+    sMMHooksPendingUnregister.push_back(hookId);
+}
+
+extern "C" void MM_GameHooks_ExecuteOnGameStateMainStart(void) {
+    for (uint32_t deadId : sMMHooksPendingUnregister) {
+        for (size_t i = 0; i < sMMHooksOnGameStateMainStart.size(); i++) {
+            if (sMMHooksOnGameStateMainStart[i].id == deadId) {
+                sMMHooksOnGameStateMainStart.erase(sMMHooksOnGameStateMainStart.begin() +
+                                                   static_cast<std::ptrdiff_t>(i));
+                break;
+            }
+        }
+    }
+    sMMHooksPendingUnregister.clear();
+
+    // Snapshot the count: a hook may register another hook mid-walk (the
+    // vector may reallocate — hence indices, not iterators); new hooks first
+    // run on the next dispatch, matching the registration contract.
+    const size_t count = sMMHooksOnGameStateMainStart.size();
+    for (size_t i = 0; i < count; i++) {
+        sMMHooksOnGameStateMainStart[i].fn();
+    }
+}
+
+extern "C" uint32_t MM_GameHooks_CountOnGameStateMainStart(void) {
+    return static_cast<uint32_t>(sMMHooksOnGameStateMainStart.size());
+}
+
+extern "C" void MM_GameHooks_ResetForTest(void) {
+    sMMHooksOnGameStateMainStart.clear();
+    sMMHooksPendingUnregister.clear();
+}
+
+std::vector<GIEvent>& MM_GameEvents_Queue() {
+    return sMMEventQueue;
+}
+
+GIEvent& MM_GameEvents_Current() {
+    return sMMCurrentEvent;
+}
+
 // Integration test hook frame counter (reset each time hooks are registered)
 static int sGameStateMainFrameCount = 0;
 
@@ -248,10 +343,11 @@ static const int kSceneLoadWatchdogFrames = 1800;
  * former crash site, MM_Actor_SpawnEntry), and the first room's commands ran.
  */
 static bool MM_SceneLoadComplete(void) {
-    // Both games' frame loops fire the same shared OnGameStateMainStart hook
-    // storage, so MM-registered test hooks also run during OoT frames — and
-    // MM's suspended PlayState stays non-NULL across a switch away. Only
-    // count MM's own frames (#344).
+    // MM's test hooks are dispatched from MM's own frame loop via the
+    // MM-owned shim (#395), so this gate is belt-and-braces today — but the
+    // unit-test harness also drives the dispatch headlessly, and MM's
+    // suspended PlayState stays non-NULL across a switch away. Only count
+    // MM's own frames (#344).
     if (Context_GetCurrentGame() != GAME_MM) {
         return false;
     }
@@ -277,8 +373,8 @@ static bool MM_SceneLoadComplete(void) {
  * watchdog has fired so callers can stop doing per-frame work.
  */
 static bool MM_SceneLoadWatchdogExpired(const char* testName) {
-    // MM-registered hooks also fire during OoT frames (shared hook storage);
-    // only MM's own frames count against the watchdog budget.
+    // Only MM's own frames count against the watchdog budget (the unit-test
+    // harness dispatches the shim headlessly with no game active).
     if (Context_GetCurrentGame() != GAME_MM) {
         return false;
     }
@@ -340,7 +436,7 @@ static void MM_RegisterIntegrationTestHooks(void) {
         // the title-demo Play state crashed in MM_Actor_SpawnEntry. (The
         // OnConsoleLogoUpdate hook was dead anyway: MM's executor is excluded
         // in single-exe builds and the call resolves to a no-op stub.)
-        GameInteractor::Instance->RegisterGameHook<GameInteractor::OnGameStateMainStart>([]() {
+        MM_GameHooks_RegisterOnGameStateMainStart([]() {
             if (!MM_SceneLoadComplete()) {
                 sSceneLoadStableFrames = 0;
                 MM_SceneLoadWatchdogExpired("int-boot-mm");
@@ -371,7 +467,7 @@ static void MM_RegisterIntegrationTestHooks(void) {
         // (#344) PASS requires MM to complete the South Clock Town scene
         // load the entrance link asked for (0xD800, the tower-exit arrival),
         // not just tick frames.
-        GameInteractor::Instance->RegisterGameHook<GameInteractor::OnGameStateMainStart>([]() {
+        MM_GameHooks_RegisterOnGameStateMainStart([]() {
             if (!MM_SceneLoadComplete() || MM_gPlayState->sceneId != SCENE_CLOCKTOWER) {
                 static bool sWrongSceneLogged = false;
                 sSceneLoadStableFrames = 0;
@@ -412,7 +508,7 @@ static void MM_RegisterIntegrationTestHooks(void) {
         sSceneLoadWaitFrames = 0;
         sSceneLoadStableFrames = 0;
 
-        GameInteractor::Instance->RegisterGameHook<GameInteractor::OnGameStateMainStart>([]() {
+        MM_GameHooks_RegisterOnGameStateMainStart([]() {
             static bool sTriggered = false;
             if (sTriggered) {
                 return;
@@ -495,7 +591,7 @@ static void MM_RegisterIntegrationTestHooks(void) {
         sSceneLoadWaitFrames = 0;
         sSceneLoadStableFrames = 0;
 
-        GameInteractor::Instance->RegisterGameHook<GameInteractor::OnGameStateMainStart>([]() {
+        MM_GameHooks_RegisterOnGameStateMainStart([]() {
             // Fire once per arrival, ~10 stable frames after (re)entry, then
             // re-arm for the next MM arrival (reached via MM_Game_Resume).
             // (#344) Frames only count while a completed scene load is live,
@@ -557,12 +653,14 @@ static void MM_RegisterIntegrationTestHooks(void) {
         // Combo_CheckEntranceSwitch(nextEntrance), which freezes MM's live
         // SaveContext, exactly like a player walking into the tower.
         //
-        // The MM driver deliberately does NOT use GameInteractor hooks: MM's
-        // per-frame hook dispatch goes through the cross-bound OoT wrappers,
-        // which #367 no-ops while MM is the active game (correctly — that
-        // gate is production behavior the repro must run WITH). Instead MM's
-        // graph loop calls MM_IntegrationGameplayFrameTick() directly
-        // (games/mm/src/code/graph.c), which is a no-op outside this mode.
+        // The MM driver predates the MM-owned hook shim (#395) and drives
+        // frames directly: MM's graph loop calls
+        // MM_IntegrationGameplayFrameTick() (games/mm/src/code/graph.c),
+        // which is a no-op outside this mode. (Historically it could not use
+        // GameInteractor hooks at all — MM's dispatch went through the
+        // cross-bound OoT wrappers, which #367 no-ops while MM is active.)
+        // Kept as-is: the direct tick is proven by the soak tier and needs
+        // none of the shim's registration machinery.
         sGpMMLastPhase = GP_PHASE_DONE;
         sGpMMStableFrames = 0;
         sGpMMPlayFrames = 0;
@@ -574,39 +672,24 @@ static void MM_RegisterIntegrationTestHooks(void) {
     }
 }
 
-// ============================================================================
-// TEMPORARY #395 diagnostics — REMOVE with the shim migration commit.
-// ============================================================================
-// Mirror of the OoT_GI_ProbeRegisterOnMainStart* helpers in
-// games/oot/soh/Enhancements/game-interactor/GameInteractor_Hooks.cpp, but
-// compiled in THIS translation unit — the same TU, headers and flags as the
-// four live RegisterGameHook call sites above. The mm-gi-shim diagnostic test
-// runs both variants against oversized zeroed buffers and reports which byte
-// offsets each one writes:
-//  - Direct measures what the four call sites above actually execute
-//    (inlining included) — expected to write MM's nextHookId offset (96),
-//    i.e. the #395 out-of-bounds write, since inlined bodies bypass the
-//    linker's COMDAT fold entirely.
-//  - OutOfLine measures the linker-selected COMDAT copy as seen from MM.
-extern "C" uint32_t MM_GI_DiagRegisterOnMainStartDirect(void* storage, void (*fn)(void)) {
-    return static_cast<GameInteractor*>(storage)->RegisterGameHook<GameInteractor::OnGameStateMainStart>(fn);
+// C entry point for the mm-gi-shim test (games/mm/2s2h/mm_gi_shim_test.cpp):
+// runs the REAL per-mode arming path against whatever mode
+// IntegrationTest_SetMode selected, so the four-mode registration surface is
+// locked ROM-free (the operator-batch check on #392 covers live arming).
+extern "C" void MM_GIShim_TestArmIntegrationHooks(void) {
+    MM_RegisterIntegrationTestHooks();
 }
 
-extern "C" uint32_t MM_GI_DiagRegisterOnMainStartOutOfLine(void* storage, void (*fn)(void)) {
-    auto reg = &GameInteractor::RegisterGameHook<GameInteractor::OnGameStateMainStart>;
-    GameInteractor* gi = static_cast<GameInteractor*>(storage);
-#ifdef __cpp_lib_source_location
-    return (gi->*reg)(fn, std::source_location::current());
-#else
-    return (gi->*reg)(fn);
-#endif
-}
-
-extern "C" size_t MM_GI_DiagInstanceSize(void) {
+// MM's view of the GameInteractor layout, reported from this TU's production
+// headers/flags for the mm-gi-shim layout lock. The Register* members
+// themselves are compile-time poisoned in this target
+// (games/mm/include/mm_gi_hook_guard.h), so layout facts are all this TU can
+// export — which is the point.
+extern "C" size_t MM_GI_InstanceSize(void) {
     return sizeof(GameInteractor);
 }
 
-extern "C" size_t MM_GI_DiagNextHookIdOffset(void) {
+extern "C" size_t MM_GI_NextHookIdOffset(void) {
     return offsetof(GameInteractor, nextHookId);
 }
 
@@ -975,6 +1058,103 @@ u16 AudioEditor_GetOriginalSeq(u16 seqId) {
     // replacement CVars set: original ids map to themselves, everything
     // else (custom ids, NA_BGM_DISABLED) resolves to 0.
     return seqId <= 0x7F ? seqId : 0;
+}
+
+/**
+ * Real single-exe definition for #372. MM's implementation TU
+ * (2s2h/GameInteractor/GameInteractor.cpp) is excluded ("use OoT's") and OoT
+ * defines no GameInteractor_InvertControl, so the old src/common/mm_stubs.c
+ * stub was the sole definition — and it returned the ENUM ORDINAL as the
+ * multiplier. Every caller multiplies a stick axis by the result:
+ * Lib_GetControlStickData ran x *= 2 (GI_INVERT_MOVEMENT_X == 2) on every
+ * movement frame, skewing every analog angle toward the X axis, and
+ * Actor_SetControlStickData's s8 path wrapped past half deflection.
+ *
+ * Body lifted from upstream 2s2h/GameInteractor/GameInteractor.cpp
+ * (GameInteractor_InvertControl; unchanged except explicit default: branches
+ * to keep -Wswitch quiet) — CVar-driven, so the shipped 2S2H defaults
+ * apply (camera right-stick Y and first-person aim/right-stick Y default to
+ * inverted) and Mirrored World keeps working if its toggle ever ports.
+ * Declared extern "C" in MM's GameInteractor.h, which this TU includes:
+ * signature drift here is a compile error, retiring this symbol from the
+ * mm_stubs.c drift class.
+ */
+int GameInteractor_InvertControl(GIInvertType type) {
+    int result = 1;
+
+    switch (type) {
+        case GI_INVERT_CAMERA_RIGHT_STICK_X:
+            if (CVarGetInteger("gEnhancements.Camera.RightStick.InvertXAxis", 0)) {
+                result *= -1;
+            }
+            break;
+        case GI_INVERT_CAMERA_RIGHT_STICK_Y:
+            if (CVarGetInteger("gEnhancements.Camera.RightStick.InvertYAxis", 1)) {
+                result *= -1;
+            }
+            break;
+        case GI_INVERT_FIRST_PERSON_AIM_X:
+            if (CVarGetInteger("gEnhancements.Camera.FirstPerson.InvertX", 0)) {
+                result *= -1;
+            }
+            break;
+        case GI_INVERT_FIRST_PERSON_AIM_Y:
+            if (CVarGetInteger("gEnhancements.Camera.FirstPerson.InvertY", 1)) {
+                result *= -1;
+            }
+            break;
+        case GI_INVERT_FIRST_PERSON_GYRO_X:
+            if (CVarGetInteger("gEnhancements.Camera.FirstPerson.GyroInvertX", 0)) {
+                result *= -1;
+            }
+            break;
+        case GI_INVERT_FIRST_PERSON_GYRO_Y:
+            if (CVarGetInteger("gEnhancements.Camera.FirstPerson.GyroInvertY", 0)) {
+                result *= -1;
+            }
+            break;
+        case GI_INVERT_FIRST_PERSON_RIGHT_STICK_X:
+            if (CVarGetInteger("gEnhancements.Camera.FirstPerson.RightStickInvertX", 0)) {
+                result *= -1;
+            }
+            break;
+        case GI_INVERT_FIRST_PERSON_RIGHT_STICK_Y:
+            if (CVarGetInteger("gEnhancements.Camera.FirstPerson.RightStickInvertY", 1)) {
+                result *= -1;
+            }
+            break;
+        case GI_INVERT_SHIELD_Y:
+            if (CVarGetInteger("gEnhancements.Equipment.InvertShieldY", 0)) {
+                result *= -1;
+            }
+            break;
+        default:
+            break;
+    }
+
+    // Invert all X axis inputs if the Mirrored World mode is enabled
+    if (CVarGetInteger("gModes.MirroredWorld.State", 0)) {
+        switch (type) {
+            case GI_INVERT_CAMERA_RIGHT_STICK_X:
+            case GI_INVERT_MOVEMENT_X:
+            case GI_INVERT_SHIELD_X:
+            case GI_INVERT_SHOP_X:
+            case GI_INVERT_HORSE_X:
+            case GI_INVERT_ZORA_SWIM_X:
+            case GI_INVERT_DEBUG_DPAD_X:
+            case GI_INVERT_TELESCOPE_X:
+            case GI_INVERT_FIRST_PERSON_AIM_X:
+            case GI_INVERT_FIRST_PERSON_GYRO_X:
+            case GI_INVERT_FIRST_PERSON_RIGHT_STICK_X:
+            case GI_INVERT_FIRST_PERSON_MOVING_X:
+                result *= -1;
+                break;
+            default:
+                break;
+        }
+    }
+
+    return result;
 }
 
 int MM_Game_Init(int argc, char** argv) {

--- a/games/mm/2s2h/mm_gi_shim_test.cpp
+++ b/games/mm/2s2h/mm_gi_shim_test.cpp
@@ -1,0 +1,126 @@
+/**
+ * ROM-free lock for the MM GameInteractor shim (#395 / #383 GameInteractor
+ * item). CTest label "redship", row mm-gi-shim in src/common/test_runner.cpp.
+ *
+ * DIAGNOSTIC PHASE (this revision deliberately FAILS): before migrating MM's
+ * four RegisterGameHook call sites off the shared C++ class, this test
+ * measures — from real OoT and MM translation units compiled with their
+ * production flags — which byte offsets each side's registration path
+ * actually writes, by running registrations against oversized zeroed buffers:
+ *
+ *  - Direct probes measure the real call sites (inlining included).
+ *  - OutOfLine probes (member-function-pointer calls) measure the
+ *    linker-selected COMDAT copy of RegisterGameHook<OnGameStateMainStart> —
+ *    the one every non-inlined call site in EITHER game binds.
+ *
+ * CI runs ctest with --output-on-failure, so the intentional failure is what
+ * publishes the measurements to the build-linux log. The follow-up commit
+ * replaces this body with the real regression lock.
+ */
+
+#ifdef RSBS_SINGLE_EXECUTABLE
+
+#include <cstddef>
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+
+// MM's 2s2h/GameInteractor/GameInteractor.h is force-included into every MM
+// C++ TU (games/mm/CMakeLists.txt), so GameInteractor here is MM's layout.
+
+extern "C" {
+// games/oot/soh/Enhancements/game-interactor/GameInteractor_Hooks.cpp
+size_t OoT_GI_InstanceSize(void);
+size_t OoT_GI_NextHookIdOffset(void);
+uint32_t OoT_GI_ProbeRegisterOnMainStartDirect(void* storage, void (*fn)(void));
+uint32_t OoT_GI_ProbeRegisterOnMainStartOutOfLine(void* storage, void (*fn)(void));
+void OoT_GI_ProbeUnregisterOnMainStart(uint32_t hookId);
+void OoT_GI_ProbePumpOnMainStart(void);
+// GameExports_SingleExe.cpp (TEMPORARY diagnostics, same TU as the live
+// MM call sites)
+uint32_t MM_GI_DiagRegisterOnMainStartDirect(void* storage, void (*fn)(void));
+uint32_t MM_GI_DiagRegisterOnMainStartOutOfLine(void* storage, void (*fn)(void));
+size_t MM_GI_DiagInstanceSize(void);
+size_t MM_GI_DiagNextHookIdOffset(void);
+}
+
+namespace {
+
+constexpr size_t kProbeBufSize = 256;
+
+void GIShimNoopHook(void) {
+}
+
+// Prints every byte range [lo, hi) that is nonzero after a probe ran against
+// a zeroed buffer. The registration path writes only nextHookId, so the
+// ranges directly name the layout the executed code was compiled against.
+void ReportWrites(const char* label, const unsigned char* buf, size_t n) {
+    printf("[GI-DIAG] %-28s wrote:", label);
+    bool any = false;
+    size_t i = 0;
+    while (i < n) {
+        if (buf[i] != 0) {
+            size_t lo = i;
+            while (i < n && buf[i] != 0) {
+                i++;
+            }
+            printf(" [%zu,%zu)", lo, i);
+            any = true;
+        } else {
+            i++;
+        }
+    }
+    if (!any) {
+        printf(" nothing");
+    }
+    printf("\n");
+}
+
+} // namespace
+
+extern "C" int MM_GIShim_RunHeadless(void) {
+    printf("[GI-DIAG] layout: OoT sizeof=%zu nextHookId@%zu | MM sizeof=%zu nextHookId@%zu\n", OoT_GI_InstanceSize(),
+           OoT_GI_NextHookIdOffset(), MM_GI_DiagInstanceSize(), MM_GI_DiagNextHookIdOffset());
+
+    struct ProbeCase {
+        const char* label;
+        uint32_t (*probe)(void*, void (*)(void));
+    };
+    const ProbeCase cases[] = {
+        { "OoT direct call", OoT_GI_ProbeRegisterOnMainStartDirect },
+        { "OoT out-of-line (COMDAT)", OoT_GI_ProbeRegisterOnMainStartOutOfLine },
+        { "MM direct call", MM_GI_DiagRegisterOnMainStartDirect },
+        { "MM out-of-line (COMDAT)", MM_GI_DiagRegisterOnMainStartOutOfLine },
+    };
+
+    uint32_t ids[4] = { 0, 0, 0, 0 };
+    int idCount = 0;
+
+    for (const ProbeCase& c : cases) {
+        unsigned char* buf = static_cast<unsigned char*>(calloc(1, kProbeBufSize));
+        if (buf == nullptr) {
+            printf("[TEST] FAIL: probe buffer allocation failed\n");
+            return 1;
+        }
+        uint32_t id = c.probe(buf, GIShimNoopHook);
+        ids[idCount++] = id;
+        ReportWrites(c.label, buf, kProbeBufSize);
+        free(buf);
+    }
+
+    // Clean the shared inline-static hook map back up: queue all probe hooks
+    // for unregistration, then pump once (the flush happens at the head of
+    // ExecuteHooks, so nothing actually executes).
+    for (int i = 0; i < idCount; i++) {
+        OoT_GI_ProbeUnregisterOnMainStart(ids[i]);
+    }
+    OoT_GI_ProbePumpOnMainStart();
+
+    printf("[TEST] FAIL: mm-gi-shim is in DIAGNOSTIC mode — intentional failure so ctest "
+           "--output-on-failure publishes the probe report above. The shim migration commit "
+           "replaces this with the real regression lock.\n");
+    return 1;
+}
+
+#endif // RSBS_SINGLE_EXECUTABLE

--- a/games/mm/2s2h/mm_gi_shim_test.cpp
+++ b/games/mm/2s2h/mm_gi_shim_test.cpp
@@ -2,20 +2,55 @@
  * ROM-free lock for the MM GameInteractor shim (#395 / #383 GameInteractor
  * item). CTest label "redship", row mm-gi-shim in src/common/test_runner.cpp.
  *
- * DIAGNOSTIC PHASE (this revision deliberately FAILS): before migrating MM's
- * four RegisterGameHook call sites off the shared C++ class, this test
- * measures — from real OoT and MM translation units compiled with their
- * production flags — which byte offsets each side's registration path
- * actually writes, by running registrations against oversized zeroed buffers:
+ * What was broken: both ports define a global-namespace `class GameInteractor`
+ * with different layouts — OoT sizeof 4 / nextHookId at 0; MM sizeof 104 /
+ * nextHookId at 96 under MSVC, 72 / 64 under Linux GCC — and the single
+ * shared allocation is OoT's. MM's four integration-test hook registrations
+ * went through MM's view of the class: compiled as MM's body, each one writes
+ * nextHookId ~60-92 bytes past the end of the 4-byte block.
  *
- *  - Direct probes measure the real call sites (inlining included).
- *  - OutOfLine probes (member-function-pointer calls) measure the
- *    linker-selected COMDAT copy of RegisterGameHook<OnGameStateMainStart> —
- *    the one every non-inlined call site in EITHER game binds.
+ * What the PR #415 diagnostic run measured (Linux, production flags): all
+ * four probe variants — OoT direct, OoT out-of-line, MM direct, MM
+ * out-of-line — wrote OoT's offset [0,4). I.e. on that build the MM call
+ * sites were NOT inlined and the linker folded every
+ * RegisterGameHook<OnGameStateMainStart> COMDAT to OoT's copy, so the OOB
+ * write was latent rather than firing. That is luck, not safety: the #383
+ * FlagTable incident showed fold winners FLIP when an unrelated link-set
+ * change lands, one inlining decision (LTO, /O2 heuristics, a bigger caller)
+ * executes MM's body regardless of the fold, and MM's events/currentEvent
+ * data members are out-of-bounds on the shared instance whenever touched.
+ * MM registrations therefore go through the MM-owned extern "C" shim
+ * (games/mm/include/mm_game_hooks.h), dispatched from MM's own frame loop,
+ * and this test pins the folded copy to OoT's layout.
  *
- * CI runs ctest with --output-on-failure, so the intentional failure is what
- * publishes the measurements to the build-linux log. The follow-up commit
- * replaces this body with the real regression lock.
+ * Three locks, in order of strength:
+ *
+ * 1. LAYOUT PREMISE (machine-verified, not assumed). The two ports' sizeof /
+ *    offsetof(nextHookId) are compared at runtime, each reported from its own
+ *    TU with its own production headers and flags. If they ever agree, the
+ *    fault class evaporates and this test should be revisited.
+ *
+ * 2. FOLD/CALL-SITE BEHAVIOR (the lock linker ICF cannot defeat). OoT-side
+ *    registration is run against an oversized zeroed buffer twice — once as a
+ *    normal (inlinable) call, once through a member-function pointer, which
+ *    is exactly the linker-selected COMDAT copy of
+ *    RegisterGameHook<OnGameStateMainStart>. Passing requires every byte
+ *    written to lie inside OoT's sizeof — i.e. no surviving registration path
+ *    executes MM's offset-96 body. If MM code ever reintroduces a
+ *    RegisterGameHook instantiation into the link and it wins the fold (the
+ *    hazard Lane C's 2ship_enh/2ship_rando un-elision can trigger), this
+ *    fails loudly. The compile-time half lives in
+ *    games/mm/include/mm_gi_hook_guard.h, which poisons the Register* member
+ *    names in 2ship_port/2ship_src TUs — including this one, which is why the
+ *    MM side of this test only exports layout facts.
+ *
+ * 3. SHIM CONTRACT + FOUR-MODE ARMING. The MM_GameHooks_* registry must
+ *    register/dispatch/deferred-unregister as documented, and the REAL
+ *    per-mode arming path (MM_RegisterIntegrationTestHooks, reached via
+ *    IntegrationTest_SetMode + the C test entry) must register exactly one
+ *    MM-frame hook for each of the four hook-driven integration modes
+ *    (boot-mm, T1, T2, T4) and none for the direct-tick round-trip mode.
+ *    Live arming on a real boot is the operator-batch check on #392.
  */
 
 #ifdef RSBS_SINGLE_EXECUTABLE
@@ -26,101 +61,186 @@
 #include <cstdlib>
 #include <cstring>
 
-// MM's 2s2h/GameInteractor/GameInteractor.h is force-included into every MM
-// C++ TU (games/mm/CMakeLists.txt), so GameInteractor here is MM's layout.
+#include "mm_game_hooks.h"
+#include "integration_test_hooks.h"
+#include "context.h"
 
 extern "C" {
-// games/oot/soh/Enhancements/game-interactor/GameInteractor_Hooks.cpp
+// games/oot/soh/Enhancements/game-interactor/GameInteractor_Hooks.cpp — OoT's
+// own view of its layout plus registration probes compiled in OoT's TU.
 size_t OoT_GI_InstanceSize(void);
 size_t OoT_GI_NextHookIdOffset(void);
 uint32_t OoT_GI_ProbeRegisterOnMainStartDirect(void* storage, void (*fn)(void));
 uint32_t OoT_GI_ProbeRegisterOnMainStartOutOfLine(void* storage, void (*fn)(void));
 void OoT_GI_ProbeUnregisterOnMainStart(uint32_t hookId);
 void OoT_GI_ProbePumpOnMainStart(void);
-// GameExports_SingleExe.cpp (TEMPORARY diagnostics, same TU as the live
-// MM call sites)
-uint32_t MM_GI_DiagRegisterOnMainStartDirect(void* storage, void (*fn)(void));
-uint32_t MM_GI_DiagRegisterOnMainStartOutOfLine(void* storage, void (*fn)(void));
-size_t MM_GI_DiagInstanceSize(void);
-size_t MM_GI_DiagNextHookIdOffset(void);
+// games/mm/2s2h/GameExports_SingleExe.cpp — MM's view of the layout (facts
+// only; MM registration members are compile-time poisoned) and the C entry
+// that runs the real integration-mode arming path.
+size_t MM_GI_InstanceSize(void);
+size_t MM_GI_NextHookIdOffset(void);
+void MM_GIShim_TestArmIntegrationHooks(void);
 }
 
 namespace {
 
 constexpr size_t kProbeBufSize = 256;
 
+#define GIS_ASSERT(cond, msg)                                             \
+    do {                                                                  \
+        if (!(cond)) {                                                    \
+            printf("[TEST] FAIL: %s (%s:%d)\n", msg, __FILE__, __LINE__); \
+            return 1;                                                     \
+        }                                                                 \
+    } while (0)
+
 void GIShimNoopHook(void) {
 }
 
-// Prints every byte range [lo, hi) that is nonzero after a probe ran against
-// a zeroed buffer. The registration path writes only nextHookId, so the
-// ranges directly name the layout the executed code was compiled against.
-void ReportWrites(const char* label, const unsigned char* buf, size_t n) {
-    printf("[GI-DIAG] %-28s wrote:", label);
-    bool any = false;
-    size_t i = 0;
-    while (i < n) {
-        if (buf[i] != 0) {
-            size_t lo = i;
-            while (i < n && buf[i] != 0) {
-                i++;
-            }
-            printf(" [%zu,%zu)", lo, i);
-            any = true;
-        } else {
-            i++;
+int sHookACalls = 0;
+int sHookBCalls = 0;
+
+void GIShimHookA(void) {
+    sHookACalls++;
+}
+
+void GIShimHookB(void) {
+    sHookBCalls++;
+}
+
+// True iff every nonzero byte after a probe against a zeroed buffer lies
+// inside [0, limit). Prints any violating range so a regression names the
+// layout that wrote it.
+bool WritesConfinedBelow(const char* label, const unsigned char* buf, size_t n, size_t limit) {
+    bool ok = true;
+    for (size_t i = 0; i < n; i++) {
+        if (buf[i] != 0 && i >= limit) {
+            printf("[TEST] %s wrote byte at offset %zu (allowed range is [0,%zu)) — an MM-layout "
+                   "registration body is back in the link\n",
+                   label, i, limit);
+            ok = false;
         }
     }
-    if (!any) {
-        printf(" nothing");
-    }
-    printf("\n");
+    return ok;
 }
 
 } // namespace
 
 extern "C" int MM_GIShim_RunHeadless(void) {
-    printf("[GI-DIAG] layout: OoT sizeof=%zu nextHookId@%zu | MM sizeof=%zu nextHookId@%zu\n", OoT_GI_InstanceSize(),
-           OoT_GI_NextHookIdOffset(), MM_GI_DiagInstanceSize(), MM_GI_DiagNextHookIdOffset());
+    // ---- 1. Layout premise: the two ports really do disagree -------------
+    const size_t ootSize = OoT_GI_InstanceSize();
+    const size_t ootOff = OoT_GI_NextHookIdOffset();
+    const size_t mmSize = MM_GI_InstanceSize();
+    const size_t mmOff = MM_GI_NextHookIdOffset();
+    printf("[TEST] GameInteractor layout — OoT sizeof=%zu nextHookId@%zu, MM sizeof=%zu nextHookId@%zu\n", ootSize,
+           ootOff, mmSize, mmOff);
+    GIS_ASSERT(ootSize != mmSize || ootOff != mmOff,
+               "MM and OoT GameInteractor layouts agree — the premise of #395 no longer holds, revisit this lock");
+    GIS_ASSERT(mmOff + sizeof(uint32_t) > ootSize,
+               "MM's nextHookId lies inside OoT's allocation — probe confinement below would be vacuous, revisit");
 
+    // ---- 2. Registration writes stay inside OoT's allocation -------------
+    // Direct = what OoT's real call sites execute (inlining included).
+    // OutOfLine = the linker-selected COMDAT copy, the body any non-inlined
+    // call site in EITHER game binds.
     struct ProbeCase {
         const char* label;
         uint32_t (*probe)(void*, void (*)(void));
     };
     const ProbeCase cases[] = {
-        { "OoT direct call", OoT_GI_ProbeRegisterOnMainStartDirect },
-        { "OoT out-of-line (COMDAT)", OoT_GI_ProbeRegisterOnMainStartOutOfLine },
-        { "MM direct call", MM_GI_DiagRegisterOnMainStartDirect },
-        { "MM out-of-line (COMDAT)", MM_GI_DiagRegisterOnMainStartOutOfLine },
+        { "OoT direct-call registration", OoT_GI_ProbeRegisterOnMainStartDirect },
+        { "COMDAT-fold registration", OoT_GI_ProbeRegisterOnMainStartOutOfLine },
     };
-
-    uint32_t ids[4] = { 0, 0, 0, 0 };
-    int idCount = 0;
-
-    for (const ProbeCase& c : cases) {
+    uint32_t probeIds[2] = { 0, 0 };
+    for (int c = 0; c < 2; c++) {
         unsigned char* buf = static_cast<unsigned char*>(calloc(1, kProbeBufSize));
-        if (buf == nullptr) {
-            printf("[TEST] FAIL: probe buffer allocation failed\n");
-            return 1;
-        }
-        uint32_t id = c.probe(buf, GIShimNoopHook);
-        ids[idCount++] = id;
-        ReportWrites(c.label, buf, kProbeBufSize);
+        GIS_ASSERT(buf != nullptr, "probe buffer allocation failed");
+        probeIds[c] = cases[c].probe(buf, GIShimNoopHook);
+        const bool confined = WritesConfinedBelow(cases[c].label, buf, kProbeBufSize, ootSize);
+        const bool touched = buf[ootOff] != 0 || buf[ootOff + 1] != 0 || buf[ootOff + 2] != 0 || buf[ootOff + 3] != 0;
         free(buf);
+        GIS_ASSERT(probeIds[c] != 0, "probe registration returned id 0");
+        GIS_ASSERT(confined, "registration wrote outside OoT's GameInteractor — MM's layout is being executed");
+        GIS_ASSERT(touched, "registration did not write OoT's nextHookId — probe is not measuring the real path");
     }
-
-    // Clean the shared inline-static hook map back up: queue all probe hooks
-    // for unregistration, then pump once (the flush happens at the head of
-    // ExecuteHooks, so nothing actually executes).
-    for (int i = 0; i < idCount; i++) {
-        OoT_GI_ProbeUnregisterOnMainStart(ids[i]);
-    }
+    GIS_ASSERT(probeIds[0] != probeIds[1], "probe registrations returned the same hook id");
+    // Clean the shared inline-static hook map back up: queue both probe hooks
+    // for unregistration, then pump once (the flush runs at the head of
+    // ExecuteHooks, so nothing actually executes here).
+    OoT_GI_ProbeUnregisterOnMainStart(probeIds[0]);
+    OoT_GI_ProbeUnregisterOnMainStart(probeIds[1]);
     OoT_GI_ProbePumpOnMainStart();
 
-    printf("[TEST] FAIL: mm-gi-shim is in DIAGNOSTIC mode — intentional failure so ctest "
-           "--output-on-failure publishes the probe report above. The shim migration commit "
-           "replaces this with the real regression lock.\n");
-    return 1;
+    // ---- 3. Shim contract: register / dispatch / deferred unregister -----
+    MM_GameHooks_ResetForTest();
+    sHookACalls = 0;
+    sHookBCalls = 0;
+
+    GIS_ASSERT(MM_GameHooks_RegisterOnGameStateMainStart(nullptr) == 0, "NULL hook must be rejected with id 0");
+    const uint32_t idA = MM_GameHooks_RegisterOnGameStateMainStart(GIShimHookA);
+    const uint32_t idB = MM_GameHooks_RegisterOnGameStateMainStart(GIShimHookB);
+    GIS_ASSERT(idA != 0 && idB != 0 && idA != idB, "shim registration ids must be nonzero and unique");
+    GIS_ASSERT(MM_GameHooks_CountOnGameStateMainStart() == 2, "two hooks registered, count != 2");
+
+    MM_GameHooks_ExecuteOnGameStateMainStart();
+    GIS_ASSERT(sHookACalls == 1 && sHookBCalls == 1, "dispatch did not run both hooks exactly once");
+
+    MM_GameHooks_UnregisterOnGameStateMainStart(idA);
+    GIS_ASSERT(MM_GameHooks_CountOnGameStateMainStart() == 2,
+               "unregister must be deferred to the next dispatch, not applied immediately");
+    MM_GameHooks_ExecuteOnGameStateMainStart();
+    GIS_ASSERT(sHookACalls == 1, "unregistered hook still ran");
+    GIS_ASSERT(sHookBCalls == 2, "surviving hook did not run");
+    GIS_ASSERT(MM_GameHooks_CountOnGameStateMainStart() == 1, "count did not drop after the deferred flush");
+    MM_GameHooks_UnregisterOnGameStateMainStart(0);      // ignored by contract
+    MM_GameHooks_UnregisterOnGameStateMainStart(0xDEAD); // unknown id: no-op
+    MM_GameHooks_ExecuteOnGameStateMainStart();
+    GIS_ASSERT(sHookBCalls == 3, "hook lost after no-op unregisters");
+
+    // ---- 4. Four-mode arming registers through the shim ------------------
+    // Pin the harness state the real lambdas gate on: with no game active,
+    // dispatching them is a headless no-op (MM_SceneLoadComplete and the
+    // watchdog both require GAME_MM).
+    const GameId prevGame = Context_GetCurrentGame();
+    Context_SetCurrentGame(GAME_NONE);
+
+    struct ModeCase {
+        IntegrationTestMode mode;
+        uint32_t expectedHooks;
+        const char* label;
+    };
+    const ModeCase modes[] = {
+        { INT_TEST_BOOT_MM, 1, "boot-mm" },
+        { INT_TEST_SWITCH_OOT_HMS_TO_MM, 1, "switch-oot-hms-to-mm (T1)" },
+        { INT_TEST_SWITCH_MM_CLOCKTOWN_SOUTH_TO_OOT, 1, "switch-mm-clocktown-south-to-oot (T2)" },
+        { INT_TEST_ARCHIVE_HOTSWAP_CYCLE, 1, "archive-hotswap-cycle (T4)" },
+        { INT_TEST_GAMEPLAY_ROUNDTRIP, 0, "gameplay-roundtrip (direct tick, no hooks)" },
+        { INT_TEST_NONE, 0, "none (arming must early-out)" },
+    };
+    for (const ModeCase& m : modes) {
+        MM_GameHooks_ResetForTest();
+        IntegrationTest_SetMode(m.mode);
+        MM_GIShim_TestArmIntegrationHooks();
+        const uint32_t got = MM_GameHooks_CountOnGameStateMainStart();
+        if (got != m.expectedHooks) {
+            printf("[TEST] FAIL: mode %s armed %u shim hooks, expected %u\n", m.label, got, m.expectedHooks);
+            IntegrationTest_SetMode(INT_TEST_NONE);
+            MM_GameHooks_ResetForTest();
+            Context_SetCurrentGame(prevGame);
+            return 1;
+        }
+        // The armed hooks must be dispatchable headlessly (their scene-load
+        // predicates gate on GAME_MM and fail closed with no game running).
+        MM_GameHooks_ExecuteOnGameStateMainStart();
+    }
+
+    IntegrationTest_SetMode(INT_TEST_NONE);
+    MM_GameHooks_ResetForTest();
+    Context_SetCurrentGame(prevGame);
+
+    printf("[TEST] PASS: mm-gi-shim — MM hook registration stays off the shared 4-byte instance, all four "
+           "hook-driven integration modes arm through the MM-owned shim\n");
+    return 0;
 }
 
 #endif // RSBS_SINGLE_EXECUTABLE

--- a/games/mm/CMakeLists.txt
+++ b/games/mm/CMakeLists.txt
@@ -690,6 +690,19 @@ if(SINGLE_EXECUTABLE_BUILD)
         "${_fi}${CMAKE_CURRENT_SOURCE_DIR}/include/macros.h"
         "${_fi}${CMAKE_CURRENT_SOURCE_DIR}/include/z64.h"
     )
+    # #395 compile-time lock: poison GameInteractor's Register* member names in
+    # MM C++ TUs so hook registration cannot bind MM's 104-byte layout to the
+    # shared 4-byte OoT-owned instance again (MM code uses the extern "C" shim
+    # in include/mm_game_hooks.h instead). Appended AFTER GameInteractor.h so
+    # the class definition itself parses with the real names; only later USES
+    # in a TU fail. 2ship_enh / 2ship_rando are exempt for now: their TUs
+    # still carry upstream RegisterGameHook calls (compiled but link-elided,
+    # see the WHOLE_ARCHIVE note above). Lane C must migrate those calls onto
+    # the shim and extend this guard when it un-elides them (#392).
+    set(_force_include_cxx_guarded
+        ${_force_include_cxx}
+        "${_fi}${CMAKE_CURRENT_SOURCE_DIR}/include/mm_gi_hook_guard.h"
+    )
     set(_force_include_c
         "${_fi}${CMAKE_CURRENT_SOURCE_DIR}/include/ultra64.h"
         "${_fi}${CMAKE_CURRENT_SOURCE_DIR}/include/global.h"
@@ -712,11 +725,16 @@ if(SINGLE_EXECUTABLE_BUILD)
     # generator builds broke. Per-source properties hand both generators the
     # command lines Ninja was already producing.
     get_target_property(_target_sources ${_t} SOURCES)
+    if(_t STREQUAL "2ship_enh" OR _t STREQUAL "2ship_rando")
+        set(_force_include_cxx_for_target "${_force_include_cxx}")
+    else()
+        set(_force_include_cxx_for_target "${_force_include_cxx_guarded}")
+    endif()
     foreach(_src IN LISTS _target_sources)
         if(_src MATCHES "\\.c$")
             set_source_files_properties(${_src} PROPERTIES COMPILE_OPTIONS "${_force_include_c}")
         elseif(_src MATCHES "\\.(cpp|cxx|cc)$")
-            set_source_files_properties(${_src} PROPERTIES COMPILE_OPTIONS "${_force_include_cxx}")
+            set_source_files_properties(${_src} PROPERTIES COMPILE_OPTIONS "${_force_include_cxx_for_target}")
         endif()
     endforeach()
 else()

--- a/games/mm/include/mm_game_hooks.h
+++ b/games/mm/include/mm_game_hooks.h
@@ -1,0 +1,105 @@
+/**
+ * MM-owned GameInteractor shim for single-executable builds (#395, #383).
+ *
+ * WHY THIS EXISTS. Both ports define a global-namespace `class GameInteractor`
+ * with different layouts: OoT's has one data member (HOOK_ID nextHookId,
+ * sizeof 4) and owns the single shared allocation; MM's carries
+ * std::vector<GIEvent> events / GIEvent currentEvent ahead of nextHookId
+ * (sizeof 104 / offset 96 under MSVC, 72 / 64 under Linux GCC). MM's
+ * implementation TUs are excluded from the single-exe link ("use OoT's",
+ * games/mm/CMakeLists.txt), so any MM code that touches an instance member
+ * through the class reads/writes MM offsets into OoT's 4-byte allocation —
+ * a ~60-92-byte out-of-bounds access (#395, machine-verified). The PR #415
+ * diagnostic run showed the linker's COMDAT fold happened to hand MM's
+ * non-inlined registration calls OoT's body on Linux, making the write
+ * latent there — a fold-order accident (see the #383 FlagTable flip), not a
+ * guarantee, and no help for the events/currentEvent data members.
+ *
+ * Namespacing MM's class (the ShipInit/S2H precedent) does NOT transfer here:
+ * MM's only allocator (BenPort.cpp) is an excluded TU, so an S2H-namespaced
+ * Instance would never be allocated — null derefs and silently un-armed
+ * integration tests. Instead, MM code registers per-frame hooks and stores
+ * GIEvents through this MM-owned, extern "C" surface, and never names the
+ * C++ class. The registry below is dispatched from MM's own frame loop
+ * (games/mm/src/code/game.c, MM_GameState_Update) — the semantics MM's
+ * upstream executor had. This also side-steps the #367 hazard class: MM hook
+ * ids never enter OoT's registry, so no MM handler can run against OoT state
+ * (or vice versa) via ordinal/type aliasing.
+ *
+ * CONTRACT FOR LANE C (2ship_rando / 2ship_enh un-elision, #392):
+ *  - Every `GameInteractor::Instance->RegisterGameHook<...>` in MM code must
+ *    migrate to an MM_GameHooks_* registration BEFORE its TU enters the link.
+ *    Add further hook types here as they are needed (OnSaveLoad, OnSaveInit,
+ *    OnFlagSet, ... — one Register/Unregister/Execute triple per type, with
+ *    the Execute call placed at the point in MM's frame/save path where
+ *    upstream 2S2H dispatched that hook).
+ *  - Every `GameInteractor::Instance->events` / `->currentEvent` access must
+ *    migrate to MM_GameEvents_Queue() / MM_GameEvents_Current() below.
+ *  - A compile-time guard (games/mm/include/mm_gi_hook_guard.h, force-included
+ *    after MM's GameInteractor.h) poisons the Register* member names in
+ *    2ship_port/2ship_src C++ TUs; extend it to 2ship_enh/2ship_rando as
+ *    their TUs migrate.
+ */
+#ifndef MM_GAME_HOOKS_H
+#define MM_GAME_HOOKS_H
+
+#ifdef RSBS_SINGLE_EXECUTABLE
+
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * Register fn to run once per MM frame, at the top of MM_GameState_Update —
+ * where upstream 2S2H dispatched OnGameStateMainStart. Returns a nonzero
+ * hook id, or 0 if fn is NULL. Hooks registered during dispatch first run on
+ * the NEXT dispatch.
+ */
+uint32_t MM_GameHooks_RegisterOnGameStateMainStart(void (*fn)(void));
+
+/**
+ * Queue a hook for removal. Safe to call from inside the hook itself; the
+ * removal is applied at the start of the next dispatch (mirroring the C++
+ * registry's deferred-unregister contract). Id 0 is ignored.
+ */
+void MM_GameHooks_UnregisterOnGameStateMainStart(uint32_t hookId);
+
+/**
+ * Dispatch point — called from MM's frame loop (games/mm/src/code/game.c).
+ * Flushes queued unregistrations, then runs the registered hooks in
+ * registration order.
+ */
+void MM_GameHooks_ExecuteOnGameStateMainStart(void);
+
+/** Number of currently registered hooks (queued unregistrations included
+ *  until the next dispatch flushes them). Test/introspection helper. */
+uint32_t MM_GameHooks_CountOnGameStateMainStart(void);
+
+/** Drop all hooks and pending unregistrations. Unit-test harness only —
+ *  production code must unregister by id. */
+void MM_GameHooks_ResetForTest(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+/*
+ * C++ surface: MM-owned storage for the GIEvent queue that MM code used to
+ * reach as GameInteractor::Instance->events / ->currentEvent (MM-only data
+ * members entirely past the end of the 4-byte shared allocation — the same #395
+ * OOB, on the read/write path). GIEvent comes from MM's force-included
+ * 2s2h/GameInteractor/GameInteractor.h; its include guard gates this section
+ * so C TUs and non-MM includers see only the C API above.
+ */
+#if defined(__cplusplus) && defined(GAME_INTERACTOR_H)
+#include <vector>
+
+std::vector<GIEvent>& MM_GameEvents_Queue();
+GIEvent& MM_GameEvents_Current();
+#endif
+
+#endif /* RSBS_SINGLE_EXECUTABLE */
+
+#endif /* MM_GAME_HOOKS_H */

--- a/games/mm/include/mm_gi_hook_guard.h
+++ b/games/mm/include/mm_gi_hook_guard.h
@@ -11,9 +11,10 @@
  * allocation. MM code registers per-frame hooks through the MM-owned
  * extern "C" shim instead: games/mm/include/mm_game_hooks.h.
  *
- * The Execute*/Unregister*/GetHookData members only touch the inline-static
- * per-hook-type maps (no instance state), so they stay usable — e.g. the
- * GameInteractor_ExecuteOnRoomInit wrappers in GameExports_SingleExe.cpp.
+ * The Execute*, Unregister*, and GetHookData members only touch the
+ * inline-static per-hook-type maps (no instance state), so they stay usable
+ * — e.g. the GameInteractor_ExecuteOnRoomInit wrappers in
+ * GameExports_SingleExe.cpp.
  *
  * Mechanism: force-included AFTER GameInteractor.h (games/mm/CMakeLists.txt,
  * the _force_include_cxx_guarded list), so the class definition itself parses

--- a/games/mm/include/mm_gi_hook_guard.h
+++ b/games/mm/include/mm_gi_hook_guard.h
@@ -1,0 +1,42 @@
+/**
+ * Compile-time lock for #395: MM translation units must not instantiate
+ * GameInteractor's hook-REGISTRATION members.
+ *
+ * In single-exe builds the one GameInteractor allocation is OoT's (sizeof 4),
+ * while MM's force-included 2s2h/GameInteractor/GameInteractor.h compiles the
+ * same-named class at sizeof 104 / nextHookId offset 96 (MSVC; 72 / 64 under
+ * Linux GCC). The Register* member templates read AND write this->nextHookId,
+ * so an MM-compiled instantiation (inlined at the call site, or winning the
+ * linker's COMDAT fold) writes ~60-92 bytes past the end of the real
+ * allocation. MM code registers per-frame hooks through the MM-owned
+ * extern "C" shim instead: games/mm/include/mm_game_hooks.h.
+ *
+ * The Execute*/Unregister*/GetHookData members only touch the inline-static
+ * per-hook-type maps (no instance state), so they stay usable — e.g. the
+ * GameInteractor_ExecuteOnRoomInit wrappers in GameExports_SingleExe.cpp.
+ *
+ * Mechanism: force-included AFTER GameInteractor.h (games/mm/CMakeLists.txt,
+ * the _force_include_cxx_guarded list), so the class definition itself parses
+ * with the real member names; any LATER use of a poisoned name in the TU
+ * fails to compile with an identifier that points here. Applied to
+ * 2ship_port/2ship_src; 2ship_enh and 2ship_rando are exempt until Lane C
+ * migrates their (currently link-elided) upstream RegisterGameHook calls onto
+ * the shim — extend the guarded list in games/mm/CMakeLists.txt when that
+ * happens (#392).
+ *
+ * Escape hatch for deliberate probes: `#undef` the macro in the probing TU
+ * (precedent: the rename #undefs in games/mm/2s2h/mm_culling_test.cpp).
+ */
+#ifndef MM_GI_HOOK_GUARD_H
+#define MM_GI_HOOK_GUARD_H
+
+#ifdef __cplusplus
+
+#define RegisterGameHook RSBS_MM_must_not_touch_GameInteractor_registration_use_mm_game_hooks_h_395
+#define RegisterGameHookForID RSBS_MM_must_not_touch_GameInteractor_registration_use_mm_game_hooks_h_395_ForID
+#define RegisterGameHookForPtr RSBS_MM_must_not_touch_GameInteractor_registration_use_mm_game_hooks_h_395_ForPtr
+#define RegisterGameHookForFilter RSBS_MM_must_not_touch_GameInteractor_registration_use_mm_game_hooks_h_395_ForFilter
+
+#endif /* __cplusplus */
+
+#endif /* MM_GI_HOOK_GUARD_H */

--- a/games/mm/src/code/game.c
+++ b/games/mm/src/code/game.c
@@ -13,6 +13,9 @@
 #include "debug.h"
 
 #include "2s2h/GameInteractor/GameInteractor.h"
+#ifdef RSBS_SINGLE_EXECUTABLE
+#include "mm_game_hooks.h" // MM-owned hook dispatch (#395), games/mm/include
+#endif
 
 #pragma increment_block_number "n64-us:128"
 
@@ -154,6 +157,14 @@ void MM_GameState_Update(GameState* gameState) {
     MM_GameState_SetFrameBuffer(gameState->gfxCtx);
 
     GameInteractor_ExecuteOnGameStateMainStart();
+#ifdef RSBS_SINGLE_EXECUTABLE
+    // #395: the call above cross-binds to OoT's extern "C" wrapper, which
+    // (correctly) no-ops while MM is the active game — the #367 VB-ordinal
+    // gate. MM-side per-frame hooks therefore live in an MM-owned registry
+    // dispatched here, on MM's own frames, matching the spot where upstream
+    // 2S2H executed OnGameStateMainStart.
+    MM_GameHooks_ExecuteOnGameStateMainStart();
+#endif
 
     gameState->main(gameState);
 

--- a/games/oot/soh/Enhancements/game-interactor/GameInteractor_Hooks.cpp
+++ b/games/oot/soh/Enhancements/game-interactor/GameInteractor_Hooks.cpp
@@ -1,6 +1,8 @@
 #include "GameInteractor_Hooks.h"
 
 #ifdef RSBS_SINGLE_EXECUTABLE
+#include <cstddef> // offsetof/size_t for the #395 layout probes below
+#include <cstdint>
 #include "context.h" // src/common/context.h via redship_common's public include dir
 // In the single executable MM's own GameInteractor layer is not compiled, so
 // MM code links against these unprefixed extern "C" wrappers, and MM's
@@ -520,5 +522,62 @@ extern "C" void GameInteractor_TestArmVBVeto(int32_t flag) {
     sTestVBVetoHookId = GameInteractor::Instance->RegisterGameHookForID<GameInteractor::OnVanillaBehavior>(
         static_cast<GIVanillaBehavior>(flag),
         [](GIVanillaBehavior _, bool* should, va_list _originalArgs) { *should = false; });
+}
+
+// MARK: - #395 GameInteractor layout probes (redship --test mm-gi-shim)
+//
+// OoT's class here has sizeof 4 with nextHookId at offset 0; MM's same-named
+// class compiles at sizeof 104 with nextHookId at offset 96, and the linker
+// keeps ONE copy of every RegisterGameHook<...> COMDAT instantiation. These
+// helpers let the mm-gi-shim test measure, from a real OoT translation unit,
+// which layout the surviving registration code actually writes — by running a
+// registration against a caller-supplied oversized zeroed buffer and letting
+// the test inspect which bytes changed. Two variants:
+//
+//  - Direct: a normal inlinable call, measuring what OoT's real registration
+//    call sites (this TU and the rest of soh) execute.
+//  - OutOfLine: through a member-function pointer, which cannot be inlined
+//    and therefore measures the linker-selected COMDAT symbol itself — the
+//    copy any non-inlined call site in EITHER game binds.
+//
+// The write goes to nextHookId only; the hook map/hookData are inline-static
+// (per-process, instance-independent), which is why a fake instance works.
+// Unregister + Pump exist so probes can clean the shared static map back up.
+
+extern "C" size_t OoT_GI_InstanceSize(void) {
+    return sizeof(GameInteractor);
+}
+
+extern "C" size_t OoT_GI_NextHookIdOffset(void) {
+    return offsetof(GameInteractor, nextHookId);
+}
+
+extern "C" uint32_t OoT_GI_ProbeRegisterOnMainStartDirect(void* storage, void (*fn)(void)) {
+    return static_cast<GameInteractor*>(storage)->RegisterGameHook<GameInteractor::OnGameStateMainStart>(fn);
+}
+
+extern "C" uint32_t OoT_GI_ProbeRegisterOnMainStartOutOfLine(void* storage, void (*fn)(void)) {
+    auto reg = &GameInteractor::RegisterGameHook<GameInteractor::OnGameStateMainStart>;
+    GameInteractor* gi = static_cast<GameInteractor*>(storage);
+#ifdef __cpp_lib_source_location
+    return (gi->*reg)(fn, std::source_location::current());
+#else
+    return (gi->*reg)(fn);
+#endif
+}
+
+extern "C" void OoT_GI_ProbeUnregisterOnMainStart(uint32_t hookId) {
+    // Unregister only queues into an inline-static vector; no instance state
+    // is touched, so no fake storage is needed here.
+    GameInteractor gi;
+    gi.UnregisterGameHook<GameInteractor::OnGameStateMainStart>(hookId);
+}
+
+extern "C" void OoT_GI_ProbePumpOnMainStart(void) {
+    // Flushes queued unregistrations, then runs whatever remains registered.
+    // Callers unregister their probe hooks first, so after the flush this
+    // executes nothing in the unit-test harness.
+    GameInteractor gi;
+    gi.ExecuteHooks<GameInteractor::OnGameStateMainStart>();
 }
 #endif

--- a/src/common/mm_stubs.c
+++ b/src/common/mm_stubs.c
@@ -124,7 +124,10 @@ void GameInteractor_ExecuteBeforeMoonCrashSaveReset(void) {}
 void GameInteractor_ExecuteBeforeInterfaceClockDraw(void) {}
 void GameInteractor_ExecuteAfterInterfaceClockDraw(void) {}
 int GameInteractor_Dpad(void* input, int dpad) { (void)input; return dpad; }
-int GameInteractor_InvertControl(int control) { return control; }
+/* GameInteractor_InvertControl moved to a real, header-checked definition in
+ * games/mm/2s2h/GameExports_SingleExe.cpp (#372): every caller uses the
+ * result as a ±1 multiplier, and the untyped stub here returned the ENUM
+ * ORDINAL — stick_x *= 2 on every Lib_GetControlStickData movement frame. */
 int GameInteractor_RightStickOcarina(void* input) { (void)input; return 0; }
 
 /* HudEditor stubs */

--- a/src/common/test_runner.cpp
+++ b/src/common/test_runner.cpp
@@ -54,8 +54,9 @@ int MM_StartupRestore_RunHeadless(void);
 int MM_CullingBinding_RunHeadless(void);
 // MM GameInteractor shim lock (games/mm/2s2h/mm_gi_shim_test.cpp, #395): MM's
 // hook registrations must never touch the shared 4-byte OoT-owned
-// GameInteractor instance through MM's 104-byte view of the class (a ~92-byte
-// out-of-bounds write). Returns 0 on pass, non-zero on fail.
+// GameInteractor instance through MM's larger view of the class (a ~60-92
+// byte out-of-bounds write, layout is platform-dependent). Returns 0 on
+// pass, non-zero on fail.
 int MM_GIShim_RunHeadless(void);
 // VB-affinity regression: MM's GameInteractor_* calls resolve to OoT's
 // extern "C" wrappers in single-exe builds, and the two games' vanilla-

--- a/src/common/test_runner.cpp
+++ b/src/common/test_runner.cpp
@@ -52,6 +52,11 @@ int MM_StartupRestore_RunHeadless(void);
 // Actor::projectedPos 8 bytes earlier than MM's Actor puts it, and the restore
 // was a one-parameter no-op stub. Returns 0 on pass, non-zero on fail.
 int MM_CullingBinding_RunHeadless(void);
+// MM GameInteractor shim lock (games/mm/2s2h/mm_gi_shim_test.cpp, #395): MM's
+// hook registrations must never touch the shared 4-byte OoT-owned
+// GameInteractor instance through MM's 104-byte view of the class (a ~92-byte
+// out-of-bounds write). Returns 0 on pass, non-zero on fail.
+int MM_GIShim_RunHeadless(void);
 // VB-affinity regression: MM's GameInteractor_* calls resolve to OoT's
 // extern "C" wrappers in single-exe builds, and the two games' vanilla-
 // behavior ordinals alias each other. The wrappers gate on the active game;
@@ -142,6 +147,12 @@ static TestResult Test_MMStartupRestore(void) {
 // the C entry point in games/mm/2s2h/mm_culling_test.cpp.
 static TestResult Test_MMCullingBinding(void) {
     return MM_CullingBinding_RunHeadless() == 0 ? TEST_PASS : TEST_FAIL;
+}
+
+// MM GameInteractor shim lock (see the extern decl above). Thin wrapper over
+// the C entry point in games/mm/2s2h/mm_gi_shim_test.cpp.
+static TestResult Test_MMGIShim(void) {
+    return MM_GIShim_RunHeadless() == 0 ? TEST_PASS : TEST_FAIL;
 }
 
 // ============================================================================
@@ -875,6 +886,8 @@ const TestDescriptor gTests[] = {
     {"active-queue", "__osGetActiveQueue returns a walkable list, not a return register (#385)", Test_ActiveQueue},
     {"mm-scene-execute", "MM scene commands execute against a PlayState (#344)", Test_MMSceneExecute},
     {"mm-culling-binding", "MM's Ship_ExtendedCulling* bind MM's Actor, not OoT's (#382)", Test_MMCullingBinding},
+    {"mm-gi-shim", "MM hook registration goes through the MM-owned shim, not the shared 4-byte instance (#395)",
+     Test_MMGIShim},
     // The two MM resume-contract tests below mutate process-global state
     // (mm-resume-arena re-inits the MM system arena + heaps; mm-startup-restore
     // scribbles and re-zeroes the unified gSaveContext). Both clean up after


### PR DESCRIPTION
## What this is

Lane G1 of the Phase 3 plan (docs/phase3-lane-prompts.md): fixes #395 (MM hook registration through the shared C++ `GameInteractor` — MM's view of the class indexes members past the end of OoT's 4-byte allocation), absorbs #372 (`GameInteractor_InvertControl` stub returned the enum ordinal instead of a ±1 multiplier), and covers the GameInteractor item of #383.

## Diagnostic result (commit 1, build-linux run on e6988704)

Per the G1 brief's constraint 4, registration probes were compiled in each game's real TU and run against oversized zeroed buffers:

```
[GI-DIAG] layout: OoT sizeof=4 nextHookId@0 | MM sizeof=72 nextHookId@64   (Linux GCC; MSVC is 104/96)
[GI-DIAG] OoT direct call              wrote: [0,1)
[GI-DIAG] OoT out-of-line (COMDAT)     wrote: [0,1)
[GI-DIAG] MM direct call               wrote: [0,1)
[GI-DIAG] MM out-of-line (COMDAT)      wrote: [0,1)
```

**Finding:** on Linux at production flags, every registration path — including MM's own call sites — executed OoT's COMDAT copy (no inlining, OoT's fold win). The #395 OOB write was therefore *latent* on that build, by fold-order luck. That is not safety: the #383 FlagTable incident showed fold winners flip when unrelated link-set changes land, any inlining decision executes MM's out-of-bounds body regardless of the fold, and MM's `events`/`currentEvent` data members are out-of-bounds whenever touched (Lane C's access pattern).

## The fix (commit 2)

- **`games/mm/include/mm_game_hooks.h`** — MM-owned extern "C" hook registry (`MM_GameHooks_RegisterOnGameStateMainStart` / `Unregister` / `Execute` / `Count`) plus MM-owned GIEvent-queue storage (`MM_GameEvents_Queue()` / `MM_GameEvents_Current()`). MM code never names the C++ class.
- **Dispatch on MM's own frames** — `games/mm/src/code/game.c` pumps the registry at the top of `MM_GameState_Update`, where upstream 2S2H executed OnGameStateMainStart. Note: since the #367 gate, the cross-bound OoT wrapper no-ops while MM is active, so MM-frame hook dispatch had **no working path at all** — the four hook-driven integration modes (boot-mm, T1, T2, T4) could not signal pass. The shim restores them.
- **Four call sites migrated** in `GameExports_SingleExe.cpp`; VB-ordinal safety is by construction (MM hook ids never enter OoT's registry).
- **Compile-time lock** — `games/mm/include/mm_gi_hook_guard.h` force-included after MM's GameInteractor.h for 2ship_port/2ship_src C++ TUs poisons the `Register*` member names. 2ship_enh/2ship_rando exempt until Lane C migrates them (documented in CMake and the header).
- **Runtime lock** — `mm-gi-shim` CTest (redship label, ROM-free): layout-premise probes from both TUs; OoT-side direct + member-pointer registration probes asserting every write stays inside OoT's sizeof (the member-pointer call *is* the folded COMDAT symbol — an MM instantiation winning a future fold fails this loudly); shim register/dispatch/deferred-unregister contract; and four-mode arming through the real `MM_RegisterIntegrationTestHooks` path via `IntegrationTest_SetMode`.
- **#372** — `GameInteractor_InvertControl` gets its real CVar-driven body in `GameExports_SingleExe.cpp`, header-checked against MM's GameInteractor.h (signature drift is now a compile error). Stub removed from `mm_stubs.c`. Premise re-checked: the loud predicted symptom (s8 wrap) sits on the scripted-movement path, but `Lib_GetControlStickData` ran `x *= 2` on every analog movement frame — real, just subtler than #372 predicted.

## Contract for Lane C (also going on #392)

Before `MM_Rando_Init` ever runs (C0/C1), every `GameInteractor::Instance->RegisterGameHook<...>` in `2s2h/Rando/**` and `2s2h/Enhancements/**` (e.g. `Rando.cpp` `OnSaveLoad`, `MiscBehavior.cpp` `OnSaveInit`, `COND_HOOK(OnFlagSet, ...)`) must migrate to `MM_GameHooks_*` registrations (adding hook types to the shim as needed), every `Instance->events` / `Instance->currentEvent` access (`CheckQueue.cpp`) must migrate to `MM_GameEvents_Queue()` / `MM_GameEvents_Current()`, and the poison guard must be extended to 2ship_enh/2ship_rando in `games/mm/CMakeLists.txt`. The mm-gi-shim fold probe will go red if an unmigrated TU's instantiation enters the link and wins the fold.

## Operator batch (#392)

Four-mode live arming check: `--integration-test` int-boot-mm / int-switch-oot-hms-to-mm / int-switch-mm-clocktown-south-to-oot / int-archive-hotswap-cycle on the Windows box with ROMs — verify each mode arms and signals.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!--- section:artifacts:start -->
### Build Artifacts
  - [rsbs-windows.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/8477919409.zip)
  - [rsbs-linux.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/8477565521.zip)
<!--- section:artifacts:end -->