### PR TITLE
Replace drifted GameInteractor_Dpad/RightStickOcarina stubs with header-checked definitions

### DIFF
--- a/games/mm/2s2h/GameExports_SingleExe.cpp
+++ b/games/mm/2s2h/GameExports_SingleExe.cpp
@@ -1158,6 +1158,79 @@ int GameInteractor_InvertControl(GIInvertType type) {
     return result;
 }
 
+/**
+ * Real single-exe definitions for the last two GameInteractor input shims
+ * that lived in src/common/mm_stubs.c — same drift class and same
+ * treatment as GameInteractor_InvertControl above (#372 / PR #415): MM's
+ * implementation TU (2s2h/GameInteractor/GameInteractor.cpp) is excluded
+ * from the link ("use OoT's") and OoT defines neither symbol, so the
+ * untyped stubs were the sole definitions.
+ *
+ * The old stub `int GameInteractor_Dpad(void* input, int dpad)` returned
+ * the button combo unconditionally, force-enabling both CVar-gated D-pad
+ * enhancements: BTN_DPAD_EQUIP (include/z64save.h) expanded to BTN_DPAD as
+ * if gEnhancements.Dpad.DpadEquips were on, and the ocarina paths in
+ * src/audio/code_8019AF00.c treated the D-pad as ocarina buttons as if
+ * gEnhancements.Playback.DpadOcarina were on.
+ *
+ * Bodies lifted verbatim from upstream 2s2h/GameInteractor/
+ * GameInteractor.cpp so the shipped 2S2H defaults apply (both
+ * enhancements off until their CVars are set). Declared extern "C" in
+ * MM's GameInteractor.h, which this TU includes: signature drift here is
+ * a compile error.
+ */
+uint32_t GameInteractor_Dpad(GIDpadType type, uint32_t buttonCombo) {
+    uint32_t result = 0;
+
+    switch (type) {
+        case GI_DPAD_OCARINA:
+            if (CVarGetInteger("gEnhancements.Playback.DpadOcarina", 0)) {
+                result = buttonCombo;
+            }
+            break;
+        case GI_DPAD_EQUIP:
+            if (CVarGetInteger("gEnhancements.Dpad.DpadEquips", 0)) {
+                result = buttonCombo;
+            }
+            break;
+    }
+
+    return result;
+}
+
+/**
+ * The old stub `int GameInteractor_RightStickOcarina(void* input)` returned
+ * 0, which matched the enhancement's default-off CVar
+ * (gEnhancements.Playback.RightStickOcarina) — but it kept the enhancement
+ * dead even when enabled, and its untyped signature (void* vs Input*) sat
+ * in the same drift class. Body lifted verbatim from upstream.
+ */
+uint32_t GameInteractor_RightStickOcarina(Input* input) {
+    uint32_t result = 0;
+
+    if (!CVarGetInteger("gEnhancements.Playback.RightStickOcarina", 0)) {
+        return result;
+    }
+
+    s8 rstick_x = input->cur.right_stick_x;
+    s8 rstick_y = input->cur.right_stick_y;
+    const s8 sensitivity = 64;
+
+    if (rstick_x > sensitivity) {
+        result |= BTN_CRIGHT;
+    } else if (rstick_x < -sensitivity) {
+        result |= BTN_CLEFT;
+    }
+
+    if (rstick_y > sensitivity) {
+        result |= BTN_CUP;
+    } else if (rstick_y < -sensitivity) {
+        result |= BTN_CDOWN;
+    }
+
+    return result;
+}
+
 int MM_Game_Init(int argc, char** argv) {
     fprintf(stderr, "[MM] Game_Init called, argc=%d\n", argc);
     fflush(stderr);

--- a/src/common/mm_stubs.c
+++ b/src/common/mm_stubs.c
@@ -123,12 +123,15 @@ void GameInteractor_ExecuteAfterEndOfCycleSave(void) {}
 void GameInteractor_ExecuteBeforeMoonCrashSaveReset(void) {}
 void GameInteractor_ExecuteBeforeInterfaceClockDraw(void) {}
 void GameInteractor_ExecuteAfterInterfaceClockDraw(void) {}
-int GameInteractor_Dpad(void* input, int dpad) { (void)input; return dpad; }
-/* GameInteractor_InvertControl moved to a real, header-checked definition in
- * games/mm/2s2h/GameExports_SingleExe.cpp (#372): every caller uses the
- * result as a ±1 multiplier, and the untyped stub here returned the ENUM
- * ORDINAL — stick_x *= 2 on every Lib_GetControlStickData movement frame. */
-int GameInteractor_RightStickOcarina(void* input) { (void)input; return 0; }
+/* GameInteractor_InvertControl, GameInteractor_Dpad, and
+ * GameInteractor_RightStickOcarina moved to real, header-checked definitions
+ * in games/mm/2s2h/GameExports_SingleExe.cpp (#372): the untyped stubs here
+ * drifted from MM's GameInteractor.h. InvertControl returned the ENUM
+ * ORDINAL as a ±1 multiplier (stick_x *= 2 on every Lib_GetControlStickData
+ * movement frame); Dpad returned the button combo unconditionally, forcing
+ * the CVar-gated D-pad-equip and D-pad-ocarina enhancements permanently ON;
+ * RightStickOcarina happened to return the right default but was one field
+ * away from the same fate. */
 
 /* HudEditor stubs */
 void* hudEditorElements = NULL;


### PR DESCRIPTION
## Summary

Retires the last two GameInteractor input shims from the `src/common/mm_stubs.c` signature-drift class, found during the G1 GameInteractor shim work (PR #415, issues #395/#372).

**`GameInteractor_Dpad`** — the stub `int GameInteractor_Dpad(void* input, int dpad)` returned the button combo unconditionally, while the real 2S2H implementation (`uint32_t GameInteractor_Dpad(GIDpadType type, uint32_t buttonCombo)`) returns 0 unless the corresponding CVar is enabled. The stub therefore force-enabled both CVar-gated D-pad enhancements in single-exe MM:
- `BTN_DPAD_EQUIP` (`games/mm/include/z64save.h`) expands to `GameInteractor_Dpad(GI_DPAD_EQUIP, BTN_DPAD)` — D-pad equips behaved as if `gEnhancements.Dpad.DpadEquips` were permanently ON
- the ocarina paths in `games/mm/src/audio/code_8019AF00.c` treated the D-pad as ocarina buttons as if `gEnhancements.Playback.DpadOcarina` were permanently ON

**`GameInteractor_RightStickOcarina`** — the stub `int GameInteractor_RightStickOcarina(void* input)` returned 0, which matches the enhancement's default-off CVar, but it kept the enhancement dead even when enabled and carried the same untyped `void*` signature drift (real signature: `uint32_t GameInteractor_RightStickOcarina(Input* input)`).

## Fix

Same treatment `GameInteractor_InvertControl` received in PR #415:
- Both functions moved to real definitions in `games/mm/2s2h/GameExports_SingleExe.cpp`, which includes `2s2h/GameInteractor/GameInteractor.h` — the `extern "C"` declarations there make any future signature drift a compile error
- Bodies lifted verbatim from `games/mm/2s2h/GameInteractor/GameInteractor.cpp` (excluded from the single-exe link by "GameInteractor (use OoT's)"), so defaults match upstream 2S2H: both enhancements off until their CVars are set
- Stubs removed from `mm_stubs.c`; the moved-symbol comment there now covers all three functions

`GameExports_SingleExe.cpp` is on the clang-format allowlist; the change is format-clean against `games/mm/.clang-format`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UptiNPLjd4f9C9St3tkrXr

---
_Generated by [Claude Code](https://claude.ai/code/session_01UptiNPLjd4f9C9St3tkrXr)_

<!--- section:artifacts:start -->
### Build Artifacts
  - [rsbs-windows.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/8480148311.zip)
  - [rsbs-linux.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/8480015879.zip)
<!--- section:artifacts:end -->