### PR TITLE
Harden the tolerated cross-binds from Lane C0 (#427): Notification layout lock + OTRGlobals non-virtual lock

### DIFF
--- a/.github/clang-format-paths.txt
+++ b/.github/clang-format-paths.txt
@@ -35,6 +35,7 @@ games/mm/2s2h/Rando/Foreign.h
 games/mm/2s2h/ShipInit.hpp
 games/mm/2s2h/mm_culling_test.cpp
 games/mm/2s2h/mm_gi_shim_test.cpp
+games/mm/2s2h/mm_notification_binding_test.cpp
 games/mm/2s2h/mm_resume_state_test.cpp
 games/mm/2s2h/z_scene_2SH.cpp
 games/mm/src/audio/lib/dcache.c

--- a/CMake/SingleExecutable.cmake
+++ b/CMake/SingleExecutable.cmake
@@ -350,6 +350,12 @@ if(BUILD_TESTING)
     # the MM-owned extern "C" shim; registering through MM's larger view of
     # the shared class writes ~60-92 bytes past OoT's 4-byte allocation.
     redship_add_test(NAME MMGIShim COMMAND redship --test mm-gi-shim)
+    # MM Notification::Emit cross-bind (#427 item 1): MM's BenGui/Notification.cpp
+    # is excluded, so MM's Rando pickup toast binds OoT's Notification::Emit —
+    # safe only while both ports' Notification::Options stay layout-identical.
+    # This compares their layout fingerprints and fails on drift (one Emit
+    # definition survives, so no link error can catch a divergence).
+    redship_add_test(NAME MMNotificationBinding COMMAND redship --test mm-notification-binding)
     redship_add_test(NAME MMResumeArena COMMAND redship --test mm-resume-arena)
     redship_add_test(NAME MMStartupRestore COMMAND redship --test mm-startup-restore)
     redship_add_test(NAME AllTests COMMAND redship --test all)

--- a/games/mm/2s2h/Enhancements/FrameInterpolation/FrameInterpolation.cpp
+++ b/games/mm/2s2h/Enhancements/FrameInterpolation/FrameInterpolation.cpp
@@ -10,6 +10,25 @@
 #include <sys_matrix.h>
 #include <z64skin_matrix.h>
 
+#ifdef RSBS_SINGLE_EXECUTABLE
+#include <type_traits>
+// #427 item 5: the FrameInterpolation_StartRecord call below reads
+// OTRGlobals::Instance->GetInterpolationFPS(). In single-exe builds MM's
+// BenPort.cpp (which defines MM's OTRGlobals::Instance and GetInterpolationFPS)
+// is excluded, so both the static Instance pointer and the method resolve to
+// OoT's — another same-name-class bind on the #395 radar. It is safe today by
+// construction: GetInterpolationFPS is NON-VIRTUAL (a direct symbol call, no
+// vtable index that MM's larger view of OTRGlobals could compute differently)
+// and this-independent (it reads only CVars + the shared Ship::Context window,
+// never OTRGlobals members). Virtualizing OTRGlobals would make this MM call
+// site emit a vtable dispatch at MM's computed slot against OoT's object — the
+// exact corruption path — so lock the load-bearing invariant from MM's view
+// here; soh/OTRGlobals.cpp carries the twin assert from OoT's view.
+static_assert(!std::is_polymorphic_v<OTRGlobals>,
+              "OTRGlobals became polymorphic — MM's OTRGlobals::Instance->GetInterpolationFPS() bind now "
+              "vtable-dispatches against OoT's object at MM's computed slot (#427/#395)");
+#endif
+
 /*
 Frame interpolation.
 

--- a/games/mm/2s2h/mm_notification_binding_test.cpp
+++ b/games/mm/2s2h/mm_notification_binding_test.cpp
@@ -1,0 +1,142 @@
+/**
+ * ROM-free lock for the deliberate MM->OoT Notification::Emit cross-bind
+ * (#427 item 1). CTest label "redship", row mm-notification-binding in
+ * src/common/test_runner.cpp.
+ *
+ * What is bound: MM's 2s2h/BenGui/Notification.cpp is excluded from the
+ * single-exe build (games/mm/CMakeLists.txt drops 2s2h/BenGui/*.cpp), so every
+ * `Notification::Emit(Options)` that MM compiles — the Rando pickup toast in
+ * 2s2h/Rando/MiscBehavior/CheckQueue.cpp — resolves to OoT's
+ * soh/Notification/Notification.cpp definition. `Notification::Emit(Options)`
+ * mangles identically in both ports and the two `namespace Notification {
+ * struct Options }` are field-identical, so the call links and runs correctly:
+ * one shared Gui overlay renders the toast over whichever game is active, which
+ * is the desirable behavior.
+ *
+ * Why it is a landmine, not a contract: nothing but the field-identical
+ * coincidence keeps it safe. If either port's Options gains, loses, reorders,
+ * or retypes a field, OoT's Emit copies/reads MM's differently-laid-out struct
+ * argument — silent memory corruption. There is NO link error to catch it:
+ * exactly one Emit definition survives, so the linker has nothing to reject
+ * (the same shape as the #382 FlagTable/culling class). The issue asks for a
+ * field-layout static probe; this is it.
+ *
+ * This test lives in an MM translation unit (like mm_culling_test.cpp and
+ * mm_gi_shim_test.cpp) so MM's 2s2h/BenGui/Notification.h — MM's own view of
+ * Options — is compiled with MM's headers and flags, and never enters OoT's or
+ * the common runner's TU. It is exposed through the C entry point
+ * MM_NotificationBinding_RunHeadless().
+ *
+ * Two locks, in order of strength:
+ *
+ * 1. FIELD TYPES (compile-time, both views). The static_asserts below pin each
+ *    Options field's type in MM's view; the twin set in
+ *    soh/Notification/Notification.cpp pins OoT's. A retype in either port —
+ *    even one applied to BOTH ports in lockstep, which the runtime compare
+ *    (2) cannot see because it only checks that the two agree — fails that
+ *    port's build. Taking &o.<field> below also makes a rename/removal a
+ *    compile error in this TU.
+ *
+ * 2. CROSS-GAME LAYOUT EQUALITY (runtime, the real lock). MM's and OoT's
+ *    Options fingerprints (sizeof + every member offset, each reported from its
+ *    own port's TU) are compared field by field. For this bind they must be
+ *    EQUAL — the inverse of the culling/gi-shim locks, where the two ports'
+ *    layouts must DIFFER. Any divergence means OoT's Emit is now reading a
+ *    struct laid out differently than MM passes it; the test fails loudly and
+ *    names the field that drifted. Offsets are measured with pointer
+ *    arithmetic on a real instance, so no platform-specific byte offset is
+ *    hardcoded and the lock holds across MSVC / libstdc++ / libc++ ABIs.
+ */
+
+#ifdef RSBS_SINGLE_EXECUTABLE
+
+#include "2s2h/BenGui/Notification.h"
+#include "notification_layout_probe.h"
+
+#include <cstddef>
+#include <cstdint>
+#include <cstdio>
+#include <type_traits>
+
+static_assert(std::is_same_v<decltype(Notification::Options::id), uint32_t>,
+              "MM Notification::Options::id retyped — breaks the OoT Emit bind (#427)");
+static_assert(std::is_same_v<decltype(Notification::Options::itemIcon), const char*>,
+              "MM Notification::Options::itemIcon retyped — breaks the OoT Emit bind (#427)");
+static_assert(std::is_same_v<decltype(Notification::Options::prefix), std::string>,
+              "MM Notification::Options::prefix retyped — breaks the OoT Emit bind (#427)");
+static_assert(std::is_same_v<decltype(Notification::Options::prefixColor), ImVec4>,
+              "MM Notification::Options::prefixColor retyped — breaks the OoT Emit bind (#427)");
+static_assert(std::is_same_v<decltype(Notification::Options::message), std::string>,
+              "MM Notification::Options::message retyped — breaks the OoT Emit bind (#427)");
+static_assert(std::is_same_v<decltype(Notification::Options::messageColor), ImVec4>,
+              "MM Notification::Options::messageColor retyped — breaks the OoT Emit bind (#427)");
+static_assert(std::is_same_v<decltype(Notification::Options::suffix), std::string>,
+              "MM Notification::Options::suffix retyped — breaks the OoT Emit bind (#427)");
+static_assert(std::is_same_v<decltype(Notification::Options::suffixColor), ImVec4>,
+              "MM Notification::Options::suffixColor retyped — breaks the OoT Emit bind (#427)");
+static_assert(std::is_same_v<decltype(Notification::Options::remainingTime), float>,
+              "MM Notification::Options::remainingTime retyped — breaks the OoT Emit bind (#427)");
+static_assert(std::is_same_v<decltype(Notification::Options::mute), bool>,
+              "MM Notification::Options::mute retyped — breaks the OoT Emit bind (#427)");
+
+extern "C" void MM_NotificationOptionsLayout(NotificationOptionsLayout* out) {
+    Notification::Options o;
+    const char* base = reinterpret_cast<const char*>(&o);
+    out->structSize = static_cast<uint32_t>(sizeof(Notification::Options));
+    out->offId = static_cast<uint32_t>(reinterpret_cast<const char*>(&o.id) - base);
+    out->offItemIcon = static_cast<uint32_t>(reinterpret_cast<const char*>(&o.itemIcon) - base);
+    out->offPrefix = static_cast<uint32_t>(reinterpret_cast<const char*>(&o.prefix) - base);
+    out->offPrefixColor = static_cast<uint32_t>(reinterpret_cast<const char*>(&o.prefixColor) - base);
+    out->offMessage = static_cast<uint32_t>(reinterpret_cast<const char*>(&o.message) - base);
+    out->offMessageColor = static_cast<uint32_t>(reinterpret_cast<const char*>(&o.messageColor) - base);
+    out->offSuffix = static_cast<uint32_t>(reinterpret_cast<const char*>(&o.suffix) - base);
+    out->offSuffixColor = static_cast<uint32_t>(reinterpret_cast<const char*>(&o.suffixColor) - base);
+    out->offRemainingTime = static_cast<uint32_t>(reinterpret_cast<const char*>(&o.remainingTime) - base);
+    out->offMute = static_cast<uint32_t>(reinterpret_cast<const char*>(&o.mute) - base);
+}
+
+namespace {
+
+#define NOTIF_FIELD_CHECK(field)                                                                           \
+    do {                                                                                                   \
+        if (mm.field != oot.field) {                                                                       \
+            printf("[TEST] FAIL: Notification::Options." #field " differs — MM %u, OoT %u (the MM->OoT " \
+                   "Emit bind now corrupts; #427)\n",                                                      \
+                   (unsigned)mm.field, (unsigned)oot.field);                                               \
+            ok = false;                                                                                    \
+        }                                                                                                  \
+    } while (0)
+
+} // namespace
+
+extern "C" int MM_NotificationBinding_RunHeadless(void) {
+    NotificationOptionsLayout mm;
+    NotificationOptionsLayout oot;
+    MM_NotificationOptionsLayout(&mm);
+    OoT_NotificationOptionsLayout(&oot);
+
+    printf("[TEST] Notification::Options sizeof — MM %u, OoT %u\n", (unsigned)mm.structSize, (unsigned)oot.structSize);
+
+    bool ok = true;
+    NOTIF_FIELD_CHECK(structSize);
+    NOTIF_FIELD_CHECK(offId);
+    NOTIF_FIELD_CHECK(offItemIcon);
+    NOTIF_FIELD_CHECK(offPrefix);
+    NOTIF_FIELD_CHECK(offPrefixColor);
+    NOTIF_FIELD_CHECK(offMessage);
+    NOTIF_FIELD_CHECK(offMessageColor);
+    NOTIF_FIELD_CHECK(offSuffix);
+    NOTIF_FIELD_CHECK(offSuffixColor);
+    NOTIF_FIELD_CHECK(offRemainingTime);
+    NOTIF_FIELD_CHECK(offMute);
+
+    if (!ok) {
+        return 1;
+    }
+
+    printf("[TEST] PASS: mm-notification-binding — MM and OoT Notification::Options are layout-identical, so MM's "
+           "Notification::Emit safely binds OoT's implementation\n");
+    return 0;
+}
+
+#endif // RSBS_SINGLE_EXECUTABLE

--- a/games/oot/soh/Notification/Notification.cpp
+++ b/games/oot/soh/Notification/Notification.cpp
@@ -138,3 +138,57 @@ void Emit(Options notification) {
 }
 
 } // namespace Notification
+
+// ---------------------------------------------------------------------------
+// Cross-game layout probe for the deliberate MM->OoT Notification::Emit bind
+// (#427 item 1). MM's 2s2h/BenGui/Notification.cpp is excluded from single-exe
+// builds, so MM's Rando pickup toast (2s2h/Rando/MiscBehavior/CheckQueue.cpp)
+// binds THIS Emit against MM's own view of Notification::Options. The bind is
+// safe only while the two views stay field-identical; the mm-notification-
+// binding CTest compares this fingerprint against MM's and fails on drift.
+//
+// Reported with pointer arithmetic on a real instance rather than offsetof so
+// it is well-defined without regard to standard-layout status, and no
+// platform-specific byte offsets are hardcoded. The field-type static_asserts
+// below turn a same-view retype (the half a cross-game offset compare cannot
+// see if BOTH games retype in lockstep) into an OoT build break.
+#include "notification_layout_probe.h"
+#include <cstddef>
+#include <type_traits>
+
+static_assert(std::is_same_v<decltype(Notification::Options::id), uint32_t>,
+              "Notification::Options::id retyped — the MM Emit bind assumes this layout (#427)");
+static_assert(std::is_same_v<decltype(Notification::Options::itemIcon), const char*>,
+              "Notification::Options::itemIcon retyped — the MM Emit bind assumes this layout (#427)");
+static_assert(std::is_same_v<decltype(Notification::Options::prefix), std::string>,
+              "Notification::Options::prefix retyped — the MM Emit bind assumes this layout (#427)");
+static_assert(std::is_same_v<decltype(Notification::Options::prefixColor), ImVec4>,
+              "Notification::Options::prefixColor retyped — the MM Emit bind assumes this layout (#427)");
+static_assert(std::is_same_v<decltype(Notification::Options::message), std::string>,
+              "Notification::Options::message retyped — the MM Emit bind assumes this layout (#427)");
+static_assert(std::is_same_v<decltype(Notification::Options::messageColor), ImVec4>,
+              "Notification::Options::messageColor retyped — the MM Emit bind assumes this layout (#427)");
+static_assert(std::is_same_v<decltype(Notification::Options::suffix), std::string>,
+              "Notification::Options::suffix retyped — the MM Emit bind assumes this layout (#427)");
+static_assert(std::is_same_v<decltype(Notification::Options::suffixColor), ImVec4>,
+              "Notification::Options::suffixColor retyped — the MM Emit bind assumes this layout (#427)");
+static_assert(std::is_same_v<decltype(Notification::Options::remainingTime), float>,
+              "Notification::Options::remainingTime retyped — the MM Emit bind assumes this layout (#427)");
+static_assert(std::is_same_v<decltype(Notification::Options::mute), bool>,
+              "Notification::Options::mute retyped — the MM Emit bind assumes this layout (#427)");
+
+extern "C" void OoT_NotificationOptionsLayout(NotificationOptionsLayout* out) {
+    Notification::Options o;
+    const char* base = reinterpret_cast<const char*>(&o);
+    out->structSize = static_cast<uint32_t>(sizeof(Notification::Options));
+    out->offId = static_cast<uint32_t>(reinterpret_cast<const char*>(&o.id) - base);
+    out->offItemIcon = static_cast<uint32_t>(reinterpret_cast<const char*>(&o.itemIcon) - base);
+    out->offPrefix = static_cast<uint32_t>(reinterpret_cast<const char*>(&o.prefix) - base);
+    out->offPrefixColor = static_cast<uint32_t>(reinterpret_cast<const char*>(&o.prefixColor) - base);
+    out->offMessage = static_cast<uint32_t>(reinterpret_cast<const char*>(&o.message) - base);
+    out->offMessageColor = static_cast<uint32_t>(reinterpret_cast<const char*>(&o.messageColor) - base);
+    out->offSuffix = static_cast<uint32_t>(reinterpret_cast<const char*>(&o.suffix) - base);
+    out->offSuffixColor = static_cast<uint32_t>(reinterpret_cast<const char*>(&o.suffixColor) - base);
+    out->offRemainingTime = static_cast<uint32_t>(reinterpret_cast<const char*>(&o.remainingTime) - base);
+    out->offMute = static_cast<uint32_t>(reinterpret_cast<const char*>(&o.mute) - base);
+}

--- a/games/oot/soh/OTRGlobals.cpp
+++ b/games/oot/soh/OTRGlobals.cpp
@@ -2,6 +2,7 @@
 #include "OTRAudio.h"
 #include <algorithm>
 #include <atomic>
+#include <type_traits>
 #include <filesystem>
 #include <fstream>
 #include <vector>
@@ -1097,6 +1098,18 @@ extern "C" int OoT_GameAssetsInitialized(void) {
     return OTRGlobals::Instance != nullptr &&
            (OTRGlobals::Instance->HasMasterQuest() || OTRGlobals::Instance->HasOriginal());
 }
+
+// #427 item 5: MM's FrameInterpolation.cpp calls
+// OTRGlobals::Instance->GetInterpolationFPS() and binds THIS definition in
+// single-exe builds (MM's BenPort.cpp copy is excluded). That same-name-class
+// bind is safe only while GetInterpolationFPS stays non-virtual — a direct
+// symbol call with no vtable slot for MM's larger view of OTRGlobals to
+// mis-compute. Virtualizing OTRGlobals would arm the corruption path from MM's
+// call site; lock the invariant from OoT's view here (MM's twin assert lives in
+// games/mm/2s2h/Enhancements/FrameInterpolation/FrameInterpolation.cpp).
+static_assert(!std::is_polymorphic_v<OTRGlobals>,
+              "OTRGlobals became polymorphic — MM's OTRGlobals::Instance->GetInterpolationFPS() bind now "
+              "vtable-dispatches against this object at MM's computed slot (#427/#395)");
 
 uint32_t OTRGlobals::GetInterpolationFPS() {
     if (CVarGetInteger(CVAR_SETTING("MatchRefreshRate"), 0)) {

--- a/src/common/notification_layout_probe.h
+++ b/src/common/notification_layout_probe.h
@@ -1,0 +1,61 @@
+/**
+ * Cross-game layout fingerprint for Notification::Options (#427 item 1).
+ *
+ * In single-exe builds MM's 2s2h/BenGui/Notification.cpp is excluded
+ * (games/mm/CMakeLists.txt drops 2s2h/BenGui/*.cpp), so every
+ * `Notification::Emit(Options)` MM compiles — e.g. the rando pickup toast in
+ * 2s2h/Rando/MiscBehavior/CheckQueue.cpp — binds OoT's
+ * soh/Notification/Notification.cpp definition. That bind is deliberate and
+ * desirable (one shared Gui overlay renders notifications over both games), but
+ * it survives purely because the two ports' `namespace Notification { struct
+ * Options }` are field-identical and `Notification::Emit(Options)` mangles the
+ * same in both — a coincidence, not a contract. If either game's Options ever
+ * gains/loses/reorders/retypes a field, OoT's Emit reads MM's differently-laid
+ * out struct: silent corruption, with no link error to catch it (only one
+ * Emit definition survives).
+ *
+ * This is the wire format for the mm-notification-binding lock
+ * (games/mm/2s2h/mm_notification_binding_test.cpp, CTest label "redship"): each
+ * game fills it from ITS OWN view of Notification::Options — measured with
+ * pointer arithmetic on a real instance so it is well-defined regardless of
+ * standard-layout status and needs no hardcoded, platform-specific byte
+ * offsets — and the lock fails the moment the two fingerprints disagree. The
+ * struct itself carries no std/ImGui types on purpose, so it is identical in
+ * both TUs' ABI.
+ */
+#ifndef NOTIFICATION_LAYOUT_PROBE_H
+#define NOTIFICATION_LAYOUT_PROBE_H
+
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct NotificationOptionsLayout {
+    uint32_t structSize;
+    uint32_t offId;
+    uint32_t offItemIcon;
+    uint32_t offPrefix;
+    uint32_t offPrefixColor;
+    uint32_t offMessage;
+    uint32_t offMessageColor;
+    uint32_t offSuffix;
+    uint32_t offSuffixColor;
+    uint32_t offRemainingTime;
+    uint32_t offMute;
+} NotificationOptionsLayout;
+
+// soh/Notification/Notification.cpp — OoT's own view of Notification::Options,
+// compiled with OoT's headers and production flags.
+void OoT_NotificationOptionsLayout(NotificationOptionsLayout* out);
+
+// games/mm/2s2h/mm_notification_binding_test.cpp — MM's own view, compiled with
+// MM's headers (2s2h/BenGui/Notification.h).
+void MM_NotificationOptionsLayout(NotificationOptionsLayout* out);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // NOTIFICATION_LAYOUT_PROBE_H

--- a/src/common/test_runner.cpp
+++ b/src/common/test_runner.cpp
@@ -58,6 +58,14 @@ int MM_CullingBinding_RunHeadless(void);
 // byte out-of-bounds write, layout is platform-dependent). Returns 0 on
 // pass, non-zero on fail.
 int MM_GIShim_RunHeadless(void);
+// MM Notification::Emit cross-bind lock (games/mm/2s2h/mm_notification_binding_test.cpp,
+// #427 item 1): MM's 2s2h/BenGui/Notification.cpp is excluded from single-exe
+// builds, so MM's Rando pickup toast binds OoT's Notification::Emit against
+// MM's own view of Notification::Options. Safe only while the two ports' Options
+// stay field-identical; this compares their layout fingerprints and fails on
+// drift (no link error can catch it — one Emit definition survives). Returns 0
+// on pass, non-zero on fail.
+int MM_NotificationBinding_RunHeadless(void);
 // VB-affinity regression: MM's GameInteractor_* calls resolve to OoT's
 // extern "C" wrappers in single-exe builds, and the two games' vanilla-
 // behavior ordinals alias each other. The wrappers gate on the active game;
@@ -167,6 +175,13 @@ static TestResult Test_MMCullingBinding(void) {
 // the C entry point in games/mm/2s2h/mm_gi_shim_test.cpp.
 static TestResult Test_MMGIShim(void) {
     return MM_GIShim_RunHeadless() == 0 ? TEST_PASS : TEST_FAIL;
+}
+
+// MM Notification::Emit cross-bind lock (see the extern decl above). Thin
+// wrapper over the C entry point in
+// games/mm/2s2h/mm_notification_binding_test.cpp.
+static TestResult Test_MMNotificationBinding(void) {
+    return MM_NotificationBinding_RunHeadless() == 0 ? TEST_PASS : TEST_FAIL;
 }
 
 // ============================================================================
@@ -1002,6 +1017,8 @@ const TestDescriptor gTests[] = {
     {"mm-culling-binding", "MM's Ship_ExtendedCulling* bind MM's Actor, not OoT's (#382)", Test_MMCullingBinding},
     {"mm-gi-shim", "MM hook registration goes through the MM-owned shim, not the shared 4-byte instance (#395)",
      Test_MMGIShim},
+    {"mm-notification-binding", "MM Notification::Emit binds OoT's only while Options stays layout-identical (#427)",
+     Test_MMNotificationBinding},
     // The two MM resume-contract tests below mutate process-global state
     // (mm-resume-arena re-inits the MM system arena + heaps; mm-startup-restore
     // scribbles and re-zeroes the unified gSaveContext). Both clean up after


### PR DESCRIPTION
Hardens the deliberate cross-game binds tracked in #427, following the Lane-H premise-verification pattern: each tolerated bind gets the cheapest genuine mitigation, and items that are already safe or can't be cheaply retired are documented rather than churned.

## Per-item verdicts

**1. `Notification::Emit` cross-bind — LOCKED.** MM's `2s2h/BenGui/Notification.cpp` is excluded from single-exe, so every `Notification::Emit(Options)` MM compiles (the Rando pickup toast in `CheckQueue.cpp`) binds OoT's `soh/Notification` definition. Safe only while both ports' `Notification::Options` stay field-identical; a drift makes OoT's Emit read MM's differently-laid-out argument with no link error to catch it (one Emit survives — the #382 shape). Added the field-layout static probe #427 asks for:
- `src/common/notification_layout_probe.h` — plain-C fingerprint wire format (sizeof + every member offset, measured via pointer arithmetic on a real instance, no hardcoded platform offsets).
- `OoT_NotificationOptionsLayout` (in `Notification.cpp`) + `MM_NotificationOptionsLayout` (in the new `mm_notification_binding_test.cpp`) report each port's own view; both TUs also carry compile-time field-**type** static_asserts (catch a lockstep retype the cross-game compare can't see).
- **`mm-notification-binding` CTest** (redship label) compares the two fingerprints and fails, naming the drifted field, the instant they diverge. This is the inverse of the culling/gi-shim locks (there the layouts must *differ*; here they must be *equal*).

**2. `2ship_enh` hook-guard exemption — DEFERRED, measured count reported on #427.** Not small/mechanical: **20 raw `RegisterGameHook*` sites across 10 compiled-but-elided TUs** (#427 estimated ~21), plus **~36 direct `Instance->events` enqueues** across ~20 more TUs — all out-of-bounds on the shared 4-byte instance per #395. Flipping the guard would force migrating all of these onto the MM-owned shim and adding ~14 new hook types (with ID/Ptr/Filter variants) plus wiring each dispatch point — deliberate Lane C work, not a mechanical flip. Exemption left in place; count posted to #427.

**5. FrameInterpolation's `OTRGlobals::Instance->GetInterpolationFPS()` — LOCKED.** Safe today by construction: MM's `BenPort.cpp` is excluded so Instance+method resolve to OoT's; the method is non-virtual and this-independent (reads only CVars + the shared window). The one way to arm corruption is to virtualize `OTRGlobals` (MM's call site would vtable-dispatch at MM's slot against OoT's object). Locked with `static_assert(!is_polymorphic<OTRGlobals>)` from **both** views (`OTRGlobals.cpp` + `FrameInterpolation.cpp`). A layout-equality lock would be *wrong* here — the two OTRGlobals layouts already differ; non-virtual is the load-bearing invariant.

**4. `UpdateGameTime` copy (`SaveEditorTimeSingleExe.cpp`) — LEFT, with justification.** Not a layout bind; a code-duplication re-sync hazard. The coexistence landmine (someone un-elides `DeveloperTools/SaveEditor.cpp` without deleting the copy → two `UpdateGameTime`) is already caught by GNU ld's ODR gate on the Linux link — `UpdateGameTime` is an unmangled strong symbol, and a duplicate is a hard multiple-definition error. The remaining risk (upstream 2S2H bumps the original while this copy silently drifts) is not mechanically lockable in-tree because the reference definition isn't in the build; it stays a documented re-sync note. No lock added.

**3. `2ship_rando_ui` elision — LEFT, tracked.** Not a cross-bind — it's the deliberate menu-surface elision (BenGui-coupled `Rando/Menu.cpp` + `CheckTracker.cpp`), already surfaced report-only by `check-registrar-elision.sh` and tracked on #383. No layout landmine, no lock applicable.

## Locks added
- redship-label CTest `mm-notification-binding` (fails the run on `Notification::Options` cross-game drift)
- compile-time field-type static_asserts on `Notification::Options` in both ports' TUs
- compile-time `!is_polymorphic<OTRGlobals>` static_asserts in both ports' TUs

#427 stays open with a reduced list (items 2/3/4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!--- section:artifacts:start -->
### Build Artifacts
  - [rsbs-windows.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/8484694757.zip)
  - [rsbs-linux.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/8484516989.zip)
<!--- section:artifacts:end -->