### PR TITLE
Move MM's Ship::Menu + MenuTypes into namespace S2H, retiring the menu-family ODR landmine (#446)

### DIFF
--- a/games/mm/2s2h/BenGui/Menu.cpp
+++ b/games/mm/2s2h/BenGui/Menu.cpp
@@ -16,6 +16,16 @@ extern "C" {
 #include "functions.h"
 extern PlayState* MM_gPlayState;
 }
+
+#ifdef RSBS_SINGLE_EXECUTABLE
+// Single-exe: MM's Ship::Menu implementation and its file-scope state
+// (windowTypeSizes, extraSearchWidgets, the BenGui::mModalWindow extern) live
+// inside namespace S2H so their symbols cannot alias OoT's identically-named,
+// differently-laid-out menu surface in SohGui/Menu.cpp. See the header
+// comment in Menu.h (#446).
+namespace S2H {
+#endif
+
 std::vector<ImVec2> windowTypeSizes = { {} };
 
 extern std::unordered_map<s16, const char*> warpPointSceneList;
@@ -879,3 +889,7 @@ void Menu::DrawElement() {
     ImGui::End();
 }
 } // namespace Ship
+
+#ifdef RSBS_SINGLE_EXECUTABLE
+} // namespace S2H
+#endif

--- a/games/mm/2s2h/BenGui/Menu.h
+++ b/games/mm/2s2h/BenGui/Menu.h
@@ -1,5 +1,8 @@
-#ifndef MENU_H
-#define MENU_H
+#ifndef S2H_MENU_H
+#define S2H_MENU_H
+// Guard renamed from MENU_H: OoT's soh/SohGui/Menu.h uses that exact guard,
+// so a TU including both headers would silently drop whichever came second
+// (#446).
 
 #include <ship/window/gui/GuiWindow.h>
 #include "UIWidgets.hpp"
@@ -8,7 +11,39 @@
 #include <unordered_map>
 #include <vector>
 
+#ifdef RSBS_SINGLE_EXECUTABLE
+// Single-exe symbol split for MM's Ship::Menu (#446).
+//
+// OoT (games/oot/soh/SohGui/Menu.h) defines an identically-named Ship::Menu
+// with a DIVERGENT layout: its window-backends map is a std::map where MM's
+// is a std::unordered_map (different size, shifting every later member), and
+// every WidgetInfo/SearchWidget-typed member and parameter diverges per the
+// MenuTypes.h header comment. OoT's implementation (SohGui/Menu.cpp) is
+// compiled into the single-exe link while MM's used to be excluded, so any
+// resurrected MM menu TU calling AddMenuEntry/AddSearchWidget/MenuDrawItem
+// silently bound OoT's code against MM's layout — the #383/FlagTable class.
+//
+// Fix, per the ShipInit.hpp / UIWidgets.hpp (#434) recipe: nest MM's
+// namespace Ship inside S2H so the two ports' menu symbols stop sharing
+// mangled names. The using-directive re-exposes libultraship's real Ship::
+// names (GuiWindow, WindowBackend, Context, ...) inside S2H::Ship, and the
+// using-declarations after the class inject MM's names back into the real
+// Ship namespace so existing MM callers (`Ship::Menu`,
+// `class BenMenu : public Ship::Menu`) compile unchanged. A deliberate side
+// effect: re-opening a bare `namespace Ship` to declare Menu in any MM TU
+// that includes this header is a compile error in single-exe builds, so the
+// split cannot silently regress. BenGui/Menu.cpp carries the matching wrap
+// and is compiled into 2ship_rando_ui (plain archive — elided until
+// referenced), so MM menu TUs that port later resolve against MM's
+// layout-correct implementation; an un-ported reference now fails the link
+// loudly instead of cross-binding.
+namespace S2H {
+#endif
+
 namespace Ship {
+#ifdef RSBS_SINGLE_EXECUTABLE
+using namespace ::Ship;
+#endif
 uint32_t GetVectorIndexOf(std::vector<std::string>& vector, std::string value);
 class Menu : public GuiWindow {
   public:
@@ -67,4 +102,16 @@ class Menu : public GuiWindow {
 };
 } // namespace Ship
 
-#endif // MENU_H
+#ifdef RSBS_SINGLE_EXECUTABLE
+} // namespace S2H
+
+// Inject MM's menu names back into the real Ship namespace so unqualified
+// upstream MM callers resolve to the S2H versions unchanged (and a bare
+// re-declaration of either name in Ship becomes a compile error).
+namespace Ship {
+using S2H::Ship::GetVectorIndexOf;
+using S2H::Ship::Menu;
+} // namespace Ship
+#endif
+
+#endif // S2H_MENU_H

--- a/games/mm/2s2h/BenGui/MenuTypes.h
+++ b/games/mm/2s2h/BenGui/MenuTypes.h
@@ -1,7 +1,33 @@
-#ifndef MENUTYPES_H
-#define MENUTYPES_H
+#ifndef S2H_MENUTYPES_H
+#define S2H_MENUTYPES_H
+// Guard renamed from MENUTYPES_H: OoT's soh/SohGui/MenuTypes.h uses that exact
+// guard, so a TU including both headers would silently drop whichever came
+// second (#446).
 
 #include "UIWidgets.hpp"
+
+#ifdef RSBS_SINGLE_EXECUTABLE
+// Single-exe symbol split for MM's menu type family (#446).
+//
+// OoT (games/oot/soh/SohGui/MenuTypes.h) defines identically-named
+// global-scope types with DIVERGENT layouts: OoT's WidgetFunc/DisableInfoFunc
+// are std::function (~32 bytes) where MM's are raw function pointers, OoT's
+// WidgetInfo carries an extra `raceDisable` field, OptionsVariant has 9 vs 6
+// alternatives, and the DisableOption/WidgetType enumerators sit at different
+// values. MenuInit's inline registries COMDAT-fold across the two games into
+// ONE shared registry, so an MM RegisterMenuInitFunc entering the link would
+// inject MM menu-builder code into the registry OoT's SohMenu executes. This
+// is the #383/FlagTable incident class: latent while MM's menu TUs stay
+// link-elided, armed by any link-set change that pulls one in.
+//
+// Fix, per the ShipInit.hpp / UIWidgets.hpp (#434) recipe: move MM's types
+// into namespace S2H so they stop sharing mangled names with OoT's, with
+// using-declarations below so unqualified MM callers compile unchanged. A
+// deliberate side effect: re-declaring any of these names at global scope in
+// an MM TU that includes this header is a compile error in single-exe builds,
+// so the split cannot silently regress.
+namespace S2H {
+#endif
 
 typedef enum {
     DISABLE_FOR_CAMERAS_OFF,
@@ -329,4 +355,108 @@ struct RegisterMenuUpdateFunc {
     }
 };
 
-#endif // MENUTYPES_H
+#ifdef RSBS_SINGLE_EXECUTABLE
+} // namespace S2H
+
+// Let unqualified upstream MM callers resolve to the S2H versions unchanged.
+// The unscoped enums are typedef'd anonymous enums, so their enumerators are
+// re-exposed one by one (`using enum` on a typedef-name of an unnamed enum is
+// not portable across our CI compilers).
+using S2H::DebugLogOption;
+using S2H::DisableOption;
+using S2H::MotionBlurOption;
+using S2H::SectionColumns;
+using S2H::WidgetType;
+
+// DisableOption enumerators
+using S2H::DISABLE_FOR_ADVANCED_RESOLUTION_OFF;
+using S2H::DISABLE_FOR_ADVANCED_RESOLUTION_ON;
+using S2H::DISABLE_FOR_AUTO_SAVE_OFF;
+using S2H::DISABLE_FOR_CAMERAS_OFF;
+using S2H::DISABLE_FOR_DEBUG_CAM_OFF;
+using S2H::DISABLE_FOR_DEBUG_CAM_ON;
+using S2H::DISABLE_FOR_DEBUG_MODE_OFF;
+using S2H::DISABLE_FOR_DIRECTX;
+using S2H::DISABLE_FOR_FRAME_ADVANCE_OFF;
+using S2H::DISABLE_FOR_FREE_LOOK_OFF;
+using S2H::DISABLE_FOR_FREE_LOOK_ON;
+using S2H::DISABLE_FOR_GYRO_OFF;
+using S2H::DISABLE_FOR_GYRO_ON;
+using S2H::DISABLE_FOR_INTRO_SKIP_OFF;
+using S2H::DISABLE_FOR_KOUME_INVINCIBLE;
+using S2H::DISABLE_FOR_LINKS_VOICE_PITCH_MULTIPLIER_OFF;
+using S2H::DISABLE_FOR_LOW_RES_MODE_ON;
+using S2H::DISABLE_FOR_MATCH_REFRESH_RATE_ON;
+using S2H::DISABLE_FOR_MOTION_BLUR_MODE;
+using S2H::DISABLE_FOR_MOTION_BLUR_OFF;
+using S2H::DISABLE_FOR_NO_MULTI_VIEWPORT;
+using S2H::DISABLE_FOR_NO_VSYNC;
+using S2H::DISABLE_FOR_NO_WINDOWED_FULLSCREEN;
+using S2H::DISABLE_FOR_NOT_DIRECTX;
+using S2H::DISABLE_FOR_NULL_PLAY_STATE;
+using S2H::DISABLE_FOR_RIGHT_STICK_OFF;
+using S2H::DISABLE_FOR_VERTICAL_RES_TOGGLE_ON;
+using S2H::DISABLE_FOR_VERTICAL_RESOLUTION_OFF;
+
+// WidgetType enumerators
+using S2H::WIDGET_AUDIO_BACKEND;
+using S2H::WIDGET_BUTTON;
+using S2H::WIDGET_CHECKBOX;
+using S2H::WIDGET_COLOR_24;
+using S2H::WIDGET_COLOR_32;
+using S2H::WIDGET_COMBOBOX;
+using S2H::WIDGET_CUSTOM;
+using S2H::WIDGET_CVAR_CHECKBOX;
+using S2H::WIDGET_CVAR_COMBOBOX;
+using S2H::WIDGET_CVAR_SLIDER_FLOAT;
+using S2H::WIDGET_CVAR_SLIDER_INT;
+using S2H::WIDGET_SEARCH;
+using S2H::WIDGET_SEPARATOR;
+using S2H::WIDGET_SEPARATOR_TEXT;
+using S2H::WIDGET_SLIDER_FLOAT;
+using S2H::WIDGET_SLIDER_INT;
+using S2H::WIDGET_TEXT;
+using S2H::WIDGET_VIDEO_BACKEND;
+using S2H::WIDGET_WINDOW_BUTTON;
+
+// SectionColumns enumerators
+using S2H::SECTION_COLUMN_1;
+using S2H::SECTION_COLUMN_2;
+using S2H::SECTION_COLUMN_3;
+
+// MotionBlurOption enumerators
+using S2H::MOTION_BLUR_ALWAYS_OFF;
+using S2H::MOTION_BLUR_ALWAYS_ON;
+using S2H::MOTION_BLUR_DYNAMIC;
+
+// DebugLogOption enumerators
+using S2H::DEBUG_LOG_CRITICAL;
+using S2H::DEBUG_LOG_DEBUG;
+using S2H::DEBUG_LOG_ERROR;
+using S2H::DEBUG_LOG_INFO;
+using S2H::DEBUG_LOG_OFF;
+using S2H::DEBUG_LOG_TRACE;
+using S2H::DEBUG_LOG_WARN;
+
+using S2H::CVarVariant;
+using S2H::DisableInfoFunc;
+using S2H::DisableVec;
+using S2H::OptionsVariant;
+using S2H::VoidFunc;
+using S2H::WidgetFunc;
+
+using S2H::disabledInfo;
+using S2H::MainMenuEntry;
+using S2H::MenuInit;
+using S2H::RegisterMenuInitFunc;
+using S2H::RegisterMenuUpdateFunc;
+using S2H::SearchWidget;
+using S2H::SidebarEntry;
+using S2H::WidgetInfo;
+using S2H::WidgetPath;
+
+using S2H::audioBackendsMap;
+using S2H::windowBackendsMap;
+#endif
+
+#endif // S2H_MENUTYPES_H

--- a/games/mm/2s2h/BenGui/ResolutionEditor.h
+++ b/games/mm/2s2h/BenGui/ResolutionEditor.h
@@ -1,5 +1,9 @@
-#ifndef RESOLUTIONEDITOR_H
-#define RESOLUTIONEDITOR_H
+#ifndef S2H_RESOLUTIONEDITOR_H
+#define S2H_RESOLUTIONEDITOR_H
+// Guard renamed from RESOLUTIONEDITOR_H: OoT's soh/SohGui/ResolutionEditor.h
+// uses that exact guard, so a TU including both headers would silently drop
+// whichever came second (#446). The declarations themselves do not collide
+// (namespace BenGui here vs SohGui there).
 
 namespace BenGui {
 bool IsDroppingFrames();
@@ -7,4 +11,4 @@ void RegisterResolutionWidgets();
 void UpdateResolutionVars();
 } // namespace BenGui
 
-#endif // RESOLUTIONEDITOR_H
+#endif // S2H_RESOLUTIONEDITOR_H

--- a/games/mm/CMakeLists.txt
+++ b/games/mm/CMakeLists.txt
@@ -122,10 +122,20 @@ file(GLOB_RECURSE ship__Rando RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} "2s2h/Rando/*
 # WidgetOptions layout (the FlagTable incident class) — now that same mistake
 # is a loud unresolved-external link error at worst, and resolves correctly
 # once this TU is pulled.
+#
+# BenGui/Menu.cpp is the same story for Ship::Menu itself (#446): MM's
+# Ship::Menu and MenuTypes family live in namespace S2H in single-exe builds
+# (OoT's Ship::Menu has a divergent layout — std::map vs unordered_map
+# backends map, std::function vs raw-pointer WidgetInfo callbacks — under
+# identical include guards), and this TU is the matching S2H implementation.
+# Same plain-archive semantics: elided today, resolves layout-correct once a
+# ported MM menu TU references it, loud unresolved external if one is pulled
+# without it.
 set(ship__Rando_ui
     "2s2h/Rando/Menu.cpp"
     "2s2h/Rando/CheckTracker/CheckTracker.cpp"
     "2s2h/BenGui/UIWidgets.cpp"
+    "2s2h/BenGui/Menu.cpp"
 )
 list(FILTER ship__Rando EXCLUDE REGEX "2s2h/Rando/Menu\\.cpp$")
 list(FILTER ship__Rando EXCLUDE REGEX "2s2h/Rando/CheckTracker/CheckTracker\\.cpp$")
@@ -227,10 +237,11 @@ if(SINGLE_EXECUTABLE_BUILD)
     # Main port glue (OTRGlobals equivalent)
     list(FILTER ship__ EXCLUDE REGEX "2s2h/BenPort\\.cpp$")
 
-    # All GUI components. Exception: BenGui/UIWidgets.cpp is compiled into
-    # 2ship_rando_ui (see the ship__Rando_ui block above) as the S2H-namespaced
-    # implementation behind MM's UIWidgets headers (#383) — the filter here
-    # only shapes 2ship_port, so no duplication results.
+    # All GUI components. Exceptions: BenGui/UIWidgets.cpp (#383) and
+    # BenGui/Menu.cpp (#446) are compiled into 2ship_rando_ui (see the
+    # ship__Rando_ui block above) as the S2H-namespaced implementations behind
+    # MM's UIWidgets/Menu headers — the filter here only shapes 2ship_port, so
+    # no duplication results.
     list(FILTER ship__ EXCLUDE REGEX "2s2h/BenGui/.*\\.cpp$")
 
     # All developer tools


### PR DESCRIPTION
Closes #446. Applies the #434 UIWidgets recipe to the last divergent-layout menu family flagged in docs/unified-surface-findings.md §1.

## What

Under `RSBS_SINGLE_EXECUTABLE` only (standalone MM builds see nothing but the guard renames):

- **`2s2h/BenGui/MenuTypes.h`** — the whole global family (`WidgetInfo`, `SearchWidget`, `disabledInfo`, `WidgetPath`, `SidebarEntry`, `MainMenuEntry`, the five widget enums, the alias types, `MenuInit` + `RegisterMenuInitFunc`/`RegisterMenuUpdateFunc`, the backend maps) moves into `namespace S2H`, with using-declarations so unqualified MM callers compile unchanged. Enumerators are re-exposed one-by-one: the enums are typedef'd *anonymous* enums, and `using enum` on a typedef-name is not portable across our CI compilers (verified acceptable on MSVC 14.44, unverifiable locally for GCC/AppleClang — so the bulletproof form).
- **`2s2h/BenGui/Menu.h`** — MM's `namespace Ship` nests inside `S2H`, with `using namespace ::Ship;` re-exposing libultraship's names inside it and `using S2H::Ship::Menu; using S2H::Ship::GetVectorIndexOf;` injected back into the real `Ship` namespace. Verified against libultraship @ d11cc8c: it declares **no** `class Menu` anywhere, and `Gui::SetMenu/GetMenu` traffic in `shared_ptr<GuiWindow>` (Gui.h:99–100), so the injection conflicts with nothing and Menu.cpp's `static_pointer_cast<Menu>(GetMenu())` stays a valid downcast.
- **`2s2h/BenGui/Menu.cpp`** — matching wrap, also covering the file-scope state (`windowTypeSizes`, `extraSearchWidgets`, `Ship::disabledTempTooltip`/`disabledTooltip`/`disabledValue`, `Ship::ModernMenu*Entry`, the Color operators) whose names OoT's `SohGui/Menu.cpp` defines as linked strong globals. Compiled into **2ship_rando_ui** (same home #434 gave `BenGui/UIWidgets.cpp`), plain archive semantics.
- **Guards renamed** `MENU_H`→`S2H_MENU_H`, `MENUTYPES_H`→`S2H_MENUTYPES_H`, and `RESOLUTIONEDITOR_H`→`S2H_RESOLUTIONEDITOR_H` (that last one is guard-only: `BenGui` vs `SohGui` namespaces already disjoint).
- **`games/mm/CMakeLists.txt`** — `2s2h/BenGui/Menu.cpp` appended to `ship__Rando_ui`; comment updated at the BenGui exclusion filter.

## Linked symbol set is IDENTICAL today

Nothing references lib2ship_rando_ui symbols, so the new Menu.o is elided exactly like Rando/Menu.o and UIWidgets.o beside it. What changes is the failure mode of a future un-elision: calls into MM's menu resolve against MM's layout-correct `S2H::Ship::Menu` implementation, or fail the link loudly — never again a silent cross-bind into OoT's `Ship::Menu` against MM's layout.

## Lock

Per the #434 reasoning: after the split there is no shared layout left to police, so no #432-style dual-view static_asserts apply. The structural guarantees are the lock — reopening a bare `namespace Ship { class Menu ... }` or redeclaring any family name at global scope in an MM TU that includes these headers is a **compile error** (using-declaration conflict), and an un-ported reference is an **unresolved external**.

## Gates

- `check-symbol-collisions.sh`: every new strong symbol from Menu.cpp is S2H-qualified (`S2H::Ship::Menu::*`, `S2H::windowTypeSizes`, ...) — no new soh/2ship intersection; baseline stays empty.
- `check-registrar-elision.sh`: 2ship_rando_ui remains report-only; its (elided) registrar set grows by Menu.cpp's dynamic initializers, which is exactly the visibility that mode exists for.
- clang-format 14.0.6 verified locally on all five files; the S2H injection pattern compile-verified against MSVC 14.44 /std:c++20 with a standalone probe of the exact namespace topology.

Verification notes beyond the findings doc are on #446 (the divergence is broader than documented: `WidgetFunc`/`DisableInfoFunc` are `std::function` vs raw pointers, so every callback member diverges, plus enumerator-value drift in `DisableOption`/`WidgetType`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!--- section:artifacts:start -->
### Build Artifacts
  - [rsbs-windows.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/8505603465.zip)
  - [rsbs-linux.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/8505325202.zip)
<!--- section:artifacts:end -->