### PR TITLE
Lane B: unified rando seed -> paired world (OoT side + shared handoff contract)

### DIFF
--- a/CMake/CheckSeedDeterminism.cmake
+++ b/CMake/CheckSeedDeterminism.cmake
@@ -1,0 +1,82 @@
+# CMake/CheckSeedDeterminism.cmake
+#
+# Lane B unified-seed determinism lock (Phase 3.0). Proves that generating the
+# SAME rando seed under the SAME pinned settings profile TWICE produces a
+# byte-identical world — the first output-EQUALITY test in the "rando" tier (the
+# existing RandoGen rows only assert generation-succeeds).
+#
+# Why two SEPARATE process invocations, not one: re-entering the 3drando
+# generator (Settings::CreateOptions / SetAllToContext) within a single process
+# has never been exercised, so a fresh process per run is the trustworthy
+# comparison rather than an unverified re-entry. Each run writes its digest (the
+# unified-seed fields plus a placement hash computed in-memory in fixed
+# RandomizerCheck order) to its OWN path via RSBS_SEED_DIGEST_OUT, so the
+# same-seed spoiler-log OVERWRITE — both runs land on the same
+# Randomizer/<hash>.json — can never make the diff compare a file against itself.
+#
+# Determinism scope: the headless harness drives generation with EMPTY
+# excluded-location / enabled-trick sets, so this locks reproducibility for the
+# pinned settings profile only; exclusion/trick-driven fills are not covered.
+#
+# Run as a CTest row in the "rando" tier (under xvfb-run):
+#   cmake -DREDSHIP_EXE=<redship> -DWORK_DIR=<dir> -P CheckSeedDeterminism.cmake
+# The pinned settings profile (RSBS_DIAG_CVARS) and the display-free env
+# (SDL_AUDIODRIVER / RSBS_DISABLE_OTR_INIT) come from the row's CTest ENVIRONMENT
+# and are inherited by both child runs; -E env only ADDS RSBS_SEED_DIGEST_OUT on
+# top, so DISPLAY (from xvfb-run) and the pinned profile pass through unchanged.
+
+if(NOT DEFINED REDSHIP_EXE)
+    message(FATAL_ERROR "CheckSeedDeterminism: -DREDSHIP_EXE=<path> is required")
+endif()
+if(NOT EXISTS "${REDSHIP_EXE}")
+    message(FATAL_ERROR "CheckSeedDeterminism: redship binary not found: ${REDSHIP_EXE}")
+endif()
+if(NOT DEFINED WORK_DIR)
+    message(FATAL_ERROR "CheckSeedDeterminism: -DWORK_DIR=<dir> is required (where the digests are written)")
+endif()
+
+set(_digest1 "${WORK_DIR}/seed-determinism-run1.txt")
+set(_digest2 "${WORK_DIR}/seed-determinism-run2.txt")
+# A stale digest from a previous invocation must never be mistaken for this run's
+# output — a missing file after a "successful" run is then an unambiguous error.
+file(REMOVE "${_digest1}" "${_digest2}")
+
+function(_run_gen out_path label)
+    execute_process(
+        COMMAND ${CMAKE_COMMAND} -E env "RSBS_SEED_DIGEST_OUT=${out_path}"
+                "${REDSHIP_EXE}" --test rando-determinism
+        RESULT_VARIABLE _rc
+        OUTPUT_VARIABLE _out
+        ERROR_VARIABLE _err
+    )
+    if(NOT _rc EQUAL 0)
+        message(FATAL_ERROR
+            "CheckSeedDeterminism: ${label} run of '--test rando-determinism' exited ${_rc} "
+            "(generation failed or the live producer did not stamp gComboCtx).\n"
+            "stdout:\n${_out}\nstderr:\n${_err}")
+    endif()
+    if(NOT EXISTS "${out_path}")
+        message(FATAL_ERROR
+            "CheckSeedDeterminism: ${label} run reported success but wrote no digest at ${out_path}.\n"
+            "stdout:\n${_out}\nstderr:\n${_err}")
+    endif()
+endfunction()
+
+_run_gen("${_digest1}" "first")
+_run_gen("${_digest2}" "second")
+
+execute_process(
+    COMMAND ${CMAKE_COMMAND} -E compare_files "${_digest1}" "${_digest2}"
+    RESULT_VARIABLE _cmp
+)
+if(NOT _cmp EQUAL 0)
+    file(READ "${_digest1}" _d1)
+    file(READ "${_digest2}" _d2)
+    message(FATAL_ERROR
+        "CheckSeedDeterminism: the SAME seed produced DIFFERENT worlds across two runs — "
+        "rando generation is not deterministic under the pinned settings profile.\n"
+        "run1:\n${_d1}\nrun2:\n${_d2}")
+endif()
+
+file(READ "${_digest1}" _digest)
+message(STATUS "Seed determinism verified — two same-seed runs agree:\n${_digest}")

--- a/CMake/SingleExecutable.cmake
+++ b/CMake/SingleExecutable.cmake
@@ -371,6 +371,40 @@ if(BUILD_TESTING)
         ENVIRONMENT "SDL_AUDIODRIVER=dummy;RSBS_DISABLE_OTR_INIT=1;RSBS_DIAG_CVARS=gRandoSettings.ShuffleSongs=3")
 
     # ========================================================================
+    # Lane B — unified seed -> paired world (Phase 3.0)
+    #
+    # The pinned settings profile is the second half of the "one seed -> paired
+    # world" contract: Playthrough_Init re-seeds the RNG with Hash(seed +
+    # settings-string), so a seed reproduces a fill only under identical settings.
+    # RSBS_DIAG_CVARS is that pinning vehicle; both rows below pin the same
+    # profile (stock rando defaults + ShuffleSongs=2, the "RSBS unified pinned
+    # profile v1").
+    # ========================================================================
+    #
+    # Single-run lock: generation succeeds AND the LIVE producer stamps
+    # gComboCtx.sourceIsRando/sharedRandoSeed at generation time (the dispatch
+    # fails if it does not). Also the --test row the completeness guard requires
+    # for the rando-determinism dispatch entry.
+    redship_add_test(NAME RandoDeterminism COMMAND redship --test rando-determinism
+        LABEL rando
+        TIMEOUT 180
+        ENVIRONMENT "SDL_AUDIODRIVER=dummy;RSBS_DISABLE_OTR_INIT=1;RSBS_DIAG_CVARS=gRandoSettings.ShuffleSongs=2")
+    # Determinism diff: run the same seed twice in TWO processes and assert the
+    # worlds are byte-identical (see CMake/CheckSeedDeterminism.cmake — two
+    # processes because generator re-entry is unverified; distinct digest paths
+    # because the same-seed spoiler log overwrites itself). A meta row (its
+    # COMMAND drives no --test entry). Larger timeout than the single-run rows: it
+    # spins up the windowed bring-up twice under llvmpipe.
+    redship_add_test(NAME SeedDeterminism
+        COMMAND ${CMAKE_COMMAND}
+                -DREDSHIP_EXE=$<TARGET_FILE:redship>
+                -DWORK_DIR=${CMAKE_BINARY_DIR}
+                -P ${CMAKE_CURRENT_LIST_DIR}/CheckSeedDeterminism.cmake
+        LABEL rando
+        TIMEOUT 300
+        ENVIRONMENT "SDL_AUDIODRIVER=dummy;RSBS_DISABLE_OTR_INIT=1;RSBS_DIAG_CVARS=gRandoSettings.ShuffleSongs=2")
+
+    # ========================================================================
     # Integration tests (requires display - use Xvfb in CI)
     # These tests actually boot the games and verify boot completion
     # ========================================================================

--- a/games/oot/soh/Enhancements/randomizer/3drando/menu.cpp
+++ b/games/oot/soh/Enhancements/randomizer/3drando/menu.cpp
@@ -17,6 +17,8 @@
 #include "../static_data.h"
 #include "../SeedContext.h"
 #include "../settings.h"
+#include "../item_location.h"
+#include "context.h" // src/common — gComboCtx, Lane B unified-seed carrier (ADR 0002)
 
 namespace {
 bool seedChanged;
@@ -64,6 +66,95 @@ extern "C" int Rando_HeadlessSeedTest(const char* seedStr) {
     bool ok = GenerateRandomizer({}, {}, seedStr ? seedStr : "");
     fprintf(stderr, "[rando-diag] GenerateRandomizer returned %s\n", ok ? "true" : "false");
     return ok ? 0 : 1;
+}
+
+// Determinism harness bridge (Lane B, Phase 3.0): run ONE seed generation and
+// emit a canonical, side-effect-free digest of (a) the unified-seed producer's
+// output in gComboCtx and (b) the full item placement, so an external wrapper
+// can prove two same-seed runs produce byte-identical worlds. Returns 0 only if
+// generation succeeded AND the live producer stamped gComboCtx; non-zero (with a
+// stderr marker) otherwise. `outPath` NULL/empty => write the digest to stdout.
+//
+// Placements are captured IN-MEMORY here rather than diffed from the spoiler
+// JSON on disk: a same-seed rerun overwrites Randomizer/<hash>.json, so a naive
+// file diff would compare a file against itself (a verified pitfall). Iterating
+// RandomizerCheck in fixed enum order [0, RC_MAX) also makes the digest
+// independent of any hash-map iteration order and of the timestamp/version
+// fields the spoiler JSON carries.
+//
+// Determinism scope: the harness drives the synchronous 3-arg GenerateRandomizer
+// with EMPTY excludedLocations/enabledTricks (see Rando_HeadlessSeedTest), so
+// this locks reproducibility for the pinned settings profile with no per-check
+// exclusions or extra tricks. Exclusion/trick-driven fills are out of scope for
+// this lock.
+extern "C" int Rando_HeadlessSeedDeterminismDigest(const char* seedStr, const char* outPath) {
+    int rc = Rando_HeadlessSeedTest(seedStr);
+    if (rc != 0) {
+        fprintf(stderr, "[rando-determinism] generation failed rc=%d\n", rc);
+        return rc;
+    }
+
+    // The live unified-seed producer (Playthrough_Init) must have stamped the
+    // ComboContext during generation. This ties the determinism lock directly to
+    // Lane B's producer: if it ever stops firing, sourceIsRando/sharedRandoSeed
+    // read 0 and this fails, instead of silently passing on an unwritten world.
+    if (!gComboCtx.sourceIsRando) {
+        fprintf(stderr, "[rando-determinism] gComboCtx.sourceIsRando not set by generation\n");
+        return 2;
+    }
+    if (gComboCtx.sharedRandoSeed == 0) {
+        fprintf(stderr, "[rando-determinism] gComboCtx.sharedRandoSeed still 0 after generation\n");
+        return 3;
+    }
+
+    auto ctx = Rando::Context::GetInstance();
+    if (!ctx) {
+        fprintf(stderr, "[rando-determinism] no Rando::Context after generation\n");
+        return 4;
+    }
+
+    // Canonical placement blob: "<rc>:<placedItem>;" for every location, in
+    // ascending RandomizerCheck order, folded through the project's FNV-1a so the
+    // digest file stays small and stable.
+    std::string blob;
+    blob.reserve(static_cast<size_t>(RC_MAX) * 8);
+    size_t placedCount = 0;
+    for (int i = 0; i < RC_MAX; i++) {
+        RandomizerGet item = ctx->GetItemLocation(static_cast<RandomizerCheck>(i))->GetPlacedRandomizerGet();
+        if (item != RG_NONE) {
+            placedCount++;
+        }
+        blob += std::to_string(i);
+        blob += ':';
+        blob += std::to_string(static_cast<int>(item));
+        blob += ';';
+    }
+    const uint32_t placementHash = SohUtils::Hash(blob);
+
+    FILE* out = stdout;
+    bool closeOut = false;
+    if (outPath && outPath[0] != '\0') {
+        out = fopen(outPath, "w");
+        if (out == nullptr) {
+            fprintf(stderr, "[rando-determinism] cannot open digest output '%s'\n", outPath);
+            return 5;
+        }
+        closeOut = true;
+    }
+    fprintf(out,
+            "seed=%08X\n"
+            "settingsHash=%08X\n"
+            "sourceIsRando=%d\n"
+            "placementHash=%08X\n"
+            "placedCount=%zu\n",
+            gComboCtx.sharedRandoSeed, gComboCtx.sharedRandoSettingsHash, gComboCtx.sourceIsRando ? 1 : 0,
+            placementHash, placedCount);
+    if (closeOut) {
+        fclose(out);
+    }
+    fprintf(stderr, "[rando-determinism] digest: seed=%08X settingsHash=%08X placementHash=%08X placed=%zu\n",
+            gComboCtx.sharedRandoSeed, gComboCtx.sharedRandoSettingsHash, placementHash, placedCount);
+    return 0;
 }
 
 bool GenerateRandomizer(std::set<RandomizerCheck> excludedLocations, std::set<RandomizerTrick> enabledTricks,

--- a/games/oot/soh/Enhancements/randomizer/3drando/playthrough.cpp
+++ b/games/oot/soh/Enhancements/randomizer/3drando/playthrough.cpp
@@ -14,6 +14,7 @@
 #include "soh/cvar_prefixes.h"
 #include "../option.h"
 #include "soh/Enhancements/debugger/performanceTimer.h"
+#include "context.h" // src/common — gComboCtx, Lane B unified-seed carrier (ADR 0002)
 
 namespace Playthrough {
 
@@ -60,6 +61,15 @@ int Playthrough_Init(uint32_t seed, std::set<RandomizerCheck> excludedLocations,
         }
     }
 
+    // Lane B (ADR 0002 §3): fingerprint the finalized settings profile BEFORE the
+    // DontGenerateSpoiler build-version mixing below, so the digest identifies the
+    // settings alone — seed-independent and build-independent. This is the second
+    // half of the unified-seed contract: sharedRandoSeed alone does NOT determine
+    // the fill, because the RNG is re-seeded with Hash(seed + settingsStr) just
+    // below, so the same numeric seed reproduces a world only under the same
+    // settings (see gComboCtx.sharedRandoSettingsHash).
+    const uint32_t rsbsSettingsHash = SohUtils::Hash(settingsStr);
+
     if (CVarGetInteger(CVAR_RANDOMIZER_SETTING("DontGenerateSpoiler"), 0)) {
         settingsStr += (char*)OoT_gBuildVersion;
     }
@@ -91,6 +101,21 @@ int Playthrough_Init(uint32_t seed, std::set<RandomizerCheck> excludedLocations,
 
     ctx->playthroughLocations.clear();
     ctx->playthroughBeatable = false;
+
+    // Lane B unified-seed producer (ADR 0002 §3): publish this OoT world's
+    // identity into the process-global ComboContext at GENERATION time — NOT at
+    // freeze time (the legacy OoT_FreezeState / BenPort freeze-time producers are
+    // dead code and must not be imitated). Both the live GUI path
+    // (RandoMain::GenerateRando -> GenerateRandomizer -> here) and the headless
+    // harness (Rando_HeadlessSeedTest -> GenerateRandomizer -> here) funnel
+    // through this one point, and we only reach it on a fully successful fill +
+    // spoiler write. `seed` == ctx->GetSeed() (the caller passes exactly that).
+    // MM (Lane C) consumes these when it becomes reachable, to reproduce the
+    // paired world (sharedRandoSeed) and verify the pinned settings profile
+    // matches (sharedRandoSettingsHash).
+    gComboCtx.sourceIsRando = true;
+    gComboCtx.sharedRandoSeed = seed;
+    gComboCtx.sharedRandoSettingsHash = rsbsSettingsHash;
 
     return 1;
 }

--- a/src/common/context.cpp
+++ b/src/common/context.cpp
@@ -210,6 +210,7 @@ void ComboContext_Init(void) {
     gComboCtx.saveSlot = -1;  // RETIRED IN PLACE (ADR 0002) — the -1 stamp is shipped behavior, kept as-is
     gComboCtx.sourceIsRando = false;
     gComboCtx.sharedRandoSeed = 0;
+    gComboCtx.sharedRandoSettingsHash = 0;  // Lane B (ADR 0002 §3): 0 == no profile recorded
     // sharedItemsTagged and the remaining reserved[] headroom are covered by
     // the memset above: all-zero IS the initialized state (every slot unset,
     // originGame == GAME_NONE). That equivalence is load-bearing — it is what

--- a/src/common/context.h
+++ b/src/common/context.h
@@ -212,14 +212,33 @@ typedef struct {
     // exactly what a zero-extended legacy record must read as.
     SharedItem sharedItemsTagged[RSBS_SHARED_ITEM_CAP];
 
+    // Lane B settings digest (ADR 0002 §3: "If B needs a settings digest beyond
+    // the u32 seed, carve it from reserved under the growth contract"). This is
+    // the FNV-1a hash of OoT's finalized rando settings string — the second half
+    // of the "one seed + one pinned settings profile" reproducibility contract:
+    // sharedRandoSeed alone does NOT determine the fill, because Playthrough_Init
+    // re-seeds the RNG with Hash(seed + settings-string) before placing items, so
+    // the same numeric seed reproduces a world only under the same settings. MM
+    // (Lane C) reads this to VERIFY both games were generated under the agreed
+    // pinned profile before pairing; a mismatch means the worlds do not pair.
+    // Seed-independent (a fixed profile hashes the same across seeds) and build-
+    // independent (computed before the DontGenerateSpoiler build-version mixing).
+    // Zero == unset: a non-rando or zero-extended legacy record reads 0, which
+    // MM treats as "no profile recorded" — the growth contract's required
+    // meaning of zero for every carved field. Carved from the FRONT of the old
+    // reserved[384] (its offset is exactly where reserved used to begin), so
+    // every field above keeps its shipped offset and the record size is
+    // unchanged.
+    uint32_t sharedRandoSettingsHash;
+
     // Headroom. Carve new fields from the FRONT of this array (as
-    // sharedItemsTagged was) so the struct stays inside
-    // RSBS_COMBO_CONTEXT_RECORD_SIZE; the on-disk record size does not change
-    // either way, so old saves keep loading. Zeroed by ComboContext_Init, which
-    // is what makes a zero-extended legacy record indistinguishable from a
+    // sharedItemsTagged and sharedRandoSettingsHash were) so the struct stays
+    // inside RSBS_COMBO_CONTEXT_RECORD_SIZE; the on-disk record size does not
+    // change either way, so old saves keep loading. Zeroed by ComboContext_Init,
+    // which is what makes a zero-extended legacy record indistinguishable from a
     // freshly-initialized one — every field carved from here must keep "zero
     // means unset".
-    uint8_t reserved[384];
+    uint8_t reserved[380];
 } ComboContext;
 
 /**
@@ -249,10 +268,18 @@ RSBS_CTX_STATIC_ASSERT(sizeof(ComboContext) <= RSBS_COMBO_CONTEXT_RECORD_SIZE,
 RSBS_CTX_STATIC_ASSERT(offsetof(ComboContext, sharedItemsTagged) == RSBS_COMBO_CONTEXT_PRECARVE_SIZE,
                        "sharedItemsTagged must sit exactly at the pre-carve reserved[] offset; "
                        "moving it orphans every shipped .redsave");
-RSBS_CTX_STATIC_ASSERT(offsetof(ComboContext, reserved) ==
+// sharedRandoSettingsHash is the first field carved from the front of the old
+// reserved[]; it must sit immediately after the tagged-item array with no gap,
+// so it occupies bytes that shipped .redsaves stored as zero (unset).
+RSBS_CTX_STATIC_ASSERT(offsetof(ComboContext, sharedRandoSettingsHash) ==
                            RSBS_COMBO_CONTEXT_PRECARVE_SIZE + RSBS_SHARED_ITEM_CAP * sizeof(SharedItem),
-                       "the tagged-item array and the remaining headroom must stay contiguous "
-                       "(no padding, no fields slipped between them)");
+                       "sharedRandoSettingsHash must be carved from the FRONT of the old reserved[] "
+                       "(contiguous with the tagged-item array); moving it changes .redsave format");
+RSBS_CTX_STATIC_ASSERT(offsetof(ComboContext, reserved) ==
+                           RSBS_COMBO_CONTEXT_PRECARVE_SIZE + RSBS_SHARED_ITEM_CAP * sizeof(SharedItem) +
+                               sizeof(uint32_t),
+                       "the tagged-item array, the settings digest, and the remaining headroom must "
+                       "stay contiguous (no padding, no fields slipped between them)");
 
 #ifdef __cplusplus
 // The raw-assignment-fails proof (ADR 0002). In C this is a constraint

--- a/src/common/test_runner.cpp
+++ b/src/common/test_runner.cpp
@@ -250,6 +250,13 @@ TestResult Test_BootOoT(void) {
 }
 
 extern "C" int Rando_HeadlessSeedTest(const char* seedStr);
+// Lane B unified-seed determinism bridge (body in
+// games/oot/soh/Enhancements/randomizer/3drando/menu.cpp). Runs ONE seed
+// generation, asserts the live producer stamped gComboCtx, and writes a
+// canonical placement+seed digest to `outPath` (NULL => stdout). Returns 0 on
+// success. Kept behind a C entry point so the OoT randomizer headers never enter
+// this delicate multi-include TU, mirroring MM_SceneExecute_RunHeadless.
+extern "C" int Rando_HeadlessSeedDeterminismDigest(const char* seedStr, const char* outPath);
 extern "C" void InitOTRForMMFirstBoot(int argc, char* argv[]);
 
 TestResult Test_RandoGen(void) {
@@ -271,6 +278,38 @@ TestResult Test_RandoGen(void) {
 
     int rc = Rando_HeadlessSeedTest("RSBSDIAG1");
     printf("[TEST] %s: seed generation rc=%d\n", rc == 0 ? "PASS" : "FAIL", rc);
+    return rc == 0 ? TEST_PASS : TEST_FAIL;
+}
+
+// Lane B unified-seed lock. Single run: bring up OoT, generate one pinned seed,
+// and (inside the bridge) assert the LIVE producer stamped
+// gComboCtx.sourceIsRando/sharedRandoSeed at generation time, then emit a
+// canonical digest of the seed fields + full placement. The two-process
+// same-seed determinism comparison is driven by the SeedDeterminism CTest row
+// (CMake/CheckSeedDeterminism.cmake), which runs this dispatch twice with
+// distinct RSBS_SEED_DIGEST_OUT paths and diffs them — two processes, because
+// re-entering the generator in one process is unverified. Needs a display
+// (Fast3dWindow) like rando-gen, so it is skipped by `--test all`.
+TestResult Test_RandoDeterminism(void) {
+    printf("[TEST] rando-determinism: unified-seed producer fires + placement digest emitted (Lane B)\n");
+
+    auto ctx = CreateHarnessStyleContext();
+    if (!ctx) {
+        printf("[TEST] FAIL: could not create Ship::Context singleton\n");
+        return TEST_FAIL;
+    }
+
+    static char arg0[] = "redship";
+    static char* fakeArgv[] = { arg0, nullptr };
+    InitOTRForMMFirstBoot(1, fakeArgv);
+
+    // Pinned SEED for the unified-seed contract. The pinned SETTINGS profile is
+    // supplied via the CTest ENVIRONMENT (RSBS_DIAG_CVARS), so the determinism
+    // wrapper's two runs share it (see CMake/CheckSeedDeterminism.cmake).
+    const char* seed = "RSBSUNIFIED1";
+    const char* digestOut = std::getenv("RSBS_SEED_DIGEST_OUT");  // NULL => digest to stdout
+    int rc = Rando_HeadlessSeedDeterminismDigest(seed, digestOut);
+    printf("[TEST] %s: determinism digest rc=%d\n", rc == 0 ? "PASS" : "FAIL", rc);
     return rc == 0 ? TEST_PASS : TEST_FAIL;
 }
 
@@ -839,6 +878,11 @@ TestResult Test_Context(void) {
 
 const TestDescriptor gTests[] = {
     {"rando-gen", "Seed generation succeeds with default settings (#337)", Test_RandoGen},
+    // Lane B unified seed: producer stamps gComboCtx at generation time; the
+    // two-process same-seed determinism diff runs via the SeedDeterminism row.
+    // Needs a display like rando-gen, so `--test all` skips it (below).
+    {"rando-determinism", "Unified-seed producer fires + same-seed fill is reproducible (Lane B)",
+     Test_RandoDeterminism},
     {"boot-oot", "Shared-context bring-up leaves no null subsystems (#329)", Test_BootOoT},
     {"boot-mm", "MM-first bring-up prerequisites on the shared context (#330)", Test_BootMM},
     {"switch-oot-mm", "Test game switch OoT -> MM", Test_SwitchOoTMM},
@@ -951,12 +995,12 @@ int TestRunner_Run(const char* testName) {
         int total = 0;
 
         for (int i = 0; gTests[i].name != nullptr; i++) {
-            // rando-gen needs a display (Fast3dWindow bring-up) and the
-            // RSBS_DISABLE_OTR_INIT environment; it runs as its own CTest
-            // ("rando" label, under xvfb-run) rather than in this
-            // display-free suite, where it would hang the 60s timeout.
-            if (strcmp(gTests[i].name, "rando-gen") == 0) {
-                printf("\n--- Skipping: %s (needs display; runs as the RandoGen CTest) ---\n", gTests[i].name);
+            // rando-gen / rando-determinism need a display (Fast3dWindow
+            // bring-up) and the RSBS_DISABLE_OTR_INIT environment; they run as
+            // their own CTests ("rando" label, under xvfb-run) rather than in
+            // this display-free suite, where they would hang the 60s timeout.
+            if (strcmp(gTests[i].name, "rando-gen") == 0 || strcmp(gTests[i].name, "rando-determinism") == 0) {
+                printf("\n--- Skipping: %s (needs display; runs as a rando-label CTest) ---\n", gTests[i].name);
                 continue;
             }
             printf("\n--- Running: %s ---\n", gTests[i].name);


### PR DESCRIPTION
## Lane B — unified seed → paired world

Revives the dead `gComboCtx.sourceIsRando` / `sharedRandoSeed` fields as the live cross-game carrier (ADR 0002 §3) and adds the settings half of the reproducibility contract. Scope is the **OoT side + the shared handoff contract**; MM consumption is deferred to Lane C (its generation path is unreachable until then).

### Where the seed write lands (the live path)

`Playthrough::Playthrough_Init` (`games/oot/soh/Enhancements/randomizer/3drando/playthrough.cpp`), stamped only on a fully successful fill + spoiler write, at **generation time** — NOT at freeze time. The legacy `OoT_FreezeState` (`OTRGlobals.cpp`, zero callers) and `MM_FreezeState`/`MM_InitFirstEntrySaveContext` (`BenPort.cpp`, excluded TU) freeze-time producers are dead code and are **not** imitated. Both the live GUI path (`RandoMain::GenerateRando` → `GenerateRandomizer` → `Playthrough_Init`) and the headless harness (`Rando_HeadlessSeedTest` → `GenerateRandomizer` → `Playthrough_Init`) funnel through this one point.

```
gComboCtx.sourceIsRando          = true;
gComboCtx.sharedRandoSeed        = seed;              // == ctx->GetSeed(), the master seed hash
gComboCtx.sharedRandoSettingsHash = Hash(settingsStr);// pinned-profile fingerprint
```

`grep` shows the non-test producer lives in `playthrough.cpp` (done-criterion: "seed visible in gComboCtx in the live path").

### The double-reseed subtlety → the pinned settings profile

`Playthrough_Init` seeds the RNG **twice**: `Random_Init(seed)`, then `Random_Init(Hash(str(seed) + settings-string))` before the fill. So a numeric seed reproduces a world **only under identical settings**. "One seed → paired world" therefore means **one seed + one pinned settings profile**.

- **Pinning vehicle:** `RSBS_DIAG_CVARS` (already used by the ShuffleSongs rando rows).
- **Pinned profile definition ("RSBS unified pinned profile v1"):** stock OoT rando defaults (from `Settings::CreateOptions` / `SetAllToContext`) **plus** `gRandoSettings.ShuffleSongs=2`. This is what both determinism rows pin, and what Lane C must agree on for MM.
- **Settings digest field:** new `uint32_t gComboCtx.sharedRandoSettingsHash`, carved from the front of `reserved[]` (384 → 380 bytes). `sizeof(ComboContext)` stays **1004**, record size stays **1024**, `RSBS_SAVE_VERSION` stays **2** — every existing `.redsave` still loads and zero-extends. It is the FNV-1a of the finalized settings string, **seed-independent** (a fixed profile hashes the same across seeds) and **build-independent** (computed before the `DontGenerateSpoiler` build-version mixing). Zero == unset. New static_asserts pin its carved offset (620) and `reserved` contiguity (624).

### Determinism test design (three verified pitfalls)

New `rando`-label CTests (xvfb, `SDL_AUDIODRIVER=dummy`, `RSBS_DISABLE_OTR_INIT=1`):

- **`RandoDeterminism`** (TIMEOUT 180) — single run; asserts generation succeeds AND the live producer stamped `gComboCtx`; also the `--test rando-determinism` row the completeness guard requires for the new dispatch entry.
- **`SeedDeterminism`** (TIMEOUT 300, meta row → `CMake/CheckSeedDeterminism.cmake`) — the actual same-seed-twice output-equality lock (the first in the `rando` tier).

Pitfalls designed around:
1. **Same-seed spoiler-log OVERWRITE** — both runs land on `Randomizer/<hash>.json`, so a naive file diff compares a file against itself. Sidestepped entirely: placements are captured **in-memory** (`Rando_HeadlessSeedDigest`, iterating `RandomizerCheck` in fixed enum order → FNV-1a) and each run writes to its **own** `RSBS_SEED_DIGEST_OUT` path.
2. **Empty exclusion/trick scope** — the headless harness drives the synchronous 3-arg `GenerateRandomizer` with empty excludedLocations/enabledTricks; documented in the test comment (this lock covers the pinned profile with no per-check exclusions/extra tricks).
3. **Unverified generator re-entry** — `Rando_HeadlessSeedTest` has never been called twice in one process, so `SeedDeterminism` uses **two separate process invocations** rather than in-process re-entry.

### Lane C handoff contract (MM consumption deferred)

> **Contract:** After a successful OoT rando generation, `gComboCtx` carries the paired-world identity, written in the live path at generation time and round-tripped through every `.redsave`:
> - `sourceIsRando` (bool) — an OoT rando world was generated; a paired MM world should exist.
> - `sharedRandoSeed` (u32) — the **master seed** = `Hash(seedString)` = `Rando::Context::GetSeed()`. Lane C seeds MM's cross-game placement from this (mixing in MM's own settings, mirroring OoT's `Random_Init(Hash(str(seed) + settingsStr))` scheme).
> - `sharedRandoSettingsHash` (u32) — FNV-1a of OoT's finalized settings profile, seed- and build-independent. Lane C **verifies** both games were generated under the agreed pinned profile before pairing; a mismatch (or `0` == "no profile recorded") means the worlds do not pair.
>
> Reproducibility depends on **both** the seed and the pinned settings profile (RSBS_DIAG_CVARS). Portable primitives are byte-identical across games: `SohUtils::Hash` ≡ MM `Ship_Hash` (FNV-1a), and the PCG-XSH-RR cores match — so the same seed string hashes identically on both sides. Lane C wires the MM consumption; nothing here reaches MM yet.

### Surface question (escalated, not decided)

Per the brief, the ComboMenuBar-vs-SohMenu surface question is escalated to #392 with a recommendation; this PR takes the minimal path (the existing CVar / SohMenu generation hook already funnels through `Playthrough_Init`, so no new UI is needed for the producer).

### Files

- `src/common/context.h` / `context.cpp` — carve `sharedRandoSettingsHash` from `reserved`; static_asserts; init.
- `games/oot/soh/Enhancements/randomizer/3drando/playthrough.cpp` — the live producer.
- `games/oot/soh/Enhancements/randomizer/3drando/menu.cpp` — `Rando_HeadlessSeedDeterminismDigest` bridge.
- `src/common/test_runner.cpp` — `rando-determinism` dispatch (skipped by `--test all`; needs a display).
- `CMake/CheckSeedDeterminism.cmake` (new) + `CMake/SingleExecutable.cmake` — the two rows.

Note: does not touch either `GameExports_SingleExe.cpp` (A1's files) or the entrance tables. The `context.h` carve is the reserved-carve A0's ADR §3 explicitly delegated to Lane B; A1 does not edit `context.h`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!--- section:artifacts:start -->
### Build Artifacts
  - [rsbs-linux.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/8477912926.zip)
  - [rsbs-windows.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/8477842756.zip)
  - [rsbs-linux.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/8477622205.zip)
<!--- section:artifacts:end -->