### PR TITLE
Reconstruct foreign placements on the spoiler-LOAD path (Lane C1 follow-up, #392)

### DIFF
--- a/games/mm/2s2h/Rando/Spoiler/Apply.cpp
+++ b/games/mm/2s2h/Rando/Spoiler/Apply.cpp
@@ -3,6 +3,13 @@
 #include <libultraship/bridge/consolevariablebridge.h>
 #include "ShipUtils.h"
 
+#ifdef RSBS_SINGLE_EXECUTABLE
+#include <cstdio>
+#include <stdexcept>
+#include <vector>
+#include "foreign_items.h" // src/common — placement table + pinned-pool reverse lookup (Lane C1, #392)
+#endif
+
 extern "C" {
 #include "overlays/actors/ovl_En_Sth/z_en_sth.h"
 }
@@ -10,6 +17,128 @@ extern "C" {
 namespace Rando {
 
 namespace Spoiler {
+
+#ifdef RSBS_SINGLE_EXECUTABLE
+// Lane C1 follow-up (#392): rebuild gComboCtx.foreignPlacements from a loaded
+// spoiler's "foreign" section — the spoiler-LOAD counterpart of generation's
+// Rando::Foreign::PlaceForeignItems (games/mm/2s2h/Rando/Foreign.cpp). Without
+// this a paired MM world entered via the LOAD path never rebuilds the placement
+// table, and its foreign checks silently degrade to the junk-class MM item they
+// physically hold (the gap the C1 landing on #392 noted).
+//
+// Overwrite semantics (grounded in save.cpp's .redsave load, which validates
+// the whole record and only then commits the ComboContext whole-struct):
+//
+//  (1) REDEMPTION IS STRUCTURALLY SAFE. This function writes ONLY
+//      foreignPlacements; it never reads or writes sharedItemsTagged, where
+//      RSBS_SHARED_ITEM_REDEEMED lives. A spoiler load therefore can never lose
+//      or re-award a redeemed crossing — the same guarantee shared_items.h
+//      already relies on (redeemed entries are never cleared).
+//
+//  (2) REFUSE-OR-PRESERVE, never silent overwrite. If foreignPlacements is
+//      already populated when this runs (the "load over a live paired session"
+//      hazard — the caller did not clear first), the existing table is
+//      PRESERVED and reconstruction refuses, because the live sharedItemsTagged
+//      crossings reference the world that table describes. The normal new-file
+//      path clears placements before applying (OnFileCreate), so it always
+//      reconstructs from an empty table; the guard only bites on an overwrite
+//      of live state.
+//
+//  (3) VALIDATE-THEN-COMMIT, atomic. The whole "foreign" section is validated
+//      into a staging buffer before any write, with the same invariants
+//      generation enforces (OoT-origin only; a named pinned-pool item, so the
+//      SharedItem is the tagged pool entry and never a raw RG_*; a known MM
+//      check; no duplicate host check; bounded by RSBS_FOREIGN_PLACEMENT_CAP).
+//      A malformed section throws before touching the table (consistent with
+//      ApplyToSaveContext's existing throw-on-malformed-check and LoadFromFile's
+//      throw-on-bad-type-tag). An ABSENT section is not an error: a solo or
+//      pre-C1 world legitimately hosts no foreign items.
+int ReconstructForeignPlacements(const nlohmann::json& spoiler) {
+    // (2) Never silently overwrite a live session's placement table.
+    if (Combo_CountForeignPlacements() > 0) {
+        fprintf(stderr,
+                "[MM] spoiler-load: foreignPlacements already populated (%d); preserving live session, "
+                "not overwriting from the spoiler\n",
+                Combo_CountForeignPlacements());
+        return -1;
+    }
+
+    // Absent section: not paired / pre-C1 — leave the (cleared) table empty.
+    if (!spoiler.contains("foreign")) {
+        return 0;
+    }
+    if (!spoiler["foreign"].is_object()) {
+        throw std::runtime_error("Spoiler 'foreign' section is not an object");
+    }
+
+    // (3) Stage-and-validate every entry before committing anything.
+    struct Pending {
+        uint16_t checkId;
+        SharedItem item;
+    };
+    std::vector<Pending> pending;
+    for (auto& [checkName, entry] : spoiler["foreign"].items()) {
+        if (!entry.is_object() || !entry.contains("originGame") || !entry.contains("item")) {
+            throw std::runtime_error("Spoiler foreign entry '" + checkName + "' is malformed");
+        }
+        const std::string originGame = entry["originGame"].get<std::string>();
+        if (originGame != "OOT") {
+            // The MVP is one-directional (OoT items into MM checks); anything
+            // else is a spoiler from an incompatible/newer build.
+            throw std::runtime_error("Spoiler foreign entry '" + checkName + "' has unsupported originGame '" +
+                                     originGame + "'");
+        }
+        const std::string itemName = entry["item"].get<std::string>();
+        SharedItem item;
+        if (!Combo_GetForeignItemByName(itemName.c_str(), &item)) {
+            throw std::runtime_error("Spoiler foreign entry '" + checkName + "' names unknown foreign item '" +
+                                     itemName + "'");
+        }
+        if (item.originGame != (uint8_t)GAME_OOT) {
+            throw std::runtime_error("Spoiler foreign entry '" + checkName + "' resolved to a non-OoT-tagged item");
+        }
+        const RandoCheckId checkId = Rando::StaticData::GetCheckIdFromName(checkName.c_str());
+        if (checkId == RC_UNKNOWN) {
+            throw std::runtime_error("Spoiler foreign section names unknown MM check '" + checkName + "'");
+        }
+        for (const Pending& p : pending) {
+            if (p.checkId == (uint16_t)checkId) {
+                throw std::runtime_error("Spoiler foreign section lists MM check '" + checkName + "' twice");
+            }
+        }
+        if (pending.size() >= (size_t)RSBS_FOREIGN_PLACEMENT_CAP) {
+            throw std::runtime_error("Spoiler foreign section exceeds the placement table capacity");
+        }
+        pending.push_back({ (uint16_t)checkId, item });
+    }
+
+    // Commit: the table was empty (guard above); rebuild it through the SAME
+    // Combo_SetForeignPlacement generation uses, so the tagged-only /
+    // no-duplicate / bounded invariants are enforced by one code path.
+    Combo_ClearForeignPlacements();
+    int placed = 0;
+    for (const Pending& p : pending) {
+        if (Combo_SetForeignPlacement(p.checkId, p.item) >= 0) {
+            placed++;
+            // ADR 0002 host invariant, restored on load: the MM save table must
+            // keep a LEGAL junk-class MM item at a foreign host check (never a
+            // raw RG_*). The spoiler's human-readable "checks" map stored this
+            // check as "<item> (Ocarina of Time)", which GetItemIdFromName
+            // cannot resolve, so ApplyToSaveContext just left RI_UNKNOWN there;
+            // the underlying junk item is not recoverable from the spoiler, so
+            // normalize to the canonical junk sentinel. Inert while the
+            // placement stands (the give path reads foreignPlacements, not this
+            // item), but it keeps the table legal and makes the check degrade to
+            // junk — not RI_UNKNOWN — if the placement is ever absent.
+            RANDO_SAVE_CHECKS[(RandoCheckId)p.checkId].randoItemId = RI_JUNK;
+            RANDO_SAVE_CHECKS[(RandoCheckId)p.checkId].shuffled = true;
+        }
+    }
+    fprintf(stderr, "[MM] spoiler-load: reconstructed %d foreign placement(s) from the spoiler's foreign section\n",
+            placed);
+    return placed;
+}
+#endif
 
 void ApplyToSaveContext(nlohmann::json spoiler) {
     gSaveContext.save.shipSaveInfo.rando.finalSeed = spoiler["finalSeed"].get<uint32_t>();
@@ -57,6 +186,15 @@ void ApplyToSaveContext(nlohmann::json spoiler) {
             RANDO_SAVE_CHECKS[randoCheckId].shuffled = true;
         }
     }
+
+#ifdef RSBS_SINGLE_EXECUTABLE
+    // Lane C1 follow-up (#392): a paired MM world entered via the spoiler-LOAD
+    // path must rebuild its cross-game placements from the spoiler, or its
+    // foreign checks degrade to the junk they physically hold. This is the LOAD
+    // counterpart of generation's Rando::Foreign::PlaceForeignItems. Runs after
+    // the checks are applied; never touches sharedItemsTagged (redemption-safe).
+    ReconstructForeignPlacements(spoiler);
+#endif
 }
 
 } // namespace Spoiler

--- a/games/mm/2s2h/Rando/Spoiler/Spoiler.h
+++ b/games/mm/2s2h/Rando/Spoiler/Spoiler.h
@@ -17,6 +17,23 @@ nlohmann::json LoadFromFile(const std::string& filePath);
 void ApplyToSaveContext(nlohmann::json spoiler);
 bool HandleFileDropped(char* path);
 
+#ifdef RSBS_SINGLE_EXECUTABLE
+// Lane C1 follow-up (#392): the spoiler-LOAD counterpart of generation's
+// Rando::Foreign::PlaceForeignItems. Rebuilds gComboCtx.foreignPlacements from
+// a loaded spoiler's "foreign" section so a paired MM world entered via LOAD
+// (not fresh generation) yields its foreign items instead of degrading to the
+// junk-class MM host item. Called by ApplyToSaveContext; exposed for the
+// MMRandoGen CTest lock.
+//
+// Returns the number of placements reconstructed (>= 0), 0 for an absent
+// "foreign" section, or -1 when it PRESERVES an already-populated (live-
+// session) table rather than overwriting it. Throws std::runtime_error on a
+// malformed section (validate-then-commit; the table is left untouched). Never
+// reads or writes gComboCtx.sharedItemsTagged, so redeemed crossings survive.
+// See Apply.cpp for the full overwrite semantics.
+int ReconstructForeignPlacements(const nlohmann::json& spoiler);
+#endif
+
 } // namespace Spoiler
 
 } // namespace Rando

--- a/games/mm/2s2h/mm_rando_gen_test.cpp
+++ b/games/mm/2s2h/mm_rando_gen_test.cpp
@@ -33,6 +33,7 @@
 #include "2s2h/GameInteractor/GameInteractor.h" // S2H::GameHooks counters (single-exe tail)
 #include "2s2h/Rando/Rando.h"
 #include "2s2h/Rando/Foreign.h"
+#include "2s2h/Rando/Spoiler/Spoiler.h"
 #include "2s2h/Rando/Logic/Logic.h"
 #include "2s2h/Rando/MiscBehavior/MiscBehavior.h"
 #include "2s2h/Rando/StaticData/StaticData.h"
@@ -305,6 +306,152 @@ extern "C" int MM_Rando_HeadlessGenTest(void) {
     }
     fprintf(stderr, "[MM-RANDO-GEN] paired world: %d foreign placements, spoiler foreign section verified\n",
             placedCount);
+
+    // ======================================================================
+    // Spoiler-LOAD reconstruction lock (Lane C1 follow-up, #392). The paired
+    // world just generated wrote gComboCtx.foreignPlacements AND a spoiler with
+    // a "foreign" section. Prove the spoiler-LOAD path
+    // (Rando::Spoiler::ReconstructForeignPlacements, the counterpart of
+    // generation's PlaceForeignItems, reached through ApplyToSaveContext)
+    // rebuilds those placements exactly — the gap the C1 landing on #392 noted,
+    // where a loaded paired world degraded its foreign checks to junk — while
+    // never disturbing redeemed cross-game state.
+    // ======================================================================
+    ComboForeignPlacement generated[RSBS_FOREIGN_PLACEMENT_CAP];
+    memcpy(generated, gComboCtx.foreignPlacements, sizeof(generated));
+
+    // Re-read the just-written spoiler through the REAL LoadFromFile validator.
+    nlohmann::json loadedSpoiler;
+    try {
+        loadedSpoiler =
+            Rando::Spoiler::LoadFromFile(std::string("RSBSPAIR") + std::to_string(gComboCtx.sharedRandoSeed) + ".json");
+    } catch (const std::exception& e) {
+        fprintf(stderr, "[MM-RANDO-GEN] FAIL(16): loading the paired spoiler threw: %s\n", e.what());
+        return 16;
+    }
+
+    // Preserve-guard: with the live table still populated, reconstruction must
+    // REFUSE (return -1) and leave it byte-identical — a spoiler load must never
+    // clobber a live paired session's placements.
+    if (Rando::Spoiler::ReconstructForeignPlacements(loadedSpoiler) != -1 ||
+        memcmp(generated, gComboCtx.foreignPlacements, sizeof(generated)) != 0) {
+        fprintf(stderr, "[MM-RANDO-GEN] FAIL(16): reconstruction overwrote a live placement table instead of "
+                        "preserving it\n");
+        return 16;
+    }
+
+    // Plant a REDEEMED cross-game entry so the lock proves reconstruction never
+    // touches sharedItemsTagged (redemption survives a spoiler load).
+    SharedItem redeemed = {};
+    redeemed.originGame = (uint8_t)GAME_OOT;
+    redeemed.flags = RSBS_SHARED_ITEM_REDEEMED;
+    redeemed.id = pool[0].item.id;
+    gComboCtx.sharedItemsTagged[0] = redeemed;
+
+    // Clear the table (the state a new-file spoiler load starts from, after
+    // OnFileCreate's pre-apply clear) and reconstruct from the loaded spoiler.
+    Combo_ClearForeignPlacements();
+    const int reconstructed = Rando::Spoiler::ReconstructForeignPlacements(loadedSpoiler);
+    if (reconstructed != poolCount) {
+        fprintf(stderr, "[MM-RANDO-GEN] FAIL(17): reconstructed %d placements, expected %d\n", reconstructed,
+                poolCount);
+        return 17;
+    }
+
+    // Reconstructed table must match the generated one EXACTLY (host check ->
+    // origin-tagged item), order-independently (a JSON object has no slot order).
+    for (int i = 0; i < (int)RSBS_FOREIGN_PLACEMENT_CAP; i++) {
+        if (generated[i].item.originGame == GAME_NONE) {
+            continue;
+        }
+        const SharedItem* got = Combo_GetForeignPlacementForCheck(generated[i].mmCheckId);
+        if (got == NULL || got->originGame != generated[i].item.originGame || got->id != generated[i].item.id ||
+            got->flags != generated[i].item.flags) {
+            fprintf(stderr, "[MM-RANDO-GEN] FAIL(18): host check %u did not reconstruct to its generated item\n",
+                    (unsigned)generated[i].mmCheckId);
+            return 18;
+        }
+        // ADR 0002 host invariant on the load path: the MM save table keeps a
+        // legal junk-class MM item at the host check (never RI_UNKNOWN / a raw
+        // RG_*), so the check degrades to junk if the placement is ever absent.
+        const RandoItemId heldAfterLoad = RANDO_SAVE_CHECKS[(RandoCheckId)generated[i].mmCheckId].randoItemId;
+        if (Rando::StaticData::Items[heldAfterLoad].randoItemType != RITYPE_JUNK) {
+            fprintf(stderr, "[MM-RANDO-GEN] FAIL(18): reconstructed host check %u holds a non-junk MM item (%d)\n",
+                    (unsigned)generated[i].mmCheckId, (int)heldAfterLoad);
+            return 18;
+        }
+    }
+    if (Combo_CountForeignPlacements() != poolCount) {
+        fprintf(stderr, "[MM-RANDO-GEN] FAIL(18): reconstructed count %d != generated %d\n",
+                Combo_CountForeignPlacements(), poolCount);
+        return 18;
+    }
+
+    // Redemption survived untouched.
+    if (memcmp(&gComboCtx.sharedItemsTagged[0], &redeemed, sizeof(SharedItem)) != 0) {
+        fprintf(stderr, "[MM-RANDO-GEN] FAIL(19): reconstruction mutated redeemed shared-item state\n");
+        return 19;
+    }
+
+    // Malformed foreign section: refuse (throw) and leave the table untouched —
+    // validate-then-commit is atomic, no partial population.
+    {
+        Combo_ClearForeignPlacements();
+        nlohmann::json malformed = loadedSpoiler;
+        for (auto& [checkName, entry] : malformed["foreign"].items()) {
+            entry["item"] = "Definitely Not A Pinned Pool Item";
+            break;
+        }
+        bool threw = false;
+        try {
+            Rando::Spoiler::ReconstructForeignPlacements(malformed);
+        } catch (const std::exception&) { threw = true; }
+        if (!threw || Combo_CountForeignPlacements() != 0) {
+            fprintf(stderr,
+                    "[MM-RANDO-GEN] FAIL(20): malformed foreign section not rejected atomically (threw=%d, "
+                    "placements=%d)\n",
+                    threw ? 1 : 0, Combo_CountForeignPlacements());
+            return 20;
+        }
+    }
+
+    // Absent foreign section: not an error; yields an empty table cleanly.
+    {
+        Combo_ClearForeignPlacements();
+        nlohmann::json noForeign = loadedSpoiler;
+        noForeign.erase("foreign");
+        if (Rando::Spoiler::ReconstructForeignPlacements(noForeign) != 0 || Combo_CountForeignPlacements() != 0) {
+            fprintf(stderr, "[MM-RANDO-GEN] FAIL(21): absent foreign section did not yield an empty table cleanly\n");
+            return 21;
+        }
+    }
+
+    // Wiring: the REAL apply path (ApplyToSaveContext, the spoiler-LOAD entry
+    // point OnFileCreate's load branch invokes) must itself drive reconstruction
+    // — not just the focused helper above. Clear, apply the whole spoiler, and
+    // confirm the placements came back.
+    Combo_ClearForeignPlacements();
+    try {
+        Rando::Spoiler::ApplyToSaveContext(loadedSpoiler);
+    } catch (const std::exception& e) {
+        fprintf(stderr, "[MM-RANDO-GEN] FAIL(22): ApplyToSaveContext threw on the paired spoiler: %s\n", e.what());
+        return 22;
+    }
+    if (Combo_CountForeignPlacements() != poolCount) {
+        fprintf(stderr,
+                "[MM-RANDO-GEN] FAIL(22): ApplyToSaveContext did not reconstruct foreign placements (found %d)\n",
+                Combo_CountForeignPlacements());
+        return 22;
+    }
+
+    // Restore the paired world's live placements for the OnSaveLoad phase below,
+    // and clear the planted redeemed entry.
+    Combo_ClearForeignPlacements();
+    memcpy(gComboCtx.foreignPlacements, generated, sizeof(generated));
+    memset(&gComboCtx.sharedItemsTagged[0], 0, sizeof(SharedItem));
+
+    fprintf(stderr, "[MM-RANDO-GEN] spoiler-LOAD reconstruction verified: preserve-live, rebuild-exact, "
+                    "redemption-safe, malformed-refused, absent-ok, apply-wired\n");
 
     // OnSaveLoad chain lock (Lane C1): dispatching the real save-load bridge
     // with the rando save live must arm the rando behaviors — the

--- a/src/common/foreign_items.c
+++ b/src/common/foreign_items.c
@@ -13,9 +13,34 @@
 
 #include "foreign_items.h"
 #include <stdio.h>
+#include <string.h>
 
 bool Combo_ForeignPairingActive(void) {
     return gComboCtx.sourceIsRando && gComboCtx.sharedRandoSettingsHash != 0;
+}
+
+bool Combo_GetForeignItemByName(const char* name, SharedItem* outItem) {
+    // Reverse of the OoT-side Combo_GetForeignItemName: walk the same pinned
+    // pool and hand back the origin-tagged SharedItem. Reused (not re-derived)
+    // so the spoiler-LOAD reconstruction shares one source of truth with
+    // generation, and so a raw RG_* is never fabricated MM-side (ADR 0002).
+    if (name == NULL) {
+        return false;
+    }
+    const ComboForeignItemDef* pool = NULL;
+    const int poolCount = Combo_GetForeignItemPool(&pool);
+    if (poolCount <= 0 || pool == NULL) {
+        return false;
+    }
+    for (int i = 0; i < poolCount; i++) {
+        if (pool[i].name != NULL && strcmp(pool[i].name, name) == 0) {
+            if (outItem != NULL) {
+                *outItem = pool[i].item;
+            }
+            return true;
+        }
+    }
+    return false;
 }
 
 int Combo_SetForeignPlacement(uint16_t mmCheckId, SharedItem item) {

--- a/src/common/foreign_items.h
+++ b/src/common/foreign_items.h
@@ -64,6 +64,19 @@ int Combo_GetForeignItemPool(const ComboForeignItemDef** outPool);
  */
 const char* Combo_GetForeignItemName(SharedItem item);
 
+/**
+ * The inverse of Combo_GetForeignItemName: resolve a pinned-pool display name
+ * back to its origin-tagged SharedItem. Used by the spoiler-LOAD path
+ * (Rando::Spoiler::ReconstructForeignPlacements) to rebuild
+ * gComboCtx.foreignPlacements from the spoiler's "foreign" section without an
+ * OoT header in scope — the SharedItem is copied straight out of the pinned
+ * pool, so a raw RG_* is never reconstructed on the MM side (ADR 0002).
+ * @param name    the display name to look up (NULL is rejected)
+ * @param outItem receives the tagged SharedItem on a match (may be NULL)
+ * @return true if a pool entry has this name, false otherwise.
+ */
+bool Combo_GetForeignItemByName(const char* name, SharedItem* outItem);
+
 // ============================================================================
 // Placement table accessors (gComboCtx.foreignPlacements)
 // ============================================================================


### PR DESCRIPTION
Closes the Lane C1 follow-up the C1 landing on #392 (PR #428) filed: a paired MM world entered via the spoiler-file **LOAD** path never rebuilt `gComboCtx.foreignPlacements`, so its foreign checks silently degraded to the junk-class MM item they physically hold. Generation (`Rando::Foreign::PlaceForeignItems`) recorded the crossings; nothing on load reconstructed them.

## What changed

- **`Rando::Spoiler::ReconstructForeignPlacements`** (`games/mm/2s2h/Rando/Spoiler/Apply.cpp`) rebuilds the placement table from the spoiler's `foreign` section, and `ApplyToSaveContext` now calls it (the single entry point that `LoadFromFile` / `HandleFileDropped` / the `OnFileCreate` load branch all funnel through — no `OnFileCreate.cpp` hunk needed).
- Same invariants as generation, enforced by **reusing generation's code path**: each entry is resolved in the pinned pool (new `Combo_GetForeignItemByName`, over the same table `Combo_GetForeignItemName` uses — so load and generation share one source of truth) and written through `Combo_SetForeignPlacement`, which already rejects untagged items, `RC_UNKNOWN` hosts, duplicate host checks, and overflow past `RSBS_FOREIGN_PLACEMENT_CAP`. A raw `RG_*` is therefore never reconstructed on the MM side (ADR 0002) — the `SharedItem` comes straight out of the OoT-defined pool.
- Each host check is normalized back to a junk-class MM item (`RI_JUNK`). The spoiler's human-readable `checks` map stored the foreign check as `"<item> (Ocarina of Time)"`, which `GetItemIdFromName` cannot resolve (it would leave `RI_UNKNOWN`); the original junk is not recoverable from the spoiler, so normalizing keeps the ADR-0002 host invariant and lets the check degrade to junk — not `RI_UNKNOWN` — if a placement is ever absent.

## Overwrite-semantics decision (item 2)

Grounded in how `.redsave` load treats `gComboCtx` (`src/common/save.cpp`: validate the whole record + CRC, then commit the ComboContext whole-struct — refuse on any defect, never partial). The reconstruction adopts the semantics that **cannot lose redeemed state**:

1. **Redemption is structurally safe.** Reconstruction writes **only** `foreignPlacements`; it never reads or writes `sharedItemsTagged`, where `RSBS_SHARED_ITEM_REDEEMED` lives. A spoiler load can therefore never lose or re-award a redeemed crossing — the same guarantee `shared_items.h` already relies on (redeemed entries are never cleared).
2. **Validate-then-commit, atomic.** The entire `foreign` section is validated into a staging buffer before any write. A **malformed** section throws before touching the table (consistent with `ApplyToSaveContext`'s existing throw-on-malformed-check and `LoadFromFile`'s throw-on-bad-type-tag — extends that pattern, doesn't fork it). An **absent** section is not an error (a solo or pre-C1 world legitimately hosts none).
3. **Refuse-or-preserve, never silent overwrite.** If `foreignPlacements` is already populated when reconstruction runs (the "load over a live paired session" hazard — the caller didn't clear first), the existing table is **preserved** and reconstruction refuses (returns `-1`), because the live `sharedItemsTagged` crossings reference the world that table describes. The normal new-file path clears placements before applying (`OnFileCreate`), so it always reconstructs from an empty table; the guard only bites on an overwrite of live state.

## Test lock (item 3)

Extends `MMRandoGen`'s paired phase (`games/mm/2s2h/mm_rando_gen_test.cpp`): generate a paired world through the real dispatch chain, snapshot `foreignPlacements`, then drive the LOAD path and assert:

- **preserve-live** — with the live table populated, reconstruction returns `-1` and leaves it byte-identical;
- **rebuild-exact** — after clearing, reconstruction restores every host-check -> origin-tagged item exactly, count matches the pool, and each host check holds a junk-class MM item;
- **redemption-safe** — a planted `RSBS_SHARED_ITEM_REDEEMED` entry in `sharedItemsTagged` is untouched;
- **malformed-refused** — a bad `item` name throws and leaves the table empty (no partial population);
- **absent-ok** — an erased `foreign` section yields an empty table without error;
- **apply-wired** — the real `ApplyToSaveContext` itself drives the reconstruction.

## Scope / constraints

Surface is `Rando/Spoiler/*`, the common foreign-item layer, and the test only — no `GameExports_SingleExe.cpp`, no `mm_stubs.c`, no `OnFileCreate.cpp` (the reconstruction lives in `ApplyToSaveContext`, avoiding the file the parallel #426 lane may be editing). Generated version stamps untouched.

Refs #392 (Lane C1 follow-up). Builds on #428.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!--- section:artifacts:start -->
### Build Artifacts
  - [rsbs-windows.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/8484768103.zip)
  - [rsbs-linux.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/8484571974.zip)
<!--- section:artifacts:end -->