### PR TITLE
Lane A1: cross-game shared-item producers/consumers + MM consumption-point timer fix (#373)

### DIFF
--- a/CMake/SingleExecutable.cmake
+++ b/CMake/SingleExecutable.cmake
@@ -25,6 +25,9 @@ set(REDSHIP_COMMON_SOURCES
     ${CMAKE_SOURCE_DIR}/src/common/zapd_subprocess.cpp
     ${CMAKE_SOURCE_DIR}/src/common/context.cpp
     ${CMAKE_SOURCE_DIR}/src/common/switch.cpp
+    # Cross-game shared-item producers/consumers over gComboCtx.sharedItemsTagged
+    # (ADR 0002, Lane A1) — read/written by both games' suspend + consumption hooks
+    ${CMAKE_SOURCE_DIR}/src/common/shared_items.c
     ${CMAKE_SOURCE_DIR}/src/common/entrance.cpp
     ${CMAKE_SOURCE_DIR}/src/common/test_runner.cpp
     ${CMAKE_SOURCE_DIR}/src/common/integration_test_hooks.cpp
@@ -57,6 +60,7 @@ set(REDSHIP_COMMON_HEADERS
     ${CMAKE_SOURCE_DIR}/src/common/headless_crash.h
     ${CMAKE_SOURCE_DIR}/src/common/zapd_subprocess.h
     ${CMAKE_SOURCE_DIR}/src/common/context.h
+    ${CMAKE_SOURCE_DIR}/src/common/shared_items.h
     ${CMAKE_SOURCE_DIR}/src/common/entrance.h
     ${CMAKE_SOURCE_DIR}/src/common/test_runner.h
     ${CMAKE_SOURCE_DIR}/src/common/integration_test_hooks.h
@@ -262,6 +266,11 @@ if(BUILD_TESTING)
     redship_add_test(NAME Roundtrip COMMAND redship --test roundtrip)
     redship_add_test(NAME RoundtripIntegrity COMMAND redship --test roundtrip-integrity)
     redship_add_test(NAME SharedRoundtrip COMMAND redship --test shared-roundtrip)
+    # Origin-tagged cross-game items (ADR 0002 / Lane A1): a recorded item must
+    # survive the full suspend->switch->resume->switch->resume round trip through
+    # the real producer/consumer + freeze/consume hooks, be visible in both
+    # directions, and be awarded exactly once per crossing (covers the F10 path).
+    redship_add_test(NAME SharedItemRoundtrip COMMAND redship --test shared-item-roundtrip)
     redship_add_test(NAME ArchiveHotswapLogic COMMAND redship --test archive-hotswap-logic)
     # Unified save (.redsave) headless tests — Phase 2 T6 (#35)
     redship_add_test(NAME SaveRoundtripTiers COMMAND redship --test save-roundtrip-tiers)

--- a/games/mm/2s2h/mm_resume_state_test.cpp
+++ b/games/mm/2s2h/mm_resume_state_test.cpp
@@ -148,6 +148,18 @@ extern "C" int MM_StartupRestore_RunHeadless(void) {
     RESUME_ASSERT(gSaveContext.save.entrance == kArrival, "startup entrance not applied to save.entrance");
     RESUME_ASSERT(gSaveContext.save.cutsceneIndex == 0, "cutsceneIndex not reset for arrival spawn");
     RESUME_ASSERT(gSaveContext.gameMode == GAMEMODE_NORMAL, "gameMode not reset for arrival spawn");
+    // ...live gameplay state carried by the frozen blob is neutralized (#373).
+    // The 0x5A fill above put every timerStates[] byte at a non-OFF value (the
+    // regression: a minigame timer frozen mid-count resumes in the arrival
+    // scene where its actor does not exist). The OoT consumption twin cleared
+    // these; MM's had drifted and did not.
+    for (int i = 0; i < TIMER_ID_MAX; i++) {
+        RESUME_ASSERT(gSaveContext.timerStates[i] == TIMER_STATE_OFF,
+                      "frozen live timer not neutralized on MM arrival (#373)");
+    }
+    RESUME_ASSERT(gSaveContext.magicState == MAGIC_STATE_IDLE, "frozen magicState not reset on MM arrival (#373)");
+    RESUME_ASSERT(gSaveContext.forcedSeqId == NA_BGM_GENERAL_SFX, "frozen forcedSeqId not reset on MM arrival (#373)");
+    RESUME_ASSERT(gSaveContext.powderKegTimer == 0, "frozen powder-keg timer not cleared on MM arrival (#373)");
     // ...and the slot is consumed.
     RESUME_ASSERT(!Combo_HasStartupEntrance(), "startup entrance not cleared after consumption");
 

--- a/games/mm/src/code/z_play.c
+++ b/games/mm/src/code/z_play.c
@@ -2314,6 +2314,38 @@ void MM_Play_ConsumeStartupEntrance(void) {
     // values every fresh-boot path uses, z_common_data.c).
     gSaveContext.seqId = NA_BGM_DISABLED;
     gSaveContext.ambienceId = AMBIENCE_ID_DISABLED;
+    // Neutralize live gameplay state carried in the frozen blob (#373). This is
+    // the MM half of the OoT twin at games/oot/src/code/z_play.c
+    // ("Per-session runtime state a fresh file-load always authors ... but the
+    // return leg never does") — the two consumption points had drifted, and
+    // MM's was missing all of it. The boot chain's MM_SaveContext_Init used to
+    // zero these before gameplay; moving the restore to this consumption point
+    // (after that memset) means a stale value now reaches the arrival scene.
+    //
+    // The concrete regression #373 filed: a minigame timer frozen mid-count
+    // (Deku Playground / Bombers hide-and-seek: timerStates[i] ==
+    // TIMER_STATE_COUNTING with a partial timerCurTimes) is re-applied into a
+    // fresh South Clock Town spawn where the minigame actor does not exist;
+    // Interface_UpdateTimers keeps counting and fires the minigame
+    // expiry/respawn handling in the wrong scene. Cross-game arrivals are plain
+    // spawns — clear the timers and the rest of the OoT-parity list.
+    memset(gSaveContext.timerStates, TIMER_STATE_OFF, sizeof(gSaveContext.timerStates));
+    gSaveContext.powderKegTimer = 0; // "big_bom_timer" — MM-specific live countdown
+    gSaveContext.jinxTimer = 0;
+    // eventInf is runtime scratch (offset 0x100C, OUTSIDE the persisted Save):
+    // minigame/race bits actors trust blindly, exactly as OoT's eventInf[0..3].
+    // Safe here — respawnFlag was already zeroed above, so the eventInf-gated
+    // DAYTELOP branch in MM_Play_Init below cannot fire regardless.
+    memset(gSaveContext.eventInf, 0, sizeof(gSaveContext.eventInf));
+    gSaveContext.minigameStatus = 0;
+    gSaveContext.dogParams = 0;                 // OoT leftover, "dog_flag"
+    gSaveContext.nayrusLoveTimer = 0;           // OoT remnant, "shield_magic_timer"
+    gSaveContext.healthAccumulator = 0;         // "life_mode"
+    gSaveContext.magicState = MAGIC_STATE_IDLE; // a frozen magic machine wedges the meter
+    // forcedSeqId would restart the old session's BGM over the declared-dead
+    // audio state above; NA_BGM_GENERAL_SFX is the no-forced-sequence value
+    // every fresh-boot path uses (z_common_data.c).
+    gSaveContext.forcedSeqId = NA_BGM_GENERAL_SFX;
     // Suppress Clock Town's first-visit intro layer: cutsceneIndex=0 above
     // does NOT cover it, because the South Clock Town intro is ACTOR-triggered
     // — ObjTokeiTobira (the tower-door prop) starts its Tatl/camera cutscene

--- a/games/oot/soh/GameExports_SingleExe.cpp
+++ b/games/oot/soh/GameExports_SingleExe.cpp
@@ -19,6 +19,7 @@
 #include "game_lifecycle.h"
 #include "integration_test_hooks.h"
 #include "context.h"
+#include "shared_items.h"
 #include "entrance.h"
 #include "soh/Enhancements/game-interactor/GameInteractor.h"
 #include "soh/Enhancements/game-interactor/GameInteractor_Hooks.h"
@@ -779,6 +780,17 @@ void OoT_Game_Suspend(void) {
     fprintf(stderr, "[OoT] Game_Suspend called\n");
     fflush(stderr);
 
+    // Producer (ADR 0002 / Lane A1): commit any staged cross-game items into
+    // gComboCtx.sharedItemsTagged before we hand control to MM. This lives at
+    // Game_Suspend — not Combo_CheckEntranceSwitch — on purpose: the F10
+    // hot-swap path (Combo_FreezeActiveGameForHotSwap) bypasses the entrance
+    // hook entirely, and GameRunner_SwitchTo calls suspend() on both switch
+    // paths, so this is the one point that never drops a hotkey switch's
+    // writes. The array itself is process-global and crosses the switch by
+    // being shared; committing here just moves staged pickups into the durable
+    // (serialized) store before the arriving game's consumer reads it.
+    Combo_CommitStagedSharedItems();
+
     // Stop OoT audio playback to prevent interference with MM (issue #160).
     // OoT_Audio_PreNMI triggers the audio reset path which stops all sequences
     // and puts the audio system into a quiescent state.
@@ -965,6 +977,43 @@ int Switch_PrepareHotSwap(GameId departing, const void* saveContext, size_t size
  */
 extern "C" int Combo_FreezeActiveGameForHotSwap(GameId departing) {
     return Switch_PrepareHotSwap(departing, &gSaveContext, sizeof(gSaveContext));
+}
+
+/**
+ * Award a single OoT-origin shared item (ADR 0002 / Lane A1 consumer callback).
+ *
+ * Invoked once per un-redeemed entry tagged GAME_OOT when the player arrives in
+ * OoT (see OoT_ConsumeSharedItems). `item->id` is an OoT RandomizerGet (RG_*).
+ *
+ * Lane A1 scope: this is the plumbing seam. Awarding an RG_* into the live game
+ * requires the randomizer save context and the foreign-item presentation Lane C
+ * owns, so here it only logs; Combo_RedeemSharedItemsForGame still marks the
+ * entry RSBS_SHARED_ITEM_REDEEMED so the crossing is single-use once wired.
+ *
+ * Lane C: replace the log with the real give — Randomizer_Item_Give
+ * ((RandomizerGet)item->id) (games/oot/soh/.../randomizer.cpp) — for the chosen
+ * foreign-item class. Do NOT clear the entry; the REDEEMED bit is the guard.
+ */
+static void OoT_AwardSharedItem(const SharedItem* item, void* ctx) {
+    (void)ctx;
+    fprintf(stderr, "[OoT] shared-item redeem (Lane A1 plumbing): RG id=%u — Lane C wires Randomizer_Item_Give\n",
+            (unsigned)item->id);
+}
+
+/**
+ * Consumer hook (ADR 0002 / Lane A1). Award every un-redeemed OoT-origin shared
+ * item and mark it redeemed. Called from OoT_Play_Init's presence-gated
+ * startup-entrance consumption (games/oot/src/code/z_play.c) — i.e. only on a
+ * cross-game arrival into OoT, once per arrival. A plain boot / .redsave load
+ * never reaches it, so un-redeemed items wait for the next switch into OoT
+ * ("applies on next switch only"; see shared_items.h).
+ *
+ * Exposed as a plain C entry point so z_play.c does not have to pull in the
+ * ADR SharedItem / GameId types (it isolates every src/common call behind bare
+ * externs).
+ */
+extern "C" void OoT_ConsumeSharedItems(void) {
+    Combo_RedeemSharedItemsForGame(GAME_OOT, OoT_AwardSharedItem, nullptr);
 }
 
 static bool sLastF10State = false;

--- a/games/oot/src/code/z_play.c
+++ b/games/oot/src/code/z_play.c
@@ -34,6 +34,12 @@ extern bool Combo_HasStartupEntranceForGame(const char* gameId);
 // silent-rollback bug, and leaving those in scope invites it back.
 extern int Combo_ConsumeFrozenState(const char* gameId, void* saveContext, size_t size);
 
+// Cross-game shared-item consumer (ADR 0002 / Lane A1). Awards every un-redeemed
+// OoT-origin item in gComboCtx.sharedItemsTagged and marks it redeemed. Exposed
+// as a plain C entry point from games/oot/soh/GameExports_SingleExe.cpp so this
+// TU stays free of the ADR SharedItem/GameId types.
+extern void OoT_ConsumeSharedItems(void);
+
 // Cross-game combo support - entrance switch checking
 extern uint16_t Combo_CheckEntranceSwitch(uint16_t entranceIndex);
 extern bool Combo_IsCrossGameSwitch(void);
@@ -547,6 +553,16 @@ void OoT_Play_Init(GameState* thisx) {
                         gSaveContext.equips.equipment = equip;
                     }
                 }
+                // Consumer (ADR 0002 / Lane A1): now that the frozen save is
+                // restored and the arrival's runtime state is neutralized,
+                // award any cross-game items tagged for OoT and retire them
+                // (RSBS_SHARED_ITEM_REDEEMED). Presence-gated by the enclosing
+                // startup-entrance branch, so it runs once per OoT arrival and
+                // never on a plain boot/.redsave load — un-redeemed items then
+                // wait for the next switch into OoT (shared_items.h). Placed
+                // after the inventory-touching age/equip fixups above so a
+                // redeemed item lands in a settled gSaveContext.
+                OoT_ConsumeSharedItems();
                 Combo_ClearStartupEntrance();
                 osSyncPrintf("[OoT] Cross-game switch: loading entrance 0x%04X\n", startupEntrance);
             }

--- a/src/common/shared_items.c
+++ b/src/common/shared_items.c
@@ -1,0 +1,161 @@
+/**
+ * @file shared_items.c
+ * @brief Cross-game shared-item producers and consumers (ADR 0002, Lane A1).
+ *
+ * See shared_items.h for the model. Everything here operates on the
+ * process-global gComboCtx.sharedItemsTagged array (the durable, serialized
+ * store) plus a small RAM-only outbox that the producer hook drains at suspend.
+ *
+ * This TU is intentionally free of game headers: it manipulates the ADR-0002
+ * SharedItem type and gComboCtx only, so it compiles into the shared
+ * redship_common library and both games' C TUs call it directly.
+ */
+
+#include "shared_items.h"
+#include <stdio.h>
+
+// ============================================================================
+// RAM outbox for the deferred (stage -> commit-at-suspend) producer path.
+//
+// Kept small: this only buffers pickups between a foreign-item give and the
+// imminent switch. Committed items land in gComboCtx.sharedItemsTagged, which
+// is the array that actually crosses the switch and serializes.
+// ============================================================================
+
+#define SHARED_ITEM_OUTBOX_CAP RSBS_SHARED_ITEM_CAP
+
+static SharedItem sOutbox[SHARED_ITEM_OUTBOX_CAP];
+static int sOutboxCount = 0;
+
+static bool IsRealGame(GameId game) {
+    return game == GAME_OOT || game == GAME_MM;
+}
+
+// ============================================================================
+// Producer
+// ============================================================================
+
+int Combo_RecordSharedItem(GameId originGame, uint16_t id) {
+    if (!IsRealGame(originGame)) {
+        return -1;
+    }
+
+    // De-dup against an existing un-redeemed entry so a re-fired producer
+    // cannot create doubles (see the header). An already-redeemed match does
+    // NOT block a fresh record — the same item crossing a second time is a
+    // real, distinct hand-off.
+    int firstFree = -1;
+    for (int i = 0; i < (int)RSBS_SHARED_ITEM_CAP; i++) {
+        SharedItem* slot = &gComboCtx.sharedItemsTagged[i];
+        if (slot->originGame == (uint8_t)GAME_NONE) {
+            if (firstFree < 0) {
+                firstFree = i;
+            }
+            continue;
+        }
+        if (slot->originGame == (uint8_t)originGame && slot->id == id &&
+            (slot->flags & RSBS_SHARED_ITEM_REDEEMED) == 0) {
+            return i; // already pending — leave it exactly as-is
+        }
+    }
+
+    if (firstFree < 0) {
+        fprintf(stderr, "[SharedItem] record dropped: array full (%u slots), origin=%s id=%u\n",
+                RSBS_SHARED_ITEM_CAP, Game_ToString(originGame), (unsigned)id);
+        return -1;
+    }
+
+    SharedItem* dst = &gComboCtx.sharedItemsTagged[firstFree];
+    dst->originGame = (uint8_t)originGame;
+    dst->flags = 0;
+    dst->id = id;
+    fprintf(stderr, "[SharedItem] recorded origin=%s id=%u in slot %d\n", Game_ToString(originGame), (unsigned)id,
+            firstFree);
+    return firstFree;
+}
+
+bool Combo_StageSharedItem(GameId originGame, uint16_t id) {
+    if (!IsRealGame(originGame)) {
+        return false;
+    }
+    if (sOutboxCount >= SHARED_ITEM_OUTBOX_CAP) {
+        fprintf(stderr, "[SharedItem] stage dropped: outbox full (%d), origin=%s id=%u\n", SHARED_ITEM_OUTBOX_CAP,
+                Game_ToString(originGame), (unsigned)id);
+        return false;
+    }
+    sOutbox[sOutboxCount].originGame = (uint8_t)originGame;
+    sOutbox[sOutboxCount].flags = 0;
+    sOutbox[sOutboxCount].id = id;
+    sOutboxCount++;
+    return true;
+}
+
+int Combo_CommitStagedSharedItems(void) {
+    int committed = 0;
+    for (int i = 0; i < sOutboxCount; i++) {
+        if (Combo_RecordSharedItem((GameId)sOutbox[i].originGame, sOutbox[i].id) >= 0) {
+            committed++;
+        }
+        // A -1 here means the durable array is full; the staged entry is
+        // dropped (already logged by Combo_RecordSharedItem) rather than left
+        // to leak forward into a later, unrelated switch.
+    }
+    sOutboxCount = 0;
+    return committed;
+}
+
+// ============================================================================
+// Consumer
+// ============================================================================
+
+int Combo_RedeemSharedItemsForGame(GameId arrivingGame, ComboSharedItemAward award, void* ctx) {
+    if (!IsRealGame(arrivingGame)) {
+        return 0;
+    }
+
+    int redeemed = 0;
+    for (int i = 0; i < (int)RSBS_SHARED_ITEM_CAP; i++) {
+        SharedItem* slot = &gComboCtx.sharedItemsTagged[i];
+        if (slot->originGame != (uint8_t)arrivingGame) {
+            continue; // empty slot or an item bound for the other game
+        }
+        if ((slot->flags & RSBS_SHARED_ITEM_REDEEMED) != 0) {
+            continue; // already awarded on an earlier arrival
+        }
+        if (award != NULL) {
+            award(slot, ctx);
+        }
+        slot->flags |= RSBS_SHARED_ITEM_REDEEMED;
+        redeemed++;
+    }
+    if (redeemed > 0) {
+        fprintf(stderr, "[SharedItem] redeemed %d item(s) for %s\n", redeemed, Game_ToString(arrivingGame));
+    }
+    return redeemed;
+}
+
+// ============================================================================
+// Read-only helpers
+// ============================================================================
+
+int Combo_CountSharedItems(GameId game, bool includeRedeemed) {
+    if (!IsRealGame(game)) {
+        return 0;
+    }
+    int count = 0;
+    for (int i = 0; i < (int)RSBS_SHARED_ITEM_CAP; i++) {
+        const SharedItem* slot = &gComboCtx.sharedItemsTagged[i];
+        if (slot->originGame != (uint8_t)game) {
+            continue;
+        }
+        if (!includeRedeemed && (slot->flags & RSBS_SHARED_ITEM_REDEEMED) != 0) {
+            continue;
+        }
+        count++;
+    }
+    return count;
+}
+
+void Combo_ClearSharedItemOutbox(void) {
+    sOutboxCount = 0;
+}

--- a/src/common/shared_items.h
+++ b/src/common/shared_items.h
@@ -1,0 +1,138 @@
+/**
+ * @file shared_items.h
+ * @brief Cross-game shared-item producers and consumers (ADR 0002, Lane A1).
+ *
+ * The carrier for cross-game items is `gComboCtx.sharedItemsTagged[]`, a
+ * process-global array shared by both games in the single exe and serialized
+ * into every `.redsave` (ADR 0002 / context.h). The freeze/restore machinery
+ * does NOT carry it — it moves only a SaveContext blob — so producers and
+ * consumers read and write the array directly at game-side hook points and the
+ * array simply crosses the switch by being process-global.
+ *
+ * The data model is a small state machine per entry:
+ *
+ *   record/commit (producer) --> occupied, flags == 0 (not redeemed)
+ *   redeem (consumer)         --> occupied, flags |= RSBS_SHARED_ITEM_REDEEMED
+ *
+ * An entry is occupied iff `originGame != GAME_NONE`; `originGame` is the game
+ * whose id-space `id` belongs to (GAME_OOT => id is an OoT RandomizerGet RG_*,
+ * GAME_MM => id is an MM RandoItemId RI_*). A redeemed entry stays in the array
+ * as the durable record of the crossing — it is never cleared — so a round trip
+ * can never award the same entry twice.
+ *
+ * Direction of flow (the concrete cross-game rando semantics this plumbs):
+ *   - The game the player is IN records a foreign pickup — an item whose
+ *     id-space belongs to the OTHER game — tagged with that other game as
+ *     `originGame`. (Lane C's give path; here for Lane A1 it is the producer
+ *     API + the round-trip test.)
+ *   - When the player next ARRIVES in the origin game, that game's consumer
+ *     awards every un-redeemed entry tagged for it and marks it redeemed.
+ *
+ * Plain `.redsave` load without a switch (decided, documented): the consumers
+ * run only at the presence-gated startup-entrance consumption points, which a
+ * cold boot or a plain load never reaches. Un-redeemed items therefore persist
+ * in the loaded `gComboCtx` and are awarded on the NEXT switch into their
+ * origin game — an explicit "applies on next switch only" semantic. No item is
+ * lost (the array is serialized and REDEEMED tracks what is done) and none is
+ * double-awarded. We deliberately do NOT redeem at load time: awarding routes
+ * through the game's live item-give machinery, which is only valid once the
+ * game has reached gameplay — exactly what the consumption point guarantees.
+ */
+
+#ifndef RSBS_COMMON_SHARED_ITEMS_H
+#define RSBS_COMMON_SHARED_ITEMS_H
+
+#include "context.h" // SharedItem, gComboCtx, GameId, RSBS_SHARED_ITEM_*, RSBS_SHARED_ITEM_CAP
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * Award callback used by the consumer. Invoked once per redeemed entry, in slot
+ * order, BEFORE the entry's RSBS_SHARED_ITEM_REDEEMED bit is set (so a callback
+ * that itself inspects the array sees the entry as not-yet-redeemed). `item` is
+ * a read-only view of the entry being awarded. Lane C supplies the real give
+ * (OoT: Randomizer_Item_Give; MM: its give path); Lane A1 wires a logging
+ * placeholder at the game sites. May be NULL to redeem without awarding.
+ */
+typedef void (*ComboSharedItemAward)(const SharedItem* item, void* ctx);
+
+/**
+ * PRODUCER (direct write). Record a cross-game item into
+ * gComboCtx.sharedItemsTagged, visible immediately in the shared context and
+ * persisted by the next `.redsave` save.
+ *
+ * @param originGame the id-space owner (GAME_OOT => `id` is RG_*, GAME_MM => RI_*)
+ * @param id         the item id within originGame's id-space
+ * @return the slot index used (>= 0), or -1 if originGame is not a real game or
+ *         the array is full.
+ *
+ * De-dups: if an identical (originGame, id) entry already exists and is NOT yet
+ * redeemed, its slot is returned unchanged rather than duplicated — so a
+ * re-fired producer (the Combo_CheckEntranceSwitch wasAlreadyPending re-entry,
+ * or two suspends with no consume between them) cannot create doubles. A
+ * matching entry that is already redeemed does NOT block a fresh record: the
+ * same item legitimately crossing again gets a new slot.
+ */
+int Combo_RecordSharedItem(GameId originGame, uint16_t id);
+
+/**
+ * PRODUCER (deferred stage). Enqueue an item into a process-global RAM outbox,
+ * to be flushed into gComboCtx by Combo_CommitStagedSharedItems at the next
+ * Game_Suspend. A caller that would rather hand off at the switch boundary than
+ * touch the serialized array mid-play uses this.
+ *
+ * @return true if staged, false if the outbox is full or originGame is invalid.
+ *
+ * NOTE: the outbox is RAM-only. A save taken between staging and the next
+ * suspend does NOT persist a staged item — use Combo_RecordSharedItem for
+ * immediate persistence.
+ */
+bool Combo_StageSharedItem(GameId originGame, uint16_t id);
+
+/**
+ * PRODUCER HOOK. Flush the outbox into gComboCtx.sharedItemsTagged (through
+ * Combo_RecordSharedItem, so the same de-dup applies), emptying the outbox.
+ *
+ * Called from BOTH OoT_Game_Suspend and MM_Game_Suspend — NOT from
+ * Combo_CheckEntranceSwitch. The F10 hot-swap path bypasses the entrance hook
+ * entirely, so a producer that lived only there would drop every hotkey
+ * switch's staged writes; Game_Suspend is on both switch paths. Idempotent and
+ * safe to call on an empty outbox.
+ *
+ * @return the number of items committed to gComboCtx this call.
+ */
+int Combo_CommitStagedSharedItems(void);
+
+/**
+ * CONSUMER HOOK. Award every occupied, un-redeemed entry whose
+ * originGame == arrivingGame via `award`, then set RSBS_SHARED_ITEM_REDEEMED on
+ * each. Entries are NOT cleared: they remain as the serialized record of the
+ * crossing.
+ *
+ * Called from each game's presence-gated startup-entrance consumption point
+ * (OoT_Play_Init / MM_Play_ConsumeStartupEntrance), which run only on a switch
+ * arrival. See the file header for the plain-load semantics.
+ *
+ * @return the number of entries redeemed this call.
+ */
+int Combo_RedeemSharedItemsForGame(GameId arrivingGame, ComboSharedItemAward award, void* ctx);
+
+/**
+ * Count occupied entries whose originGame == game. When includeRedeemed is
+ * false, only un-redeemed entries are counted. Read-only (trackers / tests).
+ */
+int Combo_CountSharedItems(GameId game, bool includeRedeemed);
+
+/**
+ * Clear the process-global outbox WITHOUT touching gComboCtx.sharedItemsTagged.
+ * For test isolation and as a defensive reset alongside a fresh combo init.
+ */
+void Combo_ClearSharedItemOutbox(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // RSBS_COMMON_SHARED_ITEMS_H

--- a/src/common/test_runner.cpp
+++ b/src/common/test_runner.cpp
@@ -851,6 +851,8 @@ const TestDescriptor gTests[] = {
     {"roundtrip", "Full round-trip with state verification", Test_Roundtrip},
     {"roundtrip-integrity", "OoT SaveContext byte-identical across OoT->MM->OoT (issue #262)", Test_RoundtripIntegrity},
     {"shared-roundtrip", "Shared flag/seed survive OoT->MM switch (issue #264)", Test_SharedStateRoundtrip},
+    {"shared-item-roundtrip", "Origin-tagged item survives suspend->switch->resume x2, both dirs (ADR 0002)",
+     Test_SharedItemRoundtrip},
     {"context", "Test context/state management", Test_Context},
     // Clears all frozen states on entry and exit, so it must not run between a
     // test that freezes and one that expects that freeze to still be there.

--- a/src/common/tests/test_shared_state_roundtrip.c
+++ b/src/common/tests/test_shared_state_roundtrip.c
@@ -19,9 +19,19 @@
  */
 
 #include "../context.h"
+#include "../shared_items.h"
 #include "../test_runner.h"
 #include <stdint.h>
 #include <stdio.h>
+#include <string.h>
+
+/* Freeze/consume policy under test (src/common/switch.cpp). Declared locally
+ * for the same reason the game TUs and test_hotswap_freeze.c declare it
+ * locally: context.h is owned elsewhere this wave, so the switch policy has no
+ * header of its own. Duplicate prototypes across the #included test files are
+ * harmless (declarations, not definitions). */
+int Switch_PrepareHotSwap(GameId departing, const void* saveContext, size_t size);
+int Combo_ConsumeFrozenState(const char* gameId, void* saveContext, size_t size);
 
 /* A representative cross-game flag: word 5 of the 64-word sharedFlags array,
  * bit 3. Both indices are comfortably in range (sharedFlags[64]). */
@@ -100,5 +110,169 @@ TestResult Test_SharedStateRoundtrip(void) {
     }
 
     printf("[TEST] PASS: shared flag + sharedRandoSeed propagate OoT -> MM\n");
+    return TEST_PASS;
+}
+
+/* ==========================================================================
+ * Origin-tagged shared-item round trip through the REAL hook functions
+ * (ADR 0002 / Lane A1). This is the non-negotiable lock: a recorded cross-game
+ * item survives suspend -> switch -> resume -> switch -> resume, visible in
+ * BOTH directions, and is awarded exactly once per crossing.
+ *
+ * "Real hook functions" means the exact src/common entry points the game hooks
+ * call — Combo_StageSharedItem / Combo_CommitStagedSharedItems (the producer at
+ * OoT_Game_Suspend / MM_Game_Suspend), Combo_RedeemSharedItemsForGame (the
+ * consumer at OoT_Play_Init / MM_Play_ConsumeStartupEntrance), and
+ * Switch_PrepareHotSwap / Combo_ConsumeFrozenState (the F10 freeze/consume,
+ * src/common/switch.cpp). test_hotswap_freeze.c is the precedent for driving
+ * these headlessly rather than booting a game. The F10 path is exercised
+ * directly: this test does NOT go through Combo_CheckEntranceSwitch, so a
+ * producer that lived only there (dropping F10 switches) would fail here.
+ * ========================================================================== */
+
+/* Recognizable, non-zero ids in each game's id-space. Zero is "none"
+ * (RG_NONE / RI_UNKNOWN) and marks an empty slot, so real crossings use
+ * non-zero values. Plain integers on purpose — the point of the tagged struct
+ * is that the origin GAME is what disambiguates these, not the numbers. */
+#define SHARED_ITEM_MM_ID 0x0042u /* an MM RandoItemId, collected while in OoT */
+#define SHARED_ITEM_OOT_ID 0x0135u /* an OoT RandomizerGet, collected while in MM */
+
+/* A slice of a SaveContext is all the freeze path needs (it clamps to the
+ * per-game capacity), matching test_hotswap_freeze.c. */
+#define SIR_BUF 256
+
+typedef struct {
+    int awardCount;
+    uint16_t lastId;
+    uint8_t lastOrigin;
+} SharedAwardCtx;
+
+/* Mock of the game-side award callback (Lane C wires the real give). Records
+ * what it was handed so the test can prove the RIGHT item was awarded, not just
+ * that something was. */
+static void SharedItemTestAward(const SharedItem* item, void* ctx) {
+    SharedAwardCtx* c = (SharedAwardCtx*)ctx;
+    c->awardCount++;
+    c->lastId = item->id;
+    c->lastOrigin = item->originGame;
+}
+
+/* Count occupied entries (any origin), redeemed or not — the "still visible"
+ * check: a redeemed entry stays as the record of the crossing. */
+static int SharedItem_OccupiedTotal(void) {
+    return Combo_CountSharedItems(GAME_OOT, /*includeRedeemed=*/true) +
+           Combo_CountSharedItems(GAME_MM, /*includeRedeemed=*/true);
+}
+
+#define SIR_ASSERT(cond)                                                                                               \
+    do {                                                                                                               \
+        if (!(cond)) {                                                                                                 \
+            printf("[TEST] FAIL: %s:%d: %s\n", __FILE__, __LINE__, #cond);                                            \
+            return TEST_FAIL;                                                                                          \
+        }                                                                                                              \
+    } while (0)
+
+TestResult Test_SharedItemRoundtrip(void) {
+    printf("[TEST] shared-item-roundtrip: tagged item survives suspend->switch->resume x2, both dirs (ADR 0002)\n");
+
+    uint8_t ootSave[SIR_BUF];
+    uint8_t mmSave[SIR_BUF];
+    uint8_t scratch[SIR_BUF];
+    SharedAwardCtx award;
+
+    /* Clean slate: empty tagged array + empty outbox + no frozen state. */
+    ComboContext_Init();
+    Context_InitFrozenStates();
+    Context_ClearAllFrozenStates();
+    Combo_ClearSharedItemOutbox();
+
+    SIR_ASSERT(SharedItem_OccupiedTotal() == 0);
+
+    /* ------------------------------------------------------------------
+     * Leg 1: in OoT, collect a foreign (MM) item, then leave OoT for MM.
+     * Uses the STAGE -> COMMIT-AT-SUSPEND producer path.
+     * ------------------------------------------------------------------ */
+    SIR_ASSERT(Combo_StageSharedItem(GAME_MM, SHARED_ITEM_MM_ID) == true);
+    /* Staged, not yet committed: the durable/serialized array is still empty. */
+    SIR_ASSERT(Combo_CountSharedItems(GAME_MM, /*includeRedeemed=*/true) == 0);
+
+    /* Suspend OoT: the F10 freeze of the departing game, then the producer
+     * commit (both are what OoT_Game_Suspend + the launcher run). */
+    memset(ootSave, 0xA1, sizeof(ootSave));
+    SIR_ASSERT(Switch_PrepareHotSwap(GAME_OOT, ootSave, sizeof(ootSave)) == 1);
+    SIR_ASSERT(Combo_CommitStagedSharedItems() == 1);
+    SIR_ASSERT(Combo_CountSharedItems(GAME_MM, /*includeRedeemed=*/false) == 1);
+
+    /* Arrive in MM: first MM entry has no frozen MM state to consume, then the
+     * consumer awards the MM-tagged item. */
+    memset(scratch, 0x00, sizeof(scratch));
+    SIR_ASSERT(Combo_ConsumeFrozenState("mm", scratch, sizeof(scratch)) == 0);
+    memset(&award, 0, sizeof(award));
+    SIR_ASSERT(Combo_RedeemSharedItemsForGame(GAME_MM, SharedItemTestAward, &award) == 1);
+    SIR_ASSERT(award.awardCount == 1);
+    SIR_ASSERT(award.lastOrigin == (uint8_t)GAME_MM);
+    SIR_ASSERT(award.lastId == SHARED_ITEM_MM_ID);
+    /* Redeemed, but still present (occupancy = originGame != GAME_NONE). */
+    SIR_ASSERT(Combo_CountSharedItems(GAME_MM, /*includeRedeemed=*/false) == 0);
+    SIR_ASSERT(Combo_CountSharedItems(GAME_MM, /*includeRedeemed=*/true) == 1);
+
+    /* ------------------------------------------------------------------
+     * Leg 2: in MM, collect a foreign (OoT) item, then leave MM for OoT.
+     * Uses the DIRECT-RECORD producer path (the other give-path entry).
+     * ------------------------------------------------------------------ */
+    SIR_ASSERT(Combo_RecordSharedItem(GAME_OOT, SHARED_ITEM_OOT_ID) >= 0);
+    /* De-dup: recording the same un-redeemed item again must not duplicate. */
+    SIR_ASSERT(Combo_RecordSharedItem(GAME_OOT, SHARED_ITEM_OOT_ID) >= 0);
+    SIR_ASSERT(Combo_CountSharedItems(GAME_OOT, /*includeRedeemed=*/false) == 1);
+
+    /* Suspend MM: F10 freeze of MM + the producer commit (nothing staged this
+     * leg — we recorded directly — so the commit is a no-op, which is fine). */
+    memset(mmSave, 0xB2, sizeof(mmSave));
+    SIR_ASSERT(Switch_PrepareHotSwap(GAME_MM, mmSave, sizeof(mmSave)) == 1);
+    SIR_ASSERT(Combo_CommitStagedSharedItems() == 0);
+
+    /* Arrive in OoT: consume the frozen OoT state frozen back on leg 1 (proves
+     * the shared-item work and the freeze/restore machinery coexist), then the
+     * consumer awards the OoT-tagged item. */
+    memset(scratch, 0x00, sizeof(scratch));
+    SIR_ASSERT(Combo_ConsumeFrozenState("oot", scratch, sizeof(scratch)) == 1);
+    SIR_ASSERT(scratch[0] == 0xA1); /* the leg-1 OoT freeze came back intact */
+    memset(&award, 0, sizeof(award));
+    SIR_ASSERT(Combo_RedeemSharedItemsForGame(GAME_OOT, SharedItemTestAward, &award) == 1);
+    SIR_ASSERT(award.awardCount == 1);
+    SIR_ASSERT(award.lastOrigin == (uint8_t)GAME_OOT);
+    SIR_ASSERT(award.lastId == SHARED_ITEM_OOT_ID);
+
+    /* Both crossings are now recorded and visible — one each direction. */
+    SIR_ASSERT(SharedItem_OccupiedTotal() == 2);
+    SIR_ASSERT(Combo_CountSharedItems(GAME_OOT, /*includeRedeemed=*/true) == 1);
+    SIR_ASSERT(Combo_CountSharedItems(GAME_MM, /*includeRedeemed=*/true) == 1);
+
+    /* ------------------------------------------------------------------
+     * Leg 3: switch back to OoT again (F10). The already-redeemed OoT item
+     * must NOT be awarded a second time, and both entries must still survive.
+     * This is the single-use guarantee (RSBS_SHARED_ITEM_REDEEMED).
+     * ------------------------------------------------------------------ */
+    memset(mmSave, 0xC3, sizeof(mmSave));
+    SIR_ASSERT(Switch_PrepareHotSwap(GAME_MM, mmSave, sizeof(mmSave)) == 1);
+    SIR_ASSERT(Combo_CommitStagedSharedItems() == 0);
+    memset(scratch, 0x00, sizeof(scratch));
+    Combo_ConsumeFrozenState("oot", scratch, sizeof(scratch)); /* no OoT freeze this leg */
+    memset(&award, 0, sizeof(award));
+    SIR_ASSERT(Combo_RedeemSharedItemsForGame(GAME_OOT, SharedItemTestAward, &award) == 0);
+    SIR_ASSERT(award.awardCount == 0);
+
+    /* Everything still visible after the full round trip, correctly tagged and
+     * marked redeemed. Nothing lost, nothing double-awarded. */
+    SIR_ASSERT(SharedItem_OccupiedTotal() == 2);
+    SIR_ASSERT(Combo_CountSharedItems(GAME_OOT, /*includeRedeemed=*/false) == 0);
+    SIR_ASSERT(Combo_CountSharedItems(GAME_MM, /*includeRedeemed=*/false) == 0);
+
+    /* Leave global state clean for any subsequent test. */
+    Context_ClearAllFrozenStates();
+    Combo_ClearSharedItemOutbox();
+    ComboContext_Init();
+
+    printf("[TEST] PASS: tagged item survives the full round trip both directions; awarded once each\n");
     return TEST_PASS;
 }


### PR DESCRIPTION
Phase 3 Lane A1. Wires the origin-tagged cross-game item plumbing (ADR 0002) and absorbs #373. OoT side + shared test infrastructure + the #373 MM timer fix; the MM-side producer/consumer wiring lands after the G1 GameInteractor-shim PR (#415), which owns MM's `GameExports_SingleExe.cpp`.

## Producers / consumers (ADR 0002)

New `src/common/shared_items.{c,h}` — the plumbing both games hook into over `gComboCtx.sharedItemsTagged[]`. The freeze/restore blob carries no ComboContext; `gComboCtx` is a process-global shared by both games, so the tagged array crosses the switch by being shared, and producers/consumers read/write it directly at game hook points.

- **Producer** `Combo_CommitStagedSharedItems()` at `OoT_Game_Suspend` drains a RAM outbox (`Combo_StageSharedItem`) into the durable/serialized array. It lives at `Game_Suspend`, **not** `Combo_CheckEntranceSwitch`: the F10 hot-swap path bypasses the entrance hook, and `GameRunner_SwitchTo` calls `suspend()` on both switch paths, so this is the one point that never drops a hotkey switch's writes. `Combo_RecordSharedItem` is the direct-write path (Lane C's give path) and de-dups an identical un-redeemed entry so a re-fired producer / the `wasAlreadyPending` re-entry cannot double.
- **Consumer** `OoT_ConsumeSharedItems()` at the presence-gated startup-entrance consumption point in `OoT_Play_Init` awards every un-redeemed OoT-origin entry and sets `RSBS_SHARED_ITEM_REDEEMED` (never re-awards; entries stay visible as the record of the crossing). Routed through a plain C entry point in GameExports so `z_play.c` stays free of the ADR `SharedItem`/`GameId` types. The Lane A1 award callback logs; **Lane C wires `Randomizer_Item_Give`**.
- **Plain `.redsave` load without a switch** (decided + documented in `shared_items.h`): the consumers only run at the switch-arrival consumption points, so un-redeemed items persist in the loaded `gComboCtx` and are awarded on the next switch into their origin game — **"applies on next switch only"**. Nothing is lost (serialized + REDEEMED) or double-awarded; redeeming at load would give items into a not-yet-live game. No hook added to `save.cpp` (A0-owned).

## Lock (non-negotiable)

`SharedItemRoundtrip` CTest (`redship` label): a recorded item survives **suspend → switch → resume → switch → resume** through the real producer, consumer, and `Switch_PrepareHotSwap`/`Combo_ConsumeFrozenState` hooks, is visible **both directions**, and is awarded **exactly once** per crossing — driving the F10 path directly (not through `Combo_CheckEntranceSwitch`). Extends `test_shared_state_roundtrip.c`; new `redship_add_test` row + `gTests[]` entry.

## #373 — MM consumption point does not neutralize live timers

The OoT and MM consumption points had drifted. `MM_Play_ConsumeStartupEntrance` now ports OoT's neutralization list: `timerStates[]` (the regression — a minigame timer frozen mid-count resumed in the arrival scene), the MM-specific `powderKegTimer`/`jinxTimer`, `eventInf`, `minigameStatus`, `dogParams`, `nayrusLoveTimer`, `healthAccumulator`, `magicState`→IDLE, `forcedSeqId`→`NA_BGM_GENERAL_SFX`. Locked by extending `mm-startup-restore`. **Closes #373.**

## Not in this PR (G1-gated)

`MM_Game_Suspend` producer + `MM_Play_ConsumeStartupEntrance` consumer wiring — both touch `games/mm/2s2h/GameExports_SingleExe.cpp` (G1 / #415). The round-trip lock does not need them (it drives the `src/common` hook functions directly), so this PR is complete and CI-lockable on its own; the MM game wiring follows once G1 merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!--- section:artifacts:start -->
### Build Artifacts
  - [rsbs-windows.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/8477835593.zip)
  - [rsbs-linux.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/8477655569.zip)
<!--- section:artifacts:end -->