### PR TITLE
Dispatch OnSaveInit at MM's cross-game arrival so the paired world actually activates (#439)

### DIFF
--- a/CMake/SingleExecutable.cmake
+++ b/CMake/SingleExecutable.cmake
@@ -437,6 +437,21 @@ if(BUILD_TESTING)
         TIMEOUT 180
         ENVIRONMENT "SDL_AUDIODRIVER=dummy;RSBS_DISABLE_OTR_INIT=1")
 
+    # #439: the paired MM world must activate on the flow a player actually
+    # takes. MMRandoGen above drives the OnSaveInit chain DIRECTLY, which is
+    # why CI stayed green through an entire playtest in which MM never paired:
+    # entering MM through the Happy Mask Shop performs a cold gamestate-chain
+    # boot (ConsoleLogo -> TitleSetup -> Play_Init) that authors a vanilla
+    # bootstrap save and never dispatches OnSaveInit at all. This row drives
+    # that boot + the real MM_Play_ConsumeStartupEntrance consumption point,
+    # and additionally locks that an existing MM save (vanilla or already
+    # paired) is never regenerated. MMRandoGen stays as direct-chain
+    # regression cover. Same display requirement, hence the same label/env.
+    redship_add_test(NAME MMPairSwitchEntry COMMAND redship --test mm-pair-switch-entry
+        LABEL rando
+        TIMEOUT 180
+        ENVIRONMENT "SDL_AUDIODRIVER=dummy;RSBS_DISABLE_OTR_INIT=1")
+
     # ========================================================================
     # Lane B — unified seed -> paired world (Phase 3.0)
     #

--- a/docs/unified-surface-findings.md
+++ b/docs/unified-surface-findings.md
@@ -18,6 +18,26 @@ thing the docs implied:
    **dormant until an `Execute` call is deliberately placed** at MM's upstream dispatch
    point. Registration ≠ dispatch is the single most load-bearing fact in this document.
 
+   > **#439 is the worked example, and it has a second edge nothing above predicted.**
+   > `OnSaveInit` *was* dispatched — from `MM_Sram_InitSave`, MM's file-select
+   > new-file flow — and MMRandoGen proved that chain green for months. But a
+   > cross-game switch never touches file select: it cold-starts the gamestate
+   > chain, and `TitleSetup_SetupTitleScreen` authors the save with
+   > `MM_Sram_InitNewSave()` + `OnSaveLoad`. So the paired MM world never
+   > generated in real play. The generalization: **a dispatch point placed on
+   > one entry path is not coverage of the feature** — enumerate every path that
+   > reaches the state the hook keys off, and put the `Execute` at the
+   > *convergence* point (for MM arrivals that is
+   > `MM_Play_ConsumeStartupEntrance`, the one place after every boot-chain wipe
+   > and before the save is interpreted).
+   >
+   > The same issue produced the mirror-image bug for `COND_HOOK` types: the
+   > boot chain's `OnSaveLoad` dispatch **disarms** every `IS_RANDO` hook
+   > (it runs against a vanilla bootstrap file), so a hook can be correctly
+   > registered, correctly dispatched, and still be *unregistered* by an
+   > earlier dispatch on the same path. Any `COND_*` condition read off save
+   > state needs a re-dispatch once the final save is known.
+
 The ODR/linker prep is **already paid for** (#415 shim + poison guard, #422 rando
 reachability, #434 S2H UIWidgets). What remains is surface work, and it decomposes far
 better than expected: **trackers are nearly free; the settings menu is the expensive

--- a/games/mm/2s2h/GameExports_SingleExe.cpp
+++ b/games/mm/2s2h/GameExports_SingleExe.cpp
@@ -34,6 +34,9 @@
 #include "integration_test_hooks.h"
 #include "context.h"
 #include "shared_items.h"
+// Paired-world keying + placement-table accessors (#439 switch-entry
+// activation logs the placement count at the pairing decision point).
+#include "foreign_items.h"
 #include "entrance.h"
 #include <ship/resource/ResourceManager.h>
 #include <ship/resource/ResourceLoader.h>
@@ -1716,6 +1719,88 @@ static void MM_AwardSharedItem(const SharedItem* item, void* ctx) {
  */
 void MM_ConsumeSharedItems(void) {
     Combo_RedeemSharedItemsForGame(GAME_MM, MM_AwardSharedItem, nullptr);
+}
+
+/**
+ * Paired-world activation on the SWITCH-ENTRY path (#439).
+ *
+ * The bug this closes is a dispatch-site gap, not a registration gap.
+ * Rando::MiscBehavior::OnFileCreate is registered against OnSaveInit at boot
+ * (Rando::MiscBehavior::Init), but OnSaveInit is only ever DISPATCHED from
+ * MM_Sram_InitSave (z_sram_NES.c) — MM's file-select "create a new file"
+ * flow. The natural player flow into the paired world never touches file
+ * select: entering the Happy Mask Shop hands off to GameRunner_SwitchTo,
+ * whose cold gamestate-chain boot runs ConsoleLogo -> TitleSetup ->
+ * MM_Play_Init. TitleSetup authors the save with MM_Sram_InitNewSave() (a
+ * plain VANILLA new file) and dispatches OnSaveLoad, never OnSaveInit. So
+ * OnFileCreate never ran, no MM fill happened, gComboCtx.foreignPlacements
+ * stayed empty and no MM spoiler was ever written — exactly the operator
+ * forensics on #439, where Lane B's producer had correctly stamped
+ * sourceIsRando/sharedRandoSeed in every slot.
+ *
+ * Called from MM_Play_ConsumeStartupEntrance (games/mm/src/code/z_play.c) —
+ * the one point that is after every boot-chain wipe and before the save is
+ * interpreted, and the same point the frozen-state restore uses.
+ *
+ * @param hadFrozenState nonzero when Combo_ConsumeFrozenState just restored a
+ *        real MM session over the boot-chain save. That save belongs to the
+ *        player, so it is NEVER regenerated — the whole point of the
+ *        "existing MM saves are never silently modified" contract.
+ *
+ * Every decision point logs to stderr with a greppable `[MM] pairing:`
+ * prefix: the operator flew blind through this seam for an entire playtest.
+ */
+void MM_Rando_PairOnCrossGameArrival(int hadFrozenState) {
+    const bool pairing = Combo_ForeignPairingActive();
+    const bool alreadyRando = (gSaveContext.save.shipSaveInfo.saveType == SAVETYPE_RANDO);
+
+    if (!pairing) {
+        fprintf(stderr,
+                "[MM] pairing: skipped-because-no-paired-oot-world "
+                "(sourceIsRando=%d settingsHash=%08X masterSeed=%u)\n",
+                gComboCtx.sourceIsRando ? 1 : 0, gComboCtx.sharedRandoSettingsHash, gComboCtx.sharedRandoSeed);
+        return;
+    }
+
+    if (hadFrozenState) {
+        // A restored MM session — vanilla or rando — is the player's own save.
+        // Re-running generation over it would wipe their progress (OnFileCreate
+        // memsets shipSaveInfo.rando and re-authors the starting state), so the
+        // paired world simply does not apply to a file that already exists.
+        fprintf(stderr,
+                "[MM] pairing: skipped-because-existing-mm-save "
+                "(frozen MM session restored, saveType=%s) — an existing file is never regenerated\n",
+                alreadyRando ? "rando" : "vanilla");
+        return;
+    }
+
+    if (alreadyRando) {
+        // Defensive: the bootstrap save the boot chain authored should always
+        // be vanilla. If some other path already paired it, do not do it twice.
+        fprintf(stderr, "[MM] pairing: skipped-because-already-paired (mmFinalSeed=%08X foreignPlacements=%d)\n",
+                gSaveContext.save.shipSaveInfo.rando.finalSeed, Combo_CountForeignPlacements());
+        return;
+    }
+
+    fprintf(stderr, "[MM] pairing: armed on switch-entry (masterSeed=%u settingsHash=%08X) — dispatching OnSaveInit\n",
+            gComboCtx.sharedRandoSeed, gComboCtx.sharedRandoSettingsHash);
+    fflush(stderr);
+
+    // The REAL dispatch — the same bridge MM_Sram_InitSave calls on the
+    // file-select path, so both entry paths converge on one generation code
+    // path (S2H::GameHooks Execute<OnSaveInit> -> Rando::MiscBehavior::OnFileCreate).
+    GameInteractor_ExecuteOnSaveInit(gSaveContext.fileNum);
+
+    if (gSaveContext.save.shipSaveInfo.saveType == SAVETYPE_RANDO) {
+        fprintf(stderr, "[MM] pairing: paired world ACTIVE (mmFinalSeed=%08X foreignPlacements=%d)\n",
+                gSaveContext.save.shipSaveInfo.rando.finalSeed, Combo_CountForeignPlacements());
+    } else {
+        // OnFileCreate's catch reverts to a vanilla save on any generation
+        // failure. That is the correct fallback, but it must never be silent.
+        fprintf(stderr, "[MM] pairing: FAILED — generation reverted the save to vanilla; MM plays vanilla this "
+                        "session (see the preceding SPDLOG_ERROR for the cause)\n");
+    }
+    fflush(stderr);
 }
 
 } // extern "C"

--- a/games/mm/2s2h/Rando/MiscBehavior/OnFileCreate.cpp
+++ b/games/mm/2s2h/Rando/MiscBehavior/OnFileCreate.cpp
@@ -247,16 +247,31 @@ void Rando::MiscBehavior::OnFileCreate(s16 fileNum) {
 #endif
 
                 if (CVarGetInteger("gRando.GenerateSpoiler", 1)) {
-                    nlohmann::json spoiler = Rando::Spoiler::GenerateFromSaveContext();
-                    spoiler["inputSeed"] = inputSeed;
+                    // The spoiler is a REPORT of the world, not part of it: the
+                    // fill above already succeeded and the save already holds a
+                    // complete, playable world. Before #439 a filesystem
+                    // failure here (missing directory, read-only install)
+                    // propagated to the outer catch, which reverts the save to
+                    // vanilla — turning "could not write a log file" into
+                    // "your paired world silently did not happen". Contain it:
+                    // log loudly, keep the world.
+                    try {
+                        nlohmann::json spoiler = Rando::Spoiler::GenerateFromSaveContext();
+                        spoiler["inputSeed"] = inputSeed;
 
-                    std::string fileName = inputSeed + ".json";
-                    Rando::Spoiler::SaveToFile(fileName, spoiler);
+                        std::string fileName = inputSeed + ".json";
+                        Rando::Spoiler::SaveToFile(fileName, spoiler);
 
-                    if (hadInputSeed) {
-                        CVarSetString("gRando.SpoilerFile", fileName.c_str());
+                        if (hadInputSeed) {
+                            CVarSetString("gRando.SpoilerFile", fileName.c_str());
+                        }
+                        Rando::Spoiler::RefreshOptions();
+                    } catch (const std::exception& e) {
+                        SPDLOG_ERROR("Spoiler write failed (world is still valid): {}", e.what());
+                        fprintf(stderr, "[MM] spoiler: NOT written — %s (the generated world is unaffected)\n",
+                                e.what());
+                        fflush(stderr);
                     }
-                    Rando::Spoiler::RefreshOptions();
                 }
 
                 Audio_PlaySfx(NA_SE_SY_ATTENTION_SOUND);

--- a/games/mm/2s2h/Rando/Spoiler/File.cpp
+++ b/games/mm/2s2h/Rando/Spoiler/File.cpp
@@ -1,26 +1,63 @@
 #include "Spoiler.h"
 #include <fstream>
+#include <filesystem>
+#include <cstdio>
+#include <spdlog/spdlog.h>
 #include "BenPort.h"
 
 namespace Rando {
 
 namespace Spoiler {
 
+std::string SpoilerDirectory() {
+#ifdef RSBS_SINGLE_EXECUTABLE
+    // Resolve against the shared app directory (see Spoiler.h). Passing no
+    // appName uses the live Ship::Context's short name, which in the combo is
+    // the one context OoT created — so MM's spoilers land beside OoT's rather
+    // than in a second app directory that portable installs never create.
+    const std::string dir = Ship::Context::GetPathRelativeToAppDirectory("randomizer-mm");
+#else
+    const std::string dir = Ship::Context::GetPathRelativeToAppDirectory("randomizer", appShortName);
+#endif
+    std::error_code ec;
+    // create_directories (not create_directory): the parent app directory can
+    // be missing on a fresh portable install, and the non-recursive form fails
+    // silently in that case, leaving the write below to throw.
+    std::filesystem::create_directories(dir, ec);
+    return dir;
+}
+
 void SaveToFile(const std::string& fileName, nlohmann::json spoiler) {
-    std::string filePath = Ship::Context::GetPathRelativeToAppDirectory("randomizer/" + fileName, appShortName);
+    const std::string filePath = SpoilerDirectory() + "/" + fileName;
+
     std::ofstream fileStream(filePath);
     if (!fileStream.is_open()) {
-        throw std::runtime_error("Failed to open spoiler file");
+        // Name the path in both the log and the exception: "Failed to open
+        // spoiler file" with no path was the entirety of the operator's
+        // diagnostic surface when the MM spoiler went missing (#439).
+        fprintf(stderr, "[MM] spoiler: WRITE FAILED at '%s'\n", filePath.c_str());
+        fflush(stderr);
+        throw std::runtime_error("Failed to open spoiler file for writing: " + filePath);
     }
 
     fileStream << spoiler.dump(4);
+    fileStream.close();
+
+    // Unconditional breadcrumb: the operator must be able to find the spoiler
+    // without knowing how app directories resolve on their platform.
+    std::error_code absEc;
+    const std::filesystem::path absPath = std::filesystem::absolute(std::filesystem::path(filePath), absEc);
+    const std::string reportedPath = absEc ? filePath : absPath.string();
+    fprintf(stderr, "[MM] spoiler: wrote '%s'\n", reportedPath.c_str());
+    fflush(stderr);
+    SPDLOG_INFO("MM spoiler written to {}", reportedPath);
 }
 
 nlohmann::json LoadFromFile(const std::string& fileName) {
-    std::string spoilerFilePath = Ship::Context::GetPathRelativeToAppDirectory("randomizer/" + fileName, appShortName);
+    const std::string spoilerFilePath = SpoilerDirectory() + "/" + fileName;
     std::ifstream fileStream(spoilerFilePath);
     if (!fileStream.is_open()) {
-        throw std::runtime_error("Failed to open spoiler file");
+        throw std::runtime_error("Failed to open spoiler file: " + spoilerFilePath);
     }
 
     nlohmann::json spoiler;

--- a/games/mm/2s2h/Rando/Spoiler/HandleFileDropped.cpp
+++ b/games/mm/2s2h/Rando/Spoiler/HandleFileDropped.cpp
@@ -38,8 +38,9 @@ bool Rando::Spoiler::HandleFileDropped(char* filePath) {
 
         // Save the spoiler file to the randomizer folder
         std::string spoilerFile = std::filesystem::path(filePath).filename().string();
-        std::string spoilerFilePath =
-            Ship::Context::GetPathRelativeToAppDirectory("randomizer/" + spoilerFile, appShortName);
+        // One shared derivation with the read/write paths (#439) — a dropped
+        // spoiler must land where RefreshOptions/LoadFromFile will look.
+        std::string spoilerFilePath = Rando::Spoiler::SpoilerDirectory() + "/" + spoilerFile;
         std::filesystem::copy_file(filePath, spoilerFilePath, std::filesystem::copy_options::overwrite_existing);
 
         // Set the spoiler file to the new file

--- a/games/mm/2s2h/Rando/Spoiler/RefreshOptions.cpp
+++ b/games/mm/2s2h/Rando/Spoiler/RefreshOptions.cpp
@@ -1,6 +1,7 @@
 #include "Spoiler.h"
 #include <libultraship/bridge/consolevariablebridge.h>
 #include <filesystem>
+#include <cstdio>
 #include "BenPort.h"
 
 #include <libultraship/libultra/types.h>
@@ -13,9 +14,12 @@ std::vector<std::string> Rando::Spoiler::spoilerOptions;
 // creates the shared Ship::Context — killing the exe at boot. A
 // function-local static defers the call to first use, which is always after
 // context bring-up (MM_Rando_Init or the spoiler read/write paths).
+//
+// The path itself now comes from Rando::Spoiler::SpoilerDirectory() (#439) so
+// this listing and the read/write paths can never disagree about where MM
+// spoilers live — they did, and the write path landed nowhere findable.
 static const std::filesystem::path& GetRandomizerFolderPath() {
-    static const std::filesystem::path randomizerFolderPath(
-        Ship::Context::GetPathRelativeToAppDirectory("randomizer", appShortName));
+    static const std::filesystem::path randomizerFolderPath(Rando::Spoiler::SpoilerDirectory());
     return randomizerFolderPath;
 }
 
@@ -27,9 +31,20 @@ void Rando::Spoiler::RefreshOptions() {
     Rando::Spoiler::spoilerOptions.push_back("Generate New Seed");
     s32 spoilerFileIndex = -1;
 
-    // ensure the randomizer folder exists
+    // ensure the randomizer folder exists (SpoilerDirectory already creates it
+    // recursively; this covers a folder deleted after first use)
     if (!std::filesystem::exists(GetRandomizerFolderPath())) {
-        std::filesystem::create_directory(GetRandomizerFolderPath());
+        std::error_code ec;
+        std::filesystem::create_directories(GetRandomizerFolderPath(), ec);
+        if (ec) {
+            // "Generate New Seed" is already in the list; leave it as the only
+            // option rather than letting directory_iterator throw.
+            fprintf(stderr, "[MM] spoiler: cannot create spoiler directory '%s' (%s)\n",
+                    GetRandomizerFolderPath().string().c_str(), ec.message().c_str());
+            CVarSetInteger("gRando.SpoilerFileIndex", 0);
+            CVarSetString("gRando.SpoilerFile", "");
+            return;
+        }
     }
 
     // Add all files in the randomizer folder to the list of spoiler options

--- a/games/mm/2s2h/Rando/Spoiler/Spoiler.h
+++ b/games/mm/2s2h/Rando/Spoiler/Spoiler.h
@@ -10,6 +10,26 @@ namespace Rando {
 namespace Spoiler {
 
 extern std::vector<std::string> spoilerOptions;
+
+/**
+ * The one directory MM spoilers are read from and written to (#439).
+ *
+ * Single source of truth for every spoiler path in this module — before this
+ * existed, four call sites each re-derived it and the write path assumed a
+ * directory nothing guaranteed to exist.
+ *
+ * In single-exe builds it resolves against the SHARED Ship::Context's app
+ * directory (OoT creates that context, so passing MM's own "2ship" short name
+ * pointed at a second app directory the combo never otherwise uses — the
+ * operator's portable install had no 2ship directory at all). The folder name
+ * is deliberately distinct from OoT's "Randomizer" because on Windows those
+ * two names collide case-insensitively and MM's directory_iterator would list
+ * OoT's spoilers as MM spoiler options.
+ *
+ * The directory is created (recursively) if missing; the return value is
+ * always a usable directory or the call throws.
+ */
+std::string SpoilerDirectory();
 void RefreshOptions();
 nlohmann::json GenerateFromSaveContext();
 void SaveToFile(const std::string& fileName, nlohmann::json spoiler);

--- a/games/mm/2s2h/mm_rando_gen_test.cpp
+++ b/games/mm/2s2h/mm_rando_gen_test.cpp
@@ -22,6 +22,7 @@
 
 #include <cstdio>
 #include <cstring>
+#include <cstdint>
 #include <fstream>
 #include <string>
 
@@ -49,6 +50,15 @@ extern "C" {
 void MM_Sram_InitNewSave(void);
 void MM_Rando_Init(void);
 extern SaveContext gSaveContext;
+
+// Switch-entry lock (#439): the real consumption point plus the switch
+// path's own state plumbing, driven exactly as rsbs/src/main.cpp and
+// MM_Play_Init drive them.
+void MM_Play_ConsumeStartupEntrance(void);
+void Combo_FreezeState(const char* gameId, uint16_t returnEntrance, const void* saveContext, size_t size);
+void Combo_ClearFrozenState(const char* gameId);
+void Combo_SetStartupEntrance(uint16_t entrance);
+void Combo_ClearStartupEntrance(void);
 }
 
 extern "C" int MM_Rando_HeadlessGenTest(void) {
@@ -148,8 +158,10 @@ extern "C" int MM_Rando_HeadlessGenTest(void) {
         return 4;
     }
 
-    std::string spoilerPath =
-        Ship::Context::GetPathRelativeToAppDirectory(std::string("randomizer/") + usedSeed + ".json", appShortName);
+    // Through the module's own directory accessor (#439): the test must look
+    // where the write path actually writes, not re-derive a second path that
+    // can silently drift from it.
+    std::string spoilerPath = Rando::Spoiler::SpoilerDirectory() + "/" + usedSeed + ".json";
     std::ifstream spoilerFile(spoilerPath);
     if (!spoilerFile.is_open()) {
         fprintf(stderr, "[MM-RANDO-GEN] FAIL(5): spoiler file missing at %s\n", spoilerPath.c_str());
@@ -294,8 +306,8 @@ extern "C" int MM_Rando_HeadlessGenTest(void) {
     // The spoiler landed under the DERIVED paired name and describes every
     // crossing: "foreign" as {checkName: {originGame, item}}, and the human-
     // readable checks list reads as the foreign item, not junk.
-    std::string pairedSpoilerPath = Ship::Context::GetPathRelativeToAppDirectory(
-        std::string("randomizer/") + "RSBSPAIR" + std::to_string(gComboCtx.sharedRandoSeed) + ".json", appShortName);
+    std::string pairedSpoilerPath =
+        Rando::Spoiler::SpoilerDirectory() + "/RSBSPAIR" + std::to_string(gComboCtx.sharedRandoSeed) + ".json";
     std::ifstream pairedFile(pairedSpoilerPath);
     if (!pairedFile.is_open()) {
         fprintf(stderr, "[MM-RANDO-GEN] FAIL(13): paired spoiler missing at %s (seed derivation broken?)\n",
@@ -673,6 +685,292 @@ extern "C" int MM_Rando_HeadlessForeignDigest(const char* outPath) {
     }
     fprintf(stderr, "[MM-FOREIGN-DIGEST] mmFinalSeed=%08X mmPlacementHash=%08X foreign=%d\n",
             gSaveContext.save.shipSaveInfo.rando.finalSeed, mmPlacementHash, Combo_CountForeignPlacements());
+    return 0;
+}
+
+// ============================================================================
+// Switch-entry pairing lock (#439)
+// ============================================================================
+/**
+ * The harness gap #439 was filed for. MMRandoGen's paired phase drives the
+ * OnSaveInit chain DIRECTLY, so it proved generation works while the only
+ * flow a player actually takes — walking into the Happy Mask Shop — never
+ * reached that chain at all. Everything below drives the SWITCH-ENTRY path:
+ * the cold gamestate-chain boot the switch performs, then the real
+ * MM_Play_ConsumeStartupEntrance consumption point, with no direct call to
+ * the generation entry point anywhere in the success path.
+ *
+ * Three phases, matching the entry-path matrix in #439:
+ *
+ *  1. fresh switch-entry + live paired OoT world -> the paired MM world
+ *     activates (rando save, foreign placements, spoiler with a foreign
+ *     section) AND the IS_RANDO behavior hooks end up armed. The boot chain
+ *     dispatches OnSaveLoad against its vanilla bootstrap file, which
+ *     DISARMS them; if nothing re-dispatches afterwards, MM plays vanilla
+ *     even with a perfectly generated world. Locked here in both halves.
+ *
+ *  2. return leg (frozen paired save) -> restored, NOT regenerated
+ *     (finalSeed and a save sentinel both survive), hooks armed again.
+ *
+ *  3. return leg with an EXISTING VANILLA MM save -> left strictly alone.
+ *     This is the "never silently modify the player's file" contract: a
+ *     paired OoT world does not entitle anything to rewrite a save that
+ *     already exists.
+ *
+ * Returns 0 on success, a distinct nonzero step code otherwise.
+ */
+extern "C" int MM_Rando_HeadlessPairSwitchEntry(void) {
+    const uint16_t kArrival = 0xD800; // ENTRANCE(SOUTH_CLOCK_TOWN, 0) — the OoT->MM arrival
+
+    auto ctx = Ship::Context::GetInstance();
+    if (ctx == nullptr || ctx->GetConsoleVariables() == nullptr) {
+        fprintf(stderr, "[MM-PAIR-SWITCH] FAIL(1): Ship::Context not live\n");
+        return 1;
+    }
+
+    MM_Rando_Init();
+    if (Rando::Logic::Regions.empty()) {
+        fprintf(stderr, "[MM-PAIR-SWITCH] FAIL(2): Logic/Regions graph empty\n");
+        return 2;
+    }
+
+    if (gRegEditor == NULL) {
+        static RegEditor sPairRegEditor = {};
+        gRegEditor = &sPairRegEditor;
+    }
+
+    // gRando.Enabled stays OFF on purpose: MM's rando menu is link-elided in
+    // the single exe, so the paired OoT generation is the ONLY opt-in. If
+    // activation ever starts depending on this CVar, this row fails.
+    CVarSetInteger("gRando.Enabled", 0);
+    CVarSetInteger("gRando.GenerateSpoiler", 1);
+    CVarSetString("gRando.InputSeed", "USERSEEDPOISON"); // the paired branch must ignore this
+    CVarSetInteger(Rando::StaticData::Options[RO_LOGIC].cvar, RO_LOGIC_NEARLY_NO_LOGIC);
+    // A stale SpoilerFileIndex must not divert the paired branch into LOADING
+    // an old world — pin the hostile value the real session can carry.
+    CVarSetInteger("gRando.SpoilerFileIndex", 3);
+
+    const ComboForeignItemDef* pool = NULL;
+    const int poolCount = Combo_GetForeignItemPool(&pool);
+    if (poolCount <= 0 || pool == NULL) {
+        fprintf(stderr, "[MM-PAIR-SWITCH] FAIL(3): pinned foreign pool is empty\n");
+        return 3;
+    }
+
+    // ----------------------------------------------------------------------
+    // Phase 1 — fresh switch-entry into a live paired OoT world.
+    // ----------------------------------------------------------------------
+    // A fixed master-seed list, for the same reason MMRandoGen keeps one: the
+    // MM fill can genuinely dead-end on an unlucky seed, and the claim under
+    // test is that the switch-entry path REACHES generation, not that any
+    // particular seed fills. Deterministic either way (fixed list, fixed fill).
+    static const uint32_t kMasterSeeds[] = { 2108649350u, 1234567u, 77777777u, 424242u, 999983u };
+    uint32_t usedMasterSeed = 0;
+
+    for (uint32_t masterSeed : kMasterSeeds) {
+        // Lane B's carrier, stamped as a live OoT generation stamps it.
+        Combo_ClearForeignPlacements();
+        Combo_ClearFrozenState("mm");
+        Combo_ClearStartupEntrance();
+        gComboCtx.sourceIsRando = 1;
+        gComboCtx.sharedRandoSeed = masterSeed;
+        gComboCtx.sharedRandoSettingsHash = 0x5DAD32CEu;
+
+        // The cold gamestate-chain boot a switch performs: ConsoleLogo skips
+        // to TitleSetup, TitleSetup authors a VANILLA bootstrap file with
+        // MM_Sram_InitNewSave and dispatches OnSaveLoad against it. File
+        // select is never touched, so OnSaveInit is never dispatched here —
+        // that absence is the whole bug.
+        memset(&gSaveContext, 0, sizeof(gSaveContext));
+        MM_Sram_InitNewSave();
+        GameInteractor_ExecuteOnSaveLoad(gSaveContext.fileNum);
+
+        const size_t hooksAfterBootChain = S2H::GameHooks::CountForTest<GameInteractor::OnFlagSet>();
+
+        // The switch path's pending arrival, then the real consumption point.
+        Combo_SetStartupEntrance(kArrival);
+        MM_Play_ConsumeStartupEntrance();
+
+        if (gSaveContext.save.shipSaveInfo.saveType == SAVETYPE_RANDO) {
+            const size_t hooksAfterConsume = S2H::GameHooks::CountForTest<GameInteractor::OnFlagSet>();
+            if (hooksAfterConsume == 0 || hooksAfterConsume <= hooksAfterBootChain) {
+                fprintf(stderr,
+                        "[MM-PAIR-SWITCH] FAIL(5): paired world generated but the IS_RANDO hooks were left "
+                        "DISARMED by the boot chain's OnSaveLoad (OnFlagSet %zu -> %zu) — MM would play with "
+                        "vanilla behavior in a rando world\n",
+                        hooksAfterBootChain, hooksAfterConsume);
+                return 5;
+            }
+            fprintf(stderr, "[MM-PAIR-SWITCH] hooks re-armed at consumption (OnFlagSet %zu -> %zu)\n",
+                    hooksAfterBootChain, hooksAfterConsume);
+            usedMasterSeed = masterSeed;
+            break;
+        }
+
+        // Discriminator: did the switch-entry path fail to REACH generation,
+        // or did this seed's fill dead-end? Re-run the same gComboCtx through
+        // the DIRECT chain MMRandoGen uses. If the direct chain pairs and the
+        // switch-entry path did not, the dispatch site is gone — the exact
+        // #439 regression, and a distinct, unambiguous failure.
+        memset(&gSaveContext, 0, sizeof(gSaveContext));
+        MM_Sram_InitNewSave();
+        Combo_ClearForeignPlacements();
+        GameInteractor_ExecuteOnSaveInit(gSaveContext.fileNum);
+        if (gSaveContext.save.shipSaveInfo.saveType == SAVETYPE_RANDO) {
+            fprintf(stderr,
+                    "[MM-PAIR-SWITCH] FAIL(4): the direct OnSaveInit chain pairs under master seed %u but "
+                    "SWITCH-ENTRY did not — MM_Play_ConsumeStartupEntrance no longer reaches generation (#439)\n",
+                    masterSeed);
+            return 4;
+        }
+        fprintf(stderr, "[MM-PAIR-SWITCH] master seed %u dead-ended on both paths (fill); trying next\n", masterSeed);
+    }
+
+    if (usedMasterSeed == 0) {
+        fprintf(stderr, "[MM-PAIR-SWITCH] FAIL(6): every pinned master seed dead-ended the MM fill — pin a "
+                        "different seed (generation machinery itself is covered by MMRandoGen)\n");
+        return 6;
+    }
+    fprintf(stderr, "[MM-PAIR-SWITCH] switch-entry paired under master seed %u\n", usedMasterSeed);
+
+    if (Combo_CountForeignPlacements() != poolCount) {
+        fprintf(stderr, "[MM-PAIR-SWITCH] FAIL(7): expected %d foreign placements after switch-entry pairing, found "
+                        "%d\n",
+                poolCount, Combo_CountForeignPlacements());
+        return 7;
+    }
+    if (gSaveContext.save.entrance != kArrival) {
+        fprintf(stderr, "[MM-PAIR-SWITCH] FAIL(8): arrival entrance 0x%04X lost to generation's start state "
+                        "(save.entrance=0x%04X)\n",
+                kArrival, gSaveContext.save.entrance);
+        return 8;
+    }
+
+    // The spoiler must exist AND be findable through the module's own
+    // directory accessor (#439 second bug: the write path resolved against a
+    // second app directory that portable installs never create, so even a
+    // working pairing produced no file the operator could find).
+    const std::string pairedSpoiler =
+        Rando::Spoiler::SpoilerDirectory() + "/RSBSPAIR" + std::to_string(usedMasterSeed) + ".json";
+    {
+        std::ifstream sf(pairedSpoiler);
+        if (!sf.is_open()) {
+            fprintf(stderr, "[MM-PAIR-SWITCH] FAIL(9): no MM spoiler at %s after switch-entry pairing\n",
+                    pairedSpoiler.c_str());
+            return 9;
+        }
+        nlohmann::json j;
+        try {
+            sf >> j;
+        } catch (const std::exception& e) {
+            fprintf(stderr, "[MM-PAIR-SWITCH] FAIL(9): paired spoiler unparseable: %s\n", e.what());
+            return 9;
+        }
+        if (!j.contains("foreign") || !j["foreign"].is_object() || (int)j["foreign"].size() != poolCount) {
+            fprintf(stderr, "[MM-PAIR-SWITCH] FAIL(10): spoiler 'foreign' section missing or wrong size\n");
+            return 10;
+        }
+    }
+    fprintf(stderr, "[MM-PAIR-SWITCH] spoiler verified at %s\n", pairedSpoiler.c_str());
+
+    // ----------------------------------------------------------------------
+    // Phase 2 — return leg: an existing PAIRED save is restored, not remade.
+    // ----------------------------------------------------------------------
+    const u32 pairedFinalSeed = gSaveContext.save.shipSaveInfo.rando.finalSeed;
+    ComboForeignPlacement pairedPlacements[RSBS_FOREIGN_PLACEMENT_CAP];
+    memcpy(pairedPlacements, gComboCtx.foreignPlacements, sizeof(pairedPlacements));
+
+    // Progress the player made before leaving for OoT.
+    gSaveContext.save.saveInfo.playerData.rupees = 142;
+    gSaveContext.save.day = 3;
+    Combo_FreezeState("mm", kArrival, &gSaveContext, sizeof(gSaveContext));
+
+    memset(&gSaveContext, 0, sizeof(gSaveContext));
+    MM_Sram_InitNewSave();
+    GameInteractor_ExecuteOnSaveLoad(gSaveContext.fileNum);
+    const size_t returnHooksAfterBootChain = S2H::GameHooks::CountForTest<GameInteractor::OnFlagSet>();
+    Combo_SetStartupEntrance(kArrival);
+    MM_Play_ConsumeStartupEntrance();
+
+    if (gSaveContext.save.shipSaveInfo.saveType != SAVETYPE_RANDO) {
+        fprintf(stderr, "[MM-PAIR-SWITCH] FAIL(11): return leg lost the paired save type\n");
+        return 11;
+    }
+    if (gSaveContext.save.shipSaveInfo.rando.finalSeed != pairedFinalSeed) {
+        fprintf(stderr,
+                "[MM-PAIR-SWITCH] FAIL(12): return leg REGENERATED the world (finalSeed %08X -> %08X) — an "
+                "existing MM save must never be re-paired\n",
+                pairedFinalSeed, gSaveContext.save.shipSaveInfo.rando.finalSeed);
+        return 12;
+    }
+    if (gSaveContext.save.saveInfo.playerData.rupees != 142 || gSaveContext.save.day != 3) {
+        fprintf(stderr, "[MM-PAIR-SWITCH] FAIL(13): return leg did not preserve the player's progress "
+                        "(rupees=%d day=%d)\n",
+                gSaveContext.save.saveInfo.playerData.rupees, gSaveContext.save.day);
+        return 13;
+    }
+    if (memcmp(pairedPlacements, gComboCtx.foreignPlacements, sizeof(pairedPlacements)) != 0) {
+        fprintf(stderr, "[MM-PAIR-SWITCH] FAIL(14): return leg disturbed the foreign placement table\n");
+        return 14;
+    }
+    {
+        const size_t after = S2H::GameHooks::CountForTest<GameInteractor::OnFlagSet>();
+        if (after == 0 || after <= returnHooksAfterBootChain) {
+            fprintf(stderr,
+                    "[MM-PAIR-SWITCH] FAIL(15): return leg left the IS_RANDO hooks disarmed (OnFlagSet %zu -> "
+                    "%zu) — a restored rando save would play with vanilla behavior\n",
+                    returnHooksAfterBootChain, after);
+            return 15;
+        }
+    }
+    fprintf(stderr, "[MM-PAIR-SWITCH] return leg: restored, not regenerated, hooks re-armed\n");
+
+    // ----------------------------------------------------------------------
+    // Phase 3 — an EXISTING VANILLA MM save is never silently converted.
+    // ----------------------------------------------------------------------
+    // gComboCtx still carries the live paired keying, so pairing is "possible"
+    // here in every sense except the one that matters: this file already
+    // exists and belongs to the player.
+    Combo_ClearFrozenState("mm");
+    Combo_ClearStartupEntrance();
+    memset(&gSaveContext, 0, sizeof(gSaveContext));
+    MM_Sram_InitNewSave();
+    gSaveContext.save.saveInfo.playerData.rupees = 77;
+    gSaveContext.save.day = 2;
+    Combo_FreezeState("mm", kArrival, &gSaveContext, sizeof(gSaveContext));
+
+    ComboForeignPlacement beforeVanilla[RSBS_FOREIGN_PLACEMENT_CAP];
+    memcpy(beforeVanilla, gComboCtx.foreignPlacements, sizeof(beforeVanilla));
+
+    memset(&gSaveContext, 0, sizeof(gSaveContext));
+    MM_Sram_InitNewSave();
+    GameInteractor_ExecuteOnSaveLoad(gSaveContext.fileNum);
+    Combo_SetStartupEntrance(kArrival);
+    MM_Play_ConsumeStartupEntrance();
+
+    if (gSaveContext.save.shipSaveInfo.saveType != SAVETYPE_VANILLA) {
+        fprintf(stderr, "[MM-PAIR-SWITCH] FAIL(16): an existing VANILLA MM save was silently converted to rando "
+                        "on arrival — existing files must be skipped with a logged reason\n");
+        return 16;
+    }
+    if (gSaveContext.save.saveInfo.playerData.rupees != 77 || gSaveContext.save.day != 2) {
+        fprintf(stderr, "[MM-PAIR-SWITCH] FAIL(17): existing vanilla save was modified (rupees=%d day=%d)\n",
+                gSaveContext.save.saveInfo.playerData.rupees, gSaveContext.save.day);
+        return 17;
+    }
+    if (memcmp(beforeVanilla, gComboCtx.foreignPlacements, sizeof(beforeVanilla)) != 0) {
+        fprintf(stderr, "[MM-PAIR-SWITCH] FAIL(18): skipping a vanilla save still disturbed the placement table\n");
+        return 18;
+    }
+    fprintf(stderr, "[MM-PAIR-SWITCH] existing vanilla save left untouched (skip path)\n");
+
+    // Leave clean global state for later dispatches in the same process.
+    Combo_ClearFrozenState("mm");
+    Combo_ClearStartupEntrance();
+    Combo_ClearForeignPlacements();
+    memset(&gSaveContext, 0, sizeof(gSaveContext));
+
+    fprintf(stderr, "[MM-PAIR-SWITCH] PASS: pairing activates on the switch-entry path, existing saves untouched\n");
     return 0;
 }
 

--- a/games/mm/src/code/z_play.c
+++ b/games/mm/src/code/z_play.c
@@ -68,6 +68,14 @@ extern int Combo_ConsumeFrozenState(const char* gameId, void* saveContext, size_
 // SharedItem/GameId types.
 extern void MM_ConsumeSharedItems(void);
 
+// Paired-world activation on the switch-entry path (#439). Defined in
+// games/mm/2s2h/GameExports_SingleExe.cpp so this TU stays free of the Rando
+// C++ surface. Dispatches OnSaveInit (the generation entry point) when a live
+// paired OoT rando world exists AND this MM entry is creating the bootstrap
+// save rather than restoring the player's own. See its doc comment for why
+// the file-select-only dispatch left the natural flow unpaired.
+extern void MM_Rando_PairOnCrossGameArrival(int hadFrozenState);
+
 s32 MM_gDbgCamEnabled = false;
 u8 D_801D0D54 = false;
 
@@ -2291,7 +2299,16 @@ void MM_Play_ConsumeStartupEntrance(void) {
     // player back (#364). Retiring it here makes "frozen state exists" mean
     // "MM was left and has not been returned to", which is the only condition
     // the restore is valid for. A first MM entry has no frozen state — no-op.
-    Combo_ConsumeFrozenState("mm", &gSaveContext, sizeof(gSaveContext));
+    int hadFrozenState = Combo_ConsumeFrozenState("mm", &gSaveContext, sizeof(gSaveContext));
+    // Paired-world activation (#439). Runs HERE — after the restore, before
+    // the arrival spawn is armed below — for two reasons. (a) It needs to know
+    // whether the save under it is the player's restored session (never
+    // regenerate) or the boot chain's throwaway bootstrap file (the MM half of
+    // the paired world). (b) Generation authors its own start state
+    // (SOUTH_CLOCK_TOWN, cutsceneIndex 0, Tatl flags); running it before the
+    // arrival block means the cross-game arrival state always wins, exactly as
+    // it does over a restored frozen save.
+    MM_Rando_PairOnCrossGameArrival(hadFrozenState);
     gSaveContext.save.entrance = startupEntrance;
     // On a first MM entry this Play_Init is reached through MM's
     // title-screen boot (TitleSetup_SetupTitleScreen), so the save
@@ -2379,6 +2396,24 @@ void MM_Play_ConsumeStartupEntrance(void) {
     // load — un-redeemed items then wait for the next switch into MM.
     MM_ConsumeSharedItems();
     Combo_ClearStartupEntrance();
+
+    // Re-arm the save-shape-dependent hooks against the save that actually
+    // reaches gameplay (#439, second half of the same dispatch gap).
+    //
+    // Rando's behavior hooks are COND_HOOKs re-evaluated on every OnSaveLoad
+    // (Rando.cpp OnSaveLoadHandler -> Rando::MiscBehavior::OnFileLoad et al.,
+    // plus ShipInit::Init("IS_RANDO")); the condition is IS_RANDO, read off
+    // gSaveContext.save.shipSaveInfo.saveType. The cold gamestate-chain boot
+    // dispatches OnSaveLoad from TitleSetup_SetupTitleScreen (z_opening.c) —
+    // against MM_Sram_InitNewSave's VANILLA bootstrap file, which is not the
+    // save that reaches Play. So on EVERY cross-game arrival, including a
+    // return leg restoring a perfectly good rando save, every IS_RANDO hook
+    // was unregistered and MM played with vanilla behavior. Re-dispatching
+    // here — the first point where the final save is known — arms them
+    // correctly in both directions (a restored vanilla save still disarms).
+    // Idempotent by construction: COND_HOOK unregisters before re-registering,
+    // and upstream drives this same handler on every file load.
+    GameInteractor_ExecuteOnSaveLoad(gSaveContext.fileNum);
 }
 
 void MM_Play_Init(GameState* thisx) {

--- a/src/common/test_runner.cpp
+++ b/src/common/test_runner.cpp
@@ -415,6 +415,33 @@ TestResult Test_MMRandoGen(void) {
     return rc == 0 ? TEST_PASS : TEST_FAIL;
 }
 
+// Switch-entry activation lock (#439). MMRandoGen drives the OnSaveInit chain
+// directly; this row drives the path a player actually takes — the cold
+// gamestate-chain boot a cross-game switch performs, then the real
+// MM_Play_ConsumeStartupEntrance consumption point — and additionally locks
+// that an EXISTING MM save (vanilla or paired) is never regenerated. Bridge
+// body in games/mm/2s2h/mm_rando_gen_test.cpp. Needs a display, same as
+// mm-rando-gen, so `--test all` skips it.
+extern "C" int MM_Rando_HeadlessPairSwitchEntry(void);
+
+TestResult Test_MMPairSwitchEntry(void) {
+    printf("[TEST] mm-pair-switch-entry: paired MM world activates through the switch-entry path (#439)\n");
+
+    auto ctx = CreateHarnessStyleContext();
+    if (!ctx) {
+        printf("[TEST] FAIL: could not create Ship::Context singleton\n");
+        return TEST_FAIL;
+    }
+
+    static char arg0[] = "redship";
+    static char* fakeArgv[] = { arg0, nullptr };
+    InitOTRForMMFirstBoot(1, fakeArgv);
+
+    int rc = MM_Rando_HeadlessPairSwitchEntry();
+    printf("[TEST] %s: switch-entry pairing rc=%d\n", rc == 0 ? "PASS" : "FAIL", rc);
+    return rc == 0 ? TEST_PASS : TEST_FAIL;
+}
+
 TestResult Test_BootMM(void) {
     printf("[TEST] boot-mm: MM-first bring-up prerequisites (#330)\n");
     sTargetGame = GAME_MM;
@@ -988,6 +1015,11 @@ const TestDescriptor gTests[] = {
     // Lane C0: MM's randomizer is reachable and generates headlessly. Needs a
     // display like rando-gen, so `--test all` skips it (below).
     {"mm-rando-gen", "MM rando generation runs headlessly + writes tagged spoiler (Lane C0)", Test_MMRandoGen},
+    // #439: the paired world must activate on the SWITCH-ENTRY path (the only
+    // flow a player actually takes), not just the direct OnSaveInit chain.
+    // Same display requirement as mm-rando-gen, so `--test all` skips it.
+    {"mm-pair-switch-entry", "Paired MM world activates via switch-entry; existing saves untouched (#439)",
+     Test_MMPairSwitchEntry},
     {"boot-oot", "Shared-context bring-up leaves no null subsystems (#329)", Test_BootOoT},
     {"boot-mm", "MM-first bring-up prerequisites on the shared context (#330)", Test_BootMM},
     {"switch-oot-mm", "Test game switch OoT -> MM", Test_SwitchOoTMM},
@@ -1120,7 +1152,8 @@ int TestRunner_Run(const char* testName) {
             // their own CTests ("rando" label, under xvfb-run) rather than in
             // this display-free suite, where they would hang the 60s timeout.
             if (strcmp(gTests[i].name, "rando-gen") == 0 || strcmp(gTests[i].name, "rando-determinism") == 0 ||
-                strcmp(gTests[i].name, "mm-rando-gen") == 0) {
+                strcmp(gTests[i].name, "mm-rando-gen") == 0 ||
+                strcmp(gTests[i].name, "mm-pair-switch-entry") == 0) {
                 printf("\n--- Skipping: %s (needs display; runs as a rando-label CTest) ---\n", gTests[i].name);
                 continue;
             }


### PR DESCRIPTION
Fixes #439.

## Root cause: dispatch-site gap, not registration

`Rando::MiscBehavior::OnFileCreate` is registered against `OnSaveInit` at boot (`Rando::MiscBehavior::Init`), but `OnSaveInit` is **only ever dispatched from `MM_Sram_InitSave`** (`z_sram_NES.c`) — MM's file-select *create a new file* flow.

The flow a player actually takes never touches file select:

```
OoT Happy Mask Shop
  -> Combo_CheckEntranceSwitch (freezes OoT, sets startup entrance for "mm")
  -> GameRunner_SwitchTo(GAME_MM)  [cold gamestate-chain boot]
  -> ConsoleLogo_Main   (startup entrance pending -> skip splash)
  -> MM_TitleSetup_Init -> TitleSetup_SetupTitleScreen
        MM_Sram_InitNewSave()                  <-- a plain VANILLA save
        GameInteractor_ExecuteOnSaveLoad(...)  <-- NOT OnSaveInit
  -> MM_Play_Init -> MM_Play_ConsumeStartupEntrance
```

`OnSaveInit` is never dispatched on this path, so `OnFileCreate` never ran: no MM fill, `gComboCtx.foreignPlacements` empty, no MM spoiler. That is exactly the operator's forensics — Lane B's producer had correctly stamped `sourceIsRando` / `sharedRandoSeed` in every `.redsave` slot.

CI stayed green because `MMRandoGen` drives the `OnSaveInit` chain **directly**, so it exercised generation while the entry path was dead. This is the `docs/ci-gameplay-repro-postmortem.md` class.

### A second bug in the same seam

Even with generation fixed, MM would still have played vanilla. Rando's behavior hooks are `COND_HOOK`s conditioned on `IS_RANDO`, re-evaluated on every `OnSaveLoad`. The boot chain dispatches `OnSaveLoad` from `TitleSetup_SetupTitleScreen` **against the vanilla bootstrap file** — which *unregisters* every `IS_RANDO` hook. That happens on **every** cross-game arrival, including a return leg restoring a perfectly good rando save. So a hook can be correctly registered, correctly dispatched, and still be disarmed by an earlier dispatch on the same path.

## The fix

All at `MM_Play_ConsumeStartupEntrance` — the one point after every boot-chain wipe and before the save is interpreted (the same point the frozen-state restore already uses):

- **`MM_Rando_PairOnCrossGameArrival(hadFrozenState)`** dispatches `OnSaveInit` when a live paired OoT world exists **and** this entry is authoring the bootstrap save. `Combo_ConsumeFrozenState`'s return value distinguishes "the player's own restored session" from "the boot chain's throwaway file", so an existing MM save is never regenerated.
- **Re-dispatch `OnSaveLoad`** after the restore/pairing so the `IS_RANDO` hooks arm against the save that actually reaches gameplay — correct in both directions (a restored *vanilla* save still disarms).
- Both entry paths now converge on one generation code path; file-select is unchanged.

### Entry-path matrix

| entry path | MM save state | behavior |
|---|---|---|
| switch-entry (Happy Mask Shop) | first MM entry, no frozen state | **pairs** — MM fill + `foreignPlacements` + spoiler; hooks armed |
| switch-entry | frozen **paired** save (return leg) | restored, **not** regenerated (`finalSeed` + progress intact); hooks re-armed |
| switch-entry | frozen **vanilla** save | untouched; `skipped-because-existing-mm-save` logged |
| switch-entry | no paired OoT world | `skipped-because-no-paired-oot-world` logged |
| file-select (new file) | fresh | pairs (unchanged — this path always worked) |
| F10 hot-swap, first MM entry | no startup entrance set | title screen -> file select -> pairs via the file-select path |

Every decision point emits a greppable `[MM] pairing:` stderr breadcrumb. The operator flew blind through this seam for an entire playtest.

## MM spoiler path

- `Rando::Spoiler::SpoilerDirectory()` is now the single source of truth for all four spoiler paths (write / read / listing / file-drop) — they had each re-derived it.
- Single-exe resolves against the **shared** `Ship::Context`'s app directory rather than MM's own `"2ship"` short name (the operator's portable install had no `2ship` directory at all), under `randomizer-mm` so it cannot case-collide with OoT's `Randomizer` on Windows.
- Directory created recursively; the **absolute path is logged on every write**.
- A spoiler write failure **no longer reverts the save**. It propagated to `OnFileCreate`'s catch, which reverts to vanilla — turning "could not write a log file" into "your paired world silently did not happen".

## Lock

New `MMPairSwitchEntry` CTest (`rando` label) drives the **switch-entry** path headlessly: the cold boot chain a switch performs, then the real `MM_Play_ConsumeStartupEntrance`. No direct call to the generation entry point anywhere in its success path.

1. fresh switch-entry -> paired world active, `foreignPlacements` == pool size, arrival entrance preserved, spoiler on disk with a valid `foreign` section, **and** the `IS_RANDO` hooks armed (asserting the boot chain had disarmed them first).
2. return leg with a frozen paired save -> restored, `finalSeed` unchanged, player progress intact, placement table untouched, hooks re-armed.
3. return leg with a frozen **vanilla** save -> save type, progress, and placement table all byte-untouched.

On failure it re-runs the same `gComboCtx` through the direct chain to **discriminate a dispatch gap from a fill dead-end**, so a regression names itself. `MMRandoGen` stays as direct-chain regression cover, retargeted at the shared `SpoilerDirectory()`.

Also documents the generalization in `docs/unified-surface-findings.md` §"Dispatch, not registration": a dispatch point placed on one entry path is not coverage of the feature, and `COND_*` conditions read off save state need a re-dispatch once the final save is known.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!--- section:artifacts:start -->
### Build Artifacts
  - [rsbs-windows.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/8505422005.zip)
  - [rsbs-linux.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/8505107881.zip)
<!--- section:artifacts:end -->