### PR TITLE
CI harness tail (#376 items 4-6): wall-clock watchdog, cache-derived gameplay timeouts, drop dead build flag

### DIFF
--- a/.github/workflows/generate-builds.yml
+++ b/.github/workflows/generate-builds.yml
@@ -90,7 +90,7 @@ jobs:
       if: steps.rsbs-otr-cache.outputs.cache-hit != 'true'
       run: |
         export PATH="/usr/lib/ccache:/usr/local/opt/ccache/libexec:$PATH"
-        cmake --no-warn-unused-cli -H. -Bbuild-cmake -GNinja -DCMAKE_BUILD_TYPE:STRING=Release -DREDSHIP_BUILD_SHARED=ON
+        cmake --no-warn-unused-cli -H. -Bbuild-cmake -GNinja -DCMAKE_BUILD_TYPE:STRING=Release
         cmake --build build-cmake --config Release --target GenerateSohOtr Generate2ShipOtr -j10
     - name: Upload soh.o2r
       uses: actions/upload-artifact@v4
@@ -172,7 +172,7 @@ jobs:
     - name: Build SoH
       run: |
         export PATH="/usr/lib/ccache:/opt/homebrew/opt/ccache/libexec:/usr/local/opt/ccache/libexec:$PATH"
-        cmake --no-warn-unused-cli -H. -Bbuild-cmake -GNinja -DCMAKE_BUILD_TYPE:STRING=Release -DCMAKE_OSX_ARCHITECTURES="x86_64;arm64" -DBUILD_REMOTE_CONTROL=1 -DREDSHIP_BUILD_SHARED=ON
+        cmake --no-warn-unused-cli -H. -Bbuild-cmake -GNinja -DCMAKE_BUILD_TYPE:STRING=Release -DCMAKE_OSX_ARCHITECTURES="x86_64;arm64" -DBUILD_REMOTE_CONTROL=1
         cmake --build build-cmake --config Release --parallel 10
         (cd build-cmake && cpack)
 
@@ -266,7 +266,7 @@ jobs:
     - name: Build SoH
       run: |
         export PATH="/usr/lib/ccache:/usr/local/opt/ccache/libexec:$PATH"
-        cmake --no-warn-unused-cli -H. -Bbuild-cmake -GNinja -DCMAKE_BUILD_TYPE:STRING=Release -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DBUILD_REMOTE_CONTROL=1 -DREDSHIP_BUILD_SHARED=ON
+        cmake --no-warn-unused-cli -H. -Bbuild-cmake -GNinja -DCMAKE_BUILD_TYPE:STRING=Release -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DBUILD_REMOTE_CONTROL=1
         cmake --build build-cmake --config Release -j10
       env:
         CC: gcc-11
@@ -433,7 +433,7 @@ jobs:
         VCPKG_ROOT: ${{github.workspace}}/vcpkg
       run: |
         $env:PATH="$env:USERPROFILE/.cargo/bin;$env:PATH"
-        cmake -S . -B bw -G Ninja -DCMAKE_MAKE_PROGRAM=ninja -DCMAKE_BUILD_TYPE:STRING=Release -DCMAKE_C_COMPILER_LAUNCHER=sccache -DCMAKE_CXX_COMPILER_LAUNCHER=sccache -DBUILD_REMOTE_CONTROL=1 -DREDSHIP_BUILD_SHARED=ON -DUSE_LLD_LINKER=ON
+        cmake -S . -B bw -G Ninja -DCMAKE_MAKE_PROGRAM=ninja -DCMAKE_BUILD_TYPE:STRING=Release -DCMAKE_C_COMPILER_LAUNCHER=sccache -DCMAKE_CXX_COMPILER_LAUNCHER=sccache -DBUILD_REMOTE_CONTROL=1 -DUSE_LLD_LINKER=ON
     # Zero sccache stats before the build so the post-build "show-stats" reflects
     # ONLY this run's cache deltas (without it, hendrikmuhs/ccache-action reports
     # lifetime stats including the previous run that warmed the cache, which can

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -155,7 +155,7 @@ jobs:
     - name: Build SoH
       run: |
         export PATH="/usr/lib/ccache:/usr/local/opt/ccache/libexec:$PATH"
-        cmake --no-warn-unused-cli -H. -Bbuild-cmake -GNinja -DCMAKE_BUILD_TYPE:STRING=Release -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DBUILD_REMOTE_CONTROL=1 -DREDSHIP_BUILD_SHARED=ON
+        cmake --no-warn-unused-cli -H. -Bbuild-cmake -GNinja -DCMAKE_BUILD_TYPE:STRING=Release -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DBUILD_REMOTE_CONTROL=1
         cmake --build build-cmake --config Release -j10
       env:
         CC: gcc-11
@@ -481,7 +481,7 @@ jobs:
       if: steps.rsbs-otr-cache.outputs.cache-hit != 'true'
       run: |
         export PATH="/usr/lib/ccache:/usr/local/opt/ccache/libexec:$PATH"
-        cmake --no-warn-unused-cli -H. -Bbuild-cmake -GNinja -DCMAKE_BUILD_TYPE:STRING=Release -DREDSHIP_BUILD_SHARED=ON
+        cmake --no-warn-unused-cli -H. -Bbuild-cmake -GNinja -DCMAKE_BUILD_TYPE:STRING=Release
         cmake --build build-cmake --config Release --target GenerateSohOtr Generate2ShipOtr -j10
     - name: Upload soh.o2r
       uses: actions/upload-artifact@v4

--- a/CMake/SingleExecutable.cmake
+++ b/CMake/SingleExecutable.cmake
@@ -228,6 +228,13 @@ if(BUILD_TESTING)
     # TIMEOUT inherits REDSHIP_TEST_TIMEOUT.
     set(REDSHIP_TEST_TIMEOUT 60 CACHE STRING "Test timeout in seconds")
     set(REDSHIP_INTEGRATION_TEST_TIMEOUT 120 CACHE STRING "Integration test timeout in seconds")
+    # The gameplay round-trip repro and its multi-cycle soak run far longer than
+    # a boot check, so they keep their own knobs rather than the shared
+    # integration value — but they are STILL cache variables, not literals baked
+    # into the rows (#376 item 5): raising REDSHIP_INTEGRATION_TEST_TIMEOUT to
+    # debug a slow runner used to leave the two longest tests untouched.
+    set(REDSHIP_GAMEPLAY_TEST_TIMEOUT 300 CACHE STRING "Gameplay round-trip integration test timeout in seconds")
+    set(REDSHIP_GAMEPLAY_SOAK_TIMEOUT 900 CACHE STRING "Gameplay round-trip soak (multi-cycle) test timeout in seconds")
 
     # A test source that is never #included compiles into nothing and can never
     # run. The glob notices the file; this asserts it is actually wired in.
@@ -330,6 +337,12 @@ if(BUILD_TESTING)
     # it the no-op the thread's silence contract already assumes. Locks the
     # no-op via the producer's task counter (see test_oot_audio_init_guard.c).
     redship_add_test(NAME OoTAudioInitGuard COMMAND redship --test oot-audio-init-guard)
+    # Gameplay round-trip phase watchdog (#376 item 4). The round-trip repro it
+    # guards is ROM-gated, but the watchdog decision is pure — this row proves,
+    # ROM-free, that the budget is wall-clock and stays under the CTest TIMEOUT
+    # so its diagnostic dump can fire before the hard wall-clock kill (the old
+    # frame budget of 4080 frames could not).
+    redship_add_test(NAME GpWatchdog COMMAND redship --test gp-watchdog)
     # Active-thread-queue contract (#385). soh/stubs.c's empty-bodied
     # __osGetActiveQueue returned the return register, and both games' fault
     # handlers walk that as a thread list — so the crash handler was itself
@@ -486,17 +499,19 @@ if(BUILD_TESTING)
     # matrix can sweep scenes without new CTest rows. The soak variant runs
     # three round trips before the warp.
     #
-    # These two carry their own timeouts rather than the shared integration
+    # These two carry their own timeout knobs rather than the shared integration
     # value: the repro is far longer than a boot check, and the soak runs it
-    # three times over.
+    # three times over. Both are cache variables (see above), so a slow runner
+    # can be debugged by raising REDSHIP_GAMEPLAY_TEST_TIMEOUT /
+    # REDSHIP_GAMEPLAY_SOAK_TIMEOUT instead of editing these rows (#376 item 5).
     redship_add_test(NAME IntGameplayRoundtrip
         COMMAND redship --integration-test int-gameplay-roundtrip
         LABEL integration
-        TIMEOUT 300)
+        TIMEOUT ${REDSHIP_GAMEPLAY_TEST_TIMEOUT})
     redship_add_test(NAME IntGameplayRoundtripSoak
         COMMAND redship --integration-test int-gameplay-roundtrip
         LABEL integration-soak
-        TIMEOUT 900
+        TIMEOUT ${REDSHIP_GAMEPLAY_SOAK_TIMEOUT}
         ENVIRONMENT "RSBS_GP_CYCLES=3")
 
     # Must come after every redship_add_test()/redship_test_exempt() above —

--- a/docs/ci-gameplay-repro-postmortem.md
+++ b/docs/ci-gameplay-repro-postmortem.md
@@ -326,7 +326,7 @@ can iterate fix→build→repro→observe with no gameplay skill involved.
 
 ```bash
 git submodule update --init
-cmake -B build-cmake -S . -GNinja -DCMAKE_BUILD_TYPE:STRING=Release -DREDSHIP_BUILD_SHARED=ON
+cmake -B build-cmake -S . -GNinja -DCMAKE_BUILD_TYPE:STRING=Release
 cmake --build build-cmake --config Release --parallel
 # One-time asset staging (needs OTRExporter/oot.z64 and OTRExporter/mm.z64):
 cmake --build build-cmake --target ExtractAssets ExtractMMAssets

--- a/games/oot/soh/GameExports_SingleExe.cpp
+++ b/games/oot/soh/GameExports_SingleExe.cpp
@@ -10,6 +10,7 @@
 #include <cstdio>
 #include <cstring>
 #include <cmath>
+#include <chrono>
 #include "OTRGlobals.h"
 #include "soh/CrashHandlerExt.h"
 #include <libultraship/bridge.h>
@@ -118,8 +119,14 @@ static GameplayPhase sGpPlayerLastPhase = GP_PHASE_DONE;
 static GameplayPhase sGpWatchdogLastPhase = GP_PHASE_DONE;
 static int sGpFramesInPhase = 0;
 static int sGpSceneInits = 0;
-static int sGpWatchdogFrames = 0;
-static int sGpWatchdogLimit = 0;
+// Wall-clock phase watchdog (#376 item 4). The budget is seconds, not frames:
+// a frame budget could not fire before the CTest/`timeout` wall clock under
+// llvmpipe, so the diagnostic dump never emitted. sGpWatchdogPhaseStart is
+// re-based whenever the OoT-owned phase advances; a phase that makes no
+// progress for sGpWatchdogBudgetSecs fails the run with state.
+static std::chrono::steady_clock::time_point sGpWatchdogPhaseStart{};
+static int sGpWatchdogBudgetSecs = 0;
+static bool sGpWatchdogFired = false;
 // Door-actor presence check (bug 1a): baseline door count captured in the
 // boot-phase scene, compared on the return leg when the scene matches. -1 =
 // no baseline captured.
@@ -423,14 +430,13 @@ static void OoT_RegisterIntegrationTestHooks(void) {
         sGpWatchdogLastPhase = GP_PHASE_DONE;
         sGpFramesInPhase = 0;
         sGpSceneInits = 0;
-        sGpWatchdogFrames = 0;
-        // Generous bound: several fade/loads plus the configured gameplay
-        // window per phase; the CTest timeout stays the hard backstop.
-        {
-            const GameplayTestConfig* wcfg = IntegrationTest_GetGameplayConfig();
-            int maxPhaseFrames = wcfg->framesPerPhase > wcfg->warpFrames ? wcfg->framesPerPhase : wcfg->warpFrames;
-            sGpWatchdogLimit = maxPhaseFrames * 4 + 3600;
-        }
+        // Wall-clock budget per OoT-owned phase, sized well under the CTest
+        // TIMEOUT so the watchdog's diagnostic dump fires BEFORE the hard kill
+        // (#376 item 4). The timer is re-based below whenever the phase
+        // advances, so only a genuinely wedged phase reaches the budget.
+        sGpWatchdogPhaseStart = std::chrono::steady_clock::now();
+        sGpWatchdogBudgetSecs = IntegrationTest_GetGameplayConfig()->watchdogSecs;
+        sGpWatchdogFired = false;
 
         // Boot injection — whichever of these fires first wins; both are
         // no-ops once the phase machine has left GP_PHASE_BOOT. The title
@@ -705,7 +711,9 @@ static void OoT_RegisterIntegrationTestHooks(void) {
         });
 
         // OoT-side watchdog: fail loudly (with state) instead of timing out
-        // silently if an OoT-owned phase stops making progress.
+        // silently if an OoT-owned phase stops making progress. Budgeted in
+        // WALL-CLOCK seconds (#376 item 4) so the diagnostic below is emitted
+        // before the CTest/`timeout` kill — a frame budget lost that race.
         GameInteractor::Instance->RegisterGameHook<GameInteractor::OnGameStateMainStart>([]() {
             if (Context_GetCurrentGame() == GAME_MM) {
                 return;
@@ -719,20 +727,27 @@ static void OoT_RegisterIntegrationTestHooks(void) {
                 case GP_PHASE_OOT_EXIT:
                     break;
                 default:
-                    sGpWatchdogFrames = 0;
+                    // Not an OoT-owned phase (MM is driving, or the run is
+                    // done): re-base so the timer only measures the current
+                    // OoT phase's stall, never the MM leg.
+                    sGpWatchdogPhaseStart = std::chrono::steady_clock::now();
+                    sGpWatchdogLastPhase = phase;
                     return;
             }
+            std::chrono::steady_clock::time_point now = std::chrono::steady_clock::now();
             if (phase != sGpWatchdogLastPhase) {
+                // The phase advanced — progress. Re-base the stall timer.
                 sGpWatchdogLastPhase = phase;
-                sGpWatchdogFrames = 0;
+                sGpWatchdogPhaseStart = now;
             }
-            sGpWatchdogFrames++;
-            if (sGpWatchdogFrames == sGpWatchdogLimit) {
+            double elapsedSecs = std::chrono::duration<double>(now - sGpWatchdogPhaseStart).count();
+            if (!sGpWatchdogFired && IntegrationTest_GameplayWatchdogExpired(elapsedSecs, sGpWatchdogBudgetSecs)) {
+                sGpWatchdogFired = true;
                 PlayState* play = OoT_gPlayState;
                 fprintf(stderr,
-                        "[GP-TEST] OoT watchdog: no progress after %d frames "
+                        "[GP-TEST] OoT watchdog: no progress for %.1f s (budget %d s) in phase %d "
                         "(play=%p scene=%d entrance=0x%04X arrivedPhase=%d sceneInits=%d gameplayFrames=%d)\n",
-                        sGpWatchdogFrames, (void*)play, play ? play->sceneNum : -1,
+                        elapsedSecs, sGpWatchdogBudgetSecs, (int)phase, (void*)play, play ? play->sceneNum : -1,
                         (uint16_t)gSaveContext.entranceIndex, (int)sGpArrivalPhase, sGpSceneInits, sGpFramesInPhase);
                 fflush(stderr);
                 IntegrationTest_GameplayFail("OoT-side phase watchdog expired");

--- a/src/common/integration_test_hooks.cpp
+++ b/src/common/integration_test_hooks.cpp
@@ -59,6 +59,13 @@ const char* GameplayPhaseName(GameplayPhase phase) {
 // the real ENTR_MAX at consumption time.
 constexpr unsigned long kOoTEntranceMax = 0x0614;
 
+// Per-phase watchdog budget default, in wall-clock seconds (#376 item 4). 60 s
+// is far under the 300 s IntGameplayRoundtrip TIMEOUT and the 900 s soak, and
+// no default-config phase runs anywhere near that long, so it fires only on a
+// genuine wedge and always before the hard kill. Restated by the gp-watchdog
+// test as the contract.
+constexpr int kGpWatchdogDefaultSecs = 60;
+
 int GameplayEnvInt(const char* name, int defaultValue, int minValue) {
     const char* raw = std::getenv(name);
     if (raw == nullptr || raw[0] == '\0') {
@@ -103,14 +110,15 @@ void GameplayParseConfig(void) {
     // a long soak INSIDE the warp target, not longer windows everywhere.
     sGameplayConfig.warpFrames = GameplayEnvInt("RSBS_GP_WARP_FRAMES", sGameplayConfig.framesPerPhase, 1);
     sGameplayConfig.cameraAssert = GameplayEnvInt("RSBS_GP_CAMERA_ASSERT", 1, 0);
+    sGameplayConfig.watchdogSecs = IntegrationTest_GameplayWatchdogBudgetSecs();
     sGameplayPhase = GP_PHASE_BOOT;
     sGameplayCyclesDone = 0;
     printf("[GP-TEST] config: frames/phase=%d cycles=%d boot=0x%04X warp=0x%04X exit=0x%04X bootAge=%s "
-           "warpFrames=%d camAssert=%d\n",
+           "warpFrames=%d camAssert=%d watchdogSecs=%d\n",
            sGameplayConfig.framesPerPhase, sGameplayConfig.cycles, sGameplayConfig.bootEntrance,
            sGameplayConfig.warpEntrance, sGameplayConfig.exitEntrance,
            sGameplayConfig.bootAdult ? "adult" : "child", sGameplayConfig.warpFrames,
-           sGameplayConfig.cameraAssert);
+           sGameplayConfig.cameraAssert, sGameplayConfig.watchdogSecs);
     fflush(stdout);
 }
 
@@ -204,6 +212,34 @@ void IntegrationTest_SetGameplayPhase(GameplayPhase phase) {
 
 const GameplayTestConfig* IntegrationTest_GetGameplayConfig(void) {
     return &sGameplayConfig;
+}
+
+int IntegrationTest_GameplayWatchdogParse(const char* raw) {
+    if (raw == nullptr || raw[0] == '\0') {
+        return kGpWatchdogDefaultSecs;
+    }
+    char* end = nullptr;
+    long value = strtol(raw, &end, 0);
+    // Below 1 s is meaningless (the phase machine ticks per game frame), so
+    // reject it the same as garbage rather than arming a watchdog that fires
+    // on the first tick of every phase.
+    if (end == raw || *end != '\0' || value < 1) {
+        fprintf(stderr, "[GP-TEST] WARNING: ignoring invalid RSBS_GP_WATCHDOG_SECS='%s' (using %d)\n", raw,
+                kGpWatchdogDefaultSecs);
+        return kGpWatchdogDefaultSecs;
+    }
+    return (int)value;
+}
+
+int IntegrationTest_GameplayWatchdogBudgetSecs(void) {
+    return IntegrationTest_GameplayWatchdogParse(std::getenv("RSBS_GP_WATCHDOG_SECS"));
+}
+
+bool IntegrationTest_GameplayWatchdogExpired(double elapsedSecs, int budgetSecs) {
+    if (budgetSecs <= 0) {
+        return false;
+    }
+    return elapsedSecs >= (double)budgetSecs;
 }
 
 int IntegrationTest_GameplayCyclesDone(void) {

--- a/src/common/integration_test_hooks.h
+++ b/src/common/integration_test_hooks.h
@@ -72,6 +72,13 @@ typedef enum {
  *   RSBS_GP_CAMERA_ASSERT (1)      0 disables the return/warp-phase
  *                                  camera-follow assert (forced player march +
  *                                  camera displacement check, bug 1b)
+ *   RSBS_GP_WATCHDOG_SECS (60)     wall-clock seconds a single OoT-owned phase
+ *                                  may run WITHOUT advancing before the watchdog
+ *                                  dumps state and fails the run. Must stay well
+ *                                  under the CTest TIMEOUT so the diagnostic
+ *                                  beats the hard wall-clock kill (#376 item 4).
+ *                                  Raise it in lockstep if you raise
+ *                                  RSBS_GP_WARP_FRAMES for a long in-scene soak.
  * Entrance values accept hex (0x...) or decimal and must be < OoT's ENTR_MAX.
  */
 typedef struct {
@@ -83,6 +90,7 @@ typedef struct {
     int bootAdult;
     int warpFrames;
     int cameraAssert;
+    int watchdogSecs;
 } GameplayTestConfig;
 
 /**
@@ -162,6 +170,41 @@ void IntegrationTest_GameplayFail(const char* reason);
  * path so a wedged or crashed run is attributable from the log alone).
  */
 void IntegrationTest_LogGameplayState(const char* tag);
+
+// ----------------------------------------------------------------------------
+// Phase watchdog (#376 item 4)
+//
+// The OoT-side round-trip watchdog fails loudly, WITH state, when an OoT-owned
+// phase stops making progress — instead of letting the phase wedge until the
+// CTest/`timeout` wall clock kills the process (exit 124) and the diagnostic
+// dump the watchdog exists to produce is never emitted.
+//
+// It used to budget in FRAMES (maxPhaseFrames * 4 + 3600 == 4080 at defaults),
+// which under Xvfb + llvmpipe is 300-800 s of wall clock — longer than the
+// 300 s timeout, so it could never fire first. The budget is now WALL-CLOCK
+// seconds, per phase, defaulting well under the timeout. These pure helpers
+// carry the parse + fire decision so the fix is regression-locked ROM-free
+// (test `gp-watchdog`).
+// ----------------------------------------------------------------------------
+
+/**
+ * Resolve a watchdog budget (seconds) from a raw RSBS_GP_WATCHDOG_SECS string.
+ * Pure: NULL/empty/invalid/below-minimum all fall back to the default (60).
+ */
+int IntegrationTest_GameplayWatchdogParse(const char* raw);
+
+/**
+ * The effective per-phase watchdog budget in seconds, reading
+ * RSBS_GP_WATCHDOG_SECS from the environment (default 60).
+ */
+int IntegrationTest_GameplayWatchdogBudgetSecs(void);
+
+/**
+ * Pure predicate the OoT watchdog evaluates each phase-owned tick: has a phase
+ * that has run `elapsedSecs` of wall clock without advancing exhausted its
+ * budget? A non-positive budget disables the watchdog (never expires).
+ */
+bool IntegrationTest_GameplayWatchdogExpired(double elapsedSecs, int budgetSecs);
 
 #ifdef __cplusplus
 }

--- a/src/common/test_runner.cpp
+++ b/src/common/test_runner.cpp
@@ -148,6 +148,12 @@ extern "C" {
 // FILE SCOPE; declares its C-linkage symbols itself. No audio heap, no archives.
 #include "tests/test_oot_audio_init_guard.c"
 
+// Gameplay round-trip phase watchdog (#376 item 4). FILE SCOPE: it exercises
+// the pure watchdog helpers declared in integration_test_hooks.h (already
+// included above), proving the budget is wall-clock and can fire before the
+// CTest timeout. No display, no ROM archives, no game loop.
+#include "tests/test_gp_watchdog.c"
+
 // MM scene-command EXECUTE regression (issue #344). Unlike the parse test, the
 // body runs the parsed commands against a PlayState, so it needs MM's global.h
 // — which lives in an MM TU (games/mm/2s2h/mm_scene_execute_test.cpp) to keep
@@ -1025,6 +1031,8 @@ const TestDescriptor gTests[] = {
     {"seq-map-bounds", "Sequence-map capacity covers the id range + custom slack (#371, #378)", Test_SeqMapBounds},
     {"active-queue", "__osGetActiveQueue returns a walkable list, not a return register (#385)", Test_ActiveQueue},
     {"oot-audio-init-guard", "OoT synth no-ops while gAudioContextInitalized == false (#365)", Test_OoTAudioInitGuard},
+    {"gp-watchdog", "Gameplay round-trip watchdog is wall-clock budgeted, can fire before the timeout (#376)",
+     Test_GpWatchdog},
     {"mm-scene-execute", "MM scene commands execute against a PlayState (#344)", Test_MMSceneExecute},
     {"mm-culling-binding", "MM's Ship_ExtendedCulling* bind MM's Actor, not OoT's (#382)", Test_MMCullingBinding},
     {"mm-gi-shim", "MM hook registration goes through the MM-owned shim, not the shared 4-byte instance (#395)",

--- a/src/common/tests/test_gp_watchdog.c
+++ b/src/common/tests/test_gp_watchdog.c
@@ -1,0 +1,92 @@
+/**
+ * Gameplay round-trip phase-watchdog regression test (#376 item 4).
+ *
+ * The OoT-side watchdog (games/oot/soh/GameExports_SingleExe.cpp) exists to
+ * fail a wedged round-trip run loudly, WITH state, before the CTest/`timeout`
+ * wall clock kills the process silently. It used to budget in FRAMES
+ * (maxPhaseFrames * 4 + 3600 == 4080 at defaults), which under Xvfb + llvmpipe
+ * is 300-800 s of wall clock — longer than the 300 s IntGameplayRoundtrip
+ * TIMEOUT — so it could never fire first and the diagnostic dump never emitted.
+ * A budget that reads as coverage but cannot fire is a vacuous gate.
+ *
+ * The budget is now WALL-CLOCK seconds. The decision was factored into two pure
+ * helpers so the frame-vs-wall-clock fix is regression-locked with no display,
+ * no ROM archives, and no game loop:
+ *   - IntegrationTest_GameplayWatchdogParse  (env -> budget seconds)
+ *   - IntegrationTest_GameplayWatchdogExpired (elapsed >= budget, wall clock)
+ *
+ * The round-trip itself is ROM-gated and cannot run in hosted CI, so this is
+ * the only tier that can prove the watchdog is able to fire before the timeout.
+ *
+ * Included at FILE SCOPE by test_runner.cpp (compiled as C++); the helpers are
+ * already declared via its include of integration_test_hooks.h.
+ */
+
+#include <cstdio>
+
+// The default budget, restated independently as the contract (the source
+// spells it kGpWatchdogDefaultSecs in integration_test_hooks.cpp).
+#define GPWD_DEFAULT_SECS 60
+
+// The IntGameplayRoundtrip CTest TIMEOUT (CMake/SingleExecutable.cmake,
+// REDSHIP_GAMEPLAY_TEST_TIMEOUT default). The whole point of item 4: the
+// watchdog budget must stay comfortably under this so its dump beats the kill.
+#define GPWD_INTEGRATION_TIMEOUT_SECS 300
+
+#define GPWD_CHECK(cond, msg)                   \
+    do {                                        \
+        if (!(cond)) {                          \
+            printf("[TEST] FAIL: %s\n", (msg)); \
+            return TEST_FAIL;                   \
+        }                                       \
+    } while (0)
+
+TestResult Test_GpWatchdog(void) {
+    printf("[TEST] gp-watchdog: phase watchdog is wall-clock budgeted and can fire before the timeout (#376)\n");
+
+    // (1) The core defect. The budget must be WALL-CLOCK seconds and it must be
+    // strictly less than the CTest timeout, or the watchdog can never emit its
+    // diagnostic before the hard kill. The frame budget failed exactly this.
+    int budget = IntegrationTest_GameplayWatchdogParse(NULL);
+    GPWD_CHECK(budget == GPWD_DEFAULT_SECS, "default watchdog budget is not 60 s");
+    GPWD_CHECK(budget > 0, "default watchdog budget is non-positive (watchdog disabled)");
+    GPWD_CHECK(budget < GPWD_INTEGRATION_TIMEOUT_SECS,
+               "default watchdog budget is not under the IntGameplayRoundtrip TIMEOUT — cannot fire first");
+
+    // (2) The fire predicate is a wall-clock >= comparison, NOT a frame count.
+    // Below budget it must not fire; at or past the budget it must.
+    GPWD_CHECK(!IntegrationTest_GameplayWatchdogExpired(0.0, budget), "watchdog fired at 0 s elapsed");
+    GPWD_CHECK(!IntegrationTest_GameplayWatchdogExpired((double)budget - 0.1, budget),
+               "watchdog fired just before its budget");
+    GPWD_CHECK(IntegrationTest_GameplayWatchdogExpired((double)budget, budget),
+               "watchdog did not fire exactly at its budget");
+    GPWD_CHECK(IntegrationTest_GameplayWatchdogExpired((double)budget + 0.1, budget),
+               "watchdog did not fire past its budget");
+    // A run that wall-clock-exceeds the whole integration timeout must be well
+    // past a 60 s phase budget — the property the frame budget could not give.
+    GPWD_CHECK(IntegrationTest_GameplayWatchdogExpired((double)GPWD_INTEGRATION_TIMEOUT_SECS, budget),
+               "watchdog did not fire after a timeout's worth of wall clock");
+
+    // (3) A non-positive budget disables the watchdog rather than firing every
+    // tick (defensive: the parser floors at 1, but the predicate is public).
+    GPWD_CHECK(!IntegrationTest_GameplayWatchdogExpired(1000.0, 0), "zero budget fired");
+    GPWD_CHECK(!IntegrationTest_GameplayWatchdogExpired(1000.0, -5), "negative budget fired");
+
+    // (4) Env override + validation. A valid value is honored; anything the
+    // strtol path rejects (garbage, trailing junk, below the 1 s minimum, empty)
+    // falls back to the default so a fat-fingered knob cannot silently disable
+    // or hair-trigger the watchdog.
+    GPWD_CHECK(IntegrationTest_GameplayWatchdogParse("5") == 5, "valid override '5' not honored");
+    GPWD_CHECK(IntegrationTest_GameplayWatchdogParse("240") == 240, "valid override '240' not honored");
+    GPWD_CHECK(IntegrationTest_GameplayWatchdogParse("0x1E") == 30, "hex override '0x1E' not honored");
+    GPWD_CHECK(IntegrationTest_GameplayWatchdogParse("") == GPWD_DEFAULT_SECS, "empty override not defaulted");
+    GPWD_CHECK(IntegrationTest_GameplayWatchdogParse("0") == GPWD_DEFAULT_SECS, "below-minimum '0' not defaulted");
+    GPWD_CHECK(IntegrationTest_GameplayWatchdogParse("-3") == GPWD_DEFAULT_SECS, "negative override not defaulted");
+    GPWD_CHECK(IntegrationTest_GameplayWatchdogParse("60s") == GPWD_DEFAULT_SECS, "trailing junk not defaulted");
+    GPWD_CHECK(IntegrationTest_GameplayWatchdogParse("abc") == GPWD_DEFAULT_SECS, "non-numeric override not defaulted");
+
+    printf("[TEST] PASS: watchdog budget is wall-clock, bounded under the timeout, and validated\n");
+    return TEST_PASS;
+}
+
+#undef GPWD_CHECK


### PR DESCRIPTION
Closes the deferred remainder of #376 (items 4-6). Each premise was re-verified against the current tree first (the harness changed a lot: #404's `redship_add_test`/`TestRegistrationComplete`, #409's items 1-3 fixes, #430's collision gate).

## Premise verdicts

| # | Claim (as filed) | Verdict |
|---|---|---|
| 4 | Frame-budgeted watchdog always loses the race to the wall-clock timeout, so its diagnostic dump never emits | **Real — fixed** |
| 5 | New gameplay CTest rows hardcode `TIMEOUT 300/900` instead of a cache knob | **Real — fixed** |
| 6 | `-DREDSHIP_BUILD_SHARED=ON` matches no `option()` anywhere; silent no-op | **Real — removed** |

### Item 4 — wall-clock watchdog
`games/oot/soh/GameExports_SingleExe.cpp` budgeted the OoT round-trip watchdog in **frames** (`maxPhaseFrames * 4 + 3600` == 4080 at defaults). Under Xvfb + llvmpipe that is 300-800 s of wall clock — longer than the 300 s `IntGameplayRoundtrip` `TIMEOUT` and the step's `timeout 300` — so it could never fire before the hard kill, and the play/scene/entrance/sceneInits dump it exists to produce never emitted. A budget that reads as coverage but cannot fire.

Now budgeted in **wall-clock seconds, per phase** (`RSBS_GP_WATCHDOG_SECS`, default 60), well under the timeout; the stall timer re-bases whenever the phase advances, so only a genuinely wedged phase reaches the budget. Since normal phases complete in seconds, a wedge fires at ~budget + prior-phase time, comfortably under 300 s at the issue's own per-frame estimates.

The parse + fire decision are factored into pure helpers (`IntegrationTest_GameplayWatchdog{Parse,BudgetSecs,Expired}`) and locked by a new ROM-free unit test **`gp-watchdog`** in the `redship` tier — the round-trip repro is ROM-gated and cannot run in hosted CI, so this is the only tier that can prove the watchdog is able to fire before the timeout. See the red-then-green proof below.

### Item 5 — cache-derived gameplay timeouts
The five `Int*` boot/switch rows already honor `REDSHIP_INTEGRATION_TEST_TIMEOUT`, but `IntGameplayRoundtrip` / `IntGameplayRoundtripSoak` still hardcoded `TIMEOUT 300 / 900` as literals — so raising a knob to debug a slow runner left the two longest tests untouched. They deliberately differ from the shared integration value (far longer than a boot check), so they get their **own** cache variables `REDSHIP_GAMEPLAY_TEST_TIMEOUT` / `REDSHIP_GAMEPLAY_SOAK_TIMEOUT` (same 300/900 defaults), not literals.

### Item 6 — dead `-DREDSHIP_BUILD_SHARED=ON`
Passed in six workflow cmake invocations (generate-builds x4, integration-tests x2) but matches **no** `option()`/`if()`/variable anywhere in the tree (verified across the whole repo incl. submodules), and `--no-warn-unused-cli` suppressed even the unused-CLI diagnostic. This tree is single-executable only — there is no shared-vs-single layout to toggle — so the flag is removed from all six sites and the one postmortem-doc example command. Provably a no-op, so removal cannot change build behavior; a green CI confirms.

## Red-then-green proof (item 4 gate)
The `gp-watchdog` unit test runs in the `redship` tier at `generate-builds.yml` build-linux (`ctest -L "^redship$"`), which triggers on this PR. A temporary commit reintroducing an over-timeout budget will be pushed to show the gate goes red, then reverted to green before merge (see PR run history).

## Verification note
`integration-tests.yml` is `workflow_dispatch`-only and the gameplay/soak rows are ROM-runner-gated, so the runtime watchdog and the timeout knobs cannot be exercised by hosted PR CI (same limit #409 noted). The `gp-watchdog` unit test is the ROM-free proxy that runs here; item 5 is validated by `generate-builds` configuring the tree cleanly; item 6 by the build staying green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!--- section:artifacts:start -->
### Build Artifacts
  - [rsbs-windows.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/8486138500.zip)
  - [rsbs-linux.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/8485908605.zip)
<!--- section:artifacts:end -->