### PR TITLE
Interlock the menu IA plan with ADR 0003

### DIFF
--- a/docs/adr/0004-menu-information-architecture.md
+++ b/docs/adr/0004-menu-information-architecture.md
@@ -3,8 +3,9 @@
 - Status: **Proposed** (2026-07-21)
 - For: #392 (Phase 3.0 tracker), #34 (settings migration)
 - Depends on:
-  - the settings-namespace ADR (expected 0003) — owns CVar key naming and the
-    rename/migration rule; this ADR consumes its decisions rather than restating them
+  - **[ADR 0003](0003-settings-namespace.md)** (settings namespace) — owns CVar key naming and
+    the rename/migration rule; this ADR consumes its decisions rather than restating them.
+    **This ADR resolves ADR 0003 §4.2** — see §2d below
   - **#446** — the `Ship::Menu` / `WidgetInfo` ODR split; gates any MM menu-code port
   - **#438** — missing MM hook dispatch placements; gates real MM functionality
   - `docs/unified-surface-findings.md` — the investigation this plan acts on
@@ -52,7 +53,7 @@ beep toggles, and two Infinite Health checkboxes for what they experience as one
 Recorded here so downstream work does not relitigate them.
 
 **2a. Shared-intent mechanism is ONE shared CVar** read by both games. No UI fan-out layer to
-two per-game keys. The settings-namespace ADR owns key naming; this ADR assumes a single key.
+two per-game keys. ADR 0003 §2.2 owns key naming; this ADR assumes a single key.
 
 > **Accepted trade — no per-game override.** Under one shared CVar, "Infinite Health in MM but
 > not OoT" is **not expressible**. This is a deliberate consequence of the governing principle,
@@ -67,7 +68,38 @@ and is not part of the divergence bug list.
 **2c. Convergence direction is MM → OoT keys**, where a shared-intent setting currently has
 different keys on each side. "Where we should" is a scope limit: only (S) rows converge; (O)
 rows keep their own keys; (P) rows are disambiguated, never merged. The classification table
-§5.3 supplies the 26-row rename list; the namespace ADR owns the rename and migration rule.
+§5.3 supplies the 26-row rename list; ADR 0003 §5 owns the rename and migration rule.
+
+### 2d. Relationship to ADR 0003, including where the two differ
+
+ADR 0003 and this ADR were drafted in parallel from the same three maintainer decisions and
+measured the collision set independently. They agree on the principle, the mechanism, the
+direction, and — importantly — **both independently found the same two divergence bugs**
+(the tunic desync and the `DebugSaveFileMode` defaults). Where they differ, this section is
+the record; neither document silently overrides the other.
+
+**This ADR resolves ADR 0003 §4.2.** That section classifies four keys —
+`gSettings.Menu.ActiveHeader` and the three `…SidebarSection` keys — as class (P) bugs,
+because a section index or header name written by one menu is meaningless to the other. It
+explicitly defers disposition to the menu end-state decision, and states: *"if MM's entries
+are added into `SohMenu` instead, they become genuine class (S) automatically because there
+is then only one menu."*
+
+**This ADR makes that choice: one shell, MM entries added into `SohMenu`.** ADR 0003's four
+(P) keys therefore become class (S), and its warning — *"do not let MM's menu un-elide before
+resolving it"* — is discharged, provided MM's menu is never revived as a second shell. That
+proviso is now load-bearing for both documents, which is the second reason §3 tier 1 flags the
+sidebar-name caveat.
+
+**One live disagreement, deliberately preserved.** On `gDeveloperTools.DebugSaveFileMode`,
+ADR 0003 §4.1 classifies (S) — value spaces align, only the unwritten fallback differs,
+"acceptable, worth knowing". This document classifies it **(P)** and files it as
+[#454](https://github.com/spencerduncan/redshipblueship/issues/454). The disagreement is real
+and narrow: 0003 is right that once the key is written the games agree, and this ADR is
+taking the more conservative line that two different defaults on one shared key is a
+behaviour decision someone should make rather than inherit. **The rename pass is safe under
+either reading** — the key name already matches, so nothing renames. Whoever closes #454
+should update whichever document ends up wrong.
 
 ### 3. The four tiers
 
@@ -212,7 +244,7 @@ Ordered by what unblocks what. Nothing in this ADR is implementable before its g
 
 | # | Gate | Blocks | Status |
 |---|---|---|---|
-| 1 | **Settings-namespace ADR** (expected 0003) | All key naming; the 26-row rename list | A decision, not code |
+| 1 | **[ADR 0003](0003-settings-namespace.md)** — settings namespace | All key naming; the 26-row rename list | Proposed; scheduled as #34 |
 | 2 | **#446** — `Ship::Menu` / `WidgetInfo` ODR split | *Any* MM menu-code port | Agent landing now |
 | 3 | **#438** — MM hook dispatch placements (~22) | Real MM functionality behind any MM entry | Open |
 | 4 | `2ship_enh` migration (~56 raw sites) + WHOLE_ARCHIVE + guard flip | MM enhancements linking at all | Part of #427 |
@@ -243,7 +275,8 @@ Genuinely open, and deliberately left to the maintainer:
    not merge these until it is made.
 3. **(P) row P5 — `gDeveloperTools.DebugSaveFileMode` defaults.** The games share the key but
    disagree on the default (OoT 1 "Vanilla", MM 0 "Empty"). Reconciling requires picking one
-   behaviour; it is not a rename.
+   behaviour; it is not a rename. **ADR 0003 §4.1 reaches the opposite conclusion** and calls
+   this acceptable — see §2d and #454. Deciding it settles which document is right.
 4. **Group B rename confirmations.** Two rows need a semantic check before renaming:
    `InfiniteAmmo`/`InfiniteConsumables` (MM's scope may be wider) and
    `NoRestrictItems`/`UnrestrictedItems` (OoT drops age gating, MM drops form gating).

--- a/docs/enhancement-classification.md
+++ b/docs/enhancement-classification.md
@@ -3,10 +3,21 @@
 > Companion data for [ADR 0004 — Menu information architecture](adr/0004-menu-information-architecture.md).
 > Verified by grep against `origin/main` on 2026-07-21. Symbols-first; line numbers drift.
 >
-> **This table is the input to two ADRs.** ADR 0004 consumes the classification to lay out
-> the menu; the settings-namespace ADR consumes §5 (the convergence list) to generate its
-> rename set. A misclassification here becomes a wrong rename downstream, so every row is
+> **This table is the input to two ADRs.** [ADR 0004](adr/0004-menu-information-architecture.md)
+> consumes the classification to lay out the menu;
+> [ADR 0003](adr/0003-settings-namespace.md) consumes §5 (the convergence list) to generate
+> its rename set. A misclassification here becomes a wrong rename downstream, so every row is
 > backed by reading the implementation on both sides, not by name-matching alone.
+>
+> **On the two independent measurements.** ADR 0003 measured the collision set in parallel
+> with this document and reports **30** keys where this reports **35 exact + 2 by-design**.
+> The gap is method, and both are defensible: ADR 0003 excludes
+> `games/oot/soh/config/ConfigMigrators.h` because its `from` fields are legacy spellings OoT
+> has already migrated away from, while this document includes it. Including it is what
+> surfaced the tunic desync (§3.3 BUG 1) — the key only looks shared *because* it appears in
+> the migrator — and ADR 0003 independently arrived at the same fix by a different route
+> (its §5.1 Tier-1 rename list). The two documents agree on every substantive row except
+> `DebugSaveFileMode`; see ADR 0004 §2d for that disagreement.
 
 ## 0. Governing principle
 
@@ -29,6 +40,9 @@ These came from the maintainer and are recorded in ADR 0004; they are not reopen
 3. **Convergence direction is MM → OoT keys**, where a shared-intent setting has different
    keys on each side. "Where we should" is a scope limit: only (S) rows converge. (O) rows
    keep their own keys; (P) rows get *disambiguated*, never merged.
+
+These are the same three premises recorded in ADR 0003 §"Settled inputs"; the two documents
+were drafted in parallel from them.
 
 ## 1. Classification scheme
 
@@ -170,9 +184,13 @@ The *enum ordering happens to align*, but the **defaults disagree**: unset, OoT 
 game's debug-save behaviour away from its own default. Low blast radius (debug-only, gated
 behind `DebugEnabled`) but it is a genuine accidental divergence on a shared key.
 
-**Classification: (P)** — converge the *key* is fine, but the defaults must be reconciled to
-one value first, which is a behaviour decision, not a rename. Do not let the namespace ADR
-merge this row blind.
+**Classification: (P)** — the key already matches so nothing renames, but the defaults must be
+reconciled, which is a behaviour decision.
+
+> ⚠️ **ADR 0003 §4.1 classifies this (S)** — "value spaces align… only the unwritten fallback
+> differs. Acceptable, worth knowing." This document takes the more conservative (P) line. The
+> disagreement is narrow and safe (no rename either way); #454 decides it. Recorded rather than
+> reconciled so neither document silently overrides the other.
 
 ## 4. (P) — per-game parallel: same idea, incompatible realisation
 


### PR DESCRIPTION
Docs-only follow-up to #455. ADR 0003 (settings namespace) landed while #455 was in flight, so its cross-references were written speculatively as "expected 0003". This makes them concrete and records where the two documents actually meet.

The two ADRs were drafted in parallel from the same three maintainer decisions and measured the collision set **independently**. They agree on principle, mechanism, direction, and both independently found the same two divergence bugs. Three things were worth writing down:

### 1. ADR 0004 resolves ADR 0003 §4.2

ADR 0003 classifies `gSettings.Menu.ActiveHeader` + the three `…SidebarSection` keys as class (P) bugs — a section index written by one menu is meaningless to the other — and explicitly defers disposition to the menu end-state decision, noting:

> *"if MM's entries are added into `SohMenu` instead, they become genuine class (S) automatically because there is then only one menu."*

ADR 0004 makes exactly that choice. So its warning — *"do not let MM's menu un-elide before resolving it"* — is discharged, **provided MM's menu is never revived as a second shell.** That proviso is now load-bearing for both documents and is called out in each.

### 2. The collision counts differ by method, not by disagreement

ADR 0003 reports 30 keys; the classification inventory reports 35 exact + 2 by-design. The gap is that ADR 0003 excludes `ConfigMigrators.h` (its `from` fields are legacy spellings OoT has migrated away from) and the inventory includes it.

Both are defensible, and including it is what surfaced the tunic desync (#453) — that key *only looks shared because the migrator mentions it*. ADR 0003 reached the same fix by a different route via its §5.1 Tier-1 rename list. Worth recording so a future reader does not treat the count mismatch as an error in one of them.

### 3. One genuine disagreement, preserved rather than papered over

On `gDeveloperTools.DebugSaveFileMode`, ADR 0003 §4.1 classifies **(S)** — "value spaces align… only the unwritten fallback differs. Acceptable, worth knowing." The classification inventory classifies it **(P)** and files #454.

The disagreement is narrow: 0003 is right that once the key is written the games agree; 0004 takes the more conservative line that two different defaults on one shared key is a decision someone should make rather than inherit. **The rename pass is safe under either reading** — the key name already matches, so nothing renames. #454 settles it, and whoever closes it should correct whichever document ends up wrong.

No classification rows changed; no CVars renamed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)