### PR TITLE
Lane A1 (MM half): wire MM-side shared-item producer/consumer

### DIFF
--- a/games/mm/2s2h/GameExports_SingleExe.cpp
+++ b/games/mm/2s2h/GameExports_SingleExe.cpp
@@ -33,6 +33,7 @@
 #include "game_lifecycle.h"
 #include "integration_test_hooks.h"
 #include "context.h"
+#include "shared_items.h"
 #include "entrance.h"
 #include <ship/resource/ResourceManager.h>
 #include <ship/resource/ResourceLoader.h>
@@ -1292,6 +1293,14 @@ void MM_Game_Suspend(void) {
     fprintf(stderr, "[MM] Game_Suspend called\n");
     fflush(stderr);
 
+    // Producer (ADR 0002 / Lane A1) — mirrors OoT_Game_Suspend. Commit any
+    // staged cross-game items into gComboCtx.sharedItemsTagged before handing
+    // control to OoT. This lives at Game_Suspend, not Combo_CheckEntranceSwitch:
+    // the F10 hot-swap path bypasses the entrance hook, and GameRunner_SwitchTo
+    // calls suspend() on both switch paths, so this is the one point that never
+    // drops a hotkey switch's writes.
+    Combo_CommitStagedSharedItems();
+
     // Drain the SHARED audio thread before touching MM's audio state. In
     // single-exe builds MM's synth runs on OoT's OTRAudio_Thread (the
     // active-game dispatch in games/oot/soh/OTRGlobals.cpp) — a REAL
@@ -1469,6 +1478,33 @@ void GameInteractor_ExecuteOnRoomInit(s16 sceneId, s8 roomNum) {
 
 void GameInteractor_ExecuteAfterRoomSceneCommands(s16 sceneId, s8 roomNum) {
     GameInteractor::Instance->ExecuteHooks<GameInteractor::AfterRoomSceneCommands>(sceneId, roomNum);
+}
+
+/**
+ * Award a single MM-origin shared item (ADR 0002 / Lane A1 consumer callback),
+ * the MM twin of OoT_AwardSharedItem. `item->id` is an MM RandoItemId (RI_*).
+ *
+ * Lane A1 scope: plumbing seam only — it logs; Combo_RedeemSharedItemsForGame
+ * still marks the entry RSBS_SHARED_ITEM_REDEEMED so the crossing is single-use
+ * once wired. Lane C replaces the log with MM's real give (Rando::GiveItem /
+ * MM_Item_Give) for the chosen foreign-item class; do NOT clear the entry.
+ */
+static void MM_AwardSharedItem(const SharedItem* item, void* ctx) {
+    (void)ctx;
+    fprintf(stderr, "[MM] shared-item redeem (Lane A1 plumbing): RI id=%u — Lane C wires the MM give\n",
+            (unsigned)item->id);
+}
+
+/**
+ * Consumer hook (ADR 0002 / Lane A1), the MM twin of OoT_ConsumeSharedItems.
+ * Award every un-redeemed MM-origin shared item and mark it redeemed. Called
+ * from MM_Play_ConsumeStartupEntrance (games/mm/src/code/z_play.c), which is
+ * presence-gated and runs once per cross-game arrival into MM. A plain boot /
+ * .redsave load never reaches it, so un-redeemed items wait for the next switch
+ * into MM ("applies on next switch only"; see shared_items.h).
+ */
+void MM_ConsumeSharedItems(void) {
+    Combo_RedeemSharedItemsForGame(GAME_MM, MM_AwardSharedItem, nullptr);
 }
 
 } // extern "C"

--- a/games/mm/src/code/z_play.c
+++ b/games/mm/src/code/z_play.c
@@ -62,6 +62,12 @@ extern bool Combo_HasStartupEntranceForGame(const char* gameId);
 // silent-rollback bug, and leaving those in scope invites it back.
 extern int Combo_ConsumeFrozenState(const char* gameId, void* saveContext, size_t size);
 
+// Cross-game shared-item consumer (ADR 0002 / Lane A1). Awards every un-redeemed
+// MM-origin item in gComboCtx.sharedItemsTagged and marks it redeemed. Defined
+// in games/mm/2s2h/GameExports_SingleExe.cpp so this TU stays free of the ADR
+// SharedItem/GameId types.
+extern void MM_ConsumeSharedItems(void);
+
 s32 MM_gDbgCamEnabled = false;
 u8 D_801D0D54 = false;
 
@@ -2365,6 +2371,13 @@ void MM_Play_ConsumeStartupEntrance(void) {
     SET_WEEKEVENTREG(WEEKEVENTREG_ENTERED_WEST_CLOCK_TOWN);
     SET_WEEKEVENTREG(WEEKEVENTREG_ENTERED_NORTH_CLOCK_TOWN);
     gSaveContext.save.saveInfo.permanentSceneFlags[SCENE_INSIDETOWER].switch0 |= (1 << 0);
+    // Consumer (ADR 0002 / Lane A1), the MM twin of OoT's consume: the frozen
+    // save is restored and the arrival's runtime state neutralized above, so
+    // award any cross-game items tagged for MM and retire them
+    // (RSBS_SHARED_ITEM_REDEEMED). Presence-gated by this function's early
+    // return, so it runs once per MM arrival and never on a plain boot/.redsave
+    // load — un-redeemed items then wait for the next switch into MM.
+    MM_ConsumeSharedItems();
     Combo_ClearStartupEntrance();
 }
 


### PR DESCRIPTION
Completes Lane A1's MM half, symmetric to the OoT wiring merged in #419. The `src/common` producer/consumer plumbing (`shared_items.*`, ADR 0002) and the `SharedItemRoundtrip` lock already landed; this hooks MM's game code into it. It was deferred until now because it edits `games/mm/2s2h/GameExports_SingleExe.cpp`, owned by the now-merged G1 GameInteractor-shim PR (#415).

- **Producer** at `MM_Game_Suspend`: `Combo_CommitStagedSharedItems()` — at `Game_Suspend` (not `Combo_CheckEntranceSwitch`) so the F10 hot-swap path is covered; `GameRunner_SwitchTo` suspends on both switch paths.
- **Consumer** at `MM_Play_ConsumeStartupEntrance`: `MM_ConsumeSharedItems()` awards every un-redeemed MM-origin entry and sets `RSBS_SHARED_ITEM_REDEEMED`, once per presence-gated MM arrival. Routed through a plain C entry point in GameExports so `z_play.c` stays free of the ADR `SharedItem`/`GameId` types. The Lane A1 award callback logs; **Lane C wires MM's real give** (`Rando::GiveItem` / `MM_Item_Give`).

Both wrappers delegate to the already-tested `Combo_RedeemSharedItemsForGame` / `Combo_CommitStagedSharedItems`, so no new unit test — the merged `SharedItemRoundtrip` CTest locks both directions of the redeem/commit logic (as it does for the symmetric OoT wrappers). With this, Lane A1's producers/consumers are live on **both** sides.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!--- section:artifacts:start -->
### Build Artifacts
  - [rsbs-windows.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/8478443242.zip)
  - [rsbs-linux.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/8478162720.zip)
<!--- section:artifacts:end -->