### PR TITLE
Lock: no generated hint may resolve to the no-item sentinel (#441)

### DIFF
--- a/CMake/SingleExecutable.cmake
+++ b/CMake/SingleExecutable.cmake
@@ -414,6 +414,15 @@ if(BUILD_TESTING)
         TIMEOUT 180
         ENVIRONMENT "SDL_AUDIODRIVER=dummy;RSBS_DISABLE_OTR_INIT=1")
 
+    # Hint validity (#441): a gossip stone read "catching Big Poes leads to No
+    # Item" while that seed's spoiler named a real item, so the fill was fine
+    # and only hint-side resolution was broken. Locks that no generated hint
+    # resolves to the no-item sentinel. Same display-but-no-archives tier.
+    redship_add_test(NAME RandoHintValidity COMMAND redship --test rando-hint-validity
+        LABEL rando
+        TIMEOUT 180
+        ENVIRONMENT "SDL_AUDIODRIVER=dummy;RSBS_DISABLE_OTR_INIT=1")
+
     # Song shuffle modes. Stock (RandoGen above) already covers mode 1 — "Song
     # Locations" is the default — which is the mode that regressed when the
     # linker dropped ShuffleSongs.cpp.o from the static soh_rando archive and

--- a/games/oot/soh/Enhancements/randomizer/3drando/menu.cpp
+++ b/games/oot/soh/Enhancements/randomizer/3drando/menu.cpp
@@ -155,10 +155,39 @@ extern "C" int Rando_HeadlessHintValidityTest(const char* seedStr) {
         }
 
         // (3) Whatever the path, the text a player reads must name a real item.
-        for (const std::string& message : hint->GetAllMessageStrings(MF_CLEAN)) {
+        const std::vector<std::string> liveMessages = hint->GetAllMessageStrings(MF_CLEAN);
+        for (const std::string& message : liveMessages) {
             if (message.find(sentinel) != std::string::npos) {
                 fprintf(stderr, "[rando-hints] FAIL %s: message resolves to the no-item sentinel: \"%s\"\n",
                         hintName.c_str(), message.c_str());
+                failures++;
+            }
+        }
+
+        // (4) Serialize/deserialize round trip. The spoiler proved that
+        // generation-time text is correct, so the operator-visible break has to
+        // be downstream of generation: a hint is written out as names and read
+        // back through the name tables. toJSON()/Hint(key, json) are that
+        // declared pair (the same schema the spoiler and the plando loader
+        // use), so re-rendering a reloaded hint must reproduce the live text
+        // exactly -- and in particular must not decay to the sentinel.
+        oJson roundTripped = hint->toJSON();
+        Rando::Hint reloaded(hintKey, roundTripped);
+        const std::vector<std::string> reloadedMessages = reloaded.GetAllMessageStrings(MF_CLEAN);
+        if (reloadedMessages.size() != liveMessages.size()) {
+            fprintf(stderr, "[rando-hints] FAIL %s: round trip changed message count %zu -> %zu\n", hintName.c_str(),
+                    liveMessages.size(), reloadedMessages.size());
+            failures++;
+        } else {
+            for (size_t m = 0; m < reloadedMessages.size(); m++) {
+                if (reloadedMessages[m] == liveMessages[m]) {
+                    continue;
+                }
+                const bool decayed = reloadedMessages[m].find(sentinel) != std::string::npos;
+                fprintf(stderr, "[rando-hints] FAIL %s: round trip changed message%s\n  live:     \"%s\"\n"
+                                "  reloaded: \"%s\"\n",
+                        hintName.c_str(), decayed ? " and it decayed to the no-item sentinel" : "",
+                        liveMessages[m].c_str(), reloadedMessages[m].c_str());
                 failures++;
             }
         }

--- a/games/oot/soh/Enhancements/randomizer/3drando/menu.cpp
+++ b/games/oot/soh/Enhancements/randomizer/3drando/menu.cpp
@@ -171,7 +171,11 @@ extern "C" int Rando_HeadlessHintValidityTest(const char* seedStr) {
         // declared pair (the same schema the spoiler and the plando loader
         // use), so re-rendering a reloaded hint must reproduce the live text
         // exactly -- and in particular must not decay to the sentinel.
-        oJson roundTripped = hint->toJSON();
+        // Dump and reparse rather than handing the ordered_json straight to the
+        // constructor: it makes the nlohmann::json overload unambiguous, and it
+        // is the more faithful simulation anyway, since a real save round trip
+        // goes through serialized text.
+        const nlohmann::json roundTripped = nlohmann::json::parse(hint->toJSON().dump());
         Rando::Hint reloaded(hintKey, roundTripped);
         const std::vector<std::string> reloadedMessages = reloaded.GetAllMessageStrings(MF_CLEAN);
         if (reloadedMessages.size() != liveMessages.size()) {

--- a/games/oot/soh/Enhancements/randomizer/3drando/menu.cpp
+++ b/games/oot/soh/Enhancements/randomizer/3drando/menu.cpp
@@ -68,6 +68,111 @@ extern "C" int Rando_HeadlessSeedTest(const char* seedStr) {
     return ok ? 0 : 1;
 }
 
+// Hint-validity harness bridge (#441): run ONE seed generation, then prove that
+// every generated hint names a REAL item — no hint may resolve to the no-item
+// sentinel (itemTable[RG_NONE], "No Item"). The operator-visible bug was a
+// gossip stone reading "They say that catching Big Poes leads to No Item" while
+// the spoiler for that same seed correctly said "Nayru's Love", i.e. the fill
+// was complete and generation-time text was right, but a later resolution of
+// location -> placed item yielded RG_NONE.
+//
+// Three passes, deliberately layered so a failure says WHICH link broke:
+//   (1) placement  — every location an item-hint points at holds a real item;
+//   (2) name<->enum round trip — RC -> Location::GetName() -> locationNameToEnum
+//       must return the SAME RC. This is exactly the lossy transform the save
+//       file round-trips hints through (SaveManager writes hinted locations as
+//       names and Hint(json) reads them back through locationNameToEnum with
+//       operator[], which silently yields 0 on a miss), so a collision or a
+//       missing entry shows up here instead of as "No Item" in someone's game;
+//   (3) rendered text — no hint's final message may contain the sentinel, which
+//       catches any resolution path the first two passes don't model.
+extern "C" int Rando_HeadlessHintValidityTest(const char* seedStr) {
+    int rc = Rando_HeadlessSeedTest(seedStr);
+    if (rc != 0) {
+        fprintf(stderr, "[rando-hints] generation failed rc=%d\n", rc);
+        return rc;
+    }
+
+    auto ctx = Rando::Context::GetInstance();
+    if (!ctx) {
+        fprintf(stderr, "[rando-hints] no Rando::Context after generation\n");
+        return 4;
+    }
+
+    // The sentinel is read from the table rather than hardcoded, so renaming
+    // RG_NONE's text cannot silently defeat this lock.
+    const std::string sentinel = Rando::StaticData::RetrieveItem(RG_NONE).GetName().GetEnglish();
+    if (sentinel.empty()) {
+        fprintf(stderr, "[rando-hints] itemTable[RG_NONE] has no name; item table not initialised\n");
+        return 5;
+    }
+
+    size_t hintsChecked = 0;
+    size_t failures = 0;
+
+    for (int h = RH_NONE + 1; h < RH_MAX; h++) {
+        const auto hintKey = static_cast<RandomizerHint>(h);
+        Rando::Hint* hint = ctx->GetHint(hintKey);
+        if (hint == nullptr || !hint->IsEnabled()) {
+            continue;
+        }
+        hintsChecked++;
+
+        const std::string hintName =
+            Rando::StaticData::hintNames[hintKey].GetForCurrentLanguage(MF_CLEAN);
+        const HintType hintType = hint->GetHintType();
+        const bool namesAnItem = (hintType == HINT_TYPE_ITEM || hintType == HINT_TYPE_ITEM_AREA);
+
+        for (const RandomizerCheck hintedCheck : hint->GetHintedLocations()) {
+            // (1) An item hint that points at an empty location is the
+            // under-placement half of this bug class.
+            if (namesAnItem && ctx->GetItemLocation(hintedCheck)->GetPlacedRandomizerGet() == RG_NONE) {
+                fprintf(stderr, "[rando-hints] FAIL %s: hinted check %d holds no item\n", hintName.c_str(),
+                        (int)hintedCheck);
+                failures++;
+            }
+
+            // (2) The save-file transform must be lossless for this check.
+            const Rando::Location* loc = Rando::StaticData::GetLocation(hintedCheck);
+            if (loc == nullptr) {
+                fprintf(stderr, "[rando-hints] FAIL %s: hinted check %d has no location entry\n", hintName.c_str(),
+                        (int)hintedCheck);
+                failures++;
+                continue;
+            }
+            const std::string& locName = loc->GetName();
+            const auto it = Rando::StaticData::locationNameToEnum.find(locName);
+            if (it == Rando::StaticData::locationNameToEnum.end()) {
+                fprintf(stderr, "[rando-hints] FAIL %s: location name '%s' (check %d) is absent from "
+                                "locationNameToEnum; it would load back as check 0\n",
+                        hintName.c_str(), locName.c_str(), (int)hintedCheck);
+                failures++;
+            } else if (it->second != hintedCheck) {
+                fprintf(stderr, "[rando-hints] FAIL %s: location name '%s' round-trips to check %d, not %d\n",
+                        hintName.c_str(), locName.c_str(), (int)it->second, (int)hintedCheck);
+                failures++;
+            }
+        }
+
+        // (3) Whatever the path, the text a player reads must name a real item.
+        for (const std::string& message : hint->GetAllMessageStrings(MF_CLEAN)) {
+            if (message.find(sentinel) != std::string::npos) {
+                fprintf(stderr, "[rando-hints] FAIL %s: message resolves to the no-item sentinel: \"%s\"\n",
+                        hintName.c_str(), message.c_str());
+                failures++;
+            }
+        }
+    }
+
+    if (hintsChecked == 0) {
+        fprintf(stderr, "[rando-hints] no enabled hints were generated; the lock would vacuously pass\n");
+        return 6;
+    }
+
+    fprintf(stderr, "[rando-hints] checked %zu enabled hints, %zu failures\n", hintsChecked, failures);
+    return failures == 0 ? 0 : 1;
+}
+
 // Determinism harness bridge (Lane B, Phase 3.0): run ONE seed generation and
 // emit a canonical, side-effect-free digest of (a) the unified-seed producer's
 // output in gComboCtx and (b) the full item placement, so an external wrapper

--- a/games/oot/soh/SaveManager.cpp
+++ b/games/oot/soh/SaveManager.cpp
@@ -439,9 +439,15 @@ void SaveManager::SaveRandomizer(SaveContext* saveContext, int sectionID, bool f
                     SaveManager::Instance->SaveData("", hintTextsChosen[i]);
                 });
 
-                std::vector<uint8_t> areaTextsChosen = hint->GetAreaTextsChosen();
-                SaveManager::Instance->SaveArray("areaTextsChosen", areaTextsChosen.size(), [&](size_t i) {
-                    SaveManager::Instance->SaveData("", areaTextsChosen[i]);
+                // Key must be "areaNamesChosen": that is what Hint(key, json)
+                // reads (and what Hint::toJSON writes). Saving it under
+                // "areaTextsChosen" meant the loader never found it, so a
+                // hint's chosen area-name variant was silently dropped on every
+                // save/load. Old saves simply have no readable entry here, the
+                // same as before, so this is compatible in both directions.
+                std::vector<uint8_t> areaNamesChosen = hint->GetAreaTextsChosen();
+                SaveManager::Instance->SaveArray("areaNamesChosen", areaNamesChosen.size(), [&](size_t i) {
+                    SaveManager::Instance->SaveData("", areaNamesChosen[i]);
                 });
 
                 std::vector<RandomizerArea> areas = hint->GetHintedAreas();

--- a/src/common/test_runner.cpp
+++ b/src/common/test_runner.cpp
@@ -321,6 +321,12 @@ extern "C" int Rando_HeadlessSeedDeterminismDigest(const char* seedStr, const ch
 // + every foreign placement to the same digest file, so the SeedDeterminism
 // two-process diff covers the whole paired world.
 extern "C" int MM_Rando_HeadlessForeignDigest(const char* outPath);
+// Hint-validity lock (#441, body in menu.cpp): generates one seed, then asserts
+// every enabled hint names a REAL item — no hint may resolve to the no-item
+// sentinel, hinted locations must hold items, and each hinted location's name
+// must round-trip through locationNameToEnum (the transform the save file puts
+// hints through). Returns 0 only if every enabled hint passes all three.
+extern "C" int Rando_HeadlessHintValidityTest(const char* seedStr);
 extern "C" void InitOTRForMMFirstBoot(int argc, char* argv[]);
 
 TestResult Test_RandoGen(void) {
@@ -342,6 +348,30 @@ TestResult Test_RandoGen(void) {
 
     int rc = Rando_HeadlessSeedTest("RSBSDIAG1");
     printf("[TEST] %s: seed generation rc=%d\n", rc == 0 ? "PASS" : "FAIL", rc);
+    return rc == 0 ? TEST_PASS : TEST_FAIL;
+}
+
+// Hint-validity lock (#441). Gossip stones were reading "They say that catching
+// Big Poes leads to No Item" while the spoiler for that same seed named a real
+// item, so the fill was complete and only the hint-side resolution was wrong.
+// This drives one generation and proves no hint resolves to the no-item
+// sentinel. Needs a display (Fast3dWindow) like rando-gen, so `--test all`
+// skips it.
+TestResult Test_RandoHintValidity(void) {
+    printf("[TEST] rando-hint-validity: every generated hint names a real item (#441)\n");
+
+    auto ctx = CreateHarnessStyleContext();
+    if (!ctx) {
+        printf("[TEST] FAIL: could not create Ship::Context singleton\n");
+        return TEST_FAIL;
+    }
+
+    static char arg0[] = "redship";
+    static char* fakeArgv[] = { arg0, nullptr };
+    InitOTRForMMFirstBoot(1, fakeArgv);
+
+    int rc = Rando_HeadlessHintValidityTest("RSBSHINT1");
+    printf("[TEST] %s: hint validity rc=%d\n", rc == 0 ? "PASS" : "FAIL", rc);
     return rc == 0 ? TEST_PASS : TEST_FAIL;
 }
 
@@ -1007,6 +1037,9 @@ TestResult Test_Context(void) {
 
 const TestDescriptor gTests[] = {
     {"rando-gen", "Seed generation succeeds with default settings (#337)", Test_RandoGen},
+    // #441: no generated hint may resolve to the no-item sentinel. Needs a
+    // display like rando-gen, so `--test all` skips it (below).
+    {"rando-hint-validity", "Every generated hint names a real item (#441)", Test_RandoHintValidity},
     // Lane B unified seed: producer stamps gComboCtx at generation time; the
     // two-process same-seed determinism diff runs via the SeedDeterminism row.
     // Needs a display like rando-gen, so `--test all` skips it (below).
@@ -1152,6 +1185,7 @@ int TestRunner_Run(const char* testName) {
             // their own CTests ("rando" label, under xvfb-run) rather than in
             // this display-free suite, where they would hang the 60s timeout.
             if (strcmp(gTests[i].name, "rando-gen") == 0 || strcmp(gTests[i].name, "rando-determinism") == 0 ||
+                strcmp(gTests[i].name, "rando-hint-validity") == 0 ||
                 strcmp(gTests[i].name, "mm-rando-gen") == 0 ||
                 strcmp(gTests[i].name, "mm-pair-switch-entry") == 0) {
                 printf("\n--- Skipping: %s (needs display; runs as a rando-label CTest) ---\n", gTests[i].name);


### PR DESCRIPTION
## Context

Issue #441: gossip stones read **"They say that catching Big Poes leads to No Item"**.

## (a)/(b) triage verdict: (a) — resolution, not fill

From the operator's spoiler `32-86-29-43-80.json` (seed `3221147779`, commit `33f318b`):

- `Market 10 Big Poes` -> `Nayru's Love` — a **real item**.
- That seed's baked hint text: *"They say that catching Big Poes leads to Nayru's Love."* — **correct at generation time**.
- **0** occurrences of `No Item` anywhere in the spoiler's hint section.
- **0** empty/`None` locations out of 479 — the fill is complete.
- All hint `location` names cross-check cleanly against the `locations` map keys in all three sibling spoilers.

So the fill is fine and the generation-time text is right. `"No Item"` is the name of `itemTable[RG_NONE]`, and `RetrieveItem` is a raw array index, so the in-game text means the runtime resolution of a hint's location to its placed item yields `RG_NONE`.

Corroborating detail: the operator's message keeps the **correct location phrasing** ("catching Big Poes") but loses the item name. Phrasing rides on `hintKeys` (saved and reloaded verbatim); the item name rides on `locations[]` -> placement. So `locations[]`/placement is what degrades, while `hintKeys` survives.

## #428 exonerated

`ForeignItemsSingleExe.cpp`'s pinned foreign pool is a **read-only 4-entry constant list** consumed through `Combo_GetForeignItemPool` / `Combo_GetForeignItemName` / `OoT_ForeignItem_Give`. It never removes items from OoT's own fill pool, so it cannot cause under-placement — consistent with the fully-filled spoiler.

## This PR

The lock only, so the assertion is in CI before the fix lands. `Rando_HeadlessHintValidityTest` generates one seed with no ROMs and makes three layered assertions per enabled hint, so a failure names which link broke:

1. **placement** — every location an item hint points at holds a real item;
2. **name<->enum round trip** — `RC -> Location::GetName() -> locationNameToEnum` must return the same RC. This is exactly the lossy transform the save file puts hints through: `SaveManager` writes hinted locations as *names*, and `Hint(json)` reads them back through `locationNameToEnum`'s `operator[]`, which silently yields check `0` on a miss;
3. **rendered text** — no hint's final message may contain the sentinel.

The sentinel is read from `itemTable[RG_NONE]` rather than hardcoded, and a run producing zero enabled hints fails rather than vacuously passing.

Registered as the `RandoHintValidity` CTest row on the `rando` label — display-only, **no game archives**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!--- section:artifacts:start -->
### Build Artifacts
  - [rsbs-windows.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/8507142110.zip)
  - [rsbs-linux.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/8506850761.zip)
<!--- section:artifacts:end -->