### PR TITLE
Guard OoT_AudioMgr_CreateNextAudioBuffer on gAudioContextInitalized (#365)

### DIFF
--- a/CMake/SingleExecutable.cmake
+++ b/CMake/SingleExecutable.cmake
@@ -303,6 +303,14 @@ if(BUILD_TESTING)
     # bound-arithmetic bugs, so the capacity computation was factored into pure
     # helpers this test calls directly — display-free, ROM-free.
     redship_add_test(NAME SeqMapBounds COMMAND redship --test seq-map-bounds)
+    # OoT audio producer init-guard (#365). The shared OTRAudio_Thread runs
+    # OoT_AudioMgr_CreateNextAudioBuffer whenever MM's synth is inactive — every
+    # MM frame before MM audio boots, and the mid-switch window where OoT is
+    # suspended with gAudioContextInitalized == false. Without the guard that
+    # drove the DMA/load/synth path against a torn-down context; the guard makes
+    # it the no-op the thread's silence contract already assumes. Locks the
+    # no-op via the producer's task counter (see test_oot_audio_init_guard.c).
+    redship_add_test(NAME OoTAudioInitGuard COMMAND redship --test oot-audio-init-guard)
     # Active-thread-queue contract (#385). soh/stubs.c's empty-bodied
     # __osGetActiveQueue returned the return register, and both games' fault
     # handlers walk that as a thread list — so the crash handler was itself

--- a/games/oot/src/code/code_800E4FE0.c
+++ b/games/oot/src/code/code_800E4FE0.c
@@ -90,6 +90,15 @@ void OoT_AudioMgr_CreateNextAudioBuffer(s16* samples, u32 num_samples) {
     gAudioContext.audioRandom = (gAudioContext.audioRandom + gAudioContext.totalTaskCnt) * osGetCount();
 }
 
+// Test-only observer for the OoTAudioInitGuard lock (#365). Reports the
+// producer's task counter so the lock can assert the guarded producer is a true
+// no-op — totalTaskCnt++ is the producer's first act, so the counter not
+// advancing proves the early return fired — without pulling AudioContext's
+// layout into the C++ test translation unit.
+u32 OoT_AudioMgr_DebugTaskCnt(void) {
+    return gAudioContext.totalTaskCnt;
+}
+
 AudioTask* func_800E5000(void) {
     return NULL;
 

--- a/games/oot/src/code/code_800E4FE0.c
+++ b/games/oot/src/code/code_800E4FE0.c
@@ -43,6 +43,20 @@ extern u64 rspAspMainDataEnd[];
 void OoT_AudioMgr_CreateNextAudioBuffer(s16* samples, u32 num_samples) {
     OSMesg sp4C;
 
+    // #365: the shared OTRAudio_Thread dispatches THIS producer whenever MM's
+    // synth is not active (OTRGlobals.cpp) — which includes every MM frame before
+    // MM's audio heap comes up, and the mid-switch window after OoT_Game_Suspend
+    // runs OoT_Audio_PreNMI and clears gAudioContextInitalized. The thread already
+    // zero-fills the buffer and expects an uninitialized synth to "write nothing",
+    // but this producer never honored that: it bumped totalTaskCnt and drove the
+    // DMA/load/synth path against a torn-down OoT audio context. #362's drain
+    // closes the suspend-time use-after-free; this closes the every-MM-frame
+    // unguarded-consumer half. Return early so the caller's zeroed buffer plays as
+    // the intended silence.
+    if (!gAudioContextInitalized) {
+        return;
+    }
+
     // RSBS_AUDIO_PROBE=1 deep probe: discriminates "players never started"
     // from "players enabled but synth silent" without a debugger.
     {

--- a/src/common/test_runner.cpp
+++ b/src/common/test_runner.cpp
@@ -115,6 +115,13 @@ extern "C" {
 // symbols it needs itself. No subsystem, no archives.
 #include "tests/test_active_queue.c"
 
+// OoT audio producer init-guard (#365). The shared OTRAudio_Thread dispatches
+// OoT_AudioMgr_CreateNextAudioBuffer whenever MM's synth is inactive, including
+// while OoT is suspended with gAudioContextInitalized == false — the producer
+// must no-op there rather than drive the synth against a torn-down context.
+// FILE SCOPE; declares its C-linkage symbols itself. No audio heap, no archives.
+#include "tests/test_oot_audio_init_guard.c"
+
 // MM scene-command EXECUTE regression (issue #344). Unlike the parse test, the
 // body runs the parsed commands against a PlayState, so it needs MM's global.h
 // — which lives in an MM TU (games/mm/2s2h/mm_scene_execute_test.cpp) to keep
@@ -875,6 +882,7 @@ const TestDescriptor gTests[] = {
     {"mm-scene-parse", "MM scene commands parse via the S2H factory (#344)", Test_MMSceneParse},
     {"seq-map-bounds", "Sequence-map capacity covers the id range + custom slack (#371, #378)", Test_SeqMapBounds},
     {"active-queue", "__osGetActiveQueue returns a walkable list, not a return register (#385)", Test_ActiveQueue},
+    {"oot-audio-init-guard", "OoT synth no-ops while gAudioContextInitalized == false (#365)", Test_OoTAudioInitGuard},
     {"mm-scene-execute", "MM scene commands execute against a PlayState (#344)", Test_MMSceneExecute},
     {"mm-culling-binding", "MM's Ship_ExtendedCulling* bind MM's Actor, not OoT's (#382)", Test_MMCullingBinding},
     // The two MM resume-contract tests below mutate process-global state

--- a/src/common/tests/test_oot_audio_init_guard.c
+++ b/src/common/tests/test_oot_audio_init_guard.c
@@ -1,0 +1,72 @@
+/**
+ * OoT audio producer must no-op while its context is uninitialized (#365).
+ *
+ * WHAT BROKE
+ *
+ * In single-exe builds the shared audio pump, OTRAudio_Thread
+ * (games/oot/soh/OTRGlobals.cpp), dispatches the OoT synth
+ * (OoT_AudioMgr_CreateNextAudioBuffer, games/oot/src/code/code_800E4FE0.c)
+ * whenever MM's synth is NOT active — i.e. in the `else` of a gate that only
+ * checks MM's audio-heap flag. That `else` runs for every MM frame before MM's
+ * audio heap comes up, and for the mid-switch window after OoT_Game_Suspend has
+ * run OoT_Audio_PreNMI and cleared gAudioContextInitalized. The thread
+ * zero-fills its buffer and expects an uninitialized synth to "write nothing",
+ * but the OoT producer never honored that: it bumped totalTaskCnt and drove the
+ * DMA/load/synth path against a torn-down audio context. PR #362's drain closes
+ * the suspend-time use-after-free but leaves this every-MM-frame unguarded
+ * consumer.
+ *
+ * WHAT THIS LOCKS
+ *
+ * With gAudioContextInitalized == false the producer must be a no-op. The tell
+ * is gAudioContext.totalTaskCnt++, the producer's FIRST act — unconditional,
+ * ahead of every state-dependent branch (checking the output buffer instead is
+ * vacuous: with a zeroed context the synth writes nothing to it anyway). The
+ * guard must return before that increment, so a guarded producer leaves the
+ * counter untouched and an unguarded one advances it. The counter is read
+ * through OoT_AudioMgr_DebugTaskCnt() so this TU needs no AudioContext layout.
+ * Robust to the shared audio thread: with the flag false, every producer call
+ * (this one and any the thread makes) no-ops, so the counter is stable in the
+ * pass case; the unguarded call advances it by at least one in the fail case.
+ *
+ * Included at FILE SCOPE by test_runner.cpp (compiled as C++); the declarations
+ * carry C linkage explicitly because the definitions live in OoT C TUs. The
+ * producer is declared with int16_t/uint32_t rather than the libultra s16/u32
+ * spellings so this TU stays free of the audio umbrella headers — the C-linkage
+ * symbol is identical and the parameter types are ABI-identical.
+ */
+
+#include <cstdint>
+#include <cstdio>
+
+extern "C" {
+void OoT_AudioMgr_CreateNextAudioBuffer(int16_t* samples, uint32_t numSamples);
+uint32_t OoT_AudioMgr_DebugTaskCnt(void);
+extern int32_t gAudioContextInitalized;
+}
+
+TestResult Test_OoTAudioInitGuard(void) {
+    printf("[TEST] oot-audio-init-guard: OoT synth is a no-op while gAudioContextInitalized == false (#365)\n");
+
+    // The port's default (no game booted) is already false; save/restore anyway
+    // so this test cannot perturb a later one that assumes audio is up.
+    const int32_t saved = gAudioContextInitalized;
+    gAudioContextInitalized = 0; // OoT suspended / not booted: audio context torn down
+
+    int16_t buf[128] = { 0 }; // stereo scratch; a guarded producer never touches it
+    const uint32_t before = OoT_AudioMgr_DebugTaskCnt();
+    OoT_AudioMgr_CreateNextAudioBuffer(buf, 64);
+    const uint32_t after = OoT_AudioMgr_DebugTaskCnt();
+
+    gAudioContextInitalized = saved;
+
+    if (after != before) {
+        printf("[TEST] FAIL: producer ran while gAudioContextInitalized == false (totalTaskCnt %u -> %u) — it drove "
+               "the synth against a torn-down context instead of no-op silence\n",
+               (unsigned)before, (unsigned)after);
+        return TEST_FAIL;
+    }
+
+    printf("[TEST] PASS: oot-audio-init-guard\n");
+    return TEST_PASS;
+}


### PR DESCRIPTION
Fixes #365. Premise re-verified against the current tree (post-#362): **still real**.

## Mechanism
The shared `OTRAudio_Thread` (`OTRGlobals.cpp:1196-1205`) dispatches the synth on the active game but only gates the **MM** producer on MM's audio-heap flag. The OoT producer, `OoT_AudioMgr_CreateNextAudioBuffer` (`code_800E4FE0.c`), is the `else` fallback and runs whenever `mmSynthActive` is false — including every MM frame before MM's audio heap comes up, and the mid-switch window after `OoT_Game_Suspend` runs `OoT_Audio_PreNMI` and clears `gAudioContextInitalized`.

The thread zero-fills its buffer and, per its own comment, expects an uninitialized synth to "write nothing" — but the OoT producer never honored that. It bumped `totalTaskCnt` and drove the DMA/load/synth path against a torn-down context. **#362's drain closes the suspend-time use-after-free; it does not stop the thread or guard this per-frame consumer** — exactly the "scope what remains" the issue asks for. MM's producer has no internal guard either, but the dispatch's `mmSynthActive` gate protects it; OoT's has no such gate. The fix restores symmetry at the producer (the issue's suggested breadcrumb): an early return when `gAudioContextInitalized` is false.

## Lock (demonstrated red-then-green)
`OoTAudioInitGuard` (redship tier) asserts the producer is a no-op while `gAudioContextInitalized == false`, observed through a new `OoT_AudioMgr_DebugTaskCnt()` accessor: the producer's first act is `totalTaskCnt++` (unconditional, ahead of every state branch), so a guarded producer leaves the counter untouched.

- **Red step** (commit 1, no guard): build-linux **failed** — the lock bites.
- **Green step** (commit 2, guard added): the counter stays put and the tier goes green.

An earlier draft of this lock asserted the output buffer stayed untouched; CI showed it passing **vacuously** (with a zeroed context the synth writes nothing to the buffer anyway), so it was replaced with the counter assertion — the deterministic tell. The squash-merge ships the accessor, test, and guard together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!--- section:artifacts:start -->
### Build Artifacts
  - [rsbs-windows.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/8477774179.zip)
  - [rsbs-linux.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/8477531844.zip)
<!--- section:artifacts:end -->