### PR TITLE
Restore Deku Palace bean-side->upper-middle edge; gate MM glitchless generation (#426)

### DIFF
--- a/games/mm/2s2h/Rando/Logic/Regions/South.cpp
+++ b/games/mm/2s2h/Rando/Logic/Regions/South.cpp
@@ -150,6 +150,7 @@ static RegisterShipInitFunc initFunc([]() {
         },
         .connections = {
             CONNECTION(RR_DEKU_PALACE_OUTSIDE, CanKillEnemy(ACTOR_EN_DEKUNUTS) && CAN_BE_DEKU),
+            CONNECTION(RR_DEKU_PALACE_INSIDE_UPPER_MIDDLE, CanKillEnemy(ACTOR_EN_DEKUNUTS) && CAN_BE_DEKU),
             CONNECTION(RR_DEKU_PALACE_INSIDE_LOWER, true),
         }
     };

--- a/games/mm/2s2h/Rando/MiscBehavior/OnFileCreate.cpp
+++ b/games/mm/2s2h/Rando/MiscBehavior/OnFileCreate.cpp
@@ -121,12 +121,14 @@ void Rando::MiscBehavior::OnFileCreate(s16 fileNum) {
 
 #ifdef RSBS_SINGLE_EXECUTABLE
                 if (rsbsPaired) {
-                    // Pinned MM profile for the paired world (#392/#426): the
-                    // vendored glitchless fill deterministically dead-ends, so
-                    // the MVP pairs under Nearly No Logic — the spoiler log
-                    // carries what logic would otherwise carry (Lane D).
-                    // Pinned BEFORE the settings mix below so the profile is
-                    // part of the world identity.
+                    // Pinned MM profile for the paired world (#392): the MVP
+                    // pairs under Nearly No Logic — free-form placement, with
+                    // the spoiler log carrying what logic would otherwise
+                    // carry (Lane D). Glitchless generation itself works (the
+                    // #426 Deku Palace edge fix, locked by MMRandoGen's
+                    // gating glitchless phase); this pin is an MVP-scope
+                    // choice, not a workaround. Pinned BEFORE the settings
+                    // mix below so the profile is part of the world identity.
                     if (RANDO_SAVE_OPTIONS[RO_LOGIC] != RO_LOGIC_NEARLY_NO_LOGIC &&
                         RANDO_SAVE_OPTIONS[RO_LOGIC] != RO_LOGIC_NO_LOGIC &&
                         RANDO_SAVE_OPTIONS[RO_LOGIC] != RO_LOGIC_VANILLA) {

--- a/games/mm/2s2h/mm_rando_gen_test.cpp
+++ b/games/mm/2s2h/mm_rando_gen_test.cpp
@@ -75,13 +75,9 @@ extern "C" int MM_Rando_HeadlessGenTest(void) {
     // Pinned generation profile: new seed, fixed input strings, spoiler on,
     // RO_LOGIC = Nearly No Logic. Deliberate (Lane C0 scope): the MVP ships
     // free-form placement with the spoiler log carrying what logic would
-    // otherwise carry (Lane D is deferred), and the vendored upstream
-    // glitchless fill deterministically dead-ends on
-    // RC_DEKU_KINGS_CHAMBER_MONKEY under default options + default starting
-    // items (every seed; the check's own condition and the give path both
-    // verify correct in isolation — see the follow-up issue). The
-    // non-gating glitchless probe below keeps that state visible in every
-    // run.
+    // otherwise carry (Lane D is deferred). Glitchless generation works too
+    // — the #426 Deku Palace edge fix, locked by the GATING glitchless phase
+    // below — but the MVP default stays pinned here.
     CVarSetInteger("gRando.Enabled", 1);
     CVarSetInteger("gRando.SpoilerFileIndex", 0);
     CVarSetInteger("gRando.GenerateSpoiler", 1);
@@ -174,23 +170,50 @@ extern "C" int MM_Rando_HeadlessGenTest(void) {
         return 8;
     }
 
-    // Non-gating glitchless probe: the vendored upstream glitchless fill
-    // currently dead-ends on RC_DEKU_KINGS_CHAMBER_MONKEY with default
-    // options (see the follow-up issue filed from Lane C0). Run one attempt
-    // and REPORT so every CI log tracks whether that state changes — it does
-    // not gate this reachability lock.
+    // Gating glitchless lock (#426): upstream 2S2H PR #1622's Deku Palace
+    // region split dropped the bean-side -> upper-middle return edge, leaving
+    // the {upper middle, cell side, cell ledge} ring with no incoming edge
+    // from outside itself — so RC_DEKU_KINGS_CHAMBER_MONKEY (holding cell,
+    // entered from the cell ledge) could never enter logic and EVERY
+    // glitchless fill dead-ended with exactly that check left. Upstream PR
+    // #1661 restored the edge; the port lives in Rando/Logic/Regions/
+    // South.cpp. This phase locks it: glitchless must GENERATE. The fixed
+    // seed list mirrors the main phase (the junk-swap forward fill can
+    // genuinely dead-end on an unlucky seed); it fails only if every attempt
+    // dead-ends.
     CVarSetInteger(Rando::StaticData::Options[RO_LOGIC].cvar, RO_LOGIC_GLITCHLESS);
-    CVarSetString("gRando.InputSeed", "RSBSMMGL1");
-    // Re-pin the GENERATE branch: the successful generation above ran
-    // RefreshOptions, which repoints gRando.SpoilerFileIndex at the spoiler
-    // just written — without this the probe silently LOADS that spoiler and
-    // reports GENERATED regardless of the glitchless fill's state.
-    CVarSetInteger("gRando.SpoilerFileIndex", 0);
-    memset(&gSaveContext, 0, sizeof(gSaveContext));
-    MM_Sram_InitNewSave();
-    GameInteractor_ExecuteOnSaveInit(0);
-    fprintf(stderr, "[MM-RANDO-GEN][info] glitchless probe: %s\n",
-            gSaveContext.save.shipSaveInfo.saveType == SAVETYPE_RANDO ? "GENERATED" : "dead-ended (known)");
+    static const char* kGlitchlessSeeds[] = { "RSBSMMGL1", "RSBSMMGL2", "RSBSMMGL3", "RSBSMMGL4", "RSBSMMGL5" };
+    const char* glitchlessSeed = NULL;
+    for (const char* seed : kGlitchlessSeeds) {
+        // Re-pin the GENERATE branch every attempt: the last successful
+        // generation ran RefreshOptions, which repoints
+        // gRando.SpoilerFileIndex at the spoiler it wrote — without this the
+        // attempt silently LOADS that spoiler and "passes" regardless of the
+        // glitchless fill's state.
+        CVarSetInteger("gRando.SpoilerFileIndex", 0);
+        CVarSetString("gRando.InputSeed", seed);
+        memset(&gSaveContext, 0, sizeof(gSaveContext));
+        MM_Sram_InitNewSave();
+        GameInteractor_ExecuteOnSaveInit(0);
+        if (gSaveContext.save.shipSaveInfo.saveType == SAVETYPE_RANDO) {
+            glitchlessSeed = seed;
+            break;
+        }
+        fprintf(stderr, "[MM-RANDO-GEN] glitchless seed %s dead-ended (fill threw); trying next\n", seed);
+    }
+    if (glitchlessSeed == NULL) {
+        fprintf(stderr, "[MM-RANDO-GEN] FAIL(16): every glitchless seed dead-ended — glitchless reachability "
+                        "regressed (#426)\n");
+        return 16;
+    }
+    // The historical dead-end left RC_DEKU_KINGS_CHAMBER_MONKEY as the one
+    // unplaceable check; assert it specifically received a placement so any
+    // recurrence names itself in the log.
+    if (!RANDO_SAVE_CHECKS[RC_DEKU_KINGS_CHAMBER_MONKEY].shuffled) {
+        fprintf(stderr, "[MM-RANDO-GEN] FAIL(17): glitchless world did not place RC_DEKU_KINGS_CHAMBER_MONKEY\n");
+        return 17;
+    }
+    fprintf(stderr, "[MM-RANDO-GEN] glitchless generated with seed %s\n", glitchlessSeed);
     CVarClear(Rando::StaticData::Options[RO_LOGIC].cvar);
     CVarSetInteger(Rando::StaticData::Options[RO_LOGIC].cvar, RO_LOGIC_NEARLY_NO_LOGIC);
 


### PR DESCRIPTION
Fixes #426.

## Root cause

MM's glitchless fill dead-ended on `RC_DEKU_KINGS_CHAMBER_MONKEY` for every seed because the check's region is **structurally unreachable** in the vendored Logic/Regions graph — not because of any single-exe initialization gap.

Upstream 2S2H PR #1622 ("Deku Palace upper enemy soul bug", `6c9d024d0e`) split `RR_DEKU_PALACE_INSIDE_UPPER` into four regions, but omitted the bean-side → upper-middle return connection. `connections` are one-way outgoing edges (`FindReachableRegions`, `Logic.cpp`), so the upper ring ended up with **no incoming edge from outside itself**:

- into `RR_DEKU_PALACE_INSIDE_UPPER_MIDDLE`: only from `..._CELL_SIDE`
- into `..._CELL_SIDE`: only from `..._CELL_SIDE_LEDGE` and `..._MIDDLE`
- into `..._CELL_SIDE_LEDGE`: only from `..._CELL_SIDE` (and the holding cell's own exit, which is only entered *from* the ledge)
- `..._BEAN_SIDE` (the day-2-rain bean route up, the ring's intended entry) connected only to `OUTSIDE` and `INSIDE_LOWER`

`RR_DEKU_KINGS_CHAMBER_HOLDING_CELL` (the monkey check) is entered only via the ledge's `ENTRANCE(DEKU_KINGS_CHAMBER, 1)` exit, so the check could never enter logic; the fill placed everything else, then stalled with only junk left and threw "No non-junk items left" — deterministically, every seed. This matches PR #422's in-harness probes: the check's own lambda and the give path are sound in isolation; the reachability chain was the break.

## Upstream disposition

Genuine upstream bug, **already fixed upstream**: 2S2H PR #1661 (`c9a3b54ec1`, by sitton76 — "Deku palace was missing a connection causing failed seed gen") adds exactly one line:

```cpp
CONNECTION(RR_DEKU_PALACE_INSIDE_UPPER_MIDDLE, CanKillEnemy(ACTOR_EN_DEKUNUTS) && CAN_BE_DEKU),
```

to `RR_DEKU_PALACE_INSIDE_UPPER_BEAN_SIDE`. Our vendored snapshot contains #1622 but predates #1661. This PR ports that line verbatim, credited in the commit message. (#1661's other hunk — commenting out a should-be-trick Great Bay Temple connection — is an unrelated difficulty tweak and is deliberately not ported; noted on #426.)

## Lock

`MMRandoGen`'s glitchless probe is **promoted from non-gating report to a gating phase**: glitchless generation over a fixed seed list (`RSBSMMGL1`–`GL5`, mirroring the main phase's dead-end-retry rationale) must produce a `SAVETYPE_RANDO` save **and** must have placed `RC_DEKU_KINGS_CHAMBER_MONKEY`, else the rando-tier CTest fails with new step codes FAIL(16)/FAIL(17).

## What stays

The MVP's Nearly-No-Logic pin (main-phase profile and the paired-world pin in `OnFileCreate`) stays — free-form placement with the spoiler carrying the burden is the 3.0 design per #426, and the issue thread has no direction to change the default. Comments are reworded so the pin reads as a scope choice rather than a workaround, now that both logic modes generate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!--- section:artifacts:start -->
### Build Artifacts
  - [rsbs-windows.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/8484577621.zip)
  - [rsbs-linux.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/8484395506.zip)
<!--- section:artifacts:end -->