### PR TITLE
Migrate SavingEnhancements.cpp off the raw GameInteractor hook surface (#442)

### DIFF
--- a/games/mm/2s2h/Enhancements/Saving/SavingEnhancements.cpp
+++ b/games/mm/2s2h/Enhancements/Saving/SavingEnhancements.cpp
@@ -270,6 +270,11 @@ void RegisterSavingEnhancements() {
     S2H::GameHooks::Register<GameInteractor::BeforeMoonCrashSaveReset>([]() { DeleteOwlSave(); });
 
     S2H::GameHooks::Register<GameInteractor::OnSaveLoad>(loadRespawnData);
+
+    // TEMPORARY #442 red-then-green guard proof: a raw registration site
+    // reintroduced into this now-guarded file must fail to compile. Reverted
+    // before merge; see the PR for the CI run this produced.
+    GameInteractor::Instance->RegisterGameHook<GameInteractor::OnGameCompletion>([]() {});
 }
 
 void RegisterAutosave() {

--- a/games/mm/2s2h/Enhancements/Saving/SavingEnhancements.cpp
+++ b/games/mm/2s2h/Enhancements/Saving/SavingEnhancements.cpp
@@ -270,11 +270,6 @@ void RegisterSavingEnhancements() {
     S2H::GameHooks::Register<GameInteractor::BeforeMoonCrashSaveReset>([]() { DeleteOwlSave(); });
 
     S2H::GameHooks::Register<GameInteractor::OnSaveLoad>(loadRespawnData);
-
-    // TEMPORARY #442 red-then-green guard proof: a raw registration site
-    // reintroduced into this now-guarded file must fail to compile. Reverted
-    // before merge; see the PR for the CI run this produced.
-    GameInteractor::Instance->RegisterGameHook<GameInteractor::OnGameCompletion>([]() {});
 }
 
 void RegisterAutosave() {

--- a/games/mm/2s2h/Enhancements/Saving/SavingEnhancements.cpp
+++ b/games/mm/2s2h/Enhancements/Saving/SavingEnhancements.cpp
@@ -196,14 +196,18 @@ void loadRespawnData(s16 fileNum) {
  * where multiple cutscenes play in succession.
  */
 static void UnregisterEntranceCutsceneSkip() {
+    // #442: routed through the MM-owned S2H::GameHooks registry rather than the
+    // raw GameInteractor::Instance-> surface. In single-exe builds the one
+    // GameInteractor allocation is OoT's 4-byte object; MM's Register* member
+    // templates read/write this->nextHookId at MM's (much larger) offset, an
+    // out-of-bounds write. See games/mm/include/mm_game_hooks.h.
     if (skipEntranceCutsceneHookId) {
-        GameInteractor::Instance->UnregisterGameHookForID<GameInteractor::ShouldVanillaBehavior>(
-            skipEntranceCutsceneHookId);
+        S2H::GameHooks::UnregisterForID<GameInteractor::ShouldVanillaBehavior>(skipEntranceCutsceneHookId);
         skipEntranceCutsceneHookId = 0;
     }
 
     if (gameplayStartHookId) {
-        GameInteractor::Instance->UnregisterGameHook<GameInteractor::OnPassPlayerInputs>(gameplayStartHookId);
+        S2H::GameHooks::Unregister<GameInteractor::OnPassPlayerInputs>(gameplayStartHookId);
         gameplayStartHookId = 0;
     }
 }
@@ -221,12 +225,11 @@ void skipEntranceCutsceneOnLoad(s16 fileNum) {
 
     // Register hook to detect when gameplay starts (all cutscenes done)
     // OnPassPlayerInputs only fires during normal gameplay, not during cutscenes
-    gameplayStartHookId =
-        GameInteractor::Instance->RegisterGameHook<GameInteractor::OnPassPlayerInputs>([](Input* input) {
-            // Gameplay has started; any entrance cutscenes are done
-            // Now unregister both hooks so normal cutscenes can play
-            UnregisterEntranceCutsceneSkip();
-        });
+    gameplayStartHookId = S2H::GameHooks::Register<GameInteractor::OnPassPlayerInputs>([](Input* input) {
+        // Gameplay has started; any entrance cutscenes are done
+        // Now unregister both hooks so normal cutscenes can play
+        UnregisterEntranceCutsceneSkip();
+    });
 }
 
 void RegisterSavingEnhancements() {
@@ -257,46 +260,47 @@ void RegisterSavingEnhancements() {
         }
     });
 
-    GameInteractor::Instance->RegisterGameHook<GameInteractor::BeforeEndOfCycleSave>([]() {
+    // #442: S2H::GameHooks, not the raw GameInteractor::Instance-> surface (see
+    // UnregisterEntranceCutsceneSkip above for why).
+    S2H::GameHooks::Register<GameInteractor::BeforeEndOfCycleSave>([]() {
         SavingEnhancements_AdvancePlaytime();
         DeleteOwlSave();
     });
 
-    GameInteractor::Instance->RegisterGameHook<GameInteractor::BeforeMoonCrashSaveReset>([]() { DeleteOwlSave(); });
+    S2H::GameHooks::Register<GameInteractor::BeforeMoonCrashSaveReset>([]() { DeleteOwlSave(); });
 
-    GameInteractor::Instance->RegisterGameHook<GameInteractor::OnSaveLoad>(loadRespawnData);
+    S2H::GameHooks::Register<GameInteractor::OnSaveLoad>(loadRespawnData);
 }
 
 void RegisterAutosave() {
+    // #442: S2H::GameHooks, not the raw GameInteractor::Instance-> surface (see
+    // UnregisterEntranceCutsceneSkip above for why).
     if (autosaveGameStateUpdateHookId) {
-        GameInteractor::Instance->UnregisterGameHook<GameInteractor::OnGameStateUpdate>(autosaveGameStateUpdateHookId);
+        S2H::GameHooks::Unregister<GameInteractor::OnGameStateUpdate>(autosaveGameStateUpdateHookId);
         autosaveGameStateUpdateHookId = 0;
     }
 
     if (autosaveGameStateDrawFinishHookId) {
-        GameInteractor::Instance->UnregisterGameHook<GameInteractor::OnGameStateDrawFinish>(
-            autosaveGameStateDrawFinishHookId);
+        S2H::GameHooks::Unregister<GameInteractor::OnGameStateDrawFinish>(autosaveGameStateDrawFinishHookId);
         autosaveGameStateDrawFinishHookId = 0;
     }
 
     if (CVarGetInteger("gEnhancements.Saving.Autosave", 0)) {
-        autosaveGameStateUpdateHookId =
-            GameInteractor::Instance->RegisterGameHook<GameInteractor::OnGameStateUpdate>([]() {
-                if (MM_gPlayState == nullptr) {
-                    return;
-                }
+        autosaveGameStateUpdateHookId = S2H::GameHooks::Register<GameInteractor::OnGameStateUpdate>([]() {
+            if (MM_gPlayState == nullptr) {
+                return;
+            }
 
-                HandleAutoSave();
-            });
+            HandleAutoSave();
+        });
 
-        autosaveGameStateDrawFinishHookId =
-            GameInteractor::Instance->RegisterGameHook<GameInteractor::OnGameStateDrawFinish>([]() {
-                if (MM_gPlayState == nullptr) {
-                    return;
-                }
+        autosaveGameStateDrawFinishHookId = S2H::GameHooks::Register<GameInteractor::OnGameStateDrawFinish>([]() {
+            if (MM_gPlayState == nullptr) {
+                return;
+            }
 
-                DrawAutosaveIcon();
-            });
+            DrawAutosaveIcon();
+        });
     }
 }
 

--- a/games/mm/2s2h/GameExports_SingleExe.cpp
+++ b/games/mm/2s2h/GameExports_SingleExe.cpp
@@ -1622,6 +1622,39 @@ extern "C" void GameInteractor_ExecuteOnSaveLoad(s16 fileNum) {
     S2H::GameHooks::Execute<GameInteractor::OnSaveLoad>(fileNum);
 }
 
+/**
+ * OnGameStateUpdate / OnGameStateDrawFinish / OnPassPlayerInputs /
+ * BeforeMoonCrashSaveReset replace former mm_stubs.c no-ops (#442 follow-up:
+ * SavingEnhancements.cpp's raw registrations for these four hook types moved
+ * onto S2H::GameHooks alongside the OOB-write fix, which would otherwise have
+ * left autosave, its draw-icon, the entrance-cutscene-skip gameplay-started
+ * detector, and owl-save-on-moon-crash-reset silently registered but never
+ * dispatched). MM's own code already calls these at the right places —
+ * games/mm/src/code/game.c MM_GameState_Update (every frame, mirroring the
+ * OnGameStateMainStart pump from #415), games/mm/src/overlays/actors/
+ * ovl_player_actor/z_player.c (every gameplay-input frame), and
+ * games/mm/src/code/z_sram_NES.c (the moon-crash reset point) — so this is
+ * the same "pump already exists, only the body was a no-op" pattern as
+ * OnSaveInit/OnSaveLoad above. No ForFilter leg for OnPassPlayerInputs: the
+ * S2H registry has no Ptr/Filter surface and the linked MM set registers
+ * none (same omission #435 made for the Should family).
+ */
+extern "C" void GameInteractor_ExecuteOnGameStateUpdate() {
+    S2H::GameHooks::Execute<GameInteractor::OnGameStateUpdate>();
+}
+
+extern "C" void GameInteractor_ExecuteOnGameStateDrawFinish() {
+    S2H::GameHooks::Execute<GameInteractor::OnGameStateDrawFinish>();
+}
+
+extern "C" void GameInteractor_ExecuteOnPassPlayerInputs(Input* input) {
+    S2H::GameHooks::Execute<GameInteractor::OnPassPlayerInputs>(input);
+}
+
+extern "C" void GameInteractor_ExecuteBeforeMoonCrashSaveReset() {
+    S2H::GameHooks::Execute<GameInteractor::BeforeMoonCrashSaveReset>();
+}
+
 extern "C" void MM_GameHooks_ExecuteOnActorUpdate(Actor* actor) {
     S2H::GameHooks::Execute<GameInteractor::OnActorUpdate>(actor);
     S2H::GameHooks::ExecuteForID<GameInteractor::OnActorUpdate>(actor->id, actor);

--- a/games/mm/CMakeLists.txt
+++ b/games/mm/CMakeLists.txt
@@ -747,13 +747,44 @@ if(SINGLE_EXECUTABLE_BUILD)
     # covers 2ship_rando and 2ship_rando_ui too: their COND_* macro sites
     # route through the single-exe macro redirection at the bottom of MM's
     # GameInteractor.h and their direct Register* sites are migrated. Only
-    # 2ship_enh remains exempt — its ~21 direct Register* sites live in TUs
-    # that stay link-elided (the two force-linked members, FrameInterpolation
-    # and SkipGiantsChamber, carry no direct registrations after the macro
-    # redirect); flip it here when those TUs port (#392).
+    # 2ship_enh remains exempt as a *target* — its ~20 remaining direct
+    # Register* sites (#427's census) live in TUs that stay link-elided; flip
+    # the whole target here when the full ~56-site migration (#427 item 2)
+    # lands.
     set(_force_include_cxx_guarded
         ${_force_include_cxx}
         "${_fi}${CMAKE_CURRENT_SOURCE_DIR}/include/mm_gi_hook_guard.h"
+    )
+    # #442: 2ship_enh is a plain (non-WHOLE_ARCHIVE) static archive, so most of
+    # its ~195 TUs never enter the link — but a handful genuinely do (their
+    # symbols are referenced from compiled MM .c sources), and the guard
+    # exemption above was blind to which TUs those are. Per
+    # docs/unified-surface-findings.md's link census, the confirmed-linked set
+    # is FrameInterpolation.cpp, MotionBlur.cpp, PauseOwlWarp.cpp,
+    # SavingEnhancements.cpp, SkipGiantsChamber.cpp, AudioCollection.cpp — one
+    # of which (SavingEnhancements.cpp) is exactly how #442's raw
+    # RegisterGameHook sites reached the shared 4-byte GameInteractor
+    # instance despite the target-wide exemption "protecting" 2ship_enh.
+    # Force-including the guard on just these six sources (rather than
+    # flipping the whole target, which would still fail on ~20 real raw sites
+    # in TUs that stay elided) closes exactly the hole #442 exploited without
+    # taking on the full #427 migration. Extend this list if the link census
+    # changes (docs/unified-surface-findings.md) or another 2ship_enh TU
+    # starts exporting a symbol a compiled MM .c source references.
+    # Matched by basename suffix (see the loop below), not exact path equality:
+    # the SOURCES target property's path form (relative vs.
+    # CMAKE_CURRENT_SOURCE_DIR-absolute, / vs \) isn't contractually
+    # guaranteed across CMake versions / generators. Every filename here is
+    # unique across the whole MM tree, so a plain basename match (no directory
+    # component, so no path-separator escaping to get wrong) is unambiguous
+    # and robust either way.
+    set(_mm_gi_hook_guard_linked_enh_sources
+        "FrameInterpolation.cpp"
+        "MotionBlur.cpp"
+        "PauseOwlWarp.cpp"
+        "SavingEnhancements.cpp"
+        "SkipGiantsChamber.cpp"
+        "AudioCollection.cpp"
     )
     set(_force_include_c
         "${_fi}${CMAKE_CURRENT_SOURCE_DIR}/include/ultra64.h"
@@ -786,7 +817,16 @@ if(SINGLE_EXECUTABLE_BUILD)
         if(_src MATCHES "\\.c$")
             set_source_files_properties(${_src} PROPERTIES COMPILE_OPTIONS "${_force_include_c}")
         elseif(_src MATCHES "\\.(cpp|cxx|cc)$")
-            set_source_files_properties(${_src} PROPERTIES COMPILE_OPTIONS "${_force_include_cxx_for_target}")
+            # #442: within 2ship_enh, the handful of sources confirmed to
+            # actually enter the link (see _mm_gi_hook_guard_linked_enh_sources
+            # above) get the same poison guard as every other MM C++ TU,
+            # regardless of the target-wide exemption.
+            get_filename_component(_mm_gi_hook_guard_src_name "${_src}" NAME)
+            if(_t STREQUAL "2ship_enh" AND _mm_gi_hook_guard_src_name IN_LIST _mm_gi_hook_guard_linked_enh_sources)
+                set_source_files_properties(${_src} PROPERTIES COMPILE_OPTIONS "${_force_include_cxx_guarded}")
+            else()
+                set_source_files_properties(${_src} PROPERTIES COMPILE_OPTIONS "${_force_include_cxx_for_target}")
+            endif()
         endif()
     endforeach()
 else()

--- a/games/mm/include/mm_gi_hook_guard.h
+++ b/games/mm/include/mm_gi_hook_guard.h
@@ -20,10 +20,20 @@
  * the _force_include_cxx_guarded list), so the class definition itself parses
  * with the real member names; any LATER use of a poisoned name in the TU
  * fails to compile with an identifier that points here. Applied to
- * 2ship_port/2ship_src; 2ship_enh and 2ship_rando are exempt until Lane C
- * migrates their (currently link-elided) upstream RegisterGameHook calls onto
- * the shim — extend the guarded list in games/mm/CMakeLists.txt when that
- * happens (#392).
+ * 2ship_port/2ship_src/2ship_rando/2ship_rando_ui unconditionally. 2ship_enh
+ * is exempt as a *target* — most of its ~195 TUs stay link-elided (plain
+ * archive semantics; nothing pulls them in) and carry raw RegisterGameHook
+ * sites the full #427-item-2 migration hasn't reached yet — but
+ * games/mm/CMakeLists.txt now force-includes this guard on the specific
+ * 2ship_enh sources confirmed to actually enter the link
+ * (docs/unified-surface-findings.md's census: FrameInterpolation.cpp,
+ * MotionBlur.cpp, PauseOwlWarp.cpp, SavingEnhancements.cpp,
+ * SkipGiantsChamber.cpp, AudioCollection.cpp — see
+ * _mm_gi_hook_guard_linked_enh_sources there), since a raw registration in
+ * any of those genuinely reaches the shared instance today (#442: this is
+ * exactly how SavingEnhancements.cpp's raw sites got past the target-wide
+ * exemption). Extend that per-source list — or flip the whole target — as
+ * more 2ship_enh TUs stop being link-elided (#392).
  *
  * Escape hatch for deliberate probes: `#undef` the macro in the probing TU
  * (precedent: the rename #undefs in games/mm/2s2h/mm_culling_test.cpp).

--- a/src/common/mm_stubs.c
+++ b/src/common/mm_stubs.c
@@ -100,9 +100,17 @@ void MM_FaultDrawer_SetCharPad(int xPad, int yPad) { (void)xPad; (void)yPad; }
  * overrides fire on MM frames without MM ids ever reaching OoT's tables.
  * Re-adding Should stubs here would silently sever that dispatch. */
 void GameInteractor_ExecuteOnActorDraw(void* actor) { (void)actor; }
-void GameInteractor_ExecuteOnGameStateUpdate(void* state) { (void)state; }
+/* GameInteractor_ExecuteOnGameStateUpdate / ExecuteOnGameStateDrawFinish moved
+ * to real, header-checked dispatch in games/mm/2s2h/GameExports_SingleExe.cpp
+ * (#442): MM's own frame loop (games/mm/src/code/game.c MM_GameState_Update)
+ * already calls both at the right points every frame — the "pump" upstream
+ * 2S2H used — so once SavingEnhancements.cpp's raw registrations for these
+ * two hook types moved onto S2H::GameHooks, leaving these as no-ops would
+ * have kept autosave (OnGameStateUpdate: HandleAutoSave) and its owl-save
+ * icon (OnGameStateDrawFinish: DrawAutosaveIcon) permanently dead even though
+ * registration itself no longer corrupts memory. Re-stubbing them here would
+ * silently sever that dispatch again. */
 void GameInteractor_ExecuteOnGameStateMainFinish(void* state) { (void)state; }
-void GameInteractor_ExecuteOnGameStateDrawFinish(void* state) { (void)state; }
 void GameInteractor_ExecuteOnPlayDrawWorldEnd(void* play) { (void)play; }
 void GameInteractor_ExecuteOnInterfaceDrawStart(void* play) { (void)play; }
 void GameInteractor_ExecuteBeforeKaleidoDrawPage(void* state, int page) { (void)state; (void)page; }
@@ -128,16 +136,34 @@ void GameInteractor_ExecuteOnItemGive(int itemId) { (void)itemId; }
 void GameInteractor_ExecuteOnCameraChangeModeFlags(void* camera) { (void)camera; }
 void GameInteractor_ExecuteOnCameraChangeSettingsFlags(void* camera) { (void)camera; }
 void GameInteractor_ExecuteAfterCameraUpdate(void* camera) { (void)camera; }
-void GameInteractor_ExecuteOnPassPlayerInputs(void* input) { (void)input; }
+/* GameInteractor_ExecuteOnPassPlayerInputs moved to real, header-checked
+ * dispatch in games/mm/2s2h/GameExports_SingleExe.cpp (#442): MM's real
+ * z_player.c call site already pumps this every gameplay frame; the stub was
+ * keeping SavingEnhancements.cpp's post-migration OnPassPlayerInputs
+ * registration (cutscene-skip-on-load's gameplay-started detector) a
+ * permanent no-op. Re-stubbing here would silently sever it again. */
 void GameInteractor_ExecuteOnPlayerPostLimbDraw(void* player, int limbIndex) { (void)player; (void)limbIndex; }
 void GameInteractor_ExecuteOnBossDefeated(int bossId) { (void)bossId; }
 void GameInteractor_ExecuteOnBottleContentsUpdate(int slotId) { (void)slotId; }
 void GameInteractor_ExecuteOnConsoleLogoUpdate(void) {}
 void GameInteractor_ExecuteOnFileSelectSaveLoad(void* state, int fileNum) { (void)state; (void)fileNum; }
 void GameInteractor_ExecuteOnGameCompletion(void) {}
+/* GameInteractor_ExecuteBeforeEndOfCycleSave / ExecuteAfterEndOfCycleSave stay
+ * stubbed on purpose (#442 leaves this pair to #438, which already tracks it
+ * alongside the rest of the registered-but-dormant hook table): they are a
+ * matched before/after pair around Rando::MiscBehavior's cycle-save
+ * fix-ups, and BeforeEndOfCycleSave now also has a real S2H::GameHooks
+ * registrant from SavingEnhancements.cpp (RegisterSavingEnhancements). Wiring
+ * only the Before half here would run its memcpy backup every cycle save
+ * while AfterEndOfCycleSave's restore logic stays dead — harmless (the copy
+ * goes unread) but a half-fix; #438 wires both together. */
 void GameInteractor_ExecuteBeforeEndOfCycleSave(void) {}
 void GameInteractor_ExecuteAfterEndOfCycleSave(void) {}
-void GameInteractor_ExecuteBeforeMoonCrashSaveReset(void) {}
+/* GameInteractor_ExecuteBeforeMoonCrashSaveReset moved to real, header-checked
+ * dispatch in games/mm/2s2h/GameExports_SingleExe.cpp (#442): MM's real
+ * z_sram_NES.c call site already pumps this at the moon-crash reset point;
+ * the stub was keeping SavingEnhancements.cpp's post-migration registration
+ * (owl-save deletion on moon crash) a permanent no-op. */
 void GameInteractor_ExecuteBeforeInterfaceClockDraw(void) {}
 void GameInteractor_ExecuteAfterInterfaceClockDraw(void) {}
 /* GameInteractor_InvertControl, GameInteractor_Dpad, and


### PR DESCRIPTION
## What this is

Fixes #442: a live out-of-bounds heap write reachable in shipped builds today, not gated behind `--integration-test` and not part of the inert rest of #427's `2ship_enh` backlog.

## Premise verification

Re-checked against `origin/main@b33089b4` (this PR's base):

- **Raw sites**: `SavingEnhancements.cpp` had **10** raw `GameInteractor::Instance->` hook calls (not 6 — #427's census counted only the `RegisterGameHook*` half; the 4 matching `UnregisterGameHook*`/`UnregisterGameHookForID*` calls are equally in need of migration, see "correctness" below). Line numbers had drifted from the issue's `:225` but `skipEntranceCutsceneOnLoad`'s raw `RegisterGameHook<OnPassPlayerInputs>` call was confirmed present.
- **TU is genuinely linked**: `games/mm/src/code/z_sram_NES.c` and `z_kaleido_scope_NES.c` call `SavingEnhancements_AdvancePlaytime()` / `SavingEnhancements_GetSaveEntrance()` directly — extern "C" functions defined only in `SavingEnhancements.cpp` — so the linker must pull that TU's `.o` out of the plain-archive `2ship_enh` static lib to resolve them.
- **Registrar executes**: `RegisterShipInitFunc initFunc(RegisterRememberSaveLocation, ...)` runs via `MM_Rando_Init` → `S2H::ShipInit::InitAll()`, called unconditionally (once) from `MM_Game_Init`, regardless of whether a rando seed is active.
- **Verdict: premise holds, live hazard confirmed.** Whenever `gEnhancements.Saving.RememberSaveLocation` is set and a save loads, `skipEntranceCutsceneOnLoad`'s raw `RegisterGameHook` wrote MM's `nextHookId` (offset ~96/64) into OoT's real 4-byte `GameInteractor` allocation.
- The other five TUs the docs list as genuinely linked (`FrameInterpolation.cpp`, `MotionBlur.cpp`, `PauseOwlWarp.cpp`, `SkipGiantsChamber.cpp`, `AudioCollection.cpp`) were checked and carry **zero** raw `RegisterGameHook`/`Instance->events` sites — confirmed clean, no changes needed there.

## The fix

All 10 raw sites in `SavingEnhancements.cpp` now route through the MM-owned `S2H::GameHooks` registry (`games/mm/include/mm_game_hooks.h`), the established #415/#435 shim contract — no upstream call-site macros exist for these direct (non-`COND_HOOK`) sites, so each is migrated by hand per the PR #415 contract note ("Direct (non-macro) `Instance->RegisterGameHook` sites are migrated by hand").

**Register and Unregister were migrated together, not just Register.** `GameInteractor::UnregisterGameHook<H>` doesn't touch `GameInteractor` instance state (it only pushes into a separate `inline static` per-hook-type map), so it isn't the OOB-write hazard by itself — but it's a *different* registry than `S2H::GameHooks`. Migrating only the Register calls would have left every paired Unregister call targeting the wrong registry, silently orphaning hooks (they'd never be removable, e.g. `RegisterAutosave()` re-running would stack duplicate `OnGameStateUpdate` hooks forever). All 4 Unregister/UnregisterForID sites are migrated alongside the 6 Register sites for this reason.

## Registration is not dispatch

Checked every hook type touched by the migrated sites:

| Hook type | Dispatch before this PR | Action |
|---|---|---|
| `ShouldVanillaBehavior` | wired (#435) | none needed |
| `OnSaveLoad` | wired (#392/#415) | none needed |
| `OnGameStateUpdate` | pump exists (`game.c` `MM_GameState_Update`, every frame) but the `GameInteractor_Execute*` bridge was an `mm_stubs.c` no-op | **wired** — real bridge added in `GameExports_SingleExe.cpp` |
| `OnGameStateDrawFinish` | pump exists (`game.c`, same call site as above) but no-op stub | **wired** |
| `OnPassPlayerInputs` | pump exists (`z_player.c`, every gameplay-input frame) but no-op stub | **wired** |
| `BeforeMoonCrashSaveReset` | pump exists (`z_sram_NES.c`, moon-crash reset point) but no-op stub | **wired** |
| `BeforeEndOfCycleSave` | pump exists (`z_sram_NES.c`) but no-op stub; **already tracked as dormant on #438**, paired with `AfterEndOfCycleSave` (a real Rando registrant exists too) | **left dormant on purpose** — wiring only the Before half here would run its `memcpy` backup while `AfterEndOfCycleSave`'s restore stays dead (harmless, since nothing reads the backup without After running, but an incomplete fix). Left for #438 to wire both halves together. |

Verified via grep that no other currently-linked TU registers any of the four newly-wired hook types, so wiring their dispatch only activates `SavingEnhancements.cpp`'s own features (autosave + icon, cutscene-skip-on-load, owl-save-on-moon-crash) — no surprise activation elsewhere. No CI test config sets any `gEnhancements.Saving.*` CVar, so this doesn't change any existing test's behavior.

## Lock

Extended the #395 poison guard (`games/mm/include/mm_gi_hook_guard.h`) past the `2ship_enh` *target-wide* exemption, which was blind to which of its ~195 TUs are actually linked — exactly how `SavingEnhancements.cpp`'s raw sites got past it. `games/mm/CMakeLists.txt` now force-includes the guard on the six sources `docs/unified-surface-findings.md`'s link census confirms are linked, so a future raw registration reintroduced into any of them fails the build immediately, without taking on the full ~56-site #427 migration (which would also need the ~20 sites in still-elided TUs migrated, out of scope here).

**Red-then-green proof**: pushed a temporary commit reintroducing a raw `GameInteractor::Instance->RegisterGameHook` call in `SavingEnhancements.cpp` to confirm the guard fires (compile failure), then reverted it before merge. CI run IDs and outcome noted in a PR comment.

## Scope

Per the issue, this pulls forward only the live-hazard subset of #427 item 2 (the one linked TU with raw sites) — not the full ~56-site migration across all of `2ship_enh`, and not the `2ship_enh` guard flip itself (`#427` stays open, reduced list, noted in a comment there).

Refs #442, #427, #438.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!--- section:artifacts:start -->
### Build Artifacts
  - [rsbs-windows.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/8507118094.zip)
  - [rsbs-linux.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/8506076738.zip)
<!--- section:artifacts:end -->