### PR TITLE
Wire MM-frame Should/VB dispatch through the MM-owned shim (#392 VB follow-up)

### DIFF
--- a/games/mm/2s2h/GameExports_SingleExe.cpp
+++ b/games/mm/2s2h/GameExports_SingleExe.cpp
@@ -1636,6 +1636,62 @@ extern "C" void MM_GameHooks_ExecuteOnSceneFlagSet(s16 sceneId, FlagType flagTyp
 }
 
 /**
+ * MM-owned "Should" dispatch (#392 VB follow-up). MM call sites reach these
+ * through the single-exe macro rebind at the bottom of MM's GameInteractor.h
+ * (GameInteractor_Should -> MM_GameHooks_ExecuteVBShould, etc.), so MM VB ids
+ * and actor ids resolve against the MM-owned S2H::GameHooks registries only —
+ * never OoT's ordinal-aliased tables. Bodies are line-faithful ports of the
+ * excluded upstream executors (2s2h/GameInteractor/GameInteractor.cpp), minus
+ * the ForPtr/ForFilter legs: the S2H registry deliberately has no Ptr/Filter
+ * surface and the linked MM set registers none (the only Should filter user,
+ * DeveloperTools.cpp, stays link-elided — re-audit if it ever un-elides).
+ * Locked by MMRandoGen's VB-dispatch phase (mm_rando_gen_test.cpp).
+ */
+extern "C" bool MM_GameHooks_ExecuteVBShould(GIVanillaBehavior flag, uint32_t result, ...) {
+    va_list args;
+    va_start(args, result);
+
+    // Default argument promotion: the caller's verdict arrives as a uint32_t
+    // (va_start on a bool is UB); downcast for the hook handlers, exactly as
+    // upstream GameInteractor_Should does.
+    bool boolResult = static_cast<bool>(result);
+
+    S2H::GameHooks::Execute<GameInteractor::ShouldVanillaBehavior>(flag, &boolResult, args);
+    S2H::GameHooks::ExecuteForID<GameInteractor::ShouldVanillaBehavior>(flag, flag, &boolResult, args);
+
+    va_end(args);
+    return boolResult;
+}
+
+extern "C" bool MM_GameHooks_ExecuteShouldActorInit(Actor* actor) {
+    bool result = true;
+    S2H::GameHooks::Execute<GameInteractor::ShouldActorInit>(actor, &result);
+    S2H::GameHooks::ExecuteForID<GameInteractor::ShouldActorInit>(actor->id, actor, &result);
+    return result;
+}
+
+extern "C" bool MM_GameHooks_ExecuteShouldActorUpdate(Actor* actor) {
+    bool result = true;
+    S2H::GameHooks::Execute<GameInteractor::ShouldActorUpdate>(actor, &result);
+    S2H::GameHooks::ExecuteForID<GameInteractor::ShouldActorUpdate>(actor->id, actor, &result);
+    return result;
+}
+
+extern "C" bool MM_GameHooks_ExecuteShouldActorDraw(Actor* actor) {
+    bool result = true;
+    S2H::GameHooks::Execute<GameInteractor::ShouldActorDraw>(actor, &result);
+    S2H::GameHooks::ExecuteForID<GameInteractor::ShouldActorDraw>(actor->id, actor, &result);
+    return result;
+}
+
+extern "C" bool MM_GameHooks_ExecuteShouldItemGive(u8 item) {
+    bool result = true;
+    S2H::GameHooks::Execute<GameInteractor::ShouldItemGive>(item, &result);
+    S2H::GameHooks::ExecuteForID<GameInteractor::ShouldItemGive>(item, item, &result);
+    return result;
+}
+
+/**
  * Award a single MM-origin shared item (ADR 0002 / Lane A1 consumer callback),
  * the MM twin of OoT_AwardSharedItem. `item->id` is an MM RandoItemId (RI_*).
  *

--- a/games/mm/2s2h/GameInteractor/GameInteractor.h
+++ b/games/mm/2s2h/GameInteractor/GameInteractor.h
@@ -580,6 +580,43 @@ int GameInteractor_InvertControl(GIInvertType type);
 uint32_t GameInteractor_Dpad(GIDpadType type, uint32_t buttonCombo);
 uint32_t GameInteractor_RightStickOcarina(Input* input);
 
+#if defined(RSBS_SINGLE_EXECUTABLE)
+//
+// Single-exe MM-owned "Should" dispatch (#392 VB follow-up; #395/#367 class).
+//
+// The five upstream names below would otherwise resolve to OoT's extern "C"
+// wrappers (GameInteractor_Should/ShouldActorInit/ShouldActorUpdate in
+// games/oot/soh/Enhancements/game-interactor/GameInteractor_Hooks.cpp) or to
+// src/common/mm_stubs.c stubs (ShouldActorDraw/ShouldItemGive). Routing MM
+// calls into OoT's registry is forbidden — MM's GIVanillaBehavior ordinals
+// ALIAS OoT's (MM VB_SETUP_TRANSITION == OoT VB_PLAY_RAINBOW_BRIDGE_CS ==
+// 206) — so those wrappers gate on the active game and return the vanilla
+// verdict while MM runs. Net effect: no MM rando/enhancement override could
+// ever fire, and a rando-handled check ALSO gave its vanilla contents (the
+// C1 double-give).
+//
+// Rebind every MM call site — textually unchanged, upstream diffs still
+// apply — to MM-owned dispatchers (games/mm/2s2h/GameExports_SingleExe.cpp)
+// that consult ONLY the MM-owned S2H::GameHooks registries the macro
+// redirection below populates. Only MM TUs see this header, so MM VB ids
+// never reach OoT's GameInteractor_Should or its hook tables: ordinal safety
+// by construction, the same technique as the registration-macro redirection.
+// Placed after the upstream declarations above (which stay, un-renamed and
+// unused by MM code) and before the close of the extern "C" block so C and
+// C++ TUs both rebind.
+//
+bool MM_GameHooks_ExecuteVBShould(GIVanillaBehavior flag, uint32_t result, ...);
+bool MM_GameHooks_ExecuteShouldActorInit(Actor* actor);
+bool MM_GameHooks_ExecuteShouldActorUpdate(Actor* actor);
+bool MM_GameHooks_ExecuteShouldActorDraw(Actor* actor);
+bool MM_GameHooks_ExecuteShouldItemGive(u8 item);
+#define GameInteractor_Should MM_GameHooks_ExecuteVBShould
+#define GameInteractor_ShouldActorInit MM_GameHooks_ExecuteShouldActorInit
+#define GameInteractor_ShouldActorUpdate MM_GameHooks_ExecuteShouldActorUpdate
+#define GameInteractor_ShouldActorDraw MM_GameHooks_ExecuteShouldActorDraw
+#define GameInteractor_ShouldItemGive MM_GameHooks_ExecuteShouldItemGive
+#endif // RSBS_SINGLE_EXECUTABLE
+
 #ifdef __cplusplus
 }
 

--- a/games/mm/2s2h/mm_rando_gen_test.cpp
+++ b/games/mm/2s2h/mm_rando_gen_test.cpp
@@ -491,6 +491,70 @@ extern "C" int MM_Rando_HeadlessGenTest(void) {
     fprintf(stderr, "[MM-RANDO-GEN] OnSaveLoad dispatch armed rando hooks (OnFlagSet: %zu -> %zu)\n", flagHooksBefore,
             flagHooksAfter);
 
+    // ======================================================================
+    // VB-dispatch phase (#392 VB follow-up) — the double-give lock, both
+    // directions. GameInteractor_Should at MM call sites now resolves (macro
+    // rebind, MM's GameInteractor.h) to MM_GameHooks_ExecuteVBShould, which
+    // consults only the S2H::GameHooks registries. A rando-armed give VB
+    // returning FALSE is exactly "the vanilla item is NOT also given" at the
+    // call site (e.g. z_en_item00.c: `if (GameInteractor_Should(VB_..., true,
+    // ...)) { give vanilla item }`); the crossing itself flows through the
+    // CheckQueue give path instead. Probes use hooks whose bodies touch no
+    // play state, so they are headless-safe:
+    //  - VB_GIVE_ITEM_FROM_GREAT_FAIRY: COND_VB_SHOULD ForID leg
+    //    (EnElfgrp.cpp, unconditional *should = false under IS_RANDO);
+    //  - VB_GIVE_NEW_WAVE_BOSSA_NOVA: non-ID leg (ActorBehavior.cpp's
+    //    MiscVanillaBehaviorHandler switch, *should = false);
+    //  - VB_SETUP_TRANSITION: registered by nothing in the linked set — the
+    //    caller's verdict must pass through untouched in BOTH polarities
+    //    (this is also the ordinal-aliasing poster child: OoT's
+    //    VB_PLAY_RAINBOW_BRIDGE_CS hooks must never answer it).
+    // ======================================================================
+    const size_t vbHooks = S2H::GameHooks::CountForTest<GameInteractor::ShouldVanillaBehavior>();
+    const size_t actorInitHooks = S2H::GameHooks::CountForTest<GameInteractor::ShouldActorInit>();
+    if (vbHooks == 0 || actorInitHooks == 0) {
+        fprintf(stderr, "[MM-RANDO-GEN] FAIL(23): OnSaveLoad armed no Should hooks (VB %zu, ShouldActorInit %zu)\n",
+                vbHooks, actorInitHooks);
+        return 23;
+    }
+    if (GameInteractor_Should(VB_GIVE_ITEM_FROM_GREAT_FAIRY, true)) {
+        fprintf(stderr, "[MM-RANDO-GEN] FAIL(24): rando-armed ForID give VB not suppressed — the vanilla item "
+                        "would ALSO be given (double-give)\n");
+        return 24;
+    }
+    if (GameInteractor_Should(VB_GIVE_NEW_WAVE_BOSSA_NOVA, true)) {
+        fprintf(stderr, "[MM-RANDO-GEN] FAIL(24): rando-armed non-ID give VB not suppressed — the vanilla item "
+                        "would ALSO be given (double-give)\n");
+        return 24;
+    }
+    if (!GameInteractor_Should(VB_SETUP_TRANSITION, true) || GameInteractor_Should(VB_SETUP_TRANSITION, false)) {
+        fprintf(stderr, "[MM-RANDO-GEN] FAIL(25): un-overridden VB did not pass the caller's verdict through\n");
+        return 25;
+    }
+    fprintf(stderr, "[MM-RANDO-GEN] VB dispatch (rando save): give VBs suppressed (ForID + non-ID), "
+                    "pass-through intact (%zu VB hooks)\n", vbHooks);
+
+    // Vanilla direction: a non-rando file re-run through the REAL OnSaveLoad
+    // chain must disarm the overrides (the COND_* macros re-evaluate IS_RANDO
+    // and unregister), and the same give VBs must return the vanilla verdict
+    // again — VB dispatch must not disturb non-rando files.
+    memset(&gSaveContext, 0, sizeof(gSaveContext));
+    MM_Sram_InitNewSave();
+    if (gSaveContext.save.shipSaveInfo.saveType == SAVETYPE_RANDO) {
+        fprintf(stderr, "[MM-RANDO-GEN] FAIL(26): plain Sram_InitNewSave produced a rando save — vanilla-direction "
+                        "premise broken\n");
+        return 26;
+    }
+    GameInteractor_ExecuteOnSaveLoad(0);
+    if (!GameInteractor_Should(VB_GIVE_ITEM_FROM_GREAT_FAIRY, true) ||
+        GameInteractor_Should(VB_GIVE_ITEM_FROM_GREAT_FAIRY, false) ||
+        !GameInteractor_Should(VB_GIVE_NEW_WAVE_BOSSA_NOVA, true)) {
+        fprintf(stderr, "[MM-RANDO-GEN] FAIL(27): vanilla file's give VBs did not return the vanilla verdict — "
+                        "rando overrides leaked into a non-rando file\n");
+        return 27;
+    }
+    fprintf(stderr, "[MM-RANDO-GEN] VB dispatch (vanilla save): overrides disarmed, vanilla behavior unchanged\n");
+
     // Leave the shared context clean (this process may run more dispatches).
     ComboContext_Init();
 

--- a/src/common/mm_stubs.c
+++ b/src/common/mm_stubs.c
@@ -82,14 +82,23 @@ void MM_FaultDrawer_SetCharPad(int xPad, int yPad) { (void)xPad; (void)yPad; }
 /* GameInteractor stubs.
  *
  * These cover MM's GameInteractor_* references that no linked TU defines. A
- * second set of MM references (GameInteractor_Should, ExecuteOnFlagSet,
- * ExecuteOnActorUpdate, ...) resolves to OoT's extern "C" wrappers in
+ * second set of MM references (ExecuteOnFlagSet, ExecuteOnActorUpdate, ...)
+ * resolves to OoT's extern "C" wrappers in
  * games/oot/soh/Enhancements/game-interactor/GameInteractor_Hooks.cpp instead
  * — that is NOT a valid provider: MM's GIVanillaBehavior ordinals alias OoT's
  * (MM VB_SETUP_TRANSITION == OoT VB_PLAY_RAINBOW_BRIDGE_CS == 206), so routing
  * MM calls into OoT's hook registry runs OoT handlers against MM state. Those
  * wrappers therefore gate on Context_GetCurrentGame() and return vanilla
- * behavior while MM is active, making them equivalent to the stubs below. */
+ * behavior while MM is active, making them equivalent to the stubs below.
+ *
+ * The "Should" family (GameInteractor_Should, ShouldActorInit,
+ * ShouldActorUpdate, ShouldActorDraw, ShouldItemGive) is no longer in either
+ * bucket (#392 VB follow-up): the single-exe macro rebind at the bottom of
+ * MM's GameInteractor.h renames every MM call site to the MM-owned
+ * MM_GameHooks_Execute* dispatchers in games/mm/2s2h/GameExports_SingleExe.cpp,
+ * which consult only the S2H::GameHooks registries — rando/enhancement VB
+ * overrides fire on MM frames without MM ids ever reaching OoT's tables.
+ * Re-adding Should stubs here would silently sever that dispatch. */
 void GameInteractor_ExecuteOnActorDraw(void* actor) { (void)actor; }
 void GameInteractor_ExecuteOnGameStateUpdate(void* state) { (void)state; }
 void GameInteractor_ExecuteOnGameStateMainFinish(void* state) { (void)state; }
@@ -110,8 +119,12 @@ void GameInteractor_ExecuteAfterKaleidoDrawPage(void* state, int page) { (void)s
  * wrapper no-ops while MM is the active game (see the header comment above),
  * so MM text boxes never fire OoT text hooks. */
 void GameInteractor_ExecuteOnItemGive(int itemId) { (void)itemId; }
-int GameInteractor_ShouldItemGive(int itemId) { (void)itemId; return 1; }
-int GameInteractor_ShouldActorDraw(void* actor) { (void)actor; return 1; }
+/* GameInteractor_ShouldItemGive / GameInteractor_ShouldActorDraw stubs
+ * retired (#392 VB follow-up): MM call sites now rebind to the header-checked
+ * MM_GameHooks_ExecuteShouldItemGive / MM_GameHooks_ExecuteShouldActorDraw in
+ * games/mm/2s2h/GameExports_SingleExe.cpp (see the Should-family note above).
+ * The stubs here carried the signature-drift hazard class of #372/#424
+ * (int(int) / int(void*) against the real bool(u8) / bool(Actor*)). */
 void GameInteractor_ExecuteOnCameraChangeModeFlags(void* camera) { (void)camera; }
 void GameInteractor_ExecuteOnCameraChangeSettingsFlags(void* camera) { (void)camera; }
 void GameInteractor_ExecuteAfterCameraUpdate(void* camera) { (void)camera; }


### PR DESCRIPTION
## Summary

Closes the first item on Lane C1's "Known follow-ups" list (PR #428 / the C1 landing comment on #392):

> VB dispatch for MM frames (`GameInteractor_Should`) stays unwired: chest/NPC vanilla-give interception does not run, so a foreign chest also gives its vanilla junk contents alongside the crossing.

## Root cause

In the single exe, MM's 355+ `GameInteractor_Should` call sites (plus `ShouldActorInit`/`ShouldActorUpdate` in `z_actor.c`, `ShouldActorDraw`, and `ShouldItemGive` in `z_parameter.c`) bound to OoT's extern "C" wrappers in `GameInteractor_Hooks.cpp` — which correctly gate on `Context_GetCurrentGame()` and return the vanilla verdict while MM is active, because MM's GIVanillaBehavior ordinals ALIAS OoT's (MM `VB_SETUP_TRANSITION` == OoT `VB_PLAY_RAINBOW_BRIDGE_CS` == 206) — or to drifted `mm_stubs.c` stubs (`int(int)` / `int(void*)` against the real `bool(u8)` / `bool(Actor*)`). So every VB override C0/C1 parked in the `S2H::GameHooks` registry was registered but unreachable: a rando-handled chest gave its vanilla contents alongside the CheckQueue give, and the `ShouldActorInit` content-swap (recovery-heart params + ENBOX_RC stamp) never ran either.

## Fix — dispatch resolves MM-side by construction

- **`games/mm/2s2h/GameInteractor/GameInteractor.h`**: single-exe macro rebind of the five upstream "Should" names to MM-owned `MM_GameHooks_Execute*` dispatchers, placed in the extern-C-visible declaration region so C and C++ MM TUs both rebind (every C caller includes this header — verified; C++ TUs get it force-included). Call sites compile textually unchanged, upstream diffs still apply — the same technique as C0's registration-macro redirection. Only MM TUs see this header, so **MM VB ids never reach OoT's `GameInteractor_Should` or its hook tables**; OoT's wrappers and their MM gate stay untouched as defense in depth.
- **`games/mm/2s2h/GameExports_SingleExe.cpp`**: the five dispatchers, line-faithful ports of the excluded upstream executors (`2s2h/GameInteractor/GameInteractor.cpp`) over `S2H::GameHooks::Execute`/`ExecuteForID`, beside the existing C1 bridges. No ForPtr/ForFilter legs: the S2H registry deliberately has neither, and the linked MM set registers none (the only Should-filter user, DeveloperTools.cpp, stays link-elided — noted for re-audit in the follow-up issue). Poison guard (`mm_gi_hook_guard.h`) untouched and still ON for 2ship_port/2ship_src/2ship_rando/2ship_rando_ui.
- **`src/common/mm_stubs.c`**: retire the two drifted Should stubs (the #372/#424 signature-drift class); document the Should family as MM-owned so it cannot be silently re-stubbed.

This makes the full chest kill-chain live in gameplay: `ShouldActorInit` (ForID, content swap + check identification) -> `VB_GIVE_ITEM_FROM_CHEST` (vanilla give suppressed, rando/foreign give flows through the CheckQueue path #428 wired).

## The double-give lock (both directions)

`MMRandoGen` (rando tier) gains a VB-dispatch phase after the existing OnSaveLoad-arming phase, using probes whose hook bodies touch no play state:

- **Rando save armed**: `GameInteractor_Should(VB_GIVE_ITEM_FROM_GREAT_FAIRY, true)` must return **false** (the COND_VB_SHOULD ForID leg, EnElfgrp.cpp) and `VB_GIVE_NEW_WAVE_BOSSA_NOVA` must return **false** (the non-ID COND_HOOK leg, MiscVanillaBehaviorHandler) — a give VB returning false IS "the vanilla item is not also given" at the call site. `VB_SETUP_TRANSITION` (registered by nothing in the linked set; the aliasing poster child) must pass the caller's verdict through untouched in both polarities.
- **Vanilla file**: re-running the real OnSaveLoad chain must disarm the overrides (COND_* macros re-evaluate `IS_RANDO` and unregister), and the same give VBs must return the vanilla verdict again — rando overrides must not leak into non-rando files.

Refs #392.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!--- section:artifacts:start -->
### Build Artifacts
  - [rsbs-windows.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/8486277933.zip)
  - [rsbs-linux.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/8485563632.zip)
<!--- section:artifacts:end -->