### PR TITLE
Validate integration-hook door entrance against the real ENTR_MAX (#380)

### DIFF
--- a/games/oot/soh/GameExports_SingleExe.cpp
+++ b/games/oot/soh/GameExports_SingleExe.cpp
@@ -145,10 +145,29 @@ static float GpVecDist(const Vec3f* a, const Vec3f* b) {
  * Combo_CheckEntranceSwitch on the cross-game path, which freezes the live
  * SaveContext — and re-enters OoT_Play_Init for same-game targets.
  */
+// #380: the env-side pre-filter in src/common/integration_test_hooks.cpp keeps a
+// literal copy of this bound (kOoTEntranceMax) because src/common cannot include
+// OoT headers. Lock the two at compile time so that literal cannot silently drift
+// out of sync with the real gEntranceTable size.
+static_assert(ENTR_MAX == 0x0614, "ENTR_MAX moved; sync kOoTEntranceMax in integration_test_hooks.cpp");
+
 static void GpFireOoTDoor(uint16_t entrance, const char* what) {
     PlayState* play = OoT_gPlayState;
     if (play == NULL) {
         IntegrationTest_GameplayFail("no PlayState when firing a door transition");
+        return;
+    }
+    // #380: nextEntranceIndex is consumed as a raw linear index into
+    // gEntranceTable[ENTR_MAX] (games/oot/include/variables.h) with no bound
+    // check downstream. This is the consumption-time re-check the env filter's
+    // comment promises: an out-of-range id (e.g. RSBS_GP_WARP_ENTRANCE against a
+    // shrunken table) fails the test loudly instead of reading gEntranceTable out
+    // of bounds — the OOB-read crash class Test_StartupEntrance guards.
+    if (entrance >= ENTR_MAX) {
+        fprintf(stderr, "[GP-TEST] refusing %s: entrance 0x%04X is out of range (ENTR_MAX 0x%04X)\n", what, entrance,
+                (unsigned)ENTR_MAX);
+        fflush(stderr);
+        IntegrationTest_GameplayFail("door-transition entrance index >= ENTR_MAX");
         return;
     }
     fprintf(stderr, "[GP-TEST] firing %s: entrance 0x%04X (from scene %d, entrance 0x%04X)\n", what, entrance,


### PR DESCRIPTION
Fixes #380. Premise re-verified against the current tree: **still real** — grepping `ENTR_MAX` across the GameExports files and `src/common/` finds only comments and the doc string; no validating code, and `GpFireOoTDoor` (`games/oot/soh/GameExports_SingleExe.cpp`) assigns `nextEntranceIndex = entrance` with no check.

## The bug
The integration hook's entrance bound lived only as a literal in `src/common/integration_test_hooks.cpp:57-60`:
```
// ... the OoT-side driver re-checks against the real ENTR_MAX at consumption time.
constexpr unsigned long kOoTEntranceMax = 0x0614;
```
That justifying comment was false — no such re-check existed. `RSBS_GP_WARP_ENTRANCE` against a table whose `ENTR_MAX` had dropped below the stale literal would pass the filter, be written straight to `nextEntranceIndex`, and index `gEntranceTable` out of bounds — the OOB-read crash class `Test_StartupEntrance` guards.

## The fix (OoT-side only — no overlap with in-flight lanes)
Lands entirely in `games/oot/soh/GameExports_SingleExe.cpp`, which the concurrent G1 PR (#415) does not touch, and is not one of the G1-cautioned files (`games/mm/2s2h/GameExports_SingleExe.cpp`, `src/common/mm_stubs.c`, `src/common/integration_test_hooks.*`).

1. **Real consumption-time check.** `GpFireOoTDoor` now refuses `entrance >= ENTR_MAX` (the real enum bound from `z64scene.h`) and fails the test loudly rather than warping OOB. This also makes the `integration_test_hooks.cpp` comment truthful, so that false comment is resolved at its root without editing that (G1-cautioned) file.
2. **Compile-time lock on the literal.** `static_assert(ENTR_MAX == 0x0614, ...)` fails the build if the table size and the `kOoTEntranceMax` literal ever diverge — a gate that cannot silently rot.

## Testing
The `static_assert` is itself a non-vacuous build-time gate (evaluated every compile; the PR building green confirms `ENTR_MAX == 0x0614` holds and is visible in the TU). The runtime refusal is exercised by the ROM-gated `int-gameplay-roundtrip` warp sweep; there is no ROM-free unit path because `GpFireOoTDoor` is file-static and needs a live `PlayState`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!--- section:artifacts:start -->
### Build Artifacts
  - [rsbs-windows.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/8477411564.zip)
  - [rsbs-linux.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/8477163788.zip)
<!--- section:artifacts:end -->