### PR TITLE
Move MM's UIWidgets into namespace S2H, retiring the last divergent-layout ODR landmine (#383)

### DIFF
--- a/games/mm/2s2h/BenGui/UIWidgets.cpp
+++ b/games/mm/2s2h/BenGui/UIWidgets.cpp
@@ -7,6 +7,13 @@
 #include "2s2h/ShipUtils.h"
 #include <spdlog/fmt/fmt.h>
 
+#ifdef RSBS_SINGLE_EXECUTABLE
+// Single-exe: MM's UIWidgets lives inside namespace S2H so its symbols cannot
+// alias OoT's identically-named, differently-laid-out UIWidgets surface. See
+// the header comment in UIWidgets.hpp (#383).
+namespace S2H {
+#endif
+
 namespace UIWidgets {
 
 // Automatically adds newlines to break up text longer than a specified number of characters
@@ -1342,3 +1349,7 @@ ImVec4 VecFromRGBA8(Color_RGBA8 color) {
     ImVec4 vec = { color.r / 255.0f, color.g / 255.0f, color.b / 255.0f, color.a / 255.0f };
     return vec;
 }
+
+#ifdef RSBS_SINGLE_EXECUTABLE
+} // namespace S2H
+#endif

--- a/games/mm/2s2h/BenGui/UIWidgets.hpp
+++ b/games/mm/2s2h/BenGui/UIWidgets.hpp
@@ -17,6 +17,38 @@
 #include <libultraship/bridge/consolevariablebridge.h>
 #include <ship/window/Window.h>
 
+#ifdef RSBS_SINGLE_EXECUTABLE
+// Single-exe symbol split for MM's UIWidgets surface (#383, final item).
+//
+// OoT (games/oot/soh/SohGui/UIWidgets.hpp) opens an identically-named bare
+// `namespace UIWidgets` whose option structs share every mangled name with
+// the ones below but have DIFFERENT layouts: MM's WidgetOptions carries an
+// extra `Colors color` member (32 bytes vs OoT's 24), which also shifts every
+// derived options struct (Button/WindowButton/Checkbox/Combobox/IntSlider/
+// FloatSlider/RadioButtons/Input) and every inline setter that writes through
+// them (e.g. ButtonOptions::Color writes offset 40 in OoT's layout, offsets
+// 24+48 in MM's — same COMDAT name, divergent bodies). MM's implementations
+// in BenGui/UIWidgets.cpp used to be excluded from the single-exe link, so
+// any MM TU entering the link that called UIWidgets::Button/Checkbox/... got
+// OoT's implementation reading MM's differently-laid-out options object —
+// silently under /FORCE:MULTIPLE on Windows, and invisible to the #375
+// collision gate (which skips weak/COMDAT symbols). This is the FlagTable
+// incident class: latent while MM's menu TUs stay link-elided, armed by any
+// link-set change that pulls one in.
+//
+// Fix, per the ShipInit.hpp recipe: nest MM's namespace inside S2H so the two
+// ports' types stop sharing mangled names at all, with a namespace alias so
+// existing MM callers (`UIWidgets::...`, `using namespace UIWidgets;`)
+// compile unchanged. A deliberate side effect of the alias: reopening a bare
+// `namespace UIWidgets` in any MM TU that includes this header is a compile
+// error in single-exe builds, so the split cannot silently regress.
+// BenGui/UIWidgets.cpp carries the matching wrap and is compiled into
+// 2ship_rando_ui (plain archive — elided until referenced), so MM menu TUs
+// that port later resolve against MM's layout-correct implementations; an
+// un-ported reference now fails the link loudly instead of cross-binding.
+namespace S2H {
+#endif
+
 namespace UIWidgets {
 
 using SectionFunc = void (*)();
@@ -1164,5 +1196,19 @@ ImVec4 GetRandomValue();
 
 Color_RGBA8 RGBA8FromVec(ImVec4 vec);
 ImVec4 VecFromRGBA8(Color_RGBA8 color);
+
+#ifdef RSBS_SINGLE_EXECUTABLE
+} // namespace S2H
+
+// Let existing MM callers resolve to the S2H versions unchanged. The three
+// free helpers above are wrapped too: OoT's SohGui/UIWidgets.cpp defines
+// identically-named strong globals, and MM's definitions now compile (in
+// BenGui/UIWidgets.cpp), so leaving them at global scope would be a strong
+// duplicate-symbol collision.
+namespace UIWidgets = S2H::UIWidgets;
+using S2H::GetRandomValue;
+using S2H::RGBA8FromVec;
+using S2H::VecFromRGBA8;
+#endif
 
 #endif /* UIWidgets_hpp */

--- a/games/mm/CMakeLists.txt
+++ b/games/mm/CMakeLists.txt
@@ -110,11 +110,22 @@ file(GLOB_RECURSE ship__Rando RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} "2s2h/Rando/*
 # 2ship_rando_ui stays compiled (bit-rot protection) but links with plain
 # archive semantics: nothing references its symbols in single-exe builds
 # (Rando::Init's CheckTracker calls are compiled out there), so it is elided
-# exactly like the rest of MM's menu until that surface is ported (#383's
-# UIWidgets remainder; Lane B's surface note on #392).
+# exactly like the rest of MM's menu until that surface is ported (Lane B's
+# surface note on #392).
+#
+# BenGui/UIWidgets.cpp rides along here (#383): MM's UIWidgets lives in
+# namespace S2H in single-exe builds so its option structs stop sharing
+# mangled names with OoT's differently-laid-out UIWidgets, and this TU is the
+# matching S2H implementation. Plain archive semantics keep it elided until
+# an MM menu TU actually references it; before this, a pulled-in MM menu TU
+# silently bound OoT's UIWidgets implementations against MM's 32-byte
+# WidgetOptions layout (the FlagTable incident class) — now that same mistake
+# is a loud unresolved-external link error at worst, and resolves correctly
+# once this TU is pulled.
 set(ship__Rando_ui
     "2s2h/Rando/Menu.cpp"
     "2s2h/Rando/CheckTracker/CheckTracker.cpp"
+    "2s2h/BenGui/UIWidgets.cpp"
 )
 list(FILTER ship__Rando EXCLUDE REGEX "2s2h/Rando/Menu\\.cpp$")
 list(FILTER ship__Rando EXCLUDE REGEX "2s2h/Rando/CheckTracker/CheckTracker\\.cpp$")
@@ -216,7 +227,10 @@ if(SINGLE_EXECUTABLE_BUILD)
     # Main port glue (OTRGlobals equivalent)
     list(FILTER ship__ EXCLUDE REGEX "2s2h/BenPort\\.cpp$")
 
-    # All GUI components
+    # All GUI components. Exception: BenGui/UIWidgets.cpp is compiled into
+    # 2ship_rando_ui (see the ship__Rando_ui block above) as the S2H-namespaced
+    # implementation behind MM's UIWidgets headers (#383) — the filter here
+    # only shapes 2ship_port, so no duplication results.
     list(FILTER ship__ EXCLUDE REGEX "2s2h/BenGui/.*\\.cpp$")
 
     # All developer tools


### PR DESCRIPTION
Retires the final item of #383: the `UIWidgets::WidgetOptions` cross-port ODR layout mismatch — the last known member of the FlagTable/AudioCollection divergent-layout family.

## The measurement (done first, per the incident-class playbook)

**Who pulls MM UIWidgets symbols into today's link: nobody.**

- `2ship_src`: the C TUs that include `BenGui/HudEditor.h` (z_lifemeter, z_parameter, z_map_disp, kaleido) only see its `__cplusplus`-guarded extern-C half — the `UIWidgets.hpp` include is unreachable from C.
- `2ship_port`: BenGui/, DeveloperTools/, PresetManager/, BenPort.cpp are all excluded — no UIWidgets includes survive.
- `2ship_enh` (plain archive): the only two force-linked members, FrameInterpolation.cpp and SkipGiantsChamber.cpp, include no UIWidgets headers.
- `2ship_rando` (WHOLE_ARCHIVE — every member links): zero UIWidgets includes; Menu.cpp/CheckTracker.cpp were split into `2ship_rando_ui` by C0 (#422), and no Rando header reaches BenGui (CheckTracker.h includes only Rando.h + GuiWindow.h).
- The nine compiled TUs that DO include MM's UIWidgets.hpp (rando_ui's Menu/CheckTracker, TimeSplits x3, ItemTracker x2, MotionBlur, AudioHook via BenMenu.h) are all link-elided. Green Linux CI is the proof: any of them entering the link would either bind OoT's impls silently or fail unresolved on BenMenu symbols.

**Who wins today:** OoT, exclusively — MM contributes zero UIWidgets symbols (strong or weak) to the binary. The overlap exists only inside elided archive members: weak/COMDAT inline setters and template instantiations with identical mangled names over divergent layouts (MM's WidgetOptions is 32 bytes vs OoT's 24; e.g. `ButtonOptions::Color` writes offset 40 in OoT's body, offsets 24+48 in MM's). That is why the armed #375 collision gate's baseline stayed empty — it intersects strong symbols only. The landmine was disarmed purely by elision: any link-set change pulling one of those nine TUs armed it silently, on Windows under /FORCE:MULTIPLE with no diagnostic at all.

**Consequence:** the preferred fix costs zero BenGui porting — no linked TU needs MM's implementation.

## The fix (ShipInit.hpp recipe, exactly as prescribed in #383)

- **`games/mm/2s2h/BenGui/UIWidgets.hpp`**: under `RSBS_SINGLE_EXECUTABLE`, MM's `namespace UIWidgets` — plus the `GetRandomValue`/`RGBA8FromVec`/`VecFromRGBA8` free helpers, which OoT's SohGui/UIWidgets.cpp also defines as strong globals — nests inside `namespace S2H`, with `namespace UIWidgets = S2H::UIWidgets;` and using-decls so every existing MM caller (qualified uses, `using namespace UIWidgets;`) compiles unchanged. Deliberate side effect: reopening a bare `namespace UIWidgets` in any MM TU that includes this header is now a compile error, so the split cannot silently regress.
- **`games/mm/2s2h/BenGui/UIWidgets.cpp`**: matching wrap; now compiled into `2ship_rando_ui` (plain archive). Still elided today — the linked symbol set is bit-identical — but MM menu TUs that port later (Lane B / rando_ui) resolve against MM's layout-correct implementations, and an un-ported reference fails the link loudly (unresolved `S2H::UIWidgets::...`) instead of silently executing OoT's bodies against MM's layouts.
- **`games/mm/CMakeLists.txt`**: `UIWidgets.cpp` added to `ship__Rando_ui`; comments updated. Non-single-exe (shared) builds are untouched — the wrap is `#ifdef`'d and the BenGui glob there already includes the file.

## Gates

- **#375 collision gate**: green by construction — every new strong MM symbol is S2H-qualified; the three formerly-global helpers are wrapped for exactly this reason.
- **Registrar-elision check**: `2ship_rando_ui` is report-only; UIWidgets.obj's static-init registrar will show as (deliberately) elided, same as Menu/CheckTracker.
- **No layout-lock CTest added, on purpose**: unlike the tolerated `Notification::Emit` cross-bind (#432) where both ports must keep one shared layout, after this split the two ports' UIWidgets share no mangled names — there is no cross-view layout contract left to police. The failure mode this family enabled (silent cross-layout execution) is now structurally impossible; the residual failure mode is a hard link error.
- clang-format: UIWidgets.hpp/.cpp stay off the allowlist per its stated policy (vendored files with a small RSBS patch; whole-file reformat would be pure upstream-conflict surface).

Closes #383.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!--- section:artifacts:start -->
### Build Artifacts
  - [rsbs-windows.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/8485367781.zip)
  - [rsbs-linux.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/8485150063.zip)
<!--- section:artifacts:end -->