### PR TITLE
Lane C1: OoT->MM foreign items — the Phase 3.0 MVP pipeline (#392)

### DIFF
--- a/.github/clang-format-paths.txt
+++ b/.github/clang-format-paths.txt
@@ -29,6 +29,9 @@ games/mm/2s2h/Enhancements/Audio/AudioCollection.h
 games/mm/2s2h/Enhancements/Audio/AudioEditor.h
 games/mm/2s2h/Enhancements/FrameInterpolation/FrameInterpolation.h
 games/mm/2s2h/GameExports_SingleExe.cpp
+games/mm/2s2h/GameInteractorEventsSingleExe.cpp
+games/mm/2s2h/Rando/Foreign.cpp
+games/mm/2s2h/Rando/Foreign.h
 games/mm/2s2h/ShipInit.hpp
 games/mm/2s2h/mm_culling_test.cpp
 games/mm/2s2h/mm_gi_shim_test.cpp
@@ -46,6 +49,7 @@ games/mm/src/code/z_play.c
 games/mm/src/code/z_visfbuf.c
 games/mm/src/overlays/gamestates/ovl_title/z_title.c
 games/oot/soh/Enhancements/cosmetics/CustomLogoTitle.cpp
+games/oot/soh/Enhancements/randomizer/ForeignItemsSingleExe.cpp
 games/oot/soh/GameExports_SingleExe.cpp
 games/oot/soh/OTRGlobals.cpp
 games/oot/soh/ResourceManagerHelpers.cpp

--- a/CMake/SingleExecutable.cmake
+++ b/CMake/SingleExecutable.cmake
@@ -28,6 +28,11 @@ set(REDSHIP_COMMON_SOURCES
     # Cross-game shared-item producers/consumers over gComboCtx.sharedItemsTagged
     # (ADR 0002, Lane A1) — read/written by both games' suspend + consumption hooks
     ${CMAKE_SOURCE_DIR}/src/common/shared_items.c
+    # Foreign-item placement table over gComboCtx.foreignPlacements (Lane C1,
+    # #392) — written by MM's paired-world generation, read by MM's give path
+    # and both spoiler surfaces; the pinned pool itself is OoT-side
+    # (soh/Enhancements/randomizer/ForeignItemsSingleExe.cpp)
+    ${CMAKE_SOURCE_DIR}/src/common/foreign_items.c
     ${CMAKE_SOURCE_DIR}/src/common/entrance.cpp
     ${CMAKE_SOURCE_DIR}/src/common/test_runner.cpp
     ${CMAKE_SOURCE_DIR}/src/common/integration_test_hooks.cpp
@@ -61,6 +66,7 @@ set(REDSHIP_COMMON_HEADERS
     ${CMAKE_SOURCE_DIR}/src/common/zapd_subprocess.h
     ${CMAKE_SOURCE_DIR}/src/common/context.h
     ${CMAKE_SOURCE_DIR}/src/common/shared_items.h
+    ${CMAKE_SOURCE_DIR}/src/common/foreign_items.h
     ${CMAKE_SOURCE_DIR}/src/common/entrance.h
     ${CMAKE_SOURCE_DIR}/src/common/test_runner.h
     ${CMAKE_SOURCE_DIR}/src/common/integration_test_hooks.h
@@ -271,6 +277,10 @@ if(BUILD_TESTING)
     # the real producer/consumer + freeze/consume hooks, be visible in both
     # directions, and be awarded exactly once per crossing (covers the F10 path).
     redship_add_test(NAME SharedItemRoundtrip COMMAND redship --test shared-item-roundtrip)
+    # Lane C1 (#392): foreign-item give path lands correctly tagged in the
+    # shared structure, the crossing awards exactly once on the OoT side, and
+    # gComboCtx.foreignPlacements round-trips through the .redsave record.
+    redship_add_test(NAME ForeignItemGive COMMAND redship --test foreign-item-give)
     redship_add_test(NAME ArchiveHotswapLogic COMMAND redship --test archive-hotswap-logic)
     # Unified save (.redsave) headless tests — Phase 2 T6 (#35)
     redship_add_test(NAME SaveRoundtripTiers COMMAND redship --test save-roundtrip-tiers)

--- a/games/mm/2s2h/GameExports_SingleExe.cpp
+++ b/games/mm/2s2h/GameExports_SingleExe.cpp
@@ -1349,6 +1349,10 @@ int MM_Game_Init(int argc, char** argv) {
  * registrations must not double-register (the single-exe resume contract —
  * see MM_Game_Resume).
  */
+// The GIEvent pump registrar (Lane C1) — defined in
+// games/mm/2s2h/GameInteractorEventsSingleExe.cpp.
+extern "C" void MM_GameEvents_RegisterPump(void);
+
 extern "C" void MM_Rando_Init(void) {
     static bool sRandoInitDone = false;
     if (sRandoInitDone) {
@@ -1360,6 +1364,14 @@ extern "C" void MM_Rando_Init(void) {
     fflush(stderr);
     S2H::ShipInit::InitAll();
     Rando::Init();
+
+    // Lane C1 (#392): register the GIEvent pump (the port of upstream's
+    // ProcessEvents player-update hook, games/mm/2s2h/
+    // GameInteractorEventsSingleExe.cpp). Upstream registered it from
+    // GameInteractor::RegisterOwnHooks at boot; in the single exe only the
+    // rando queue produces GIEvents, so the rando bring-up is its natural
+    // (once-only, same guard) home.
+    MM_GameEvents_RegisterPump();
 }
 
 /**
@@ -1582,6 +1594,45 @@ void GameInteractor_ExecuteOnRoomInit(s16 sceneId, s8 roomNum) {
 
 void GameInteractor_ExecuteAfterRoomSceneCommands(s16 sceneId, s8 roomNum) {
     GameInteractor::Instance->ExecuteHooks<GameInteractor::AfterRoomSceneCommands>(sceneId, roomNum);
+}
+
+/**
+ * MM-side hook DISPATCH (Lane C1, #392) — the Execute half of the #415 shim
+ * contract. C0 parked MM's Rando/enh registrations in the MM-owned
+ * S2H::GameHooks registries; these bridges run them at the points upstream
+ * 2S2H dispatched each hook type. All of them go through S2H::GameHooks, NEVER
+ * the shared GameInteractor instance: unlike OnRoomInit above, these hook
+ * NAMES exist in both games, so touching the shared registry would be the
+ * #367/#395 aliasing class. The mm-gi-shim CTest plus MMRandoGen lock the
+ * chain (Sram_InitSave -> OnSaveInit -> OnFileCreate generation).
+ *
+ * OnSaveInit / OnSaveLoad replace the former mm_stubs.c no-ops: MM's C code
+ * already calls them at the right places (z_sram_NES.c MM_Sram_InitSave;
+ * z_file_choose_NES.c / z_opening.c / z_select.c save loads). OnActorUpdate
+ * and the flag hooks are called from RSBS-guarded additions in
+ * games/mm/src/code/z_actor.c, right beside the unqualified
+ * GameInteractor_Execute* calls that cross-bind to OoT's (correctly no-op
+ * while MM is active) wrappers.
+ */
+extern "C" void GameInteractor_ExecuteOnSaveInit(s16 fileNum) {
+    S2H::GameHooks::Execute<GameInteractor::OnSaveInit>(fileNum);
+}
+
+extern "C" void GameInteractor_ExecuteOnSaveLoad(s16 fileNum) {
+    S2H::GameHooks::Execute<GameInteractor::OnSaveLoad>(fileNum);
+}
+
+extern "C" void MM_GameHooks_ExecuteOnActorUpdate(Actor* actor) {
+    S2H::GameHooks::Execute<GameInteractor::OnActorUpdate>(actor);
+    S2H::GameHooks::ExecuteForID<GameInteractor::OnActorUpdate>(actor->id, actor);
+}
+
+extern "C" void MM_GameHooks_ExecuteOnFlagSet(FlagType flagType, u32 flag) {
+    S2H::GameHooks::Execute<GameInteractor::OnFlagSet>(flagType, flag);
+}
+
+extern "C" void MM_GameHooks_ExecuteOnSceneFlagSet(s16 sceneId, FlagType flagType, u32 flag) {
+    S2H::GameHooks::Execute<GameInteractor::OnSceneFlagSet>(sceneId, flagType, flag);
 }
 
 /**

--- a/games/mm/2s2h/GameInteractorEventsSingleExe.cpp
+++ b/games/mm/2s2h/GameInteractorEventsSingleExe.cpp
@@ -1,0 +1,159 @@
+/**
+ * GameInteractorEventsSingleExe.cpp — the MM GIEvent PUMP for single-exe
+ * builds (Phase 3.0 Lane C1, #392).
+ *
+ * Upstream 2S2H processed the GIEvent queue in ProcessEvents
+ * (2s2h/GameInteractor/GameInteractor.cpp:433), registered on the player's
+ * OnActorUpdate from GameInteractor::RegisterOwnHooks. That TU is excluded
+ * from the single-exe link (#395), so C0 gave MM-owned storage for the queue
+ * (MM_GameEvents_Queue / MM_GameEvents_Current, GameExports_SingleExe.cpp)
+ * but deliberately left the pump unwired — without it, everything the rando
+ * give path enqueues (CheckQueue's GIEventGiveItem, trap events, transition
+ * events) would sit in the queue forever: the historical "compiles fine,
+ * does nothing" failure.
+ *
+ * This is a line-faithful port of upstream ProcessEvents with exactly one
+ * substitution: every GameInteractor::Instance->events / ->currentEvent
+ * access (MM-only data members past the end of the shared 4-byte allocation
+ * — the #395 OOB read/write) becomes MM_GameEvents_Queue() /
+ * MM_GameEvents_Current(). Registration goes through the MM-owned
+ * S2H::GameHooks registry and is dispatched by MM_GameHooks_ExecuteOnActorUpdate
+ * (games/mm/src/code/z_actor.c), so it runs on MM frames only.
+ */
+#ifdef RSBS_SINGLE_EXECUTABLE
+
+#include "2s2h/GameInteractor/GameInteractor.h" // + mm_game_hooks.h C++ surface via the single-exe tail
+#include "2s2h/CustomItem/CustomItem.h"
+
+#include <cmath>
+#include <cstdio>
+#include <variant>
+
+extern "C" {
+#include "z64actor.h"
+#include "variables.h"
+#include "functions.h"
+}
+
+static void MM_ProcessGIEvents(Actor* actor) {
+    Player* player = GET_PLAYER(MM_gPlayState);
+
+    // If the player has a message active, stop
+    if (MM_gPlayState->msgCtx.msgMode != 0) {
+        return;
+    }
+
+    // If the player is in a blocking cutscene, stop
+    if (MM_Player_InBlockingCsMode(MM_gPlayState, player)) {
+        return;
+    }
+
+    // If player is dead, stop
+    if (player->stateFlags1 & PLAYER_STATE1_DEAD) {
+        return;
+    }
+
+    // If there is an event active, stop
+    const auto& currentEvent = MM_GameEvents_Current();
+    if (auto e = std::get_if<GIEventNone>(&currentEvent)) {
+        // no-op
+    } else {
+        return;
+    }
+
+    // If there are no events that need to happen, stop
+    if (MM_GameEvents_Queue().empty()) {
+        return;
+    }
+
+    MM_GameEvents_Current() = MM_GameEvents_Queue().front();
+    const auto& nextEvent = MM_GameEvents_Current();
+
+    if (auto e = std::get_if<GIEventGiveItem>(&nextEvent)) {
+        EnItem00* enItem00;
+
+        s16 flags = CustomItem::HIDE_TILL_OVERHEAD | CustomItem::KEEP_ON_PLAYER;
+
+        // If the player is climbing or in the air, deliver the item without a cutscene but freeze the player
+        if (!e->showGetItemCutscene ||
+            (player->stateFlags1 &
+             (PLAYER_STATE1_CHARGING_SPIN_ATTACK | PLAYER_STATE1_2000 | PLAYER_STATE1_4000 | PLAYER_STATE1_40000 |
+              PLAYER_STATE1_80000 | PLAYER_STATE1_100000 | PLAYER_STATE1_200000 | PLAYER_STATE1_8000000)) ||
+            (MM_Player_GetExplosiveHeld(player) > PLAYER_EXPLOSIVE_NONE)) {
+
+            flags |= CustomItem::GIVE_OVERHEAD;
+        } else {
+            flags |= CustomItem::GIVE_ITEM_CUTSCENE;
+        }
+
+        enItem00 = CustomItem::Spawn(
+            player->actor.world.pos.x, player->actor.world.pos.y, player->actor.world.pos.z, 0, flags, e->param,
+            [](Actor* actor, PlayState* play) {
+                Player* player = GET_PLAYER(MM_gPlayState);
+                const auto& nextEvent = MM_GameEvents_Current();
+                if (auto e = std::get_if<GIEventGiveItem>(&nextEvent)) {
+                    e->giveItem(actor, play);
+                    if (e->showGetItemCutscene && !(CUSTOM_ITEM_FLAGS & CustomItem::GIVE_ITEM_CUTSCENE)) {
+                        player->actor.freezeTimer = 30;
+                    }
+                    MM_GameEvents_Current() = GIEventNone{};
+                }
+            },
+            e->drawItem);
+        enItem00->actor.destroy = [](Actor* actor, PlayState* play) {
+            if (!(CUSTOM_ITEM_FLAGS & CustomItem::CALLED_ACTION)) {
+                // Event was not handled, requeue it
+                auto lostEvent = MM_GameEvents_Current();
+                MM_GameEvents_Current() = GIEventNone{};
+                MM_GameEvents_Queue().push_back(lostEvent);
+            }
+        };
+    } else if (auto e = std::get_if<GIEventTransition>(&nextEvent)) {
+        MM_gPlayState->nextEntrance = e->entrance;
+        gSaveContext.nextCutsceneIndex = e->cutsceneIndex;
+        MM_gPlayState->transitionTrigger = e->transitionTrigger;
+        MM_gPlayState->transitionType = e->transitionType;
+        MM_GameEvents_Current() = GIEventNone{};
+    } else if (auto e = std::get_if<GIEventSpawnActor>(&nextEvent)) {
+        // if true, the coordinates are made relative to the player's position and rotation, 0 rotation is facing the
+        // same direction as the player, x+ is to the players right, y+ is up, z+ is in front of the player
+        if (e->relativeCoords) {
+            f32 x = player->actor.world.pos.x;
+            f32 y = player->actor.world.pos.y;
+            f32 z = player->actor.world.pos.z;
+            f32 s = sin(player->actor.world.rot.y);
+            f32 c = cos(player->actor.world.rot.y);
+            f32 x2 = e->posX * c - e->posZ * s;
+            f32 z2 = e->posX * s + e->posZ * c;
+            MM_Actor_Spawn(&MM_gPlayState->actorCtx, MM_gPlayState, e->actorId, x + x2, y + e->posY, z + z2, 0,
+                           e->rotY + player->actor.world.rot.y, 0, e->params);
+        } else {
+            MM_Actor_Spawn(&MM_gPlayState->actorCtx, MM_gPlayState, e->actorId, e->posX, e->posY, e->posZ, e->rotX,
+                           e->rotY, e->rotZ, e->params);
+        }
+        MM_GameEvents_Current() = GIEventNone{};
+    } else if (auto e = std::get_if<GIEventTrap>(&nextEvent)) {
+        if (e->action) {
+            e->action();
+        }
+        MM_GameEvents_Current() = GIEventNone{};
+    }
+
+    MM_GameEvents_Queue().erase(MM_GameEvents_Queue().begin());
+}
+
+/**
+ * Once-only pump registration; called from MM_Rando_Init (which carries the
+ * matching once-only guard, but a second guard here keeps the contract local).
+ */
+extern "C" void MM_GameEvents_RegisterPump(void) {
+    static bool sRegistered = false;
+    if (sRegistered) {
+        return;
+    }
+    sRegistered = true;
+    S2H::GameHooks::RegisterForID<GameInteractor::OnActorUpdate>(ACTOR_PLAYER, MM_ProcessGIEvents);
+    fprintf(stderr, "[MM] GIEvent pump registered on player OnActorUpdate (Lane C1)\n");
+}
+
+#endif // RSBS_SINGLE_EXECUTABLE

--- a/games/mm/2s2h/Rando/Foreign.cpp
+++ b/games/mm/2s2h/Rando/Foreign.cpp
@@ -117,6 +117,9 @@ int PlaceForeignItems() {
         }
     }
 
+    fprintf(stderr, "[MM] foreign placement: %d pool items over %zu junk-holding candidate checks\n", poolCount,
+            candidates.size());
+
     sSelectState =
         Ship_Hash(std::to_string(gComboCtx.sharedRandoSeed) + ":" + std::to_string(gComboCtx.sharedRandoSettingsHash) +
                   ":" + std::to_string(gSaveContext.save.shipSaveInfo.rando.finalSeed) + ":foreign-v1");

--- a/games/mm/2s2h/Rando/Foreign.cpp
+++ b/games/mm/2s2h/Rando/Foreign.cpp
@@ -1,0 +1,189 @@
+/**
+ * Rando::Foreign — MM-side foreign-item placement + give-path core
+ * (Phase 3.0 Lane C1, #392).
+ *
+ * Placement model (the C0 handoff's design, ADR 0002 at every boundary):
+ * after MM's own fill has populated RANDO_SAVE_CHECKS, deterministically pick
+ * N junk-holding shuffled checks and mark them as hosting the pinned OoT
+ * progression items. The MM save table KEEPS RI_JUNK at those checks — a raw
+ * RG_* never enters an MM table — while gComboCtx.foreignPlacements records
+ * "check X hosts SharedItem{GAME_OOT, id}". If the placement table is ever
+ * absent (a pre-C1 .redsave zero-extends to an empty table), the hosting
+ * checks degrade to the junk they physically hold: nothing crashes, nothing
+ * aliases.
+ *
+ * Determinism: selection uses a LOCAL xorshift32 stream seeded from the
+ * paired-world identity (master seed + settings digest + MM final seed), so
+ * it can never be perturbed by other Ship_Random consumers, and candidate
+ * order comes from std::map's sorted iteration. Same gComboCtx + same MM
+ * options => same placements, which is what the SeedDeterminism fold locks.
+ *
+ * Paired-world generation failure (a fill dead-end under the derived seed) is
+ * NOT retried here: OnFileCreate's existing catch reverts the save to vanilla,
+ * exactly as upstream does for any failed generation. The derivation is
+ * attempt-free on purpose — a retry counter would make the world identity
+ * depend on runtime state the digest cannot see. If a pinned CI seed
+ * dead-ends, the fix is to pin a different seed, not to bend the derivation.
+ */
+#ifdef RSBS_SINGLE_EXECUTABLE
+
+#include "Foreign.h"
+#include "Rando/Rando.h"
+#include "2s2h/ShipUtils.h"
+
+// src/common — placement table + pinned pool surface. Included OUTSIDE any
+// extern "C" block: it pulls context.h, whose <type_traits> include must not
+// be wrapped in C linkage (see context.h's header comment).
+#include "foreign_items.h"
+
+#include <cstddef>
+#include <cstdio>
+#include <string>
+#include <vector>
+
+extern "C" {
+#include "variables.h"
+}
+
+namespace Rando {
+namespace Foreign {
+
+bool PairingActive() {
+    return Combo_ForeignPairingActive();
+}
+
+std::string PairedInputSeedString() {
+    // Plain decimal of the master seed with a stable prefix: deterministic,
+    // filename-safe (the spoiler lands at randomizer/<inputSeed>.json), and
+    // recognizable in logs/artifacts as a paired-world file.
+    return "RSBSPAIR" + std::to_string(gComboCtx.sharedRandoSeed);
+}
+
+static std::string MMOptionsString() {
+    // The persisted options ARE the finalized MM settings profile — the loop
+    // below must run after OnFileCreate copied them into the save. std::map
+    // iteration gives a stable option order.
+    std::string s;
+    for (auto& [randoOptionId, randoStaticOption] : Rando::StaticData::Options) {
+        s += std::to_string(RANDO_SAVE_OPTIONS[randoOptionId]);
+        s += ';';
+    }
+    return s;
+}
+
+uint32_t MixPairedFinalSeed() {
+    // Mirrors OoT's Playthrough_Init: Hash(str(master seed) + settings), so
+    // the same master seed reproduces the MM world only under the same MM
+    // options — the "one seed + one pinned settings profile" contract.
+    return Ship_Hash(std::to_string(gComboCtx.sharedRandoSeed) + MMOptionsString());
+}
+
+// Local, self-contained PRNG for placement selection (see the file header).
+static uint32_t sSelectState;
+
+static uint32_t SelectNext() {
+    uint32_t x = sSelectState;
+    x ^= x << 13;
+    x ^= x >> 17;
+    x ^= x << 5;
+    sSelectState = (x != 0) ? x : 0xB5297A4Du;
+    return sSelectState;
+}
+
+int PlaceForeignItems() {
+    Combo_ClearForeignPlacements();
+
+    if (!PairingActive()) {
+        return 0;
+    }
+
+    const ComboForeignItemDef* pool = nullptr;
+    const int poolCount = Combo_GetForeignItemPool(&pool);
+    if (poolCount <= 0 || pool == nullptr) {
+        return 0;
+    }
+
+    // Candidates: shuffled checks the fill left holding junk, in ascending
+    // RandoCheckId order (std::map).
+    std::vector<RandoCheckId> candidates;
+    for (auto& [randoCheckId, randoStaticCheck] : Rando::StaticData::Checks) {
+        if (randoStaticCheck.randoCheckId == RC_UNKNOWN) {
+            continue;
+        }
+        if (RANDO_SAVE_CHECKS[randoCheckId].shuffled && RANDO_SAVE_CHECKS[randoCheckId].randoItemId == RI_JUNK) {
+            candidates.push_back(randoCheckId);
+        }
+    }
+
+    sSelectState =
+        Ship_Hash(std::to_string(gComboCtx.sharedRandoSeed) + ":" + std::to_string(gComboCtx.sharedRandoSettingsHash) +
+                  ":" + std::to_string(gSaveContext.save.shipSaveInfo.rando.finalSeed) + ":foreign-v1");
+    if (sSelectState == 0) {
+        sSelectState = 0xB5297A4Du;
+    }
+
+    int placed = 0;
+    for (int i = 0; i < poolCount && !candidates.empty(); i++) {
+        const size_t pick = (size_t)(SelectNext() % (uint32_t)candidates.size());
+        const RandoCheckId hostCheck = candidates[pick];
+        candidates.erase(candidates.begin() + (std::ptrdiff_t)pick);
+
+        if (Combo_SetForeignPlacement((uint16_t)hostCheck, pool[i].item) >= 0) {
+            placed++;
+            fprintf(stderr, "[MM] foreign placement: '%s' hosted at MM check %s\n", pool[i].name,
+                    Rando::StaticData::Checks[hostCheck].name);
+        }
+    }
+
+    if (placed < poolCount) {
+        fprintf(stderr, "[MM] foreign placement: only %d of %d pool items placed (junk candidates exhausted)\n", placed,
+                poolCount);
+    }
+    return placed;
+}
+
+static const SharedItem* PlacementFor(RandoCheckId randoCheckId) {
+    if (randoCheckId == RC_UNKNOWN) {
+        return nullptr;
+    }
+    return Combo_GetForeignPlacementForCheck((uint16_t)randoCheckId);
+}
+
+bool IsForeignCheck(RandoCheckId randoCheckId) {
+    return PlacementFor(randoCheckId) != nullptr;
+}
+
+const char* ForeignNameForCheck(RandoCheckId randoCheckId) {
+    const SharedItem* item = PlacementFor(randoCheckId);
+    if (item == nullptr) {
+        return nullptr;
+    }
+    return Combo_GetForeignItemName(*item);
+}
+
+bool RecordForeignPickup(RandoCheckId randoCheckId) {
+    const SharedItem* item = PlacementFor(randoCheckId);
+    if (item == nullptr) {
+        return false;
+    }
+    // Durable immediately (Combo_RecordSharedItem writes the serialized array,
+    // so an MM save+quit before the next switch cannot lose the pickup — the
+    // stage/commit outbox is RAM-only, see shared_items.h). The producer
+    // de-dups an identical un-redeemed entry, so a re-fired give cannot
+    // double-record.
+    return Combo_RecordSharedItem((GameId)item->originGame, item->id) >= 0;
+}
+
+} // namespace Foreign
+} // namespace Rando
+
+// ============================================================================
+// ROM-free test bridge (redship tier; src/common/tests/test_foreign_items.c).
+// Drives the SAME give-path core the CheckQueue lambda calls, so the lock
+// covers the real recording path, not a copy.
+// ============================================================================
+extern "C" int MM_Rando_Foreign_RecordPickup(uint16_t randoCheckId) {
+    return Rando::Foreign::RecordForeignPickup((RandoCheckId)randoCheckId) ? 1 : 0;
+}
+
+#endif // RSBS_SINGLE_EXECUTABLE

--- a/games/mm/2s2h/Rando/Foreign.cpp
+++ b/games/mm/2s2h/Rando/Foreign.cpp
@@ -31,10 +31,12 @@
 #include "Rando/Rando.h"
 #include "2s2h/ShipUtils.h"
 
-// src/common — placement table + pinned pool surface. Included OUTSIDE any
-// extern "C" block: it pulls context.h, whose <type_traits> include must not
-// be wrapped in C linkage (see context.h's header comment).
+// src/common — placement table + pinned pool surface, and the A1 producer
+// (Combo_RecordSharedItem). Included OUTSIDE any extern "C" block: they pull
+// context.h, whose <type_traits> include must not be wrapped in C linkage
+// (see context.h's header comment).
 #include "foreign_items.h"
+#include "shared_items.h"
 
 #include <cstddef>
 #include <cstdio>

--- a/games/mm/2s2h/Rando/Foreign.cpp
+++ b/games/mm/2s2h/Rando/Foreign.cpp
@@ -4,13 +4,13 @@
  *
  * Placement model (the C0 handoff's design, ADR 0002 at every boundary):
  * after MM's own fill has populated RANDO_SAVE_CHECKS, deterministically pick
- * N junk-holding shuffled checks and mark them as hosting the pinned OoT
- * progression items. The MM save table KEEPS RI_JUNK at those checks — a raw
- * RG_* never enters an MM table — while gComboCtx.foreignPlacements records
- * "check X hosts SharedItem{GAME_OOT, id}". If the placement table is ever
- * absent (a pre-C1 .redsave zero-extends to an empty table), the hosting
- * checks degrade to the junk they physically hold: nothing crashes, nothing
- * aliases.
+ * N shuffled checks holding junk-CLASS items and mark them as hosting the
+ * pinned OoT progression items. The MM save table KEEPS its junk-class MM
+ * item at those checks — a raw RG_* never enters an MM table — while
+ * gComboCtx.foreignPlacements records "check X hosts SharedItem{GAME_OOT,
+ * id}". If the placement table is ever absent (a pre-C1 .redsave
+ * zero-extends to an empty table), the hosting checks degrade to the junk
+ * they physically hold: nothing crashes, nothing aliases.
  *
  * Determinism: selection uses a LOCAL xorshift32 stream seeded from the
  * paired-world identity (master seed + settings digest + MM final seed), so
@@ -105,14 +105,28 @@ int PlaceForeignItems() {
         return 0;
     }
 
-    // Candidates: shuffled checks the fill left holding junk, in ascending
-    // RandoCheckId order (std::map).
+    // Candidates: shuffled checks the fill left holding a JUNK-CLASS item
+    // (RITYPE_JUNK — ammo, rupees, and the RI_JUNK filler sentinel alike), in
+    // ascending RandoCheckId order (std::map). The literal RI_JUNK sentinel
+    // alone is NOT the criterion: the pool balancer only injects it when the
+    // check pool outnumbers the item pool, so most fills carry few or none
+    // (a measured CI fill had 2), while junk-class items are plentiful.
+    // Shop-type checks are excluded: their give/price flow and spoiler shape
+    // differ, and the MVP's generic presentation targets the ordinary
+    // eligible->CheckQueue path.
     std::vector<RandoCheckId> candidates;
     for (auto& [randoCheckId, randoStaticCheck] : Rando::StaticData::Checks) {
         if (randoStaticCheck.randoCheckId == RC_UNKNOWN) {
             continue;
         }
-        if (RANDO_SAVE_CHECKS[randoCheckId].shuffled && RANDO_SAVE_CHECKS[randoCheckId].randoItemId == RI_JUNK) {
+        if (randoStaticCheck.randoCheckType == RCTYPE_SHOP || randoStaticCheck.randoCheckType == RCTYPE_TINGLE_SHOP) {
+            continue;
+        }
+        if (!RANDO_SAVE_CHECKS[randoCheckId].shuffled) {
+            continue;
+        }
+        const RandoItemId heldItem = RANDO_SAVE_CHECKS[randoCheckId].randoItemId;
+        if (Rando::StaticData::Items[heldItem].randoItemType == RITYPE_JUNK) {
             candidates.push_back(randoCheckId);
         }
     }

--- a/games/mm/2s2h/Rando/Foreign.h
+++ b/games/mm/2s2h/Rando/Foreign.h
@@ -1,0 +1,57 @@
+/**
+ * Rando::Foreign — MM's half of the cross-game foreign-item pipeline
+ * (Phase 3.0 Lane C1, #392). Single-exe only: the whole surface is a no-op
+ * shape outside RSBS_SINGLE_EXECUTABLE (the standalone port has no paired
+ * world to key off).
+ *
+ * See Foreign.cpp for the placement algorithm and src/common/foreign_items.h
+ * for the shared placement-table/pool contract this module drives.
+ */
+#ifndef RANDO_FOREIGN_H
+#define RANDO_FOREIGN_H
+
+#ifdef RSBS_SINGLE_EXECUTABLE
+
+#include <string>
+#include "Types.h"
+
+namespace Rando {
+namespace Foreign {
+
+/** True when the paired-world keying is satisfied (Lane B's carrier contract:
+ *  gComboCtx.sourceIsRando && sharedRandoSettingsHash != 0). */
+bool PairingActive();
+
+/** The deterministic input-seed string the paired MM world generates under —
+ *  derived from gComboCtx.sharedRandoSeed, so one OoT seed names one MM
+ *  world (and one spoiler file). */
+std::string PairedInputSeedString();
+
+/** The paired final seed: Ship_Hash(master seed + MM's persisted options),
+ *  mirroring OoT's own Hash(seed + settingsStr) double-reseed (Lane B
+ *  contract). Call AFTER the options are persisted into RANDO_SAVE_OPTIONS. */
+uint32_t MixPairedFinalSeed();
+
+/** Swap deterministically-chosen junk placements for the pinned foreign pool
+ *  and record them in gComboCtx.foreignPlacements. Call after the fill/logic
+ *  apply populated RANDO_SAVE_CHECKS. Returns the number placed. */
+int PlaceForeignItems();
+
+/** True if this MM check hosts a foreign item in the current paired world. */
+bool IsForeignCheck(RandoCheckId randoCheckId);
+
+/** Display name for the foreign item hosted by this check, or nullptr. */
+const char* ForeignNameForCheck(RandoCheckId randoCheckId);
+
+/** Give-path core: record the check's foreign item into the shared structure
+ *  (durable immediately; de-duped by the A1 producer). Returns true if a
+ *  foreign item was recorded. The CheckQueue lambda calls this and layers the
+ *  generic presentation on top; the ROM-free unit test drives it directly. */
+bool RecordForeignPickup(RandoCheckId randoCheckId);
+
+} // namespace Foreign
+} // namespace Rando
+
+#endif // RSBS_SINGLE_EXECUTABLE
+
+#endif // RANDO_FOREIGN_H

--- a/games/mm/2s2h/Rando/MiscBehavior/CheckQueue.cpp
+++ b/games/mm/2s2h/Rando/MiscBehavior/CheckQueue.cpp
@@ -7,6 +7,9 @@
 #include "2s2h/Rando/StaticData/StaticData.h"
 #include "2s2h/ShipUtils.h"
 #include "Traps.h"
+#ifdef RSBS_SINGLE_EXECUTABLE
+#include "2s2h/Rando/Foreign.h" // Lane C1 (#392): foreign-check lookup + shared-structure recording
+#endif
 
 extern "C" {
 #include "variables.h"
@@ -36,6 +39,59 @@ void Rando::MiscBehavior::CheckQueue() {
 
         if (randoSaveCheck.eligible) {
             queued = true;
+
+#ifdef RSBS_SINGLE_EXECUTABLE
+            // Lane C1 (#392): a check hosting a FOREIGN item (an OoT item in
+            // this MM world — gComboCtx.foreignPlacements) hands the item to
+            // the shared structure instead of MM's give path, presented as a
+            // generic "foreign treasure" (textbox + gold-rupee model — the
+            // receiving game has no assets for the item, per the MVP's
+            // generic-presentation contract). The MM save table still holds
+            // RI_JUNK at this check; the placement table overrides it here.
+            if (Rando::Foreign::IsForeignCheck(randoCheckId)) {
+                MM_GameEvents_Queue().emplace_back(GIEventGiveItem{
+                    .showGetItemCutscene = true,
+                    .param = (int16_t)randoCheckId,
+                    .giveItem =
+                        [](Actor* actor, PlayState* play) {
+                            auto& randoSaveCheck = RANDO_SAVE_CHECKS[CUSTOM_ITEM_PARAM];
+                            const RandoCheckId checkId = (RandoCheckId)CUSTOM_ITEM_PARAM;
+                            const char* foreignName = Rando::Foreign::ForeignNameForCheck(checkId);
+
+                            // Record into gComboCtx.sharedItemsTagged (origin-
+                            // tagged, durable immediately, de-duped). OoT's
+                            // consumer awards it on the next arrival there.
+                            Rando::Foreign::RecordForeignPickup(checkId);
+
+                            CustomMessage::Entry entry = {
+                                .textboxType = 2,
+                                .icon = Rando::StaticData::GetIconForZMessage(RI_RUPEE_HUGE),
+                                .msg = std::string("You found the ") +
+                                       (foreignName != nullptr ? foreignName : "Foreign Treasure") +
+                                       "!\nIt belongs to Ocarina of Time -\nit will be awarded there!",
+                            };
+                            if (CUSTOM_ITEM_FLAGS & CustomItem::GIVE_ITEM_CUTSCENE) {
+                                CustomMessage::SetActiveCustomMessage(entry.msg, entry);
+                            } else {
+                                CustomMessage::StartTextbox(entry.msg + "\x1C\x02\x10", entry);
+                            }
+
+                            randoSaveCheck.cycleObtained = true;
+                            randoSaveCheck.obtained = true;
+                            randoSaveCheck.eligible = false;
+                            queued = false;
+                            // Post-give, CUSTOM_ITEM_PARAM carries an RI for
+                            // the draw path (matching the normal branch).
+                            CUSTOM_ITEM_PARAM = RI_RUPEE_HUGE;
+                        },
+                    .drawItem =
+                        [](Actor* actor, PlayState* play) {
+                            MM_Matrix_Scale(30.0f, 30.0f, 30.0f, MTXMODE_APPLY);
+                            Rando::DrawItem(RI_RUPEE_HUGE);
+                        } });
+                return;
+            }
+#endif
 
             MM_GameEvents_Queue().emplace_back(GIEventGiveItem{
                 .showGetItemCutscene =

--- a/games/mm/2s2h/Rando/MiscBehavior/CheckQueue.cpp
+++ b/games/mm/2s2h/Rando/MiscBehavior/CheckQueue.cpp
@@ -47,7 +47,8 @@ void Rando::MiscBehavior::CheckQueue() {
             // generic "foreign treasure" (textbox + gold-rupee model — the
             // receiving game has no assets for the item, per the MVP's
             // generic-presentation contract). The MM save table still holds
-            // RI_JUNK at this check; the placement table overrides it here.
+            // its junk-class MM item at this check; the placement table
+            // overrides it here.
             if (Rando::Foreign::IsForeignCheck(randoCheckId)) {
                 MM_GameEvents_Queue().emplace_back(GIEventGiveItem{
                     .showGetItemCutscene = true,

--- a/games/mm/2s2h/Rando/MiscBehavior/OnFileCreate.cpp
+++ b/games/mm/2s2h/Rando/MiscBehavior/OnFileCreate.cpp
@@ -6,6 +6,10 @@
 #include <libultraship/bridge/consolevariablebridge.h>
 #include "ClockShuffle.h"
 #include <spdlog/spdlog.h>
+#ifdef RSBS_SINGLE_EXECUTABLE
+#include "Rando/Foreign.h" // Lane C1 (#392): paired-world seed derivation + foreign placement
+#include "foreign_items.h" // src/common — Combo_ClearForeignPlacements
+#endif
 
 extern "C" {
 #include "functions.h"
@@ -17,7 +21,18 @@ extern "C" {
 // Very primitive randomizer implementation, when a save is created, if rando is enabled
 // we set the save type to rando and shuffle all checks and persist the results to the save
 void Rando::MiscBehavior::OnFileCreate(s16 fileNum) {
+#ifdef RSBS_SINGLE_EXECUTABLE
+    // Lane C1 (#392): a live paired OoT rando world (Lane B's carrier stamped
+    // in gComboCtx) makes a new MM file the MM HALF of that world — the MVP's
+    // "one seed produces a paired OoT+MM world". This is deliberately not
+    // gated on gRando.Enabled: MM's rando menu is link-elided in the single
+    // exe (2ship_rando_ui), so there is no in-game surface that could set the
+    // CVar; the paired OoT generation IS the user's opt-in.
+    const bool rsbsPaired = Rando::Foreign::PairingActive();
+    if (CVarGetInteger("gRando.Enabled", 0) || rsbsPaired) {
+#else
     if (CVarGetInteger("gRando.Enabled", 0)) {
+#endif
         gSaveContext.save.shipSaveInfo.saveType = SAVETYPE_RANDO;
         // Zero out the rando struct
         memset(&gSaveContext.save.shipSaveInfo.rando, 0, sizeof(gSaveContext.save.shipSaveInfo.rando));
@@ -42,6 +57,13 @@ void Rando::MiscBehavior::OnFileCreate(s16 fileNum) {
         BUTTON_ITEM_EQUIP(0, EQUIP_SLOT_B) = ITEM_NONE;
         SET_EQUIP_VALUE(EQUIP_TYPE_SHIELD, EQUIP_VALUE_SHIELD_NONE);
 
+#ifdef RSBS_SINGLE_EXECUTABLE
+        // Lane C1 (#392): a new MM rando file defines a new world — placements
+        // recorded for any previous world must not leak into it (they are
+        // re-placed below iff this world pairs with a live OoT rando world).
+        Combo_ClearForeignPlacements();
+#endif
+
         try {
             // SpoilerFileIndex == 0 means we're generating a new one
             if (CVarGetInteger("gRando.SpoilerFileIndex", 0) == 0) {
@@ -51,6 +73,19 @@ void Rando::MiscBehavior::OnFileCreate(s16 fileNum) {
                     inputSeed = std::to_string(Ship_Random(0, 1000000));
                     hadInputSeed = false;
                 }
+
+#ifdef RSBS_SINGLE_EXECUTABLE
+                if (rsbsPaired) {
+                    // One seed -> paired world (Lane B's carrier contract):
+                    // when a live OoT rando world exists, THIS file is its MM
+                    // half, so the MM seed derives from the shared master
+                    // seed rather than user input. The derived input-seed
+                    // string also names the spoiler file deterministically.
+                    inputSeed = Rando::Foreign::PairedInputSeedString();
+                    hadInputSeed = true;
+                    SPDLOG_INFO("Paired-world generation: MM seed derived from shared master seed ({})", inputSeed);
+                }
+#endif
 
                 uint32_t finalSeed = Ship_Hash(inputSeed);
                 Ship_Random_Seed(finalSeed);
@@ -66,6 +101,33 @@ void Rando::MiscBehavior::OnFileCreate(s16 fileNum) {
                 if (!RANDO_SAVE_OPTIONS[RO_SHUFFLE_GOLD_SKULLTULAS]) {
                     RANDO_SAVE_OPTIONS[RO_MINIMUM_SKULLTULA_TOKENS] = SPIDER_HOUSE_TOKENS_REQUIRED;
                 }
+
+#ifdef RSBS_SINGLE_EXECUTABLE
+                if (rsbsPaired) {
+                    // Pinned MM profile for the paired world (#392/#426): the
+                    // vendored glitchless fill deterministically dead-ends, so
+                    // the MVP pairs under Nearly No Logic — the spoiler log
+                    // carries what logic would otherwise carry (Lane D).
+                    // Pinned BEFORE the settings mix below so the profile is
+                    // part of the world identity.
+                    if (RANDO_SAVE_OPTIONS[RO_LOGIC] != RO_LOGIC_NEARLY_NO_LOGIC &&
+                        RANDO_SAVE_OPTIONS[RO_LOGIC] != RO_LOGIC_NO_LOGIC &&
+                        RANDO_SAVE_OPTIONS[RO_LOGIC] != RO_LOGIC_VANILLA) {
+                        SPDLOG_INFO("Paired-world generation: pinning MM logic to Nearly No Logic (#426)");
+                        RANDO_SAVE_OPTIONS[RO_LOGIC] = RO_LOGIC_NEARLY_NO_LOGIC;
+                    }
+                    // Re-seed with Hash(master seed + MM's finalized options),
+                    // mirroring OoT's Hash(seed + settingsStr) double-reseed
+                    // (Lane B contract): the same master seed reproduces this
+                    // world only under the same MM profile. Nothing consumed
+                    // the RNG between the first Ship_Random_Seed above and
+                    // here, and every consumer (starting items, pools, fill)
+                    // runs after this point.
+                    finalSeed = Rando::Foreign::MixPairedFinalSeed();
+                    gSaveContext.save.shipSaveInfo.rando.finalSeed = finalSeed;
+                    Ship_Random_Seed(finalSeed);
+                }
+#endif
 
                 // Persist StartingItems to the save
                 auto startingItems = Rando::GetStartingItemsFromConfig();
@@ -154,6 +216,17 @@ void Rando::MiscBehavior::OnFileCreate(s16 fileNum) {
                                              std::to_string(RANDO_SAVE_OPTIONS[RO_LOGIC]));
                 }
 
+#ifdef RSBS_SINGLE_EXECUTABLE
+                if (rsbsPaired) {
+                    // Lane C1 (#392): swap deterministically-chosen junk
+                    // placements for the pinned OoT foreign items, recorded in
+                    // gComboCtx.foreignPlacements (the MM table keeps RI_JUNK
+                    // — ADR 0002). Runs before the spoiler write so the
+                    // spoiler's foreign section describes this world.
+                    Rando::Foreign::PlaceForeignItems();
+                }
+#endif
+
                 if (CVarGetInteger("gRando.GenerateSpoiler", 1)) {
                     nlohmann::json spoiler = Rando::Spoiler::GenerateFromSaveContext();
                     spoiler["inputSeed"] = inputSeed;
@@ -187,6 +260,11 @@ void Rando::MiscBehavior::OnFileCreate(s16 fileNum) {
         } catch (const std::exception& e) {
             SPDLOG_ERROR("Error with randomizer save creation: {}", e.what());
             Audio_PlaySfx(NA_SE_SY_QUIZ_INCORRECT);
+#ifdef RSBS_SINGLE_EXECUTABLE
+            // A failed generation reverts to a vanilla save below; any foreign
+            // placements recorded for the aborted world must not survive it.
+            Combo_ClearForeignPlacements();
+#endif
             gSaveContext.save.shipSaveInfo.saveType = SAVETYPE_VANILLA;
             char invalidName[8] = { 18, 23, 31, 10, 21, 18, 13, 62 };
             memcpy(gSaveContext.save.saveInfo.playerData.playerName, invalidName, sizeof(invalidName));

--- a/games/mm/2s2h/Rando/MiscBehavior/OnFileCreate.cpp
+++ b/games/mm/2s2h/Rando/MiscBehavior/OnFileCreate.cpp
@@ -6,6 +6,7 @@
 #include <libultraship/bridge/consolevariablebridge.h>
 #include "ClockShuffle.h"
 #include <spdlog/spdlog.h>
+#include <cstdio>
 #ifdef RSBS_SINGLE_EXECUTABLE
 #include "Rando/Foreign.h" // Lane C1 (#392): paired-world seed derivation + foreign placement
 #include "foreign_items.h" // src/common — Combo_ClearForeignPlacements
@@ -29,6 +30,12 @@ void Rando::MiscBehavior::OnFileCreate(s16 fileNum) {
     // exe (2ship_rando_ui), so there is no in-game surface that could set the
     // CVar; the paired OoT generation IS the user's opt-in.
     const bool rsbsPaired = Rando::Foreign::PairingActive();
+    // Unconditional diagnostic: the paired-vs-solo decision and its inputs are
+    // the first thing to check when a paired world fails to pair (greppable in
+    // CI logs and operator sessions alike).
+    fprintf(stderr, "[MM] OnFileCreate: paired=%d (sourceIsRando=%d settingsHash=%08X masterSeed=%08X)\n",
+            rsbsPaired ? 1 : 0, gComboCtx.sourceIsRando ? 1 : 0, gComboCtx.sharedRandoSettingsHash,
+            gComboCtx.sharedRandoSeed);
     if (CVarGetInteger("gRando.Enabled", 0) || rsbsPaired) {
 #else
     if (CVarGetInteger("gRando.Enabled", 0)) {

--- a/games/mm/2s2h/Rando/MiscBehavior/OnFileCreate.cpp
+++ b/games/mm/2s2h/Rando/MiscBehavior/OnFileCreate.cpp
@@ -73,7 +73,17 @@ void Rando::MiscBehavior::OnFileCreate(s16 fileNum) {
 
         try {
             // SpoilerFileIndex == 0 means we're generating a new one
+#ifdef RSBS_SINGLE_EXECUTABLE
+            // A paired world is always GENERATED: its identity comes from the
+            // shared master seed, never from a previously saved spoiler.
+            // Without this, a stale gRando.SpoilerFileIndex (RefreshOptions
+            // repoints it at the last written spoiler after every successful
+            // generation) would silently LOAD the old world instead of
+            // deriving the paired one — caught by MMRandoGen's paired phase.
+            if (CVarGetInteger("gRando.SpoilerFileIndex", 0) == 0 || rsbsPaired) {
+#else
             if (CVarGetInteger("gRando.SpoilerFileIndex", 0) == 0) {
+#endif
                 bool hadInputSeed = true;
                 std::string inputSeed = Ship_RemoveSpecialCharacters(CVarGetString("gRando.InputSeed", ""));
                 if (inputSeed.empty()) {
@@ -227,8 +237,8 @@ void Rando::MiscBehavior::OnFileCreate(s16 fileNum) {
                 if (rsbsPaired) {
                     // Lane C1 (#392): swap deterministically-chosen junk
                     // placements for the pinned OoT foreign items, recorded in
-                    // gComboCtx.foreignPlacements (the MM table keeps RI_JUNK
-                    // — ADR 0002). Runs before the spoiler write so the
+                    // gComboCtx.foreignPlacements (the MM table keeps its
+                    // junk-class MM item — ADR 0002). Runs before the spoiler write so the
                     // spoiler's foreign section describes this world.
                     Rando::Foreign::PlaceForeignItems();
                 }

--- a/games/mm/2s2h/Rando/Spoiler/Generate.cpp
+++ b/games/mm/2s2h/Rando/Spoiler/Generate.cpp
@@ -1,5 +1,8 @@
 #include "Spoiler.h"
 #include "Rando/Rando.h"
+#ifdef RSBS_SINGLE_EXECUTABLE
+#include "Rando/Foreign.h" // Lane C1 (#392): foreign-check lookup for the spoiler
+#endif
 
 namespace Rando {
 
@@ -29,6 +32,18 @@ nlohmann::json GenerateFromSaveContext() {
             continue;
         }
 
+#ifdef RSBS_SINGLE_EXECUTABLE
+        // Lane C1 (#392): a check hosting a foreign item reads as that item,
+        // not as the RI_JUNK physically stored in the MM table — the human-
+        // readable checks list must describe what the check actually yields.
+        // The machine-readable record of the crossing is the "foreign"
+        // section below.
+        if (const char* foreignName = Rando::Foreign::ForeignNameForCheck(randoCheckId)) {
+            spoiler["checks"][randoStaticCheck.name] = std::string(foreignName) + " (Ocarina of Time)";
+            continue;
+        }
+#endif
+
         if (randoStaticCheck.randoCheckType == RCTYPE_SHOP || randoStaticCheck.randoCheckType == RCTYPE_TINGLE_SHOP) {
             spoiler["checks"][randoStaticCheck.name] = nlohmann::json::object();
             spoiler["checks"][randoStaticCheck.name]["randoItemId"] =
@@ -39,6 +54,26 @@ nlohmann::json GenerateFromSaveContext() {
                 Rando::StaticData::Items[RANDO_SAVE_CHECKS[randoCheckId].randoItemId].spoilerName;
         }
     }
+
+#ifdef RSBS_SINGLE_EXECUTABLE
+    // Lane C1 (#392): every cross-game placement, described — check name,
+    // item name, origin game — the MVP contract's "a spoiler log describes
+    // it". Only present (possibly empty) when this world was generated as the
+    // MM half of a paired world.
+    if (Rando::Foreign::PairingActive()) {
+        spoiler["foreign"] = nlohmann::json::object();
+        for (auto& [randoCheckId, randoStaticCheck] : Rando::StaticData::Checks) {
+            if (randoStaticCheck.randoCheckId == RC_UNKNOWN || !Rando::Foreign::IsForeignCheck(randoCheckId)) {
+                continue;
+            }
+            const char* foreignName = Rando::Foreign::ForeignNameForCheck(randoCheckId);
+            spoiler["foreign"][randoStaticCheck.name] = {
+                { "originGame", "OOT" },
+                { "item", foreignName != nullptr ? foreignName : "(unknown foreign item)" },
+            };
+        }
+    }
+#endif
 
     return spoiler;
 }

--- a/games/mm/2s2h/mm_rando_gen_test.cpp
+++ b/games/mm/2s2h/mm_rando_gen_test.cpp
@@ -181,6 +181,11 @@ extern "C" int MM_Rando_HeadlessGenTest(void) {
     // not gate this reachability lock.
     CVarSetInteger(Rando::StaticData::Options[RO_LOGIC].cvar, RO_LOGIC_GLITCHLESS);
     CVarSetString("gRando.InputSeed", "RSBSMMGL1");
+    // Re-pin the GENERATE branch: the successful generation above ran
+    // RefreshOptions, which repoints gRando.SpoilerFileIndex at the spoiler
+    // just written — without this the probe silently LOADS that spoiler and
+    // reports GENERATED regardless of the glitchless fill's state.
+    CVarSetInteger("gRando.SpoilerFileIndex", 0);
     memset(&gSaveContext, 0, sizeof(gSaveContext));
     MM_Sram_InitNewSave();
     GameInteractor_ExecuteOnSaveInit(0);
@@ -240,8 +245,8 @@ extern "C" int MM_Rando_HeadlessGenTest(void) {
                 gComboCtx.sharedRandoSeed);
         return 11;
     }
-    // ADR 0002: hosting checks keep a legal MM item (RI_JUNK) in the MM save
-    // table; every recorded placement carries the OoT origin tag.
+    // ADR 0002: hosting checks keep a legal MM item (junk-class) in the MM
+    // save table; every recorded placement carries the OoT origin tag.
     for (int i = 0; i < (int)RSBS_FOREIGN_PLACEMENT_CAP; i++) {
         const ComboForeignPlacement& p = gComboCtx.foreignPlacements[i];
         if (p.item.originGame == GAME_NONE) {
@@ -252,9 +257,12 @@ extern "C" int MM_Rando_HeadlessGenTest(void) {
             return 12;
         }
         const RandoCheckId hostCheck = (RandoCheckId)p.mmCheckId;
-        if (!RANDO_SAVE_CHECKS[hostCheck].shuffled || RANDO_SAVE_CHECKS[hostCheck].randoItemId != RI_JUNK) {
-            fprintf(stderr, "[MM-RANDO-GEN] FAIL(12): hosting check %u does not hold RI_JUNK in the MM table\n",
-                    (unsigned)p.mmCheckId);
+        const RandoItemId heldItem = RANDO_SAVE_CHECKS[hostCheck].randoItemId;
+        if (!RANDO_SAVE_CHECKS[hostCheck].shuffled ||
+            Rando::StaticData::Items[heldItem].randoItemType != RITYPE_JUNK) {
+            fprintf(stderr,
+                    "[MM-RANDO-GEN] FAIL(12): hosting check %u does not hold a junk-class MM item (holds %d)\n",
+                    (unsigned)p.mmCheckId, (int)heldItem);
             return 12;
         }
     }

--- a/games/mm/2s2h/mm_rando_gen_test.cpp
+++ b/games/mm/2s2h/mm_rando_gen_test.cpp
@@ -233,7 +233,11 @@ extern "C" int MM_Rando_HeadlessGenTest(void) {
 
     const int placedCount = Combo_CountForeignPlacements();
     if (placedCount != poolCount) {
-        fprintf(stderr, "[MM-RANDO-GEN] FAIL(11): expected %d foreign placements, found %d\n", poolCount, placedCount);
+        fprintf(stderr,
+                "[MM-RANDO-GEN] FAIL(11): expected %d foreign placements, found %d (test-side pairing key: "
+                "sourceIsRando=%d settingsHash=%08X seed=%08X)\n",
+                poolCount, placedCount, gComboCtx.sourceIsRando ? 1 : 0, gComboCtx.sharedRandoSettingsHash,
+                gComboCtx.sharedRandoSeed);
         return 11;
     }
     // ADR 0002: hosting checks keep a legal MM item (RI_JUNK) in the MM save
@@ -370,6 +374,19 @@ extern "C" int MM_Rando_HeadlessForeignDigest(const char* outPath) {
         fprintf(stderr, "[MM-FOREIGN-DIGEST] FAIL(3): paired MM fill dead-ended under the pinned seed — pin a "
                         "different determinism seed\n");
         return 3;
+    }
+
+    // The digest must describe an ACTUAL cross-game world: a paired
+    // generation that placed nothing would produce a stable-but-empty digest,
+    // turning lock (c) vacuous. Fail loudly instead.
+    {
+        const ComboForeignItemDef* digestPool = NULL;
+        const int digestPoolCount = Combo_GetForeignItemPool(&digestPool);
+        if (Combo_CountForeignPlacements() != digestPoolCount) {
+            fprintf(stderr, "[MM-FOREIGN-DIGEST] FAIL(5): expected %d foreign placements, found %d\n", digestPoolCount,
+                    Combo_CountForeignPlacements());
+            return 5;
+        }
     }
 
     // Canonical MM placement blob in fixed check order (std::map), folded

--- a/games/mm/2s2h/mm_rando_gen_test.cpp
+++ b/games/mm/2s2h/mm_rando_gen_test.cpp
@@ -23,16 +23,24 @@
 #include <cstdio>
 #include <cstring>
 #include <fstream>
+#include <string>
 
 #include <ship/Context.h>
 #include <libultraship/bridge/consolevariablebridge.h>
 #include <nlohmann/json.hpp>
 
 #include "2s2h/BenPort.h" // appShortName
+#include "2s2h/GameInteractor/GameInteractor.h" // S2H::GameHooks counters (single-exe tail)
 #include "2s2h/Rando/Rando.h"
+#include "2s2h/Rando/Foreign.h"
 #include "2s2h/Rando/Logic/Logic.h"
 #include "2s2h/Rando/MiscBehavior/MiscBehavior.h"
 #include "2s2h/Rando/StaticData/StaticData.h"
+#include "2s2h/ShipUtils.h"
+
+// src/common — placement table + pool surface (Lane C1). Outside extern "C":
+// it pulls context.h, whose <type_traits> include must not sit in C linkage.
+#include "foreign_items.h"
 
 extern "C" {
 #include "z64save.h"
@@ -107,7 +115,12 @@ extern "C" int MM_Rando_HeadlessGenTest(void) {
         memset(&gSaveContext, 0, sizeof(gSaveContext));
         MM_Sram_InitNewSave();
 
-        Rando::MiscBehavior::OnFileCreate(0);
+        // Through the REAL dispatch chain (Lane C1): this is the exact bridge
+        // MM_Sram_InitSave calls (z_sram_NES.c) — GameInteractor_ExecuteOnSaveInit
+        // -> S2H::GameHooks Execute<OnSaveInit> -> Rando::MiscBehavior::OnFileCreate.
+        // If the bridge is ever re-stubbed (its former mm_stubs.c state),
+        // generation silently never runs and this test fails at FAIL(3).
+        GameInteractor_ExecuteOnSaveInit(0);
 
         // OnFileCreate's catch-path reverts the save type to vanilla on ANY
         // generation failure — a single, reliable failure signal.
@@ -170,13 +183,237 @@ extern "C" int MM_Rando_HeadlessGenTest(void) {
     CVarSetString("gRando.InputSeed", "RSBSMMGL1");
     memset(&gSaveContext, 0, sizeof(gSaveContext));
     MM_Sram_InitNewSave();
-    Rando::MiscBehavior::OnFileCreate(0);
+    GameInteractor_ExecuteOnSaveInit(0);
     fprintf(stderr, "[MM-RANDO-GEN][info] glitchless probe: %s\n",
             gSaveContext.save.shipSaveInfo.saveType == SAVETYPE_RANDO ? "GENERATED" : "dead-ended (known)");
     CVarClear(Rando::StaticData::Options[RO_LOGIC].cvar);
+    CVarSetInteger(Rando::StaticData::Options[RO_LOGIC].cvar, RO_LOGIC_NEARLY_NO_LOGIC);
+
+    // ======================================================================
+    // Paired-world phase (Lane C1, #392) — the spoiler's foreign section
+    // lock. Stamp the Lane B carrier the way OoT's live producer would, then
+    // generate through the real dispatch chain: the single-exe branch in
+    // OnFileCreate must derive the seed from the master seed, swap junk
+    // placements for the pinned OoT items (gComboCtx.foreignPlacements; the
+    // MM table keeps RI_JUNK), and describe every crossing in the spoiler's
+    // "foreign" section. Retries over fixed master seeds mirror the main
+    // phase: an unlucky derived seed can genuinely dead-end the fill.
+    // ======================================================================
+    const ComboForeignItemDef* pool = NULL;
+    const int poolCount = Combo_GetForeignItemPool(&pool);
+    if (poolCount <= 0 || pool == NULL) {
+        fprintf(stderr, "[MM-RANDO-GEN] FAIL(9): pinned foreign pool is empty\n");
+        return 9;
+    }
+
+    ComboContext_Init();
+    gComboCtx.sourceIsRando = true;
+    gComboCtx.sharedRandoSettingsHash = 0x51A7E57Du; // nonzero: "profile recorded" (Lane B contract)
+    static const uint32_t kMasterSeeds[] = { 0x00C0C0A1u, 0x00C0C0A2u, 0x00C0C0A3u, 0x00C0C0A4u, 0x00C0C0A5u };
+    bool pairedGenerated = false;
+    for (uint32_t masterSeed : kMasterSeeds) {
+        gComboCtx.sharedRandoSeed = masterSeed;
+        // The paired branch must IGNORE the user seed; leave a poison value to
+        // prove it (a world generated from this string would name a different
+        // spoiler file than the derived name asserted below).
+        CVarSetString("gRando.InputSeed", "USERSEEDPOISON");
+        memset(&gSaveContext, 0, sizeof(gSaveContext));
+        MM_Sram_InitNewSave();
+        GameInteractor_ExecuteOnSaveInit(0);
+        if (gSaveContext.save.shipSaveInfo.saveType == SAVETYPE_RANDO) {
+            pairedGenerated = true;
+            break;
+        }
+        fprintf(stderr, "[MM-RANDO-GEN] paired master seed %08X dead-ended; trying next\n", masterSeed);
+    }
+    if (!pairedGenerated) {
+        fprintf(stderr, "[MM-RANDO-GEN] FAIL(10): every paired master seed dead-ended\n");
+        return 10;
+    }
+
+    const int placedCount = Combo_CountForeignPlacements();
+    if (placedCount != poolCount) {
+        fprintf(stderr, "[MM-RANDO-GEN] FAIL(11): expected %d foreign placements, found %d\n", poolCount, placedCount);
+        return 11;
+    }
+    // ADR 0002: hosting checks keep a legal MM item (RI_JUNK) in the MM save
+    // table; every recorded placement carries the OoT origin tag.
+    for (int i = 0; i < (int)RSBS_FOREIGN_PLACEMENT_CAP; i++) {
+        const ComboForeignPlacement& p = gComboCtx.foreignPlacements[i];
+        if (p.item.originGame == GAME_NONE) {
+            continue;
+        }
+        if (p.item.originGame != GAME_OOT || Combo_GetForeignItemName(p.item) == NULL) {
+            fprintf(stderr, "[MM-RANDO-GEN] FAIL(12): placement slot %d not a named OoT-tagged pool item\n", i);
+            return 12;
+        }
+        const RandoCheckId hostCheck = (RandoCheckId)p.mmCheckId;
+        if (!RANDO_SAVE_CHECKS[hostCheck].shuffled || RANDO_SAVE_CHECKS[hostCheck].randoItemId != RI_JUNK) {
+            fprintf(stderr, "[MM-RANDO-GEN] FAIL(12): hosting check %u does not hold RI_JUNK in the MM table\n",
+                    (unsigned)p.mmCheckId);
+            return 12;
+        }
+    }
+
+    // The spoiler landed under the DERIVED paired name and describes every
+    // crossing: "foreign" as {checkName: {originGame, item}}, and the human-
+    // readable checks list reads as the foreign item, not junk.
+    std::string pairedSpoilerPath = Ship::Context::GetPathRelativeToAppDirectory(
+        std::string("randomizer/") + "RSBSPAIR" + std::to_string(gComboCtx.sharedRandoSeed) + ".json", appShortName);
+    std::ifstream pairedFile(pairedSpoilerPath);
+    if (!pairedFile.is_open()) {
+        fprintf(stderr, "[MM-RANDO-GEN] FAIL(13): paired spoiler missing at %s (seed derivation broken?)\n",
+                pairedSpoilerPath.c_str());
+        return 13;
+    }
+    nlohmann::json pairedSpoiler;
+    try {
+        pairedFile >> pairedSpoiler;
+    } catch (const std::exception& e) {
+        fprintf(stderr, "[MM-RANDO-GEN] FAIL(13): paired spoiler unparseable: %s\n", e.what());
+        return 13;
+    }
+    if (!pairedSpoiler.contains("foreign") || !pairedSpoiler["foreign"].is_object() ||
+        (int)pairedSpoiler["foreign"].size() != poolCount) {
+        fprintf(stderr, "[MM-RANDO-GEN] FAIL(14): spoiler 'foreign' section missing or wrong size\n");
+        return 14;
+    }
+    for (auto& [checkName, entry] : pairedSpoiler["foreign"].items()) {
+        if (!entry.contains("originGame") || entry["originGame"] != "OOT" || !entry.contains("item")) {
+            fprintf(stderr, "[MM-RANDO-GEN] FAIL(14): foreign entry '%s' malformed\n", checkName.c_str());
+            return 14;
+        }
+        const std::string itemName = entry["item"];
+        if (!pairedSpoiler["checks"].contains(checkName) ||
+            pairedSpoiler["checks"][checkName] != itemName + " (Ocarina of Time)") {
+            fprintf(stderr, "[MM-RANDO-GEN] FAIL(14): checks entry for '%s' does not read as the foreign item\n",
+                    checkName.c_str());
+            return 14;
+        }
+    }
+    fprintf(stderr, "[MM-RANDO-GEN] paired world: %d foreign placements, spoiler foreign section verified\n",
+            placedCount);
+
+    // OnSaveLoad chain lock (Lane C1): dispatching the real save-load bridge
+    // with the rando save live must arm the rando behaviors — the
+    // OnSaveLoadHandler -> OnFileLoad -> COND_HOOK chain registers OnFlagSet
+    // handlers in the MM-owned registry.
+    const size_t flagHooksBefore = S2H::GameHooks::CountForTest<GameInteractor::OnFlagSet>();
+    GameInteractor_ExecuteOnSaveLoad(0);
+    const size_t flagHooksAfter = S2H::GameHooks::CountForTest<GameInteractor::OnFlagSet>();
+    if (flagHooksAfter == 0) {
+        fprintf(stderr, "[MM-RANDO-GEN] FAIL(15): OnSaveLoad dispatch armed no OnFlagSet hooks (%zu -> %zu)\n",
+                flagHooksBefore, flagHooksAfter);
+        return 15;
+    }
+    fprintf(stderr, "[MM-RANDO-GEN] OnSaveLoad dispatch armed rando hooks (OnFlagSet: %zu -> %zu)\n", flagHooksBefore,
+            flagHooksAfter);
+
+    // Leave the shared context clean (this process may run more dispatches).
+    ComboContext_Init();
 
     fprintf(stderr, "[MM-RANDO-GEN] PASS: %zu regions, %d shuffled checks, spoiler written + tagged\n",
             Rando::Logic::Regions.size(), shuffled);
+    return 0;
+}
+
+/**
+ * Foreign-placement determinism digest (Lane C1, #392) — the MM half of the
+ * SeedDeterminism lock. Runs inside the rando-determinism dispatch AFTER the
+ * OoT half generated and its LIVE producer stamped gComboCtx (this bridge
+ * refuses to run otherwise), so the pairing key under test is the real
+ * end-to-end one, not a test fixture. Generates the paired MM world through
+ * the real dispatch chain and APPENDS the MM world identity + every foreign
+ * placement to the digest file; CheckSeedDeterminism's two-process
+ * byte-compare then covers OoT's fill AND the MM fill AND the foreign
+ * placements in one diff.
+ *
+ * Deliberately attempt-free: the derived MM seed is a pure function of the
+ * digest run's pinned OoT seed. If that derivation ever dead-ends the MM
+ * fill, this fails loudly (rather than retrying into a world the derivation
+ * cannot name) and the fix is to pin a different determinism seed.
+ *
+ * Returns 0 on success; nonzero step codes with stderr markers otherwise.
+ */
+extern "C" int MM_Rando_HeadlessForeignDigest(const char* outPath) {
+    if (!Combo_ForeignPairingActive()) {
+        fprintf(stderr, "[MM-FOREIGN-DIGEST] FAIL(1): pairing key not stamped (OoT live producer did not run?)\n");
+        return 1;
+    }
+
+    MM_Rando_Init();
+    if (Rando::Logic::Regions.empty()) {
+        fprintf(stderr, "[MM-FOREIGN-DIGEST] FAIL(2): Logic/Regions graph empty\n");
+        return 2;
+    }
+
+    // Pin every CVar this generation depends on — CVar state can leak between
+    // dispatches through the shared config store, and determinism must not
+    // hinge on which test ran first. No spoiler file: the digest is the
+    // artifact, and skipping the write avoids the same-path-overwrite pitfall
+    // the OoT digest documents.
+    CVarSetInteger("gRando.Enabled", 1);
+    CVarSetInteger("gRando.SpoilerFileIndex", 0);
+    CVarSetInteger("gRando.GenerateSpoiler", 0);
+    CVarSetInteger(Rando::StaticData::Options[RO_LOGIC].cvar, RO_LOGIC_NEARLY_NO_LOGIC);
+    CVarSetString("gRando.InputSeed", "USERSEEDPOISON"); // paired branch must ignore this
+
+    if (gRegEditor == NULL) {
+        static RegEditor sDigestRegEditor = {};
+        gRegEditor = &sDigestRegEditor;
+    }
+
+    memset(&gSaveContext, 0, sizeof(gSaveContext));
+    MM_Sram_InitNewSave();
+    GameInteractor_ExecuteOnSaveInit(0);
+    if (gSaveContext.save.shipSaveInfo.saveType != SAVETYPE_RANDO) {
+        fprintf(stderr, "[MM-FOREIGN-DIGEST] FAIL(3): paired MM fill dead-ended under the pinned seed — pin a "
+                        "different determinism seed\n");
+        return 3;
+    }
+
+    // Canonical MM placement blob in fixed check order (std::map), folded
+    // through the project's FNV-1a — mirrors the OoT digest's placementHash.
+    std::string blob;
+    for (auto& [randoCheckId, randoStaticCheck] : Rando::StaticData::Checks) {
+        if (randoStaticCheck.randoCheckId == RC_UNKNOWN) {
+            continue;
+        }
+        blob += std::to_string((int)randoCheckId);
+        blob += ':';
+        blob += std::to_string((int)RANDO_SAVE_CHECKS[randoCheckId].randoItemId);
+        blob += ';';
+    }
+    const uint32_t mmPlacementHash = Ship_Hash(blob);
+
+    FILE* out = stdout;
+    bool closeOut = false;
+    if (outPath != NULL && outPath[0] != '\0') {
+        out = fopen(outPath, "a"); // APPEND: the OoT half wrote the file first
+        if (out == NULL) {
+            fprintf(stderr, "[MM-FOREIGN-DIGEST] FAIL(4): cannot open digest output '%s'\n", outPath);
+            return 4;
+        }
+        closeOut = true;
+    }
+    fprintf(out,
+            "mmFinalSeed=%08X\n"
+            "mmPlacementHash=%08X\n"
+            "foreignCount=%d\n",
+            gSaveContext.save.shipSaveInfo.rando.finalSeed, mmPlacementHash, Combo_CountForeignPlacements());
+    for (int i = 0; i < (int)RSBS_FOREIGN_PLACEMENT_CAP; i++) {
+        const ComboForeignPlacement& p = gComboCtx.foreignPlacements[i];
+        if (p.item.originGame == GAME_NONE) {
+            continue;
+        }
+        fprintf(out, "foreign%d=%u:%u:%u\n", i, (unsigned)p.mmCheckId, (unsigned)p.item.originGame,
+                (unsigned)p.item.id);
+    }
+    if (closeOut) {
+        fclose(out);
+    }
+    fprintf(stderr, "[MM-FOREIGN-DIGEST] mmFinalSeed=%08X mmPlacementHash=%08X foreign=%d\n",
+            gSaveContext.save.shipSaveInfo.rando.finalSeed, mmPlacementHash, Combo_CountForeignPlacements());
     return 0;
 }
 

--- a/games/mm/src/code/z_actor.c
+++ b/games/mm/src/code/z_actor.c
@@ -32,6 +32,21 @@
 #include "2s2h/ObjectExtension/ActorListIndex.h"
 #include <libultraship/bridge/consolevariablebridge.h>
 
+#ifdef RSBS_SINGLE_EXECUTABLE
+// Lane C1 (#392): MM-side hook dispatch. The unqualified
+// GameInteractor_Execute* calls in this file bind OoT's extern "C" wrappers,
+// which (correctly, #367) no-op while MM is the active game — and OoT's
+// wrapper signatures truncate MM's u32 flags to int16_t, so forwarding
+// through them is the exact typed-surface aliasing the shim architecture
+// exists to prevent. These MM_ twins, defined in
+// games/mm/2s2h/GameExports_SingleExe.cpp, dispatch the MM-owned
+// S2H::GameHooks registries with MM's own types; each call below sits beside
+// the upstream call at the exact point upstream 2S2H dispatched that hook.
+void MM_GameHooks_ExecuteOnFlagSet(FlagType flagType, u32 flag);
+void MM_GameHooks_ExecuteOnSceneFlagSet(s16 sceneId, FlagType flagType, u32 flag);
+void MM_GameHooks_ExecuteOnActorUpdate(Actor* actor);
+#endif
+
 // bss
 // FaultClient sActorFaultClient; // 2 funcs
 
@@ -812,6 +827,9 @@ void MM_Flags_SetSwitch(PlayState* play, s32 flag) {
         play->actorCtx.sceneFlags.switches[(flag & ~0x1F) >> 5] |= 1 << (flag & 0x1F);
         if (previouslyOff) {
             GameInteractor_ExecuteOnSceneFlagSet(play->sceneId, FLAG_CYCL_SCENE_SWITCH, flag);
+#ifdef RSBS_SINGLE_EXECUTABLE
+            MM_GameHooks_ExecuteOnSceneFlagSet(play->sceneId, FLAG_CYCL_SCENE_SWITCH, flag);
+#endif
         }
     }
 }
@@ -844,6 +862,9 @@ void MM_Flags_SetTreasure(PlayState* play, s32 flag) {
     play->actorCtx.sceneFlags.chest |= (1 << flag);
     if (previouslyOff) {
         GameInteractor_ExecuteOnSceneFlagSet(play->sceneId, FLAG_CYCL_SCENE_CHEST, flag);
+#ifdef RSBS_SINGLE_EXECUTABLE
+        MM_GameHooks_ExecuteOnSceneFlagSet(play->sceneId, FLAG_CYCL_SCENE_CHEST, flag);
+#endif
     }
 }
 
@@ -876,6 +897,9 @@ void MM_Flags_SetClear(PlayState* play, s32 roomNumber) {
     play->actorCtx.sceneFlags.clearedRoom |= (1 << roomNumber);
     if (previouslyOff) {
         GameInteractor_ExecuteOnSceneFlagSet(play->sceneId, FLAG_CYCL_SCENE_CLEARED_ROOM, roomNumber);
+#ifdef RSBS_SINGLE_EXECUTABLE
+        MM_GameHooks_ExecuteOnSceneFlagSet(play->sceneId, FLAG_CYCL_SCENE_CLEARED_ROOM, roomNumber);
+#endif
     }
 }
 
@@ -930,6 +954,9 @@ void MM_Flags_SetCollectible(PlayState* play, s32 flag) {
         play->actorCtx.sceneFlags.collectible[(flag & ~0x1F) >> 5] |= 1 << (flag & 0x1F);
         if (previouslyOff) {
             GameInteractor_ExecuteOnSceneFlagSet(play->sceneId, FLAG_CYCL_SCENE_COLLECTIBLE, flag);
+#ifdef RSBS_SINGLE_EXECUTABLE
+            MM_GameHooks_ExecuteOnSceneFlagSet(play->sceneId, FLAG_CYCL_SCENE_COLLECTIBLE, flag);
+#endif
         }
     }
 }
@@ -941,6 +968,9 @@ void Flags_SetWeekEventReg(s32 flag) {
     WEEKEVENTREG((flag) >> 8) = GET_WEEKEVENTREG((flag) >> 8) | ((flag)&0xFF);
     if (previouslyOff) {
         GameInteractor_ExecuteOnFlagSet(FLAG_WEEK_EVENT_REG, flag);
+#ifdef RSBS_SINGLE_EXECUTABLE
+        MM_GameHooks_ExecuteOnFlagSet(FLAG_WEEK_EVENT_REG, flag);
+#endif
     }
 }
 
@@ -958,6 +988,9 @@ void Flags_SetWeekEventRegHorseRace(u8 state) {
     WEEKEVENTREG(92) = WEEKEVENTREG(92) | (u8)((WEEKEVENTREG(92) & ~WEEKEVENTREG_HORSE_RACE_STATE_MASK) | (state));
     if (previousState != state) {
         GameInteractor_ExecuteOnFlagSet(FLAG_WEEK_EVENT_REG_HORSE_RACE, state);
+#ifdef RSBS_SINGLE_EXECUTABLE
+        MM_GameHooks_ExecuteOnFlagSet(FLAG_WEEK_EVENT_REG_HORSE_RACE, state);
+#endif
     }
 }
 
@@ -966,6 +999,9 @@ void MM_Flags_SetEventInf(s32 flag) {
     gSaveContext.eventInf[(flag) >> 4] |= (1 << ((flag)&0xF));
     if (previouslyOff) {
         GameInteractor_ExecuteOnFlagSet(FLAG_EVENT_INF, flag);
+#ifdef RSBS_SINGLE_EXECUTABLE
+        MM_GameHooks_ExecuteOnFlagSet(FLAG_EVENT_INF, flag);
+#endif
     }
 }
 
@@ -988,6 +1024,9 @@ void Flags_SetRandoInf(s32 flag) {
     gSaveContext.save.shipSaveInfo.rando.randoInf[flag >> 4] |= (1 << (flag & 0xF));
     if (previouslyOff) {
         GameInteractor_ExecuteOnFlagSet(FLAG_RANDO_INF, flag);
+#ifdef RSBS_SINGLE_EXECUTABLE
+        MM_GameHooks_ExecuteOnFlagSet(FLAG_RANDO_INF, flag);
+#endif
     }
 }
 
@@ -2790,6 +2829,12 @@ Actor* Actor_UpdateActor(UpdateActor_Params* params) {
                 if (GameInteractor_ShouldActorUpdate(actor)) {
                     actor->update(actor, play);
                     GameInteractor_ExecuteOnActorUpdate(actor);
+#ifdef RSBS_SINGLE_EXECUTABLE
+                    // Lane C1 (#392): MM's own OnActorUpdate dispatch — the
+                    // CheckQueue scan and the GIEvent pump both hang off the
+                    // player's id here (see the declaration-block comment).
+                    MM_GameHooks_ExecuteOnActorUpdate(actor);
+#endif
                 }
                 DynaPoly_UnsetAllInteractFlags(play, &play->colCtx.dyna, actor);
             }

--- a/games/oot/soh/Enhancements/randomizer/ForeignItemsSingleExe.cpp
+++ b/games/oot/soh/Enhancements/randomizer/ForeignItemsSingleExe.cpp
@@ -1,0 +1,126 @@
+/**
+ * ForeignItemsSingleExe.cpp — the pinned foreign-item pool and the OoT-side
+ * redemption give (Phase 3.0 Lane C1, #392; ADR 0002).
+ *
+ * This is the ONE translation unit where the cross-game item class is defined,
+ * because it is the one place the real RG_* enumerators may appear: everything
+ * leaves this TU as an origin-tagged SharedItem (or a plain display string),
+ * so a raw RG_* integer never crosses a game boundary (ADR 0002, the #356 bug
+ * class). MM and the ROM-free test harness reach the pool through the
+ * extern "C" surface declared in src/common/foreign_items.h.
+ *
+ * Pool choice (C0 handoff on #392): ~4 OoT progression items with clean give
+ * semantics. The handoff's example list named RG_PROGRESSIVE_STRENGTH_UPGRADE,
+ * which does not exist; the real enumerator is RG_PROGRESSIVE_STRENGTH.
+ *
+ * Redemption give: progressive entries resolve against the LIVE save via
+ * Item::GetGIEntry_Copy() — Logic's save context is pointed at gSaveContext on
+ * every save load (SaveManager.cpp / savefile.cpp), so this is the same
+ * resolution SoH's own in-game gives use — then dispatch mirrors
+ * savefile.cpp's StartingItemGive: MOD_NONE entries through OoT_Item_Give
+ * (the NULL-play starting-item precedent), MOD_RANDOMIZER entries through
+ * Randomizer_Item_Give.
+ *
+ * Lives in soh/Enhancements/randomizer/ (soh_rando) which links WHOLE_ARCHIVE,
+ * so these definitions always survive the link.
+ */
+#ifdef RSBS_SINGLE_EXECUTABLE
+
+#include <cstdio>
+
+#include "soh/OTRGlobals.h"
+#include "soh/Enhancements/randomizer/randomizerTypes.h"
+#include "soh/Enhancements/randomizer/static_data.h"
+#include "soh/Enhancements/randomizer/item.h"
+#include "soh/Enhancements/randomizer/SeedContext.h"
+#include "soh/Enhancements/randomizer/logic.h"
+
+#include "foreign_items.h" // src/common — ComboForeignItemDef, SharedItem
+
+extern "C" {
+#include <z64.h>
+#include "variables.h"
+#include "functions.h" // OoT_Item_Give
+u16 Randomizer_Item_Give(PlayState* play, GetItemEntry giEntry);
+}
+
+// savefile.cpp's rupee helper (C++ linkage there; no header of its own).
+void GiveLinkRupees(int numOfRupees);
+
+// ============================================================================
+// The pinned pool ("foreign item class v1")
+// ============================================================================
+
+// Aggregate member-wise init is the sanctioned way to build a SharedItem (the
+// ADR's static_asserts reject raw-integer conversion; explicit members carry
+// the tag). Values must fit the struct's uint8_t/uint16_t members — a
+// constant-expression enumerator that fits is not a narrowing conversion.
+static const ComboForeignItemDef kForeignPoolV1[] = {
+    { { (uint8_t)GAME_OOT, 0, (uint16_t)RG_PROGRESSIVE_HOOKSHOT }, "Progressive Hookshot" },
+    { { (uint8_t)GAME_OOT, 0, (uint16_t)RG_FAIRY_BOW }, "Fairy Bow" },
+    { { (uint8_t)GAME_OOT, 0, (uint16_t)RG_BOMB_BAG }, "Bomb Bag" },
+    { { (uint8_t)GAME_OOT, 0, (uint16_t)RG_PROGRESSIVE_STRENGTH }, "Progressive Strength Upgrade" },
+};
+
+static constexpr int kForeignPoolCount = sizeof(kForeignPoolV1) / sizeof(kForeignPoolV1[0]);
+static_assert(kForeignPoolCount <= (int)RSBS_FOREIGN_PLACEMENT_CAP,
+              "the pinned foreign pool must fit the gComboCtx placement carve");
+
+extern "C" int Combo_GetForeignItemPool(const ComboForeignItemDef** outPool) {
+    if (outPool != nullptr) {
+        *outPool = kForeignPoolV1;
+    }
+    return kForeignPoolCount;
+}
+
+extern "C" const char* Combo_GetForeignItemName(SharedItem item) {
+    for (const ComboForeignItemDef& def : kForeignPoolV1) {
+        if (def.item.originGame == item.originGame && def.item.id == item.id) {
+            return def.name;
+        }
+    }
+    return nullptr;
+}
+
+// ============================================================================
+// Redemption give (called by OoT_AwardSharedItem, the A1 consumer callback)
+// ============================================================================
+
+extern "C" int OoT_ForeignItem_Give(uint16_t rgId) {
+    // Progressive resolution walks Rando::Context / Logic / OTRGlobals; all
+    // three exist once OoT has booted to gameplay, which the presence-gated
+    // consumption point guarantees. Guard anyway: a give we cannot perform is
+    // logged loudly rather than crashing the arrival path.
+    if (OTRGlobals::Instance == nullptr || OTRGlobals::Instance->gRandomizer == nullptr ||
+        Rando::Context::GetInstance() == nullptr || Rando::Context::GetInstance()->GetLogic() == nullptr) {
+        fprintf(stderr, "[OoT] foreign give unavailable (rando context not live), RG id=%u\n", (unsigned)rgId);
+        return 0;
+    }
+
+    const GetItemEntry entry = Rando::StaticData::RetrieveItem((RandomizerGet)rgId).GetGIEntry_Copy();
+
+    // Mirror savefile.cpp's StartingItemGive dispatch (NULL play: the
+    // starting-item precedent; none of the pool's resolved entries touch play).
+    if (entry.modIndex == MOD_NONE) {
+        if (entry.itemId >= ITEM_RUPEE_GREEN && entry.itemId <= ITEM_RUPEE_GOLD) {
+            static const int kRupeeCounts[] = { 1, 5, 20, 50, 200 };
+            GiveLinkRupees(kRupeeCounts[entry.itemId - ITEM_RUPEE_GREEN]);
+        } else {
+            OoT_Item_Give(NULL, (uint8_t)entry.itemId);
+        }
+        return 1;
+    }
+    if (entry.modIndex == MOD_RANDOMIZER) {
+        if (entry.getItemId == RG_ICE_TRAP) {
+            gSaveContext.ship.pendingIceTrapCount++;
+        } else {
+            Randomizer_Item_Give(NULL, entry);
+        }
+        return 1;
+    }
+
+    fprintf(stderr, "[OoT] foreign give: unhandled modIndex %d for RG id=%u\n", (int)entry.modIndex, (unsigned)rgId);
+    return 0;
+}
+
+#endif // RSBS_SINGLE_EXECUTABLE

--- a/games/oot/soh/GameExports_SingleExe.cpp
+++ b/games/oot/soh/GameExports_SingleExe.cpp
@@ -20,6 +20,7 @@
 #include "integration_test_hooks.h"
 #include "context.h"
 #include "shared_items.h"
+#include "foreign_items.h" // OoT_ForeignItem_Give (Lane C1 redemption)
 #include "entrance.h"
 #include "soh/Enhancements/game-interactor/GameInteractor.h"
 #include "soh/Enhancements/game-interactor/GameInteractor_Hooks.h"
@@ -999,24 +1000,28 @@ extern "C" int Combo_FreezeActiveGameForHotSwap(GameId departing) {
 }
 
 /**
- * Award a single OoT-origin shared item (ADR 0002 / Lane A1 consumer callback).
+ * Award a single OoT-origin shared item (ADR 0002 / Lane A1 consumer callback,
+ * real give wired by Lane C1 #392).
  *
  * Invoked once per un-redeemed entry tagged GAME_OOT when the player arrives in
  * OoT (see OoT_ConsumeSharedItems). `item->id` is an OoT RandomizerGet (RG_*).
  *
- * Lane A1 scope: this is the plumbing seam. Awarding an RG_* into the live game
- * requires the randomizer save context and the foreign-item presentation Lane C
- * owns, so here it only logs; Combo_RedeemSharedItemsForGame still marks the
- * entry RSBS_SHARED_ITEM_REDEEMED so the crossing is single-use once wired.
- *
- * Lane C: replace the log with the real give — Randomizer_Item_Give
- * ((RandomizerGet)item->id) (games/oot/soh/.../randomizer.cpp) — for the chosen
- * foreign-item class. Do NOT clear the entry; the REDEEMED bit is the guard.
+ * The give itself lives in OoT_ForeignItem_Give
+ * (soh/Enhancements/randomizer/ForeignItemsSingleExe.cpp): GetGIEntry
+ * resolution (progressives resolve against the live save) + the
+ * StartingItemGive-style dispatch into OoT_Item_Give / Randomizer_Item_Give.
+ * Combo_RedeemSharedItemsForGame marks the entry RSBS_SHARED_ITEM_REDEEMED
+ * after this returns, so the crossing stays single-use; the entry is never
+ * cleared (the durable record of the crossing). A give that reports failure is
+ * logged but still consumes the redemption — by the time this callback can
+ * run, OoT is at its presence-gated arrival point and the guarded
+ * prerequisites are live, so that path is defensive, not expected.
  */
 static void OoT_AwardSharedItem(const SharedItem* item, void* ctx) {
     (void)ctx;
-    fprintf(stderr, "[OoT] shared-item redeem (Lane A1 plumbing): RG id=%u — Lane C wires Randomizer_Item_Give\n",
-            (unsigned)item->id);
+    int given = OoT_ForeignItem_Give(item->id);
+    fprintf(stderr, "[OoT] shared-item redeem: RG id=%u %s (Lane C1 foreign give)\n", (unsigned)item->id,
+            given ? "awarded" : "NOT awarded — give path unavailable");
 }
 
 /**

--- a/src/common/context.h
+++ b/src/common/context.h
@@ -192,7 +192,7 @@ RSBS_CTX_STATIC_ASSERT(offsetof(SharedItem, originGame) == 0 && offsetof(SharedI
  * Why this lives in gComboCtx and not in MM's own rando save table (ADR 0002):
  * MM's RandoSaveCheckInfo.randoItemId is an MM RandoItemId — a raw RG_* stored
  * there would alias MM's id-space, the #356 bug class. The MM save table keeps
- * a legal MM item (RI_JUNK) at the hosting check; THIS table, keyed by the MM
+ * a legal junk-class MM item at the hosting check; THIS table, keyed by the MM
  * RandoCheckId, is what says "that check actually yields a foreign item", with
  * the item carried as an origin-tagged SharedItem at every boundary.
  *

--- a/src/common/context.h
+++ b/src/common/context.h
@@ -148,6 +148,14 @@ void Context_UpdateShadowCopy(GameId game, const void* saveContext, size_t size)
 #define RSBS_SHARED_ITEM_REDEEMED 0x01u
 
 /**
+ * Capacity of ComboContext.foreignPlacements (Lane C1, #392). The MVP pins ~4
+ * OoT progression items into MM checks; 8 slots leave headroom without
+ * spending reserved[] bytes we would rather keep (growing later is legal under
+ * the growth contract).
+ */
+#define RSBS_FOREIGN_PLACEMENT_CAP 8u
+
+/**
  * One cross-game item, tagged with the game whose id-space `id` belongs to.
  *
  * Why a struct and not a packed integer (ADR 0002): OoT's RandomizerGet (RG_*)
@@ -176,6 +184,33 @@ RSBS_CTX_STATIC_ASSERT(sizeof(SharedItem) == 4,
 RSBS_CTX_STATIC_ASSERT(offsetof(SharedItem, originGame) == 0 && offsetof(SharedItem, flags) == 1 &&
                            offsetof(SharedItem, id) == 2,
                        "SharedItem member offsets are .redsave format and must not move");
+
+/**
+ * One cross-game item PLACEMENT: an MM check that hosts an item from another
+ * game's id-space (Lane C1, #392; MVP direction is OoT items in MM checks).
+ *
+ * Why this lives in gComboCtx and not in MM's own rando save table (ADR 0002):
+ * MM's RandoSaveCheckInfo.randoItemId is an MM RandoItemId — a raw RG_* stored
+ * there would alias MM's id-space, the #356 bug class. The MM save table keeps
+ * a legal MM item (RI_JUNK) at the hosting check; THIS table, keyed by the MM
+ * RandoCheckId, is what says "that check actually yields a foreign item", with
+ * the item carried as an origin-tagged SharedItem at every boundary.
+ *
+ * Zero means unset for every member (growth contract): a slot is occupied iff
+ * item.originGame != GAME_NONE (mmCheckId 0 == MM's RC_UNKNOWN, which never
+ * hosts anything). A zero-extended legacy record therefore reads as "no
+ * foreign placements", which is correct: pre-C1 worlds have none.
+ */
+typedef struct {
+    uint16_t mmCheckId; // MM RandoCheckId hosting the foreign item; RC_UNKNOWN (0) when empty
+    SharedItem item;    // the foreign item, origin-tagged; originGame == GAME_NONE marks an empty slot
+} ComboForeignPlacement;
+
+RSBS_CTX_STATIC_ASSERT(sizeof(ComboForeignPlacement) == 6,
+                       "ComboForeignPlacement is serialized raw inside the .redsave Tier-1 record; its layout is "
+                       "format");
+RSBS_CTX_STATIC_ASSERT(offsetof(ComboForeignPlacement, mmCheckId) == 0 && offsetof(ComboForeignPlacement, item) == 2,
+                       "ComboForeignPlacement member offsets are .redsave format and must not move");
 
 typedef struct {
     char magic[8];        // "OoT+MM<3"
@@ -231,14 +266,23 @@ typedef struct {
     // unchanged.
     uint32_t sharedRandoSettingsHash;
 
+    // Lane C1 (#392): cross-game item placements for the paired world, written
+    // by MM's OnFileCreate placement pass when a paired rando world generates,
+    // read by MM's give path (which check yields a foreign item) and by both
+    // spoiler surfaces. Carved from the FRONT of the old reserved[380] under
+    // the growth contract: all-zero = no foreign placements, which is exactly
+    // what a zero-extended pre-C1 record must read as. See foreign_items.h for
+    // the accessors; raw entries must always carry the origin tag (ADR 0002).
+    ComboForeignPlacement foreignPlacements[RSBS_FOREIGN_PLACEMENT_CAP];
+
     // Headroom. Carve new fields from the FRONT of this array (as
-    // sharedItemsTagged and sharedRandoSettingsHash were) so the struct stays
-    // inside RSBS_COMBO_CONTEXT_RECORD_SIZE; the on-disk record size does not
-    // change either way, so old saves keep loading. Zeroed by ComboContext_Init,
-    // which is what makes a zero-extended legacy record indistinguishable from a
-    // freshly-initialized one — every field carved from here must keep "zero
-    // means unset".
-    uint8_t reserved[380];
+    // sharedItemsTagged, sharedRandoSettingsHash, and foreignPlacements were)
+    // so the struct stays inside RSBS_COMBO_CONTEXT_RECORD_SIZE; the on-disk
+    // record size does not change either way, so old saves keep loading.
+    // Zeroed by ComboContext_Init, which is what makes a zero-extended legacy
+    // record indistinguishable from a freshly-initialized one — every field
+    // carved from here must keep "zero means unset".
+    uint8_t reserved[332];
 } ComboContext;
 
 /**
@@ -275,11 +319,21 @@ RSBS_CTX_STATIC_ASSERT(offsetof(ComboContext, sharedRandoSettingsHash) ==
                            RSBS_COMBO_CONTEXT_PRECARVE_SIZE + RSBS_SHARED_ITEM_CAP * sizeof(SharedItem),
                        "sharedRandoSettingsHash must be carved from the FRONT of the old reserved[] "
                        "(contiguous with the tagged-item array); moving it changes .redsave format");
-RSBS_CTX_STATIC_ASSERT(offsetof(ComboContext, reserved) ==
+// foreignPlacements is the next carve from the front of the old reserved[]:
+// it must sit immediately after the settings digest with no gap, occupying
+// bytes every shipped .redsave stored as zero (unset).
+RSBS_CTX_STATIC_ASSERT(offsetof(ComboContext, foreignPlacements) ==
                            RSBS_COMBO_CONTEXT_PRECARVE_SIZE + RSBS_SHARED_ITEM_CAP * sizeof(SharedItem) +
                                sizeof(uint32_t),
-                       "the tagged-item array, the settings digest, and the remaining headroom must "
-                       "stay contiguous (no padding, no fields slipped between them)");
+                       "foreignPlacements must be carved from the FRONT of the old reserved[] "
+                       "(contiguous with the settings digest); moving it changes .redsave format");
+RSBS_CTX_STATIC_ASSERT(offsetof(ComboContext, reserved) ==
+                           RSBS_COMBO_CONTEXT_PRECARVE_SIZE + RSBS_SHARED_ITEM_CAP * sizeof(SharedItem) +
+                               sizeof(uint32_t) +
+                               RSBS_FOREIGN_PLACEMENT_CAP * sizeof(ComboForeignPlacement),
+                       "the tagged-item array, the settings digest, the foreign-placement table, and "
+                       "the remaining headroom must stay contiguous (no padding, no fields slipped "
+                       "between them)");
 
 #ifdef __cplusplus
 // The raw-assignment-fails proof (ADR 0002). In C this is a constraint
@@ -292,6 +346,9 @@ static_assert(!std::is_assignable<SharedItem&, int>::value && !std::is_assignabl
               "a raw integer must never be assignable into a SharedItem — tag the origin game");
 static_assert(!std::is_assignable<SharedItem&, GameId>::value,
               "a bare GameId is not a SharedItem either; populate the struct members explicitly");
+static_assert(!std::is_convertible<int, ComboForeignPlacement>::value &&
+                  !std::is_assignable<ComboForeignPlacement&, int>::value,
+              "a raw integer must never become a foreign placement — the item member carries the origin tag");
 static_assert(std::is_trivially_copyable<ComboContext>::value,
               "gComboCtx is serialized with memcpy; ComboContext must stay trivially copyable");
 #endif

--- a/src/common/foreign_items.c
+++ b/src/common/foreign_items.c
@@ -1,0 +1,86 @@
+/**
+ * @file foreign_items.c
+ * @brief Foreign-item placement table accessors (Phase 3.0 Lane C1, #392).
+ *
+ * See foreign_items.h for the model. Like shared_items.c, this TU is
+ * deliberately free of game headers: it manipulates the ADR-0002 tagged types
+ * and gComboCtx only, so it compiles into redship_common and both games (and
+ * the ROM-free test harness) call it directly. The pinned POOL half of the
+ * header (Combo_GetForeignItemPool / Combo_GetForeignItemName /
+ * OoT_ForeignItem_Give) is defined OoT-side, where the RG_* enumerators are
+ * in scope.
+ */
+
+#include "foreign_items.h"
+#include <stdio.h>
+
+bool Combo_ForeignPairingActive(void) {
+    return gComboCtx.sourceIsRando && gComboCtx.sharedRandoSettingsHash != 0;
+}
+
+int Combo_SetForeignPlacement(uint16_t mmCheckId, SharedItem item) {
+    if (mmCheckId == 0 || item.originGame == (uint8_t)GAME_NONE) {
+        return -1; // RC_UNKNOWN never hosts; an untagged item must not enter the table
+    }
+
+    int firstFree = -1;
+    for (int i = 0; i < (int)RSBS_FOREIGN_PLACEMENT_CAP; i++) {
+        ComboForeignPlacement* slot = &gComboCtx.foreignPlacements[i];
+        if (slot->item.originGame == (uint8_t)GAME_NONE) {
+            if (firstFree < 0) {
+                firstFree = i;
+            }
+            continue;
+        }
+        if (slot->mmCheckId == mmCheckId) {
+            fprintf(stderr, "[ForeignItem] placement rejected: MM check %u already hosts origin=%u id=%u\n",
+                    (unsigned)mmCheckId, (unsigned)slot->item.originGame, (unsigned)slot->item.id);
+            return -1; // one check hosts at most one foreign item
+        }
+    }
+
+    if (firstFree < 0) {
+        fprintf(stderr, "[ForeignItem] placement dropped: table full (%u slots), check=%u id=%u\n",
+                RSBS_FOREIGN_PLACEMENT_CAP, (unsigned)mmCheckId, (unsigned)item.id);
+        return -1;
+    }
+
+    ComboForeignPlacement* dst = &gComboCtx.foreignPlacements[firstFree];
+    dst->mmCheckId = mmCheckId;
+    dst->item = item;
+    fprintf(stderr, "[ForeignItem] placed origin=%u id=%u at MM check %u (slot %d)\n", (unsigned)item.originGame,
+            (unsigned)item.id, (unsigned)mmCheckId, firstFree);
+    return firstFree;
+}
+
+const SharedItem* Combo_GetForeignPlacementForCheck(uint16_t mmCheckId) {
+    if (mmCheckId == 0) {
+        return NULL;
+    }
+    for (int i = 0; i < (int)RSBS_FOREIGN_PLACEMENT_CAP; i++) {
+        const ComboForeignPlacement* slot = &gComboCtx.foreignPlacements[i];
+        if (slot->item.originGame != (uint8_t)GAME_NONE && slot->mmCheckId == mmCheckId) {
+            return &slot->item;
+        }
+    }
+    return NULL;
+}
+
+int Combo_CountForeignPlacements(void) {
+    int count = 0;
+    for (int i = 0; i < (int)RSBS_FOREIGN_PLACEMENT_CAP; i++) {
+        if (gComboCtx.foreignPlacements[i].item.originGame != (uint8_t)GAME_NONE) {
+            count++;
+        }
+    }
+    return count;
+}
+
+void Combo_ClearForeignPlacements(void) {
+    for (int i = 0; i < (int)RSBS_FOREIGN_PLACEMENT_CAP; i++) {
+        gComboCtx.foreignPlacements[i].mmCheckId = 0;
+        gComboCtx.foreignPlacements[i].item.originGame = (uint8_t)GAME_NONE;
+        gComboCtx.foreignPlacements[i].item.flags = 0;
+        gComboCtx.foreignPlacements[i].item.id = 0;
+    }
+}

--- a/src/common/foreign_items.h
+++ b/src/common/foreign_items.h
@@ -1,0 +1,117 @@
+/**
+ * @file foreign_items.h
+ * @brief Cross-game (foreign) item placements and the pinned foreign-item pool
+ *        (Phase 3.0 Lane C1, #392; ADR 0002).
+ *
+ * The MVP contract ships ONE direction, ONE item class: a pinned set of OoT
+ * progression items placeable into MM checks. Two data surfaces live behind
+ * this header:
+ *
+ *  1. The PLACEMENT TABLE — `gComboCtx.foreignPlacements[]` (context.h), the
+ *     serialized record of "MM check X hosts foreign item Y". Written once by
+ *     MM's generation pass (Rando::Foreign::PlaceForeignItems at OnFileCreate)
+ *     when a paired world generates; read by MM's give path and both spoiler
+ *     surfaces. The MM save's own check table keeps a legal MM item (RI_JUNK)
+ *     at hosting checks — a raw RG_* never enters an MM table (ADR 0002).
+ *
+ *  2. The PINNED POOL — the fixed foreign-item class. Its table is DEFINED on
+ *     the OoT side (games/oot/soh/Enhancements/randomizer/
+ *     ForeignItemsSingleExe.cpp), the only place the real RG_* enumerators are
+ *     in scope, and served here as origin-tagged SharedItems plus stable
+ *     display names. MM and the tests consume it through these C entry points
+ *     and never see an OoT header.
+ *
+ * The give-time flow (who calls what):
+ *   MM CheckQueue foreign branch -> Combo_GetForeignPlacementForCheck ->
+ *   Combo_RecordSharedItem (shared_items.h; durable immediately) -> presented
+ *   with Combo_GetForeignItemName. On the next arrival in OoT, A1's consumer
+ *   (Combo_RedeemSharedItemsForGame) awards it via OoT_ForeignItem_Give and
+ *   marks it RSBS_SHARED_ITEM_REDEEMED — single-use per crossing.
+ */
+
+#ifndef RSBS_COMMON_FOREIGN_ITEMS_H
+#define RSBS_COMMON_FOREIGN_ITEMS_H
+
+#include "context.h" // SharedItem, ComboForeignPlacement, gComboCtx, RSBS_FOREIGN_PLACEMENT_CAP
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * One pinned foreign-item class member: the origin-tagged item plus its
+ * stable, human-readable name (used by the MM textbox presentation and by
+ * both spoiler surfaces — the name is deliberately game-neutral text so the
+ * spoiler stays meaningful without OoT's enum in scope).
+ */
+typedef struct {
+    SharedItem item;  // originGame == GAME_OOT, flags == 0, id == the RG_* value
+    const char* name; // e.g. "Progressive Hookshot"
+} ComboForeignItemDef;
+
+/**
+ * The pinned foreign-item pool (defined OoT-side, see the file header).
+ * @param outPool receives a pointer to the static pool table (never NULL on a
+ *                nonzero return)
+ * @return the number of pool entries
+ */
+int Combo_GetForeignItemPool(const ComboForeignItemDef** outPool);
+
+/**
+ * Display/spoiler name for a foreign item, or NULL if (originGame, id) is not
+ * in the pinned pool. Flags are ignored on purpose: a redeemed entry keeps its
+ * name.
+ */
+const char* Combo_GetForeignItemName(SharedItem item);
+
+// ============================================================================
+// Placement table accessors (gComboCtx.foreignPlacements)
+// ============================================================================
+
+/**
+ * True when the paired-world keying is satisfied: an OoT rando world was
+ * generated in the live path (gComboCtx.sourceIsRando) AND it recorded its
+ * settings profile digest (sharedRandoSettingsHash != 0 — Lane B's carrier
+ * contract: 0 means "no profile recorded" and the worlds must not pair).
+ */
+bool Combo_ForeignPairingActive(void);
+
+/**
+ * Record "MM check `mmCheckId` hosts `item`". Rejects (returning -1) an unset
+ * item tag, an mmCheckId of 0 (MM's RC_UNKNOWN), a full table, or a duplicate
+ * mmCheckId — one check hosts at most one foreign item.
+ * @return the slot index used (>= 0), or -1.
+ */
+int Combo_SetForeignPlacement(uint16_t mmCheckId, SharedItem item);
+
+/**
+ * The foreign item hosted by MM check `mmCheckId`, or NULL if that check hosts
+ * none. The returned pointer aliases gComboCtx (read-only use).
+ */
+const SharedItem* Combo_GetForeignPlacementForCheck(uint16_t mmCheckId);
+
+/** Number of occupied placement slots. */
+int Combo_CountForeignPlacements(void);
+
+/**
+ * Wipe the placement table. Called by MM's placement pass before re-placing
+ * (a re-generated MM world must not inherit a previous world's placements).
+ */
+void Combo_ClearForeignPlacements(void);
+
+/**
+ * OoT-side redemption give (defined in ForeignItemsSingleExe.cpp): resolve the
+ * RG_* id to its GetItemEntry — progressive items resolve against the LIVE
+ * save, the same path SoH's own in-game gives take — and hand it to the
+ * matching give routine (OoT_Item_Give for vanilla-equivalent entries,
+ * Randomizer_Item_Give for MOD_RANDOMIZER entries).
+ * @return 1 if the item was given, 0 if the give path was unavailable (logged;
+ *         the redemption bit is set by the caller's consumer either way).
+ */
+int OoT_ForeignItem_Give(uint16_t rgId);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // RSBS_COMMON_FOREIGN_ITEMS_H

--- a/src/common/mm_stubs.c
+++ b/src/common/mm_stubs.c
@@ -98,8 +98,12 @@ void GameInteractor_ExecuteOnPlayDrawWorldEnd(void* play) { (void)play; }
 void GameInteractor_ExecuteOnInterfaceDrawStart(void* play) { (void)play; }
 void GameInteractor_ExecuteBeforeKaleidoDrawPage(void* state, int page) { (void)state; (void)page; }
 void GameInteractor_ExecuteAfterKaleidoDrawPage(void* state, int page) { (void)state; (void)page; }
-void GameInteractor_ExecuteOnSaveInit(int fileNum) { (void)fileNum; }
-void GameInteractor_ExecuteOnSaveLoad(int fileNum) { (void)fileNum; }
+/* GameInteractor_ExecuteOnSaveInit / GameInteractor_ExecuteOnSaveLoad moved to
+ * real, header-checked dispatch in games/mm/2s2h/GameExports_SingleExe.cpp
+ * (Lane C1, #392): they now Execute the MM-owned S2H::GameHooks registries
+ * (OnSaveInit -> Rando::MiscBehavior::OnFileCreate at MM_Sram_InitSave,
+ * OnSaveLoad -> Rando's OnSaveLoadHandler at the file-select/opening loads).
+ * Re-stubbing them here would silently sever MM rando generation. */
 /* GameInteractor_ExecuteOnOpenText resolves to OoT's wrapper in
  * games/oot/soh/Enhancements/game-interactor/GameInteractor_Hooks.cpp
  * (signature (uint16_t* textId, bool* loadFromMessageTable), #228). That

--- a/src/common/test_runner.cpp
+++ b/src/common/test_runner.cpp
@@ -103,6 +103,12 @@ extern "C" {
 // FILE SCOPE (compiled as C++): they drive the C++-linkage rsbs::SaveManager.
 #include "tests/test_save_roundtrip.c"
 
+// Lane C1 foreign-item pipeline locks (#392, ADR 0002): give-path tagging,
+// round-trip survival with a real pool entry, and the foreignPlacements carve
+// serialization. FILE SCOPE (compiled as C++) for rsbs::SaveManager; the
+// pipeline symbols it drives are C-linkage and declared in the file.
+#include "tests/test_foreign_items.c"
+
 // MM scene-command parse regression (issue #344). Included at FILE SCOPE
 // (compiled as C++): it drives MM's S2H::ResourceFactoryBinarySceneV0 directly
 // over a synthetic scene buffer — no ROM archives or display needed.
@@ -276,6 +282,12 @@ extern "C" int Rando_HeadlessSeedTest(const char* seedStr);
 // success. Kept behind a C entry point so the OoT randomizer headers never enter
 // this delicate multi-include TU, mirroring MM_SceneExecute_RunHeadless.
 extern "C" int Rando_HeadlessSeedDeterminismDigest(const char* seedStr, const char* outPath);
+// Lane C1 foreign-placement determinism (body in games/mm/2s2h/
+// mm_rando_gen_test.cpp): generates the PAIRED MM world keyed off the
+// gComboCtx the OoT digest run just stamped and APPENDS the MM world identity
+// + every foreign placement to the same digest file, so the SeedDeterminism
+// two-process diff covers the whole paired world.
+extern "C" int MM_Rando_HeadlessForeignDigest(const char* outPath);
 extern "C" void InitOTRForMMFirstBoot(int argc, char* argv[]);
 
 TestResult Test_RandoGen(void) {
@@ -329,7 +341,18 @@ TestResult Test_RandoDeterminism(void) {
     const char* digestOut = std::getenv("RSBS_SEED_DIGEST_OUT");  // NULL => digest to stdout
     int rc = Rando_HeadlessSeedDeterminismDigest(seed, digestOut);
     printf("[TEST] %s: determinism digest rc=%d\n", rc == 0 ? "PASS" : "FAIL", rc);
-    return rc == 0 ? TEST_PASS : TEST_FAIL;
+    if (rc != 0) {
+        return TEST_FAIL;
+    }
+
+    // Lane C1: the MM half of the paired world, keyed off the gComboCtx the
+    // live OoT producer stamped during the generation above — the real
+    // end-to-end pairing path. Appends to the same digest, so the
+    // SeedDeterminism diff locks OoT fill + MM fill + foreign placements
+    // together.
+    int mmRc = MM_Rando_HeadlessForeignDigest(digestOut);
+    printf("[TEST] %s: foreign-placement digest rc=%d\n", mmRc == 0 ? "PASS" : "FAIL", mmRc);
+    return mmRc == 0 ? TEST_PASS : TEST_FAIL;
 }
 
 // Lane C0 reachability lock (#392): MM's 2ship_rando is un-elided and
@@ -946,6 +969,10 @@ const TestDescriptor gTests[] = {
     {"shared-roundtrip", "Shared flag/seed survive OoT->MM switch (issue #264)", Test_SharedStateRoundtrip},
     {"shared-item-roundtrip", "Origin-tagged item survives suspend->switch->resume x2, both dirs (ADR 0002)",
      Test_SharedItemRoundtrip},
+    // Lane C1: the foreign-item give path tags the shared structure, the
+    // crossing awards exactly once, and the placement carve serializes.
+    {"foreign-item-give", "Foreign give path tags shared structure; awards once; placements serialize (Lane C1)",
+     Test_ForeignItemGive},
     {"context", "Test context/state management", Test_Context},
     // Clears all frozen states on entry and exit, so it must not run between a
     // test that freezes and one that expects that freeze to still be there.

--- a/src/common/tests/test_foreign_items.c
+++ b/src/common/tests/test_foreign_items.c
@@ -1,0 +1,209 @@
+/**
+ * @file test_foreign_items.c
+ * @brief ROM-free locks for the Lane C1 foreign-item pipeline (#392, ADR 0002).
+ *
+ * Three of the C1 CI locks live here:
+ *
+ *  (a) GIVE-PATH TAGGING: a foreign item entering the REAL give-path core
+ *      (MM_Rando_Foreign_RecordPickup -> Rando::Foreign::RecordForeignPickup,
+ *      the exact function MM's CheckQueue foreign branch calls) lands in
+ *      gComboCtx.sharedItemsTagged correctly origin-tagged, and a re-fired
+ *      give de-dups instead of double-recording.
+ *
+ *  (b) ROUND-TRIP SURVIVAL (the SharedItemRoundtrip sibling, with a REAL
+ *      pool entry rather than an arbitrary id): the recorded crossing
+ *      survives the MM suspend -> OoT arrival leg through the real
+ *      freeze/consume + consumer hooks, is awarded exactly once with the
+ *      pool item's id, and never awards again.
+ *
+ *  (+) CARVE SERIALIZATION: gComboCtx.foreignPlacements round-trips
+ *      byte-exact through a .redsave Save/Load, and unset slots stay unset
+ *      (the growth contract's zero-means-unset, mirroring SaveTaggedItems).
+ *
+ * The pinned pool itself is also sanity-locked: every entry must be tagged
+ * GAME_OOT with a nonzero id and a display name, and the name lookup must
+ * round-trip — the MM textbox and both spoiler surfaces depend on it.
+ *
+ * Linkage note: #included into test_runner.cpp at FILE SCOPE (compiled as
+ * C++, like test_save_roundtrip.c) for the rsbs::SaveManager half; every
+ * pipeline symbol it drives is C-linkage.
+ */
+
+#include "../context.h"
+#include "../foreign_items.h"
+#include "../save.h"
+#include "../shared_items.h"
+#include "../test_runner.h"
+
+#include <cstdio>
+#include <cstring>
+
+// The C-linkage pipeline pieces this test drives (declared locally like
+// test_shared_state_roundtrip.c does for the switch policy).
+extern "C" {
+int MM_Rando_Foreign_RecordPickup(uint16_t randoCheckId);
+int Switch_PrepareHotSwap(GameId departing, const void* saveContext, size_t size);
+int Combo_ConsumeFrozenState(const char* gameId, void* saveContext, size_t size);
+}
+
+#define FI_ASSERT(cond)                                                                                                \
+    do {                                                                                                               \
+        if (!(cond)) {                                                                                                 \
+            printf("[TEST] FAIL: %s:%d: %s\n", __FILE__, __LINE__, #cond);                                             \
+            return TEST_FAIL;                                                                                          \
+        }                                                                                                              \
+    } while (0)
+
+namespace {
+// Arbitrary MM RandoCheckId values for the common-layer accessors: the table
+// stores them opaquely (MM interprets them), so any nonzero u16 exercises the
+// format. Zero is RC_UNKNOWN and must be rejected.
+const uint16_t kForeignTestCheckA = 0x0123;
+const uint16_t kForeignTestCheckB = 0x0456;
+const char* const kForeignSaveDir = "rsbs_test_saves_foreign";
+
+struct ForeignAwardCtx {
+    int awardCount;
+    uint16_t lastId;
+    uint8_t lastOrigin;
+};
+
+void ForeignTestAward(const SharedItem* item, void* ctx) {
+    ForeignAwardCtx* c = (ForeignAwardCtx*)ctx;
+    c->awardCount++;
+    c->lastId = item->id;
+    c->lastOrigin = item->originGame;
+}
+} // namespace
+
+TestResult Test_ForeignItemGive(void) {
+    printf("[TEST] foreign-item-give: give-path core tags the shared structure; crossing survives + awards once "
+           "(Lane C1)\n");
+
+    // ------------------------------------------------------------------
+    // Pool sanity: pinned, OoT-tagged, named, lookup round-trips.
+    // ------------------------------------------------------------------
+    const ComboForeignItemDef* pool = NULL;
+    const int poolCount = Combo_GetForeignItemPool(&pool);
+    FI_ASSERT(pool != NULL);
+    FI_ASSERT(poolCount >= 1 && poolCount <= (int)RSBS_FOREIGN_PLACEMENT_CAP);
+    for (int i = 0; i < poolCount; i++) {
+        FI_ASSERT(pool[i].item.originGame == (uint8_t)GAME_OOT);
+        FI_ASSERT(pool[i].item.id != 0);
+        FI_ASSERT(pool[i].item.flags == 0);
+        FI_ASSERT(pool[i].name != NULL && pool[i].name[0] != '\0');
+        FI_ASSERT(Combo_GetForeignItemName(pool[i].item) == pool[i].name);
+    }
+
+    // ------------------------------------------------------------------
+    // Clean slate + the pairing gate (Lane B's carrier contract).
+    // ------------------------------------------------------------------
+    ComboContext_Init();
+    Context_InitFrozenStates();
+    Context_ClearAllFrozenStates();
+    Combo_ClearSharedItemOutbox();
+    FI_ASSERT(!Combo_ForeignPairingActive()); // zero-extended state: no pairing
+    gComboCtx.sourceIsRando = true;
+    FI_ASSERT(!Combo_ForeignPairingActive()); // seed without settings digest: still no pairing
+    gComboCtx.sharedRandoSeed = 0xC0FFEE01u;
+    gComboCtx.sharedRandoSettingsHash = 0x5EED5A5Au;
+    FI_ASSERT(Combo_ForeignPairingActive());
+
+    // ------------------------------------------------------------------
+    // Placement-table accessors reject the malformed and de-dup by check.
+    // ------------------------------------------------------------------
+    SharedItem untagged;
+    untagged.originGame = (uint8_t)GAME_NONE;
+    untagged.flags = 0;
+    untagged.id = 7;
+    FI_ASSERT(Combo_SetForeignPlacement(kForeignTestCheckA, untagged) < 0); // untagged item rejected
+    FI_ASSERT(Combo_SetForeignPlacement(0, pool[0].item) < 0);              // RC_UNKNOWN rejected
+    FI_ASSERT(Combo_SetForeignPlacement(kForeignTestCheckA, pool[0].item) >= 0);
+    FI_ASSERT(Combo_SetForeignPlacement(kForeignTestCheckA, pool[0].item) < 0); // duplicate check rejected
+    if (poolCount > 1) {
+        FI_ASSERT(Combo_SetForeignPlacement(kForeignTestCheckB, pool[1].item) >= 0);
+    }
+    FI_ASSERT(Combo_CountForeignPlacements() == (poolCount > 1 ? 2 : 1));
+    const SharedItem* hosted = Combo_GetForeignPlacementForCheck(kForeignTestCheckA);
+    FI_ASSERT(hosted != NULL);
+    FI_ASSERT(hosted->originGame == (uint8_t)GAME_OOT && hosted->id == pool[0].item.id);
+    FI_ASSERT(Combo_GetForeignPlacementForCheck(0x0999) == NULL);
+
+    // ------------------------------------------------------------------
+    // (a) The REAL give-path core records the foreign item, tagged; a
+    //     re-fired give de-dups.
+    // ------------------------------------------------------------------
+    FI_ASSERT(Combo_CountSharedItems(GAME_OOT, /*includeRedeemed=*/true) == 0);
+    FI_ASSERT(MM_Rando_Foreign_RecordPickup(0x0999) == 0); // not a foreign check: nothing recorded
+    FI_ASSERT(MM_Rando_Foreign_RecordPickup(kForeignTestCheckA) == 1);
+    FI_ASSERT(Combo_CountSharedItems(GAME_OOT, /*includeRedeemed=*/false) == 1);
+    FI_ASSERT(gComboCtx.sharedItemsTagged[0].originGame == (uint8_t)GAME_OOT);
+    FI_ASSERT(gComboCtx.sharedItemsTagged[0].id == pool[0].item.id);
+    FI_ASSERT(gComboCtx.sharedItemsTagged[0].flags == 0);
+    FI_ASSERT(MM_Rando_Foreign_RecordPickup(kForeignTestCheckA) == 1); // de-dup: same slot, no double
+    FI_ASSERT(Combo_CountSharedItems(GAME_OOT, /*includeRedeemed=*/false) == 1);
+
+    // ------------------------------------------------------------------
+    // (b) The crossing survives MM suspend -> OoT arrival through the real
+    //     hooks and awards exactly once (RSBS_SHARED_ITEM_REDEEMED).
+    // ------------------------------------------------------------------
+    uint8_t mmSave[256];
+    uint8_t scratch[256];
+    memset(mmSave, 0xB2, sizeof(mmSave));
+    FI_ASSERT(Switch_PrepareHotSwap(GAME_MM, mmSave, sizeof(mmSave)) == 1);
+    FI_ASSERT(Combo_CommitStagedSharedItems() == 0); // give recorded directly; outbox stays empty
+
+    memset(scratch, 0x00, sizeof(scratch));
+    Combo_ConsumeFrozenState("oot", scratch, sizeof(scratch)); // first OoT arrival: no frozen OoT state
+    ForeignAwardCtx award;
+    memset(&award, 0, sizeof(award));
+    FI_ASSERT(Combo_RedeemSharedItemsForGame(GAME_OOT, ForeignTestAward, &award) == 1);
+    FI_ASSERT(award.awardCount == 1);
+    FI_ASSERT(award.lastOrigin == (uint8_t)GAME_OOT);
+    FI_ASSERT(award.lastId == pool[0].item.id);
+    // Redeemed but still present — the durable record of the crossing.
+    FI_ASSERT(Combo_CountSharedItems(GAME_OOT, /*includeRedeemed=*/false) == 0);
+    FI_ASSERT(Combo_CountSharedItems(GAME_OOT, /*includeRedeemed=*/true) == 1);
+    // Single-use: a second arrival awards nothing.
+    memset(&award, 0, sizeof(award));
+    FI_ASSERT(Combo_RedeemSharedItemsForGame(GAME_OOT, ForeignTestAward, &award) == 0);
+    FI_ASSERT(award.awardCount == 0);
+    // The PLACEMENT survives redemption: the world still hosts the item (the
+    // spoiler stays truthful); only the crossing is marked done.
+    FI_ASSERT(Combo_GetForeignPlacementForCheck(kForeignTestCheckA) != NULL);
+
+    // ------------------------------------------------------------------
+    // Carve serialization: foreignPlacements round-trips byte-exact through
+    // a .redsave; unset slots stay unset.
+    // ------------------------------------------------------------------
+    ComboForeignPlacement expected[RSBS_FOREIGN_PLACEMENT_CAP];
+    memcpy(expected, gComboCtx.foreignPlacements, sizeof(expected));
+
+    rsbs::SaveManager& mgr = rsbs::SaveManager::Instance();
+    mgr.SetSaveDirectory(kForeignSaveDir);
+    mgr.DeleteSave(0);
+    FI_ASSERT(mgr.Save(0));
+
+    ComboContext_Init(); // wipe live state...
+    memset(gComboCtx.foreignPlacements, 0x5A, sizeof(gComboCtx.foreignPlacements)); // ...then scribble
+    FI_ASSERT(mgr.Load(0));
+    FI_ASSERT(memcmp(expected, gComboCtx.foreignPlacements, sizeof(expected)) == 0);
+    // Typed spot-checks so a memcmp-passing-but-misread layout fails loudly.
+    FI_ASSERT(gComboCtx.foreignPlacements[0].mmCheckId == kForeignTestCheckA);
+    FI_ASSERT(gComboCtx.foreignPlacements[0].item.originGame == (uint8_t)GAME_OOT);
+    FI_ASSERT(gComboCtx.foreignPlacements[0].item.id == pool[0].item.id);
+    const int lastSlot = (int)RSBS_FOREIGN_PLACEMENT_CAP - 1;
+    FI_ASSERT(gComboCtx.foreignPlacements[lastSlot].mmCheckId == 0 &&
+              gComboCtx.foreignPlacements[lastSlot].item.originGame == (uint8_t)GAME_NONE);
+    // The pairing key round-tripped with it (it rides the same record).
+    FI_ASSERT(Combo_ForeignPairingActive());
+    mgr.DeleteSave(0);
+
+    // Leave global state clean for any subsequent test.
+    Context_ClearAllFrozenStates();
+    Combo_ClearSharedItemOutbox();
+    ComboContext_Init();
+
+    printf("[TEST] PASS: foreign give path tags + de-dups; crossing awards once; placements serialize\n");
+    return TEST_PASS;
+}


### PR DESCRIPTION
The final engineering leg of the Phase 3.0 MVP: one seed produces a paired OoT+MM world in which a pinned class of OoT progression items crosses into MM checks, the crossing survives a full round trip, and both the spoiler log and the determinism digest describe it. Executes the C0 handoff design on #392 verbatim, with the deviations listed at the bottom.

## The pipeline as wired

**Placement** — `Rando::MiscBehavior::OnFileCreate` single-exe branch (`games/mm/2s2h/Rando/MiscBehavior/OnFileCreate.cpp`): when Lane B's carrier says a live OoT rando world exists (`gComboCtx.sourceIsRando && sharedRandoSettingsHash != 0`), a new MM file becomes that world's MM half:
- the MM input seed derives from `sharedRandoSeed` (`RSBSPAIR<seed>`, which also names the spoiler file deterministically), and the final seed re-mixes with MM's persisted options — the Lane B `Hash(seed + settings)` double-reseed contract;
- MM logic is pinned to **Nearly No Logic** (#426 — the vendored glitchless fill deterministically dead-ends; the spoiler log carries what logic would otherwise carry, Lane D deferred);
- after the fill, `Rando::Foreign::PlaceForeignItems` (`games/mm/2s2h/Rando/Foreign.cpp`) deterministically picks junk-holding shuffled checks (local xorshift stream seeded from the paired-world identity; `std::map` candidate order) and records them in the new **`gComboCtx.foreignPlacements[8]`** carve as `{mmCheckId, SharedItem{GAME_OOT, RG_*}}`. **The MM save table keeps `RI_JUNK` at hosting checks — a raw `RG_*` never enters an MM table (ADR 0002).** A zero-extended pre-C1 record reads as "no placements" and those checks degrade to the junk they physically hold.

**Give** — `CheckQueue` foreign branch (`games/mm/2s2h/Rando/MiscBehavior/CheckQueue.cpp`): an eligible check hosting a foreign item queues a `GIEventGiveItem` whose give lambda calls `Rando::Foreign::RecordForeignPickup` -> `Combo_RecordSharedItem` (A1 producer: durable immediately, de-duped) and presents the generic foreign-treasure textbox + gold-rupee model (the MVP's generic-presentation contract).

**Redeem** — `OoT_AwardSharedItem` (`games/oot/soh/GameExports_SingleExe.cpp`) now performs the real give via `OoT_ForeignItem_Give` (`soh/Enhancements/randomizer/ForeignItemsSingleExe.cpp`): `Rando::StaticData::RetrieveItem(rg).GetGIEntry_Copy()` — progressives resolve against the **live** save, the same path SoH's in-game gives use — then the `StartingItemGive`-style dispatch (`OoT_Item_Give` for MOD_NONE, `Randomizer_Item_Give` for MOD_RANDOMIZER). Single-use via `RSBS_SHARED_ITEM_REDEEMED`; plain load still applies on next switch only (A1 semantics).

**Pinned pool** (the one TU where `RG_*` may appear): `RG_PROGRESSIVE_HOOKSHOT`, `RG_FAIRY_BOW`, `RG_BOMB_BAG`, `RG_PROGRESSIVE_STRENGTH` — served to MM and the tests as origin-tagged `SharedItem`s + display names through `src/common/foreign_items.h`.

**Dispatch wiring** (the Execute half of the #415 shim contract, all through `S2H::GameHooks`, poison guard untouched):
- `GameInteractor_ExecuteOnSaveInit` / `OnSaveLoad`: mm_stubs no-ops **removed**, real header-checked dispatch in MM's `GameExports_SingleExe.cpp` — `MM_Sram_InitSave` now reaches `OnFileCreate`, file loads arm the rando behaviors;
- `MM_GameHooks_ExecuteOnActorUpdate` beside the upstream call in `z_actor.c` — CheckQueue's player-update scan runs;
- the **GIEvent pump**: a line-faithful port of upstream `ProcessEvents` (`games/mm/2s2h/GameInteractorEventsSingleExe.cpp`, `Instance->events/currentEvent` -> `MM_GameEvents_*`), registered on the player's OnActorUpdate from `MM_Rando_Init`;
- `MM_GameHooks_ExecuteOnFlagSet` / `OnSceneFlagSet` beside the 8 upstream call sites in `z_actor.c` — flag-driven checks (chests, collectibles, week events, rando-inf) become eligible in live gameplay. OoT's same-named wrappers truncate MM's u32 flags to int16_t, so forwarding through them was not an option.

**Spoiler** — `Rando::Spoiler::GenerateFromSaveContext` gains a `foreign` section (`{checkName: {originGame: "OOT", item: name}}`) and the human-readable `checks` map reads foreign checks as `"<name> (Ocarina of Time)"` instead of the junk they physically hold. The record lives in the MM spoiler (the two games' spoiler files share no infra; the OoT spoiler is untouched — noted per the lane brief).

**Format** — `foreignPlacements[8]` is carved from the front of `reserved[380]` -> `[332]`; 6-byte `ComboForeignPlacement` layout, offsets, and contiguity are pinned by static_asserts; zero = unset; `sizeof(ComboContext)` still 1004, record size 1024, `RSBS_SAVE_VERSION` 2, `COMBO_CONTEXT_VERSION` 1.

## CI locks (the four required)

- **(a) give-path tagging** — new `ForeignItemGive` CTest (redship tier, `src/common/tests/test_foreign_items.c`): drives the *real* give core (`MM_Rando_Foreign_RecordPickup`) and asserts the shared structure holds `{GAME_OOT, id}` un-redeemed, plus de-dup, pool sanity, and pairing-gate behavior.
- **(b) round-trip survival** — same test, the SharedItemRoundtrip sibling: the crossing survives MM suspend -> OoT arrival through the real freeze/consume + consumer hooks, awards exactly once with the pool item's id, never twice; the placement carve also round-trips byte-exact through a `.redsave` (SaveTaggedItems mirror).
- **(c) placement determinism** — folded into B's SeedDeterminism: the `rando-determinism` dispatch now generates the **paired MM world in the same process, keyed off the gComboCtx the live OoT producer just stamped**, and appends `mmFinalSeed` / `mmPlacementHash` / every foreign placement to the same digest file; the two-process diff in `CheckSeedDeterminism.cmake` covers OoT fill + MM fill + foreign placements together.
- **(d) spoiler foreign section** — `MMRandoGen` gained a paired-world phase: Lane B carrier stamped, generation through the real `GameInteractor_ExecuteOnSaveInit` chain (re-stubbing the bridge now fails the test), placements verified over `RI_JUNK` hosts, spoiler asserted to carry a correctly-shaped `foreign` section under the derived `RSBSPAIR*` filename, and `GameInteractor_ExecuteOnSaveLoad` asserted to arm OnFlagSet hooks.

## Deviations from the recorded design (with rationale)

1. **`Combo_RecordSharedItem` instead of `Combo_StageSharedItem` at give time.** Same A1 producer family and de-dup semantics, but Record writes the serialized array immediately — the stage outbox is RAM-only, so an MM save+quit between pickup and the next switch would lose a staged item after the check was already marked obtained. shared_items.h itself prescribes Record for give-time durability.
2. **`RG_PROGRESSIVE_STRENGTH` for the handoff's `RG_PROGRESSIVE_STRENGTH_UPGRADE`** — that enumerator does not exist; the handoff's list was explicitly an example ("e.g.").
3. **Pairing is not gated on `gRando.Enabled`.** MM's rando menu is link-elided in the single exe (2ship_rando_ui), so no in-game surface can set the CVar; the paired OoT generation is the user's opt-in, which is also what makes the operator flow (and the MVP contract sentence) executable at all. Un-paired MM files still require the CVar, unchanged.
4. **OnFlagSet/OnSceneFlagSet dispatch wired beyond the handoff's minimum list** (OnSaveInit, OnSaveLoad, CheckQueue pump). Without it no flag-driven check can ever become eligible in gameplay, and the operator-batch confirmation ("pick up a foreign item in MM") would depend on luck in where the seed placed the items. Contained: 8 one-line guarded additions in one file, same pattern as the pinned points.
5. **Paired-seed derivation is attempt-free.** If a derived MM seed dead-ends the fill (possible under the junk-swap heuristic), OnFileCreate's existing catch reverts to vanilla exactly as upstream; the operator regenerates the OoT seed. A retry counter would make the world identity depend on runtime state the determinism digest cannot see.

## Known follow-ups (not in scope, will file on merge)

- VB dispatch for MM frames (`GameInteractor_Should`) stays unwired: chest/NPC vanilla-give interception does not run, so a foreign chest also gives its vanilla junk contents alongside the crossing — cosmetic under a no-logic MVP.
- The spoiler-LOAD path (`gRando.SpoilerFileIndex != 0`) does not reconstruct foreign placements (it clears them); paired worlds are generate-only in 3.0.
- MM->OoT direction and a unified "generate paired world" UI remain Lane D / 3.1 material (Lane B's surface note).

Refs #392 (Lane C1). Builds on #410/#419/#420/#418/#422.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!--- section:artifacts:start -->
### Build Artifacts
  - [rsbs-windows.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/8483535298.zip)
  - [rsbs-linux.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/8483383247.zip)
<!--- section:artifacts:end -->