### PR TITLE
MM binds its own FB_DrawFromFramebufferScaled reading MM's screen dimensions (#386)

### DIFF
--- a/.github/clang-format-paths.txt
+++ b/.github/clang-format-paths.txt
@@ -34,6 +34,8 @@ games/mm/2s2h/Rando/Foreign.cpp
 games/mm/2s2h/Rando/Foreign.h
 games/mm/2s2h/ShipInit.hpp
 games/mm/2s2h/mm_culling_test.cpp
+games/mm/2s2h/mm_fb_effects_test.cpp
+games/mm/2s2h/mm_framebuffer_effects.c
 games/mm/2s2h/mm_gi_shim_test.cpp
 games/mm/2s2h/mm_notification_binding_test.cpp
 games/mm/2s2h/mm_resume_state_test.cpp

--- a/CMake/SingleExecutable.cmake
+++ b/CMake/SingleExecutable.cmake
@@ -356,6 +356,13 @@ if(BUILD_TESTING)
     # This compares their layout fingerprints and fails on drift (one Emit
     # definition survives, so no link error can catch a divergence).
     redship_add_test(NAME MMNotificationBinding COMMAND redship --test mm-notification-binding)
+    # MM scaled framebuffer draw (#386): MM's framebuffer_effects.c is excluded,
+    # so MM's FB_DrawFromFramebufferScaled bound OoT's surviving body, which
+    # reads OoT_gScreenWidth/Height. MM's dimensions diverge (HiRes 576 with the
+    # Bombers' Notebook open vs OoT's 320), so the shared body mis-scales MM's
+    # VisFbuf draw. This locks MM's call to its own MM_-dimension body (only one
+    # definition survived, so no link error could catch the cross-bind).
+    redship_add_test(NAME MMFbEffectsBinding COMMAND redship --test mm-fb-effects-binding)
     redship_add_test(NAME MMResumeArena COMMAND redship --test mm-resume-arena)
     redship_add_test(NAME MMStartupRestore COMMAND redship --test mm-startup-restore)
     redship_add_test(NAME AllTests COMMAND redship --test all)

--- a/games/mm/2s2h/framebuffer_effects.h
+++ b/games/mm/2s2h/framebuffer_effects.h
@@ -3,6 +3,11 @@
 
 #include "ultra64.h"
 
+// Single-exe: rename FB_DrawFromFramebufferScaled -> MM_FB_DrawFromFramebufferScaled
+// so MM binds its OWN body (reading MM_gScreenWidth/Height) instead of OoT's
+// surviving one (reading OoT_gScreenWidth/Height). See the header for #386.
+#include "mm_framebuffer_effects_prefix.h"
+
 extern s32 gPauseFrameBuffer;
 extern s32 gBlurFrameBuffer;
 extern s32 gReusableFrameBuffer;

--- a/games/mm/2s2h/mm_fb_effects_test.cpp
+++ b/games/mm/2s2h/mm_fb_effects_test.cpp
@@ -1,0 +1,108 @@
+/**
+ * ROM-free lock for MM's scaled framebuffer-draw binding (#386). CTest label
+ * "redship", row mm-fb-effects-binding in src/common/test_runner.cpp.
+ *
+ * What was broken: games/mm/2s2h/framebuffer_effects.c is excluded from the
+ * single-exe build (games/mm/CMakeLists.txt) because its FB_* symbols collide
+ * wholesale with OoT's soh/framebuffer_effects.c, so exactly one definition of
+ * each FB_* helper survived the link and it was OoT's. MM's callers write the
+ * FB_* names unprefixed, so MM executed OoT's bodies.
+ *
+ * Four of the five are game-agnostic (they read only the 320x240 N64 constants
+ * and the shared render window), so sharing OoT's body is correct. The fifth,
+ * FB_DrawFromFramebufferScaled, scales about the screen center using the ACTIVE
+ * game's framebuffer dimensions — OoT's surviving body reads OoT_gScreenWidth /
+ * OoT_gScreenHeight, which are SEPARATE storage from MM_gScreenWidth /
+ * MM_gScreenHeight and diverge (MM goes to HiRes 576 while the Bombers'
+ * Notebook is open; OoT stays 320). MM's VisFbuf shrink-window scaled draw
+ * (z_visfbuf.c) then mis-scales. No link error can catch it: only ONE
+ * definition survived, so GNU ld — the repo's only working ODR gate (Windows
+ * links /FORCE:MULTIPLE) — had nothing to reject. Silent mis-scale.
+ *
+ * The fix (mirroring #382's culling family) renames MM's caller-visible
+ * FB_DrawFromFramebufferScaled to MM_FB_DrawFromFramebufferScaled via
+ * include/mm_framebuffer_effects_prefix.h and gives MM its own body reading MM's
+ * own dimensions in 2s2h/mm_framebuffer_effects.c.
+ *
+ * This lock is link-time, not behavioral: FB_DrawFromFramebufferScaled emits
+ * gfx commands through OTRGetGameRenderWidth()/OTRGetRectDimension*(), which
+ * dereference the Fast3dWindow — absent in the display-free unit-test tier, so
+ * calling it here would crash rather than test. Instead it proves MM's
+ * unprefixed source-level call resolves to a DIFFERENT body than OoT's
+ * surviving one (assertion 1), and that the two ports' screen dimensions are
+ * genuinely separate storage — the precondition that makes binding the wrong
+ * body a mis-scale (assertion 2).
+ *
+ * Assertion 1 is robust against identical-code-folding: MM's body reads the
+ * MM_gScreen* symbols and OoT's reads the OoT_gScreen* symbols, so the two
+ * bodies carry different relocations and cannot be merged into one address by
+ * the linker. Before the fix the two names resolve to the same OoT body and the
+ * assertion fails loudly; that is the regression this row exists to catch.
+ */
+
+#ifdef RSBS_SINGLE_EXECUTABLE
+
+#include "mm_framebuffer_effects_prefix.h" // activates the FB_DrawFromFramebufferScaled rename
+
+#include <cstdint>
+#include <cstdio>
+
+// With the rename in force this declares MM_FB_DrawFromFramebufferScaled — the
+// body an ordinary MM caller's unprefixed source-level call binds to. Declared
+// opaque and extern "C" (C-linkage, no parameter types in the symbol name);
+// only ever addressed here, never called.
+extern "C" void FB_DrawFromFramebufferScaled(void);
+static void* const sMmBound = reinterpret_cast<void*>(&FB_DrawFromFramebufferScaled);
+
+// Drop the rename so the unprefixed OoT-side symbol can be named directly.
+#undef FB_DrawFromFramebufferScaled
+
+extern "C" {
+// OoT's surviving body (games/oot/soh/framebuffer_effects.c).
+void FB_DrawFromFramebufferScaled(void);
+
+// The two ports' screen-dimension storage. Separate globals
+// (mm/src/code/main.c vs oot/src/code/main.c); the bug is that OoT's body reads
+// the OoT pair for MM's draw.
+extern int32_t MM_gScreenWidth;
+extern int32_t MM_gScreenHeight;
+extern int32_t OoT_gScreenWidth;
+extern int32_t OoT_gScreenHeight;
+}
+
+static void* const sOotBound = reinterpret_cast<void*>(&FB_DrawFromFramebufferScaled);
+
+namespace {
+
+#define FB_ASSERT(cond, msg)                                              \
+    do {                                                                  \
+        if (!(cond)) {                                                    \
+            printf("[TEST] FAIL: %s (%s:%d)\n", msg, __FILE__, __LINE__); \
+            return 1;                                                     \
+        }                                                                 \
+    } while (0)
+
+} // namespace
+
+extern "C" int MM_FbEffectsBinding_RunHeadless(void) {
+    // ---- 1. MM binds its own body, not OoT's shared one -----------------
+    printf("[TEST] FB_DrawFromFramebufferScaled — MM %p, OoT %p\n", sMmBound, sOotBound);
+    FB_ASSERT(sMmBound != sOotBound,
+              "MM's FB_DrawFromFramebufferScaled still binds OoT's body (reads OoT_gScreenWidth) — #386");
+
+    // ---- 2. The two ports' screen dimensions are separate storage -------
+    // If these ever share one global the whole fault class evaporates and this
+    // row should be revisited; while they differ, binding OoT's body mis-scales
+    // MM's draw whenever MM's dimensions diverge (HiRes notebook = 576 vs 320).
+    printf("[TEST] gScreenWidth storage — MM %p, OoT %p\n", (void*)&MM_gScreenWidth, (void*)&OoT_gScreenWidth);
+    FB_ASSERT((void*)&MM_gScreenWidth != (void*)&OoT_gScreenWidth,
+              "MM and OoT gScreenWidth are the same storage — the premise of #386 no longer holds, revisit");
+    FB_ASSERT((void*)&MM_gScreenHeight != (void*)&OoT_gScreenHeight,
+              "MM and OoT gScreenHeight are the same storage — the premise of #386 no longer holds, revisit");
+
+    printf("[TEST] PASS: mm-fb-effects-binding — MM's scaled framebuffer draw binds its own body against MM's "
+           "dimensions\n");
+    return 0;
+}
+
+#endif // RSBS_SINGLE_EXECUTABLE

--- a/games/mm/2s2h/mm_framebuffer_effects.c
+++ b/games/mm/2s2h/mm_framebuffer_effects.c
@@ -1,0 +1,64 @@
+/**
+ * MM-owned scaled framebuffer draw (#386).
+ *
+ * games/mm/2s2h/framebuffer_effects.c is excluded from the single-exe build
+ * (its FB_* symbols collide wholesale with OoT's soh/framebuffer_effects.c), so
+ * OoT's bodies survive the link. Four of the five FB_* helpers are game-agnostic
+ * and correctly shared. FB_DrawFromFramebufferScaled is NOT: it scales about the
+ * screen center using the ACTIVE game's framebuffer dimensions, and OoT's
+ * surviving body reads OoT_gScreenWidth/Height — the wrong dimensions for MM,
+ * which diverge to HiRes 576 while the Bombers' Notebook is open.
+ *
+ * This TU gives MM its own body, reading MM_gScreenWidth/MM_gScreenHeight. The
+ * include of framebuffer_effects.h pulls in mm_framebuffer_effects_prefix.h,
+ * which renames the definition below to MM_FB_DrawFromFramebufferScaled in
+ * single-exe builds; MM's callers are renamed by the same shim, so they bind
+ * here rather than to OoT's body. Locked by mm-fb-effects-binding
+ * (games/mm/2s2h/mm_fb_effects_test.cpp). The body is otherwise a verbatim copy
+ * of the excluded twin — this is a binding fix, not a change to the effect.
+ *
+ * Guarded to single-exe: in a standalone 2ship build the excluded twin is
+ * compiled instead and owns the unprefixed FB_DrawFromFramebufferScaled, so this
+ * TU must contribute nothing there or the two definitions collide.
+ */
+#ifdef RSBS_SINGLE_EXECUTABLE
+
+#include "framebuffer_effects.h"
+#include "global.h"
+#include "BenPort.h"
+
+/**
+ * Similar to FB_DrawFromFramebuffer, but scales the image relative to the center
+ * of the screen. This function uses opcodes from f3dex2 but may be called when
+ * s2dex is loaded, such as during shrink window. Make sure f3dex2 is loaded
+ * before this function is called.
+ */
+void FB_DrawFromFramebufferScaled(Gfx** gfxp, s32 fb, u8 alpha, float scaleX, float scaleY) {
+    Gfx* gfx = *gfxp;
+
+    gDPSetEnvColor(gfx++, 255, 255, 255, alpha);
+
+    gDPSetOtherMode(gfx++,
+                    G_AD_NOISE | G_CD_NOISE | G_CK_NONE | G_TC_FILT | G_TF_POINT | G_TT_NONE | G_TL_TILE | G_TD_CLAMP |
+                        G_TP_NONE | G_CYC_1CYCLE | G_PM_NPRIMITIVE,
+                    G_AC_NONE | G_ZS_PRIM | G_RM_CLD_SURF | G_RM_CLD_SURF2);
+
+    gDPSetCombineLERP(gfx++, TEXEL0, 0, ENVIRONMENT, 0, 0, 0, 0, ENVIRONMENT, TEXEL0, 0, ENVIRONMENT, 0, 0, 0, 0,
+                      ENVIRONMENT);
+
+    gDPSetScissor(gfx++, G_SC_NON_INTERLACE, 0, 0, SCREEN_WIDTH, SCREEN_HEIGHT);
+
+    gDPSetTextureImageFB(gfx++, 0, 0, 0, fb);
+
+    float x0 = MM_gScreenWidth * 0.5f * scaleX;
+    float y0 = MM_gScreenHeight * 0.5f * scaleY;
+
+    gDPImageRectangle(gfx++, OTRGetRectDimensionFromLeftEdge(x0) << 2, (int)(y0) << 2, 0, 0,
+                      OTRGetRectDimensionFromRightEdge((float)(MM_gScreenWidth - x0)) << 2,
+                      (int)((float)(MM_gScreenHeight - y0)) << 2, OTRGetGameRenderWidth(), OTRGetGameRenderHeight(),
+                      G_TX_RENDERTILE, OTRGetGameRenderWidth(), OTRGetGameRenderHeight());
+
+    *gfxp = gfx;
+}
+
+#endif // RSBS_SINGLE_EXECUTABLE

--- a/games/mm/include/mm_framebuffer_effects_prefix.h
+++ b/games/mm/include/mm_framebuffer_effects_prefix.h
@@ -1,0 +1,58 @@
+#ifndef MM_FRAMEBUFFER_EFFECTS_PREFIX_H
+#define MM_FRAMEBUFFER_EFFECTS_PREFIX_H
+
+/**
+ * Single-exe symbol-prefix shim for MM's scaled framebuffer draw (#386).
+ *
+ * Both ports define an identically-named extern-C FB_* framebuffer-effects API.
+ * `games/mm/2s2h/framebuffer_effects.c` is excluded from the single-exe build
+ * (games/mm/CMakeLists.txt) because its symbols collide wholesale with OoT's
+ * soh/framebuffer_effects.c, so exactly one definition of each FB_* helper
+ * survives the link and it is OoT's. MM's callers (z_visfbuf.c, z_play.c,
+ * sys_cfb.c, ovl_En_Arrow) call them unprefixed, so MM executes OoT's bodies.
+ *
+ * For four of the five that is harmless: FB_CreateFramebuffers,
+ * FB_CopyToFramebuffer, FB_WriteFramebufferSliceToCPU and FB_DrawFromFramebuffer
+ * read only the N64-resolution constants (SCREEN_WIDTH/HEIGHT, 320x240 in both
+ * ports) and the SHARED render-window state (OTRGetGameRenderWidth/Height,
+ * OTRGetAspectRatio), so either port's body is correct.
+ *
+ * FB_DrawFromFramebufferScaled is the exception and the whole of #386. It scales
+ * about the center of the screen using the ACTIVE game's framebuffer dimensions:
+ *
+ *     x0 = gScreenWidth  * 0.5f * scaleX;   // and the symmetric width/height
+ *     y0 = gScreenHeight * 0.5f * scaleY;   // reads at the far edge
+ *
+ * OoT's surviving body reads OoT_gScreenWidth / OoT_gScreenHeight
+ * (games/oot/soh/framebuffer_effects.c). MM's excluded twin read
+ * MM_gScreenWidth / MM_gScreenHeight. Those two are SEPARATE storage
+ * (oot/src/code/main.c vs mm/src/code/main.c) and diverge: MM assigns
+ * gCfbWidth, which becomes HIRES_BUFFER_WIDTH (576) while the Bombers' Notebook
+ * is open (sys_cfb.c / MM_Play_Draw), where OoT_gScreenWidth stays 320. When
+ * MM's VisFbuf shrink-window scaled draw (z_visfbuf.c) runs against OoT's body
+ * it mis-scales — the exact latent correctness landmine #386 records.
+ *
+ * There is no link error to catch it: only ONE FB_DrawFromFramebufferScaled
+ * definition existed, so GNU ld (this repo's only working ODR gate — Windows
+ * links with /FORCE:MULTIPLE by design) had nothing to reject. Same silent
+ * cross-bind class already reconciled in soh/mixer.c and #382's culling family.
+ *
+ * The fix mirrors #382: rename MM's caller-visible FB_DrawFromFramebufferScaled
+ * to MM_FB_DrawFromFramebufferScaled, and give MM its own body — reading MM's
+ * OWN dimensions — in 2s2h/mm_framebuffer_effects.c. Every MM caller reaches
+ * this shim through "framebuffer_effects.h", which they already include; the
+ * MM body TU includes the same header, so its definition is renamed to match.
+ * The soh side keeps the unprefixed name. The other four FB_* stay shared —
+ * their cross-bind is correct, not a bug — so only the scaled draw is renamed.
+ *
+ * The ROM-free lock mm-fb-effects-binding (games/mm/2s2h/mm_fb_effects_test.cpp)
+ * asserts the rename is actually in force by comparing the address MM's
+ * unprefixed source-level call resolves to against OoT's surviving body.
+ */
+#ifdef RSBS_SINGLE_EXECUTABLE
+
+#define FB_DrawFromFramebufferScaled MM_FB_DrawFromFramebufferScaled
+
+#endif // RSBS_SINGLE_EXECUTABLE
+
+#endif // MM_FRAMEBUFFER_EFFECTS_PREFIX_H

--- a/src/common/test_runner.cpp
+++ b/src/common/test_runner.cpp
@@ -66,6 +66,12 @@ int MM_GIShim_RunHeadless(void);
 // drift (no link error can catch it — one Emit definition survives). Returns 0
 // on pass, non-zero on fail.
 int MM_NotificationBinding_RunHeadless(void);
+// MM scaled framebuffer-draw binding (games/mm/2s2h/mm_fb_effects_test.cpp,
+// #386): MM's FB_DrawFromFramebufferScaled used to bind OoT's surviving body,
+// which reads OoT_gScreenWidth/Height — the wrong dimensions for MM, which go
+// to HiRes 576 while the Bombers' Notebook is open. Returns 0 on pass, non-zero
+// on fail.
+int MM_FbEffectsBinding_RunHeadless(void);
 // VB-affinity regression: MM's GameInteractor_* calls resolve to OoT's
 // extern "C" wrappers in single-exe builds, and the two games' vanilla-
 // behavior ordinals alias each other. The wrappers gate on the active game;
@@ -182,6 +188,12 @@ static TestResult Test_MMGIShim(void) {
 // games/mm/2s2h/mm_notification_binding_test.cpp.
 static TestResult Test_MMNotificationBinding(void) {
     return MM_NotificationBinding_RunHeadless() == 0 ? TEST_PASS : TEST_FAIL;
+}
+
+// MM scaled framebuffer-draw binding lock (see the extern decl above). Thin
+// wrapper over the C entry point in games/mm/2s2h/mm_fb_effects_test.cpp.
+static TestResult Test_MMFbEffectsBinding(void) {
+    return MM_FbEffectsBinding_RunHeadless() == 0 ? TEST_PASS : TEST_FAIL;
 }
 
 // ============================================================================
@@ -1019,6 +1031,8 @@ const TestDescriptor gTests[] = {
      Test_MMGIShim},
     {"mm-notification-binding", "MM Notification::Emit binds OoT's only while Options stays layout-identical (#427)",
      Test_MMNotificationBinding},
+    {"mm-fb-effects-binding", "MM's scaled framebuffer draw binds its own body against MM's dimensions (#386)",
+     Test_MMFbEffectsBinding},
     // The two MM resume-contract tests below mutate process-global state
     // (mm-resume-arena re-inits the MM system arena + heaps; mm-startup-restore
     // scribbles and re-zeroes the unified gSaveContext). Both clean up after


### PR DESCRIPTION
## Premise (verified real against HEAD c311cd0c)

`games/mm/2s2h/framebuffer_effects.c` is excluded from the single-exe build (`games/mm/CMakeLists.txt:257`), so OoT's `soh/framebuffer_effects.c` bodies survive the link and MM's unprefixed callers bind to them. None of the recent merges (#402 prefix-header renames, #408 collision-gate cleanup, C0's ShipUtils work) touched this binding — the fault #386 records is still live in the tree.

Four of the five `FB_*` helpers read only the 320x240 N64 constants (`SCREEN_WIDTH`/`SCREEN_HEIGHT`) and the shared render window (`OTRGetGameRenderWidth/Height`), so sharing OoT's body is **correct**. The fifth is the bug:

`FB_DrawFromFramebufferScaled` scales about the screen center using the **active game's** framebuffer dimensions. OoT's surviving body reads `OoT_gScreenWidth`/`OoT_gScreenHeight` (`games/oot/soh/framebuffer_effects.c:168-173`). Those are separate storage from `MM_gScreenWidth`/`MM_gScreenHeight` and diverge: MM assigns `gCfbWidth`, which becomes `HIRES_BUFFER_WIDTH` (576) while the Bombers' Notebook is open, where `OoT_gScreenWidth` stays 320. MM's VisFbuf shrink-window scaled draw (`games/mm/src/code/z_visfbuf.c:243` — the only MM caller of the scaled variant) then mis-scales. No link error can catch it: only one definition survived, so GNU ld has nothing to reject.

## Fix (mirrors the #382 culling family)

- **`games/mm/include/mm_framebuffer_effects_prefix.h`** — single-exe shim renaming `FB_DrawFromFramebufferScaled` → `MM_FB_DrawFromFramebufferScaled`, reached through `2s2h/framebuffer_effects.h` (which every MM caller already includes). Only the scaled draw is renamed; the four correctly-shared helpers keep OoT's body.
- **`games/mm/2s2h/mm_framebuffer_effects.c`** — MM-owned body reading `MM_gScreenWidth`/`MM_gScreenHeight`, guarded to single-exe (the excluded twin owns the unprefixed name in standalone builds).
- **`games/mm/2s2h/mm_fb_effects_test.cpp`** — ROM-free binding lock `mm-fb-effects-binding`, registered via `redship_add_test` + `gTests[]`. Link-time (not behavioral: the gfx body dereferences the Fast3dWindow, absent in the display-free unit tier). Asserts MM's unprefixed source-level call resolves to a **different** body than OoT's, and that the two ports' screen dims are separate storage. Fails loudly pre-fix (both names resolve to OoT's body); robust against ICF because the two bodies read different global symbols.

No `games/mm/CMakeLists.txt` edit needed — both new TUs auto-glob into `ship__`, and the exclusion regex `2s2h/framebuffer_effects\.c$` does not match the new filenames. `GameExports_SingleExe.cpp` untouched.

Closes #386

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!--- section:artifacts:start -->
### Build Artifacts
  - [rsbs-windows.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/8485529758.zip)
  - [rsbs-linux.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/8485330926.zip)
<!--- section:artifacts:end -->