### PR TITLE
MM trackers track both games: shared-Gui registration, OnSceneInit dispatch, active-game gating (#392)

### DIFF
--- a/.github/clang-format-paths.txt
+++ b/.github/clang-format-paths.txt
@@ -33,12 +33,15 @@ games/mm/2s2h/GameInteractorEventsSingleExe.cpp
 games/mm/2s2h/Rando/Foreign.cpp
 games/mm/2s2h/Rando/Foreign.h
 games/mm/2s2h/ShipInit.hpp
+games/mm/2s2h/TrackersGuiSingleExe.cpp
+games/mm/2s2h/TrackersGuiSingleExe.h
 games/mm/2s2h/mm_culling_test.cpp
 games/mm/2s2h/mm_fb_effects_test.cpp
 games/mm/2s2h/mm_framebuffer_effects.c
 games/mm/2s2h/mm_gi_shim_test.cpp
 games/mm/2s2h/mm_notification_binding_test.cpp
 games/mm/2s2h/mm_resume_state_test.cpp
+games/mm/2s2h/mm_trackers_gui_test.cpp
 games/mm/2s2h/z_scene_2SH.cpp
 games/mm/src/audio/lib/dcache.c
 games/mm/src/audio/lib/load.c

--- a/CMake/SingleExecutable.cmake
+++ b/CMake/SingleExecutable.cmake
@@ -394,6 +394,13 @@ if(BUILD_TESTING)
     # VisFbuf draw. This locks MM's call to its own MM_-dimension body (only one
     # definition survived, so no link error could catch the cross-bind).
     redship_add_test(NAME MMFbEffectsBinding COMMAND redship --test mm-fb-effects-binding)
+    # MM tracker registration surface (#392): the four MM tracker windows must
+    # register on the shared Gui under "MM "-prefixed names (SoH owns the
+    # unprefixed ones; Gui::AddGuiWindow rejects duplicates) and their
+    # Draw/Update path must be inert unless MM is the active game — unified
+    # gSaveContext storage means an ungated MM tracker reads OoT bytes through
+    # MM's SaveContext layout.
+    redship_add_test(NAME MMTrackersGui COMMAND redship --test mm-trackers-gui)
     redship_add_test(NAME MMResumeArena COMMAND redship --test mm-resume-arena)
     redship_add_test(NAME MMStartupRestore COMMAND redship --test mm-startup-restore)
     redship_add_test(NAME AllTests COMMAND redship --test all)

--- a/games/mm/2s2h/Enhancements/Trackers/ItemTracker/ItemTracker.cpp
+++ b/games/mm/2s2h/Enhancements/Trackers/ItemTracker/ItemTracker.cpp
@@ -408,7 +408,13 @@ void ItemTrackerWindow::Draw() {
     bool singleWindowOpen = false;
     if (!shouldWindowSplit) {
         ImGui::PushStyleColor(ImGuiCol_WindowBg, windowBg);
+#ifdef RSBS_SINGLE_EXECUTABLE
+        // OoT's item tracker owns the "Item Tracker" ImGui id on the shared
+        // Gui (#392): sharing it would merge the two trackers' ImGui windows.
+        singleWindowOpen = ImGui::Begin("Item Tracker (MM)", nullptr, windowFlags);
+#else
         singleWindowOpen = ImGui::Begin("Item Tracker", nullptr, windowFlags);
+#endif
     }
 
     uint32_t index = 0;

--- a/games/mm/2s2h/GameExports_SingleExe.cpp
+++ b/games/mm/2s2h/GameExports_SingleExe.cpp
@@ -1355,6 +1355,9 @@ int MM_Game_Init(int argc, char** argv) {
 // The GIEvent pump registrar (Lane C1) — defined in
 // games/mm/2s2h/GameInteractorEventsSingleExe.cpp.
 extern "C" void MM_GameEvents_RegisterPump(void);
+// MM tracker windows on the shared Gui (#392) — defined in
+// games/mm/2s2h/TrackersGuiSingleExe.cpp.
+extern "C" void MM_TrackersGui_Init(void);
 
 extern "C" void MM_Rando_Init(void) {
     static bool sRandoInitDone = false;
@@ -1375,6 +1378,12 @@ extern "C" void MM_Rando_Init(void) {
     // rando queue produces GIEvents, so the rando bring-up is its natural
     // (once-only, same guard) home.
     MM_GameEvents_RegisterPump();
+
+    // MM tracker windows (#392): register on the shared Gui, gated to draw
+    // only while MM is the active game. Upstream did this from BenGui.cpp's
+    // SetupGuiElements (excluded); the bypass surface lives in
+    // 2s2h/TrackersGuiSingleExe.cpp. No-op when the harness has no window.
+    MM_TrackersGui_Init();
 }
 
 /**
@@ -1628,6 +1637,24 @@ extern "C" void GameInteractor_ExecuteOnSaveLoad(s16 fileNum) {
 extern "C" void MM_GameHooks_ExecuteOnActorUpdate(Actor* actor) {
     S2H::GameHooks::Execute<GameInteractor::OnActorUpdate>(actor);
     S2H::GameHooks::ExecuteForID<GameInteractor::OnActorUpdate>(actor->id, actor);
+}
+
+/**
+ * OnSceneInit dispatch (#392 tracker follow-up). Called from MM's Play_Init
+ * (games/mm/src/code/z_play.c) at the exact point upstream 2S2H called its
+ * excluded 2-arg GameInteractor_ExecuteOnSceneInit — which the single exe
+ * could not call: the unprefixed name binds OoT's 1-arg executor, and firing
+ * the shared registry would hit the #367 type-aliasing class. The MM-owned
+ * S2H::GameHooks registry has neither problem. Runs every parked OnSceneInit
+ * registration in the linked MM set: the check tracker's scroll-to-scene
+ * hook (Rando/CheckTracker), Rando::MiscBehavior::OnSceneInit, and the
+ * open-dungeons COND_ID_HOOKs (all IS_RANDO-conditioned). The ForFilter leg
+ * is deliberately absent: the S2H registry has no filter surface and the
+ * linked MM set registers none (same deviation as the Should executors).
+ */
+extern "C" void MM_GameHooks_ExecuteOnSceneInit(s16 sceneId, s8 spawnNum) {
+    S2H::GameHooks::Execute<GameInteractor::OnSceneInit>(sceneId, spawnNum);
+    S2H::GameHooks::ExecuteForID<GameInteractor::OnSceneInit>(sceneId, sceneId, spawnNum);
 }
 
 extern "C" void MM_GameHooks_ExecuteOnFlagSet(FlagType flagType, u32 flag) {

--- a/games/mm/2s2h/Rando/CheckTracker/CheckTracker.cpp
+++ b/games/mm/2s2h/Rando/CheckTracker/CheckTracker.cpp
@@ -464,7 +464,13 @@ void CheckTrackerWindow::Draw() {
 
     ImGui::SetNextWindowSize(ImVec2(485.0f, 500.0f), ImGuiCond_FirstUseEver);
 
+#ifdef RSBS_SINGLE_EXECUTABLE
+    // OoT's check tracker owns the "Check Tracker" ImGui id on the shared Gui
+    // (#392): sharing it would merge the two trackers' ImGui windows/ini state.
+    ImGui::Begin("Check Tracker (MM)", nullptr, ImGuiWindowFlags_NoNav | ImGuiWindowFlags_NoFocusOnAppearing);
+#else
     ImGui::Begin("Check Tracker", nullptr, ImGuiWindowFlags_NoNav | ImGuiWindowFlags_NoFocusOnAppearing);
+#endif
 
     trackerBG.w = ImGui::IsWindowDocked() ? 1.0f : CVAR_TRACKER_OPACITY;
     ImGui::SetWindowFontScale(trackerScale);

--- a/games/mm/2s2h/Rando/Rando.cpp
+++ b/games/mm/2s2h/Rando/Rando.cpp
@@ -13,10 +13,7 @@
 void OnSaveLoadHandler(s16 fileNum) {
     Rando::MiscBehavior::OnFileLoad();
     Rando::ActorBehavior::OnFileLoad();
-#ifndef RSBS_SINGLE_EXECUTABLE
-    // Single-exe: check-tracker UI stays link-elided (see Rando::Init below).
     Rando::CheckTracker::OnFileLoad();
-#endif
     Rando::ClockShuffle::OnFileLoad();
 
     // Re-initalizes enhancements that are effected by the save being rando or not
@@ -28,14 +25,12 @@ void Rando::Init() {
     Rando::Spoiler::RefreshOptions();
     Rando::MiscBehavior::Init();
     Rando::ActorBehavior::Init();
-#ifndef RSBS_SINGLE_EXECUTABLE
-    // Single-exe: the MM check-tracker window is BenGui UI, which stays
-    // link-elided with the rest of MM's menu (2ship_rando_ui — see
-    // games/mm/CMakeLists.txt and the Lane B surface note on #392). Calling
-    // into it here would drag the whole UIWidgets/BenMenu surface into the
-    // link.
+    // Single-exe: these calls are what pull CheckTracker.obj (and its S2H
+    // UIWidgets) out of the plain 2ship_rando_ui archive; the window globals
+    // it references live in 2s2h/TrackersGuiSingleExe.cpp, which registers
+    // the tracker windows on the shared Gui without touching BenMenu.
+    // Rando/Menu.cpp stays elided (#392).
     Rando::CheckTracker::Init();
-#endif
     // Null-guarded for the headless unit harness (mm-rando-gen), which
     // brings up Ship::Context without a file-drop manager.
     auto fileDropMgr = Ship::Context::GetInstance()->GetFileDropMgr();

--- a/games/mm/2s2h/TrackersGuiSingleExe.cpp
+++ b/games/mm/2s2h/TrackersGuiSingleExe.cpp
@@ -50,6 +50,7 @@
 #include "2s2h/Rando/CheckTracker/CheckTracker.h"
 #include "2s2h/Enhancements/Trackers/ItemTracker/ItemTracker.h"
 #include "2s2h/Enhancements/Trackers/ItemTracker/ItemTrackerSettings.h"
+#include "2s2h/DeveloperTools/SaveEditor.h"
 #include "2s2h/ShipUtils.h"
 
 #include "context.h" // src/common — Context_GetCurrentGame / GameId
@@ -69,6 +70,71 @@ std::shared_ptr<Rando::CheckTracker::SettingsWindow> mRandoCheckTrackerSettingsW
 std::shared_ptr<ItemTrackerWindow> mItemTrackerWindow;
 std::shared_ptr<ItemTrackerSettingsWindow> mItemTrackerSettingsWindow;
 } // namespace BenGui
+
+/**
+ * Single-exe home for SaveEditor.cpp's safe-item table (the
+ * SaveEditorTimeSingleExe.cpp pattern). Upstream defines
+ * safeItemsForInventorySlot and populates it from
+ * SaveEditorWindow::InitElement — both in the excluded DeveloperTools TU —
+ * and the item tracker reads slot [0] as the vanilla-icon fallback for empty
+ * inventory slots. Declaration comes from DeveloperTools/SaveEditor.h (the
+ * S2H-wrapped header the tracker TUs reach through UIWidgets.hpp), so the
+ * definition below is compiler-checked against the extern the trackers bind.
+ * If upstream 2S2H changes initSafeItemsForInventorySlot, re-sync this copy
+ * (provenance: SaveEditor.cpp, upstream shape as of this port).
+ */
+namespace S2H {
+std::vector<ItemId> safeItemsForInventorySlot[SLOT_MASK_FIERCE_DEITY + 1] = {};
+} // namespace S2H
+
+namespace {
+
+// Verbatim port of SaveEditor.cpp's initSafeItemsForInventorySlot, plus an
+// idempotence guard (upstream relies on GuiElement::Init's once-only; here
+// RegisterWindows is the single caller, but a re-run must not duplicate).
+void InitSafeItemsForInventorySlot() {
+    static bool sInitialized = false;
+    if (sInitialized) {
+        return;
+    }
+    sInitialized = true;
+
+    for (int i = 0; i < sizeof(MM_gItemSlots); i++) {
+        InventorySlot slot = static_cast<InventorySlot>(MM_gItemSlots[i]);
+        switch (slot) {
+            case SLOT_BOTTLE_1:
+                if (i != ITEM_LONGSHOT) { // No longshot in bottles
+                    safeItemsForInventorySlot[SLOT_BOTTLE_1].push_back(static_cast<ItemId>(i));
+                    safeItemsForInventorySlot[SLOT_BOTTLE_2].push_back(static_cast<ItemId>(i));
+                    safeItemsForInventorySlot[SLOT_BOTTLE_3].push_back(static_cast<ItemId>(i));
+                    safeItemsForInventorySlot[SLOT_BOTTLE_4].push_back(static_cast<ItemId>(i));
+                    safeItemsForInventorySlot[SLOT_BOTTLE_5].push_back(static_cast<ItemId>(i));
+                    safeItemsForInventorySlot[SLOT_BOTTLE_6].push_back(static_cast<ItemId>(i));
+                }
+                break;
+            case SLOT_BOW:
+                if (i == ITEM_BOW) { // No elemental bows here
+                    safeItemsForInventorySlot[slot].push_back(static_cast<ItemId>(i));
+                }
+                break;
+            case SLOT_TRADE_KEY_MAMA:
+                if (i != ITEM_SLINGSHOT) { // No slingshot in trade items
+                    safeItemsForInventorySlot[slot].push_back(static_cast<ItemId>(i));
+                }
+                break;
+            case SLOT_TRADE_DEED:
+                if (i != ITEM_OCARINA_FAIRY) { // No fairy ocarina in trade items
+                    safeItemsForInventorySlot[slot].push_back(static_cast<ItemId>(i));
+                }
+                break;
+            default:
+                safeItemsForInventorySlot[slot].push_back(static_cast<ItemId>(i));
+                break;
+        }
+    }
+}
+
+} // namespace
 
 namespace {
 
@@ -114,6 +180,11 @@ void RegisterWindows(std::shared_ptr<Ship::Gui> gui) {
     if (gui->GetGuiWindow(kCheckTrackerWindowName) != nullptr) {
         return;
     }
+
+    // The item tracker's vanilla-icon fallback indexes [0] of each slot's
+    // safe-item list; populate it before any window can draw (upstream did
+    // this from the excluded SaveEditorWindow::InitElement).
+    InitSafeItemsForInventorySlot();
 
     // CVar names and sizes mirror BenGui.cpp::SetupGuiElements; only the
     // registration names carry the "MM " prefix (SoH owns the unprefixed

--- a/games/mm/2s2h/TrackersGuiSingleExe.cpp
+++ b/games/mm/2s2h/TrackersGuiSingleExe.cpp
@@ -1,0 +1,169 @@
+/**
+ * MM tracker windows on the shared Gui, bypassing the BenMenu shell (#392).
+ *
+ * Upstream 2S2H wires its trackers in BenGui.cpp::SetupGuiElements — an
+ * excluded TU whose only caller (BenPort.cpp) is also excluded — so the whole
+ * MM tracker surface was link-elided. This TU is the MVP registration surface
+ * from docs/unified-surface-findings.md §3:
+ *
+ *  - It defines the four BenGui::m*Window globals the vendored tracker TUs
+ *    reference (CheckTracker.cpp needs mRandoCheckTrackerWindow,
+ *    ItemTrackerSettings.cpp needs mItemTrackerWindow), which is what lets
+ *    the linker pull CheckTracker.obj / UIWidgets.obj out of the plain
+ *    2ship_rando_ui archive and ItemTracker(.Settings).obj out of 2ship_enh
+ *    WITHOUT dragging in Rando/Menu.cpp's BenMenu externals — Menu.obj stays
+ *    elided because nothing references its symbols.
+ *
+ *  - It registers the windows on the shared Ship::Context Gui under
+ *    "MM "-prefixed names: SoH already owns "Check Tracker" / "Item Tracker"
+ *    (games/oot/soh/SohGui/SohGui.cpp) and Gui::AddGuiWindow refuses
+ *    duplicate names. Visibility CVars stay MM's upstream "gWindows.*" — OoT
+ *    windows use "gOpenWindows.*", so there is no store collision to rename
+ *    around.
+ *
+ *  - Every window is wrapped in an active-game gate. The shared Gui draws
+ *    every registered window every frame regardless of which game runs, and
+ *    gSaveContext storage is unified: an MM tracker drawing while OoT is
+ *    active would read OoT bytes through MM's SaveContext layout, and MM's
+ *    tracker Draw bodies hardcode ImGui ids that would land in the same
+ *    frame as OoT's trackers. The gate makes MM tracker windows a strict
+ *    no-op unless Context_GetCurrentGame() == GAME_MM.
+ *
+ * Teardown, deliberately absent: windows registered here persist across game
+ * switches (dormant behind the gate, exactly like SoH's windows persist over
+ * MM). Do NOT reach for BenGui::Destroy as a teardown — it calls
+ * Gui::RemoveAllGuiWindows, which would drop SoH's windows too.
+ *
+ * Locked ROM-free by the mm-trackers-gui CTest (mm_trackers_gui_test.cpp):
+ * registration list + name de-collision + gate flip.
+ */
+#ifdef RSBS_SINGLE_EXECUTABLE
+
+#include "TrackersGuiSingleExe.h"
+
+#include <memory>
+
+#include <ship/Context.h>
+#include <ship/window/Window.h>
+#include <ship/window/gui/Gui.h>
+
+#include "2s2h/Rando/CheckTracker/CheckTracker.h"
+#include "2s2h/Enhancements/Trackers/ItemTracker/ItemTracker.h"
+#include "2s2h/Enhancements/Trackers/ItemTracker/ItemTrackerSettings.h"
+#include "2s2h/ShipUtils.h"
+
+#include "context.h" // src/common — Context_GetCurrentGame / GameId
+
+// games/mm/2s2h/GameExports_SingleExe.cpp — true once LoadMMArchives
+// registered mm.o2r. Tracker icon loading needs the archive; in the ROM-free
+// harness Gui::LoadGuiTexture null-derefs on the missing resource.
+extern "C" bool MM_Rando_AssetsReady(void);
+
+namespace BenGui {
+// The globals the vendored tracker TUs extern-declare (BenGui.cpp, which
+// upstream defines them in, is excluded from single-exe builds — no ODR
+// overlap). Types must match those extern declarations exactly:
+// CheckTracker.cpp / Rando/Menu.cpp / ItemTracker(.Settings).cpp.
+std::shared_ptr<Rando::CheckTracker::CheckTrackerWindow> mRandoCheckTrackerWindow;
+std::shared_ptr<Rando::CheckTracker::SettingsWindow> mRandoCheckTrackerSettingsWindow;
+std::shared_ptr<ItemTrackerWindow> mItemTrackerWindow;
+std::shared_ptr<ItemTrackerSettingsWindow> mItemTrackerSettingsWindow;
+} // namespace BenGui
+
+namespace {
+
+/**
+ * Active-game gate. Draw() covers the per-frame ImGui path (both the base
+ * GuiWindow::Draw used by the settings windows and the full Draw overrides in
+ * CheckTracker.cpp / ItemTracker.cpp); UpdateElement() covers Gui's
+ * unconditional per-frame Update(). The bases' bodies run only while MM is
+ * the active game. The mm-trackers-gui lock calls Draw() with OoT active and
+ * no ImGui context, so an ungated path aborts the test process.
+ */
+template <typename BaseWindow> class MMActiveGated final : public BaseWindow {
+  public:
+    using BaseWindow::BaseWindow;
+
+    void Draw() override {
+        if (!MM_TrackersGui_ShouldDraw()) {
+            return;
+        }
+        BaseWindow::Draw();
+    }
+
+  protected:
+    void UpdateElement() override {
+        if (!MM_TrackersGui_ShouldDraw()) {
+            return;
+        }
+        BaseWindow::UpdateElement();
+    }
+};
+
+} // namespace
+
+namespace S2H {
+namespace TrackersGui {
+
+void RegisterWindows(std::shared_ptr<Ship::Gui> gui) {
+    if (gui == nullptr) {
+        return;
+    }
+    // Idempotence: MM_Rando_Init is once-only guarded, but the headless
+    // harness may drive registration directly more than once.
+    if (gui->GetGuiWindow(kCheckTrackerWindowName) != nullptr) {
+        return;
+    }
+
+    // CVar names and sizes mirror BenGui.cpp::SetupGuiElements; only the
+    // registration names carry the "MM " prefix (SoH owns the unprefixed
+    // ones). CheckTrackerWindow::Draw ignores the ctor CVar and reads
+    // "gWindows.CheckTracker" itself, so the ctor CVar must stay in sync
+    // with the vendored macro (CVAR_NAME_SHOW_CHECK_TRACKER).
+    BenGui::mRandoCheckTrackerWindow = std::make_shared<MMActiveGated<Rando::CheckTracker::CheckTrackerWindow>>(
+        "gWindows.CheckTracker", kCheckTrackerWindowName, ImVec2(375, 460));
+    gui->AddGuiWindow(BenGui::mRandoCheckTrackerWindow);
+
+    BenGui::mRandoCheckTrackerSettingsWindow = std::make_shared<MMActiveGated<Rando::CheckTracker::SettingsWindow>>(
+        "gWindows.CheckTrackerSettings", kCheckTrackerSettingsWindowName);
+    gui->AddGuiWindow(BenGui::mRandoCheckTrackerSettingsWindow);
+
+    BenGui::mItemTrackerWindow =
+        std::make_shared<MMActiveGated<ItemTrackerWindow>>("gWindows.ItemTracker", kItemTrackerWindowName);
+    gui->AddGuiWindow(BenGui::mItemTrackerWindow);
+
+    BenGui::mItemTrackerSettingsWindow = std::make_shared<MMActiveGated<ItemTrackerSettingsWindow>>(
+        "gWindows.ItemTrackerSettings", kItemTrackerSettingsWindowName, ImVec2(800, 400));
+    gui->AddGuiWindow(BenGui::mItemTrackerSettingsWindow);
+}
+
+} // namespace TrackersGui
+} // namespace S2H
+
+extern "C" bool MM_TrackersGui_ShouldDraw(void) {
+    return Context_GetCurrentGame() == GAME_MM;
+}
+
+extern "C" void MM_TrackersGui_Init(void) {
+    auto ctx = Ship::Context::GetInstance();
+    if (ctx == nullptr || ctx->GetWindow() == nullptr) {
+        // ROM-free unit harness: shared subsystems without a window/Gui.
+        return;
+    }
+    auto gui = ctx->GetWindow()->GetGui();
+    if (gui == nullptr) {
+        return;
+    }
+
+    S2H::TrackersGui::RegisterWindows(gui);
+
+    // Tracker icons (check-type icons, item/quest icons). Upstream loads
+    // these from BenPort.cpp's InitOTR; gated on the archive because the
+    // string-path LoadGuiTexture crashes on a missing resource (#330 class),
+    // and mm-rando-gen brings this path up windowed but archive-free.
+    if (MM_Rando_AssetsReady()) {
+        MM_LoadGuiTextures();
+    }
+}
+
+#endif // RSBS_SINGLE_EXECUTABLE

--- a/games/mm/2s2h/TrackersGuiSingleExe.h
+++ b/games/mm/2s2h/TrackersGuiSingleExe.h
@@ -1,0 +1,88 @@
+/**
+ * MM tracker registration surface for single-executable builds (#392).
+ *
+ * Upstream 2S2H instantiates its tracker windows in BenGui.cpp's
+ * SetupGuiElements, whose only caller is the excluded BenPort.cpp — so in the
+ * single exe the whole MM menu/tracker surface was link-elided. This is the
+ * BenMenu-bypass registration surface from docs/unified-surface-findings.md
+ * §3: it defines the BenGui::m*Window globals the tracker TUs link against and
+ * registers ONLY the tracker windows on the shared Ship::Context Gui, leaving
+ * BenMenu/BenMenuBar (and Rando/Menu.cpp, which references them) elided.
+ *
+ * Names are prefixed "MM " because SoH already owns "Check Tracker" /
+ * "Item Tracker" / their settings twins on the shared Gui, and
+ * Gui::AddGuiWindow rejects duplicate names (silently, from the caller's
+ * perspective — SPDLOG_ERROR and return).
+ *
+ * Every registered window is wrapped in a per-active-game gate: gSaveContext
+ * storage is unified, so an MM tracker drawing while OoT is active would read
+ * OoT bytes through MM's SaveContext layout. The gate also keeps MM's
+ * hardcoded ImGui window ids from colliding with OoT's tracker windows in the
+ * same frame. See TrackersGuiSingleExe.cpp.
+ */
+#ifndef TRACKERS_GUI_SINGLE_EXE_H
+#define TRACKERS_GUI_SINGLE_EXE_H
+
+#ifdef RSBS_SINGLE_EXECUTABLE
+#ifdef __cplusplus
+
+#include <memory>
+
+namespace Ship {
+class Gui;
+}
+
+namespace S2H {
+namespace TrackersGui {
+
+// Gui registration names. SoH owns the unprefixed forms on the shared Gui —
+// keep these distinct from every name games/oot/soh/SohGui/SohGui.cpp
+// registers. The mm-trackers-gui CTest locks the de-collision.
+inline constexpr const char* kCheckTrackerWindowName = "MM Check Tracker";
+inline constexpr const char* kCheckTrackerSettingsWindowName = "MM Check Tracker Settings";
+inline constexpr const char* kItemTrackerWindowName = "MM Item Tracker";
+inline constexpr const char* kItemTrackerSettingsWindowName = "MM Item Tracker Settings";
+inline constexpr const char* kAllTrackerWindowNames[] = {
+    kCheckTrackerWindowName,
+    kCheckTrackerSettingsWindowName,
+    kItemTrackerWindowName,
+    kItemTrackerSettingsWindowName,
+};
+
+/**
+ * Instantiate the MM tracker windows (populating the BenGui::m*Window
+ * globals) and register them on `gui`. Idempotent: if the check-tracker
+ * window name is already registered, returns without touching anything.
+ * Never call BenGui::Destroy to undo this — it calls RemoveAllGuiWindows,
+ * which would drop SoH's windows off the shared Gui too.
+ */
+void RegisterWindows(std::shared_ptr<Ship::Gui> gui);
+
+} // namespace TrackersGui
+} // namespace S2H
+
+extern "C" {
+#endif // __cplusplus
+
+/**
+ * Per-active-game gate shared by every MM tracker window: true iff MM is the
+ * active game (Context_GetCurrentGame() == GAME_MM). Split out so the
+ * ROM-free lock can flip it without a Gui.
+ */
+bool MM_TrackersGui_ShouldDraw(void);
+
+/**
+ * Production entry point, called from MM_Rando_Init (once-only by its guard):
+ * registers the tracker windows on the shared Ship::Context Gui and loads
+ * MM's tracker icon textures when mm.o2r is available. Safe no-op when the
+ * context has no window/Gui (ROM-free unit harness).
+ */
+void MM_TrackersGui_Init(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // RSBS_SINGLE_EXECUTABLE
+
+#endif // TRACKERS_GUI_SINGLE_EXE_H

--- a/games/mm/2s2h/mm_trackers_gui_test.cpp
+++ b/games/mm/2s2h/mm_trackers_gui_test.cpp
@@ -203,7 +203,7 @@ extern "C" int MM_TrackersGui_RunHeadless(void) {
     // Cleanup: don't leak forced-visible tracker CVars into later tests or a
     // saved cvar file.
     for (const char* cvar : kMMWindowVisibilityCVars) {
-        CVarClearVariable(cvar);
+        CVarClear(cvar);
     }
 
     printf("[TEST] PASS: mm-trackers-gui — four MM tracker windows register under de-collided names beside "

--- a/games/mm/2s2h/mm_trackers_gui_test.cpp
+++ b/games/mm/2s2h/mm_trackers_gui_test.cpp
@@ -1,0 +1,214 @@
+/**
+ * ROM-free lock for the MM tracker registration surface (#392). CTest label
+ * "redship", row mm-trackers-gui in src/common/test_runner.cpp.
+ *
+ * What it locks (docs/unified-surface-findings.md §3, the BenMenu-bypass
+ * tracker route):
+ *
+ * 1. REGISTRATION + NAME DE-COLLISION. Gui::AddGuiWindow rejects duplicate
+ *    names, and SoH already owns "Check Tracker" / "Item Tracker" / their
+ *    settings twins on the shared Gui — so if MM's windows ever regress to
+ *    the upstream names, they silently never register. Stand-in windows
+ *    occupy SoH's names first; S2H::TrackersGui::RegisterWindows must then
+ *    land all four MM windows under their "MM "-prefixed names while the
+ *    stand-ins keep theirs. Also locks AddGuiWindow's duplicate rejection
+ *    itself (the premise the prefixing rests on) and registration
+ *    idempotence.
+ *
+ * 2. ACTIVE-GAME GATING. gSaveContext storage is unified, so an MM tracker
+ *    drawing while OoT is active reads OoT bytes through MM's SaveContext
+ *    layout. MM_TrackersGui_ShouldDraw() must flip with
+ *    Context_SetCurrentGame, and — the wired half — calling Draw()/Update()
+ *    on every registered MM window while OoT (or nothing) is active must be
+ *    a strict no-op. That second half is a hard tripwire: this harness has
+ *    NO ImGui context, and the windows' visibility CVars are forced on, so
+ *    an ungated Draw() reaches ImGui::Begin and aborts the test process.
+ *    (Draw() with MM active is deliberately NOT called: it would need an
+ *    ImGui context plus MM play state, which is operator/integration
+ *    territory.)
+ *
+ * 3. HEADLESS SAFETY of the production entry point: MM_TrackersGui_Init()
+ *    must no-op cleanly when the shared context has no window (the exact
+ *    state MM_Rando_Init sees in ROM-free harnesses).
+ */
+
+#ifdef RSBS_SINGLE_EXECUTABLE
+
+#include <cstdio>
+#include <memory>
+
+#include <ship/Context.h>
+#include <ship/window/gui/Gui.h>
+#include <ship/window/gui/GuiWindow.h>
+
+#include "TrackersGuiSingleExe.h"
+#include "2s2h/Rando/CheckTracker/CheckTracker.h"
+#include "2s2h/Enhancements/Trackers/ItemTracker/ItemTracker.h"
+#include "2s2h/Enhancements/Trackers/ItemTracker/ItemTrackerSettings.h"
+#include "context.h"
+
+namespace BenGui {
+// Defined in 2s2h/TrackersGuiSingleExe.cpp; populated by RegisterWindows.
+extern std::shared_ptr<Rando::CheckTracker::CheckTrackerWindow> mRandoCheckTrackerWindow;
+extern std::shared_ptr<Rando::CheckTracker::SettingsWindow> mRandoCheckTrackerSettingsWindow;
+extern std::shared_ptr<ItemTrackerWindow> mItemTrackerWindow;
+extern std::shared_ptr<ItemTrackerSettingsWindow> mItemTrackerSettingsWindow;
+} // namespace BenGui
+
+namespace {
+
+#define TGT_ASSERT(cond, msg)                                             \
+    do {                                                                  \
+        if (!(cond)) {                                                    \
+            printf("[TEST] FAIL: %s (%s:%d)\n", msg, __FILE__, __LINE__); \
+            return 1;                                                     \
+        }                                                                 \
+    } while (0)
+
+// Minimal stand-in for a SoH-owned window: empty cvar (no ConsoleVariables
+// traffic in the ctor) and inert overrides.
+class StandinWindow final : public Ship::GuiWindow {
+  public:
+    using GuiWindow::GuiWindow;
+
+    void InitElement() override {
+    }
+    void DrawElement() override {
+    }
+    void UpdateElement() override {
+    }
+};
+
+// The names SoH registers on the shared Gui (games/oot/soh/SohGui/SohGui.cpp).
+const char* kSohOwnedNames[] = {
+    "Check Tracker",
+    "Check Tracker Settings",
+    "Item Tracker",
+    "Item Tracker Settings",
+};
+
+// Visibility CVars of the four MM windows, forced ON so that an UNGATED
+// Draw() cannot early-out on !IsVisible() before reaching ImGui — the gate
+// must be what stops it.
+const char* kMMWindowVisibilityCVars[] = {
+    "gWindows.CheckTracker",
+    "gWindows.CheckTrackerSettings",
+    "gWindows.ItemTracker",
+    "gWindows.ItemTrackerSettings",
+};
+
+} // namespace
+
+extern "C" int MM_TrackersGui_RunHeadless(void) {
+    auto ctx = Ship::Context::GetInstance();
+    TGT_ASSERT(ctx != nullptr, "Ship::Context singleton missing — run the shared bring-up first");
+    TGT_ASSERT(ctx->GetConsoleVariables() != nullptr, "ConsoleVariables missing — GuiWindow ctors need them");
+    TGT_ASSERT(ctx->GetConfig() != nullptr, "Config missing — ItemTrackerSettings::InitElement needs it");
+    TGT_ASSERT(ctx->GetConsole() != nullptr, "Console missing — Gui's default ConsoleWindow needs it");
+    TGT_ASSERT(ctx->GetWindow() == nullptr,
+               "harness unexpectedly has a real window — the headless-safety leg below would be vacuous");
+
+    // ---- 3. Production entry point is headless-safe ----------------------
+    // MM_Rando_Init calls this in every ROM-free harness; with no window it
+    // must return without touching a Gui.
+    MM_TrackersGui_Init();
+
+    // ---- 1. Registration + de-collision on a standalone Gui --------------
+    // A bare Ship::Gui never Init()ed: AddGuiWindow/GetGuiWindow work without
+    // an ImGui context, which is exactly what makes the gate tripwire below a
+    // hard one.
+    auto gui = std::make_shared<Ship::Gui>();
+
+    std::shared_ptr<Ship::GuiWindow> standins[4];
+    for (int i = 0; i < 4; i++) {
+        standins[i] = std::make_shared<StandinWindow>("", kSohOwnedNames[i]);
+        gui->AddGuiWindow(standins[i]);
+        TGT_ASSERT(gui->GetGuiWindow(kSohOwnedNames[i]) == standins[i], "stand-in failed to register");
+    }
+
+    // Force every MM window visible BEFORE construction (the ctor reads the
+    // CVar; setting it afterwards would need Show(), which dereferences the
+    // null window through SaveConsoleVariablesNextFrame).
+    for (const char* cvar : kMMWindowVisibilityCVars) {
+        CVarSetInteger(cvar, 1);
+    }
+
+    S2H::TrackersGui::RegisterWindows(gui);
+
+    for (const char* name : S2H::TrackersGui::kAllTrackerWindowNames) {
+        TGT_ASSERT(gui->GetGuiWindow(name) != nullptr, "MM tracker window missing from the Gui registry");
+    }
+    TGT_ASSERT(gui->GetGuiWindow(S2H::TrackersGui::kCheckTrackerWindowName) == BenGui::mRandoCheckTrackerWindow,
+               "registry entry is not the BenGui check-tracker global the vendored TUs link against");
+    TGT_ASSERT(gui->GetGuiWindow(S2H::TrackersGui::kCheckTrackerSettingsWindowName) ==
+                   BenGui::mRandoCheckTrackerSettingsWindow,
+               "registry entry is not the BenGui check-tracker-settings global");
+    TGT_ASSERT(gui->GetGuiWindow(S2H::TrackersGui::kItemTrackerWindowName) == BenGui::mItemTrackerWindow,
+               "registry entry is not the BenGui item-tracker global the vendored TUs link against");
+    TGT_ASSERT(gui->GetGuiWindow(S2H::TrackersGui::kItemTrackerSettingsWindowName) ==
+                   BenGui::mItemTrackerSettingsWindow,
+               "registry entry is not the BenGui item-tracker-settings global");
+
+    // SoH's names must still belong to the stand-ins: MM registration must
+    // not have displaced (or been swallowed by) the unprefixed names.
+    for (int i = 0; i < 4; i++) {
+        TGT_ASSERT(gui->GetGuiWindow(kSohOwnedNames[i]) == standins[i],
+                   "MM registration disturbed a SoH-owned window name");
+    }
+
+    // AddGuiWindow's duplicate rejection — the premise the prefixing rests
+    // on. A late arrival under an MM name must bounce off.
+    auto usurper = std::make_shared<StandinWindow>("", S2H::TrackersGui::kCheckTrackerWindowName);
+    gui->AddGuiWindow(usurper);
+    TGT_ASSERT(gui->GetGuiWindow(S2H::TrackersGui::kCheckTrackerWindowName) == BenGui::mRandoCheckTrackerWindow,
+               "duplicate AddGuiWindow displaced the registered MM window");
+
+    // Idempotence: a second RegisterWindows must leave the registry as-is.
+    auto before = BenGui::mRandoCheckTrackerWindow;
+    S2H::TrackersGui::RegisterWindows(gui);
+    TGT_ASSERT(BenGui::mRandoCheckTrackerWindow == before, "re-registration replaced the window instances");
+
+    // ---- 2. Active-game gating -------------------------------------------
+    const GameId prevGame = Context_GetCurrentGame();
+
+    std::shared_ptr<Ship::GuiWindow> mmWindows[] = {
+        BenGui::mRandoCheckTrackerWindow,
+        BenGui::mRandoCheckTrackerSettingsWindow,
+        BenGui::mItemTrackerWindow,
+        BenGui::mItemTrackerSettingsWindow,
+    };
+
+    const GameId inactiveGames[] = { GAME_OOT, GAME_NONE };
+    for (GameId game : inactiveGames) {
+        Context_SetCurrentGame(game);
+        if (MM_TrackersGui_ShouldDraw()) {
+            printf("[TEST] FAIL: MM_TrackersGui_ShouldDraw() true while game %d is active\n", (int)game);
+            Context_SetCurrentGame(prevGame);
+            return 1;
+        }
+        // Hard tripwire: visibility CVars are ON and there is NO ImGui
+        // context, so an ungated Draw() reaches ImGui::Begin and aborts.
+        // Surviving these calls == the gate held for every window.
+        for (auto& window : mmWindows) {
+            window->Draw();
+            window->Update();
+        }
+    }
+
+    Context_SetCurrentGame(GAME_MM);
+    const bool mmActiveDraws = MM_TrackersGui_ShouldDraw();
+    Context_SetCurrentGame(prevGame);
+    TGT_ASSERT(mmActiveDraws, "MM_TrackersGui_ShouldDraw() false while MM is the active game");
+
+    // Cleanup: don't leak forced-visible tracker CVars into later tests or a
+    // saved cvar file.
+    for (const char* cvar : kMMWindowVisibilityCVars) {
+        CVarClearVariable(cvar);
+    }
+
+    printf("[TEST] PASS: mm-trackers-gui — four MM tracker windows register under de-collided names beside "
+           "SoH's, and their draw path is inert unless MM is the active game\n");
+    return 0;
+}
+
+#endif // RSBS_SINGLE_EXECUTABLE

--- a/games/mm/src/code/z_play.c
+++ b/games/mm/src/code/z_play.c
@@ -5,6 +5,15 @@
 #include "z64visfbuf.h"
 #include <libultraship/bridge/consolevariablebridge.h>
 
+#ifdef RSBS_SINGLE_EXECUTABLE
+// (#392) MM-side OnSceneInit dispatch, defined in
+// games/mm/2s2h/GameExports_SingleExe.cpp. The unprefixed
+// GameInteractor_ExecuteOnSceneInit would bind OoT's 1-arg executor in the
+// single exe; this MM_ twin dispatches the MM-owned S2H::GameHooks registry
+// with MM's own signature (same pattern as z_actor.c's MM_GameHooks_* calls).
+void MM_GameHooks_ExecuteOnSceneInit(s16 sceneId, s8 spawnNum);
+#endif
+
 // Variables are put before most headers as a hacky way to bypass bss reordering
 s16 MM_sTransitionFillTimer;
 Input D_801F6C18;
@@ -2712,14 +2721,15 @@ void MM_Play_Init(GameState* thisx) {
     sJustClosedBomberNotebook = false;
 
 #ifdef RSBS_SINGLE_EXECUTABLE
-    // (#344) Don't fire scene-init hooks here in single-exe builds. MM's own
-    // 2-arg executor is excluded, so this unprefixed call would bind to OoT's
-    // 1-arg GameInteractor_ExecuteOnSceneInit and run OoT enhancement hooks
-    // with an MM scene id against OoT's suspended play state. The shared
-    // OnSceneInit hook type also has different signatures in the two games'
-    // headers over merged storage, so an MM-side executor can't safely fire
-    // it either. Integration tests detect completed scene loads via play
-    // state predicates instead (games/mm/2s2h/GameExports_SingleExe.cpp).
+    // (#392, supersedes the #344 skip) Fire MM's scene-init hooks through the
+    // MM-owned S2H::GameHooks registry. The unprefixed call below would bind
+    // OoT's 1-arg executor and run OoT enhancement hooks against MM state —
+    // and the shared registry's OnSceneInit signatures diverge between the
+    // games — but the MM_ twin touches only MM-registered hooks with MM's own
+    // types, so neither hazard applies. Registration without this dispatch
+    // left every parked OnSceneInit hook (check tracker scroll, rando
+    // MiscBehavior/open-dungeons) silently dormant.
+    MM_GameHooks_ExecuteOnSceneInit(sceneIdAbsolute, spawnNum);
 #else
     GameInteractor_ExecuteOnSceneInit(sceneIdAbsolute, spawnNum);
 #endif

--- a/src/common/test_runner.cpp
+++ b/src/common/test_runner.cpp
@@ -72,6 +72,15 @@ int MM_NotificationBinding_RunHeadless(void);
 // to HiRes 576 while the Bombers' Notebook is open. Returns 0 on pass, non-zero
 // on fail.
 int MM_FbEffectsBinding_RunHeadless(void);
+// MM tracker registration surface (games/mm/2s2h/mm_trackers_gui_test.cpp,
+// #392): the four MM tracker windows must register on a Gui under
+// "MM "-prefixed names (SoH owns the unprefixed ones and Gui::AddGuiWindow
+// rejects duplicates), and their Draw/Update path must be inert unless MM is
+// the active game (unified gSaveContext storage — an ungated MM tracker
+// would read OoT bytes through MM's layout). Needs the display-free shared
+// bring-up first (ConsoleVariables/Config/Console). Returns 0 on pass,
+// non-zero on fail.
+int MM_TrackersGui_RunHeadless(void);
 // VB-affinity regression: MM's GameInteractor_* calls resolve to OoT's
 // extern "C" wrappers in single-exe builds, and the two games' vanilla-
 // behavior ordinals alias each other. The wrappers gate on the active game;
@@ -929,6 +938,27 @@ TestResult Test_VBAffinity(void) {
     return TEST_PASS;
 }
 
+// MM tracker registration surface (#392). The bridge (see the extern decl at
+// the top) constructs a standalone Ship::Gui, so it needs the same
+// display-free shared bring-up as boot-oot: GuiWindow ctors read
+// ConsoleVariables, ItemTrackerSettings::InitElement reads Config, and the
+// Gui ctor's default ConsoleWindow registers Console commands.
+TestResult Test_MMTrackersGui(void) {
+    printf("[TEST] mm-trackers-gui: MM tracker windows register de-collided + gate on the active game (#392)\n");
+
+    auto ctx = CreateHarnessStyleContext();
+    if (!ctx) {
+        printf("[TEST] FAIL: could not create Ship::Context singleton\n");
+        return TEST_FAIL;
+    }
+    if (OoT_InitSharedContextSubsystems() != 0) {
+        printf("[TEST] FAIL: shared bring-up reported failure\n");
+        return TEST_FAIL;
+    }
+
+    return MM_TrackersGui_RunHeadless() == 0 ? TEST_PASS : TEST_FAIL;
+}
+
 TestResult Test_RoundtripIntegrity(void) {
     printf("[TEST] roundtrip-integrity: OoT SaveContext byte-integrity across roundtrip (issue #262)\n");
     int failures = TestRoundtripIntegrity_Run();
@@ -1082,6 +1112,8 @@ const TestDescriptor gTests[] = {
      Test_MMNotificationBinding},
     {"mm-fb-effects-binding", "MM's scaled framebuffer draw binds its own body against MM's dimensions (#386)",
      Test_MMFbEffectsBinding},
+    {"mm-trackers-gui", "MM tracker windows register de-collided on the shared Gui + gate on the active game (#392)",
+     Test_MMTrackersGui},
     // The two MM resume-contract tests below mutate process-global state
     // (mm-resume-arena re-inits the MM system arena + heaps; mm-startup-restore
     // scribbles and re-zeroes the unified gSaveContext). Both clean up after


### PR DESCRIPTION
Delivers the maintainer's "we want all the trackers to track both games" ask via the MVP route from `docs/unified-surface-findings.md` §3 ("Trackers — the surprise: nearly free"): MM's **native** Check Tracker and Item Tracker (+ both settings windows) register on the shared `Ship::Context` Gui and work while MM is the active game — **bypassing the BenMenu shell entirely**. The true *combo* tracker (both games in one window, shadows + `foreignPlacements`) is a follow-up issue, not this PR.

## What registers, and when it draws

`games/mm/2s2h/TrackersGuiSingleExe.cpp` (new, 2ship_port via the existing glob) defines the four `BenGui::m*Window` globals the vendored tracker TUs extern-declare and registers, from `MM_Rando_Init` (so: on MM's first boot, once-only, window-null-safe for headless harnesses):

| Gui name | class | visibility CVar |
|---|---|---|
| `MM Check Tracker` | `Rando::CheckTracker::CheckTrackerWindow` | `gWindows.CheckTracker` |
| `MM Check Tracker Settings` | `Rando::CheckTracker::SettingsWindow` | `gWindows.CheckTrackerSettings` |
| `MM Item Tracker` | `S2H::ItemTrackerWindow` | `gWindows.ItemTracker` |
| `MM Item Tracker Settings` | `S2H::ItemTrackerSettingsWindow` | `gWindows.ItemTrackerSettings` |

- **Names are "MM "-prefixed** because SoH already owns the unprefixed four on the shared Gui and `Gui::AddGuiWindow` rejects duplicates (SPDLOG_ERROR + return — a silent no-register from the caller's side).
- **CVars stay MM's upstream `gWindows.*`** — measured, not assumed: OoT's window CVars are `gOpenWindows.*` (`CVAR_PREFIX_WINDOW`, CMake/soh-cvars.cmake), so there is no store collision to rename around, and MM's own `UIWidgets::WindowButton` sites keep working untouched.
- The two hardcoded `ImGui::Begin` titles in the vendored Draw bodies get `(MM)` suffixes under `RSBS_SINGLE_EXECUTABLE` so the ImGui window ids / imgui.ini state can't merge with OoT's same-named tracker windows.
- Tracker icon textures load via the real `MM_LoadGuiTextures` (upstream did this from excluded BenPort.cpp), gated on `MM_Rando_AssetsReady()` — the string-path `LoadGuiTexture` crashes on a missing resource (#330 class) and mm-rando-gen reaches this path windowed but archive-free.

**Per-active-game gating is the load-bearing part**: `gSaveContext` storage is unified, so an MM tracker drawing while OoT is active reads OoT bytes through MM's SaveContext layout — and the shared Gui calls `Update()`+`Draw()` on every registered window every frame regardless of active game. Every MM window is wrapped in an `MMActiveGated<Base>` adapter: `Draw`/`UpdateElement` are strict no-ops unless `Context_GetCurrentGame() == GAME_MM`. Windows persist across switches, dormant behind the gate — the exact mirror of SoH's windows persisting over MM. `BenGui::Destroy` is deliberately not reused (`RemoveAllGuiWindows` would nuke SoH's windows).

## Un-elision mechanism: member-granular, no CMake split needed

PR #422 split `Menu.cpp` + `CheckTracker.cpp` into plain-archive `2ship_rando_ui` and measured 5 BenGui externals. Those externals split cleanly by member: `mBenMenu`/`BenMenu::Add*`/`GetMenuThemeColor` live **only in Menu.obj**; CheckTracker.obj's only BenGui external is `mRandoCheckTrackerWindow`. So:

- Re-enabling the `Rando::CheckTracker::Init/OnFileLoad` calls C0 compiled out of `Rando.cpp` (WHOLE_ARCHIVE'd 2ship_rando) pulls **CheckTracker.obj** — and #434's S2H **UIWidgets.obj** — out of `2ship_rando_ui` by plain archive semantics.
- The new TU's BenGui globals + window vtable references pull **ItemTracker.obj / ItemTrackerSettings.obj** out of `2ship_enh` (both were S2H-namespaced by the #434-family prep; neither carries a raw `RegisterGameHook` or event-enqueue site — verified, consistent with the findings doc).
- **Menu.obj stays elided** — nothing references its symbols; the BenMenu surface never enters the link. No guard flip, no `2ship_enh` migration, registrar-elision check for rando_ui remains report-only by design.
- New strong symbols audited against OoT for the #375 collision gate (tracker globals, draw helpers, `BenGui::m*`): no shared mangled names.

## Dispatch wired: `OnSceneInit` (registration is not dispatch)

`MM_GameHooks_ExecuteOnSceneInit` (GameExports_SingleExe.cpp) fires the MM-owned `S2H::GameHooks` OnSceneInit registry (Execute + ExecuteForID; no filter leg, same documented deviation as the Should executors) from `MM_Play_Init` in `z_play.c` — upstream's exact dispatch point, replacing the #344 skip. The skip's two stated hazards were both properties of the *shared* registry (unprefixed name binding OoT's 1-arg executor; divergent hook signatures over merged storage); the MM-owned registry has neither, which is the same argument that wired OnSaveInit/OnSaveLoad/VB in #435. This wakes the check tracker's scroll-to-current-scene hook plus the parked `IS_RANDO`-conditioned OnSceneInit hooks (`Rando::MiscBehavior::OnSceneInit`, open-dungeons `COND_ID_HOOK`s) — all dormant-registered since C0, all no-ops on vanilla saves.

## Lock (ROM-free, redship tier): `mm-trackers-gui`

`games/mm/2s2h/mm_trackers_gui_test.cpp`, row + one `redship_add_test` line. Window registration **is** testable headlessly: a bare `Ship::Gui` (never `Init()`ed — no ImGui context) supports AddGuiWindow/GetGuiWindow after the display-free shared bring-up. The test:

1. occupies SoH's four names with stand-ins, runs `S2H::TrackersGui::RegisterWindows`, and asserts all four MM windows land under de-collided names, the stand-ins keep theirs, a usurping duplicate bounces off, and re-registration is idempotent;
2. asserts `MM_TrackersGui_Init()` is a clean no-op with no window (the state every ROM-free harness's `MM_Rando_Init` sees);
3. flips `Context_SetCurrentGame` and asserts the predicate — **and** calls `Draw()`/`Update()` on every registered window with OoT/none active, with visibility CVars forced on and no ImGui context, so an ungated path reaches `ImGui::Begin` and aborts the process. The gate assertions are tripwires, not smoke. (Draw-with-MM-active needs ImGui + MM play state — operator/integration territory, see below.)

## Operator-visible verification (not CI-provable)

On a build with both archives: boot OoT → switch to MM through the Happy Mask Shop → toggle `gWindows.CheckTracker`/`gWindows.ItemTracker` (console `set`, or MM's tracker settings windows once opened) → MM trackers draw over MM, with icons, and the check tracker scrolls on scene change (the wired dispatch); switch back to OoT → MM windows vanish, OoT's own trackers behave as before.

Scope fence honored: no BenMenu port, no combo tracker, no `2ship_enh` guard flip. Rando/** hunk kept minimal (#439 pairing courtesy — no open PR at time of writing).

Part of #392.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!--- section:artifacts:start -->
### Build Artifacts
  - [rsbs-windows.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/8507180646.zip)
  - [rsbs-linux.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/8506890287.zip)
<!--- section:artifacts:end -->

## The one unresolved external, and how it was resolved

Un-eliding the ItemTracker TUs left exactly one symbol bound to an excluded TU: **`S2H::safeItemsForInventorySlot`**, defined in `games/mm/2s2h/DeveloperTools/SaveEditor.cpp:72` and populated by `initSafeItemsForInventorySlot()` (same file, called from `SaveEditorWindow::InitElement`). Its declaration reaches the trackers via `SaveEditor.h` -> `UIWidgets.hpp`; `ItemTracker.cpp:93` and `ItemTrackerSettings.cpp:38` read `safeItemsForInventorySlot[itemId][0]` as the vanilla-icon fallback for empty inventory slots.

Force-linking `SaveEditor.obj` was rejected — it would drag the whole DeveloperTools/save-editor surface into the link, against this PR's scope fence. Instead the definition plus a **verbatim** copy of the initializer is ported into `TrackersGuiSingleExe.cpp`, following the `SaveEditorTimeSingleExe.cpp` precedent (#422's `UpdateGameTime` port), and populated from `RegisterWindows` — the point where upstream's `InitElement` did it. Including the S2H-wrapped `SaveEditor.h` makes the definition **compiler-checked** against the extern the trackers actually bind.

Two things this changes versus upstream, both audited:

- **The table is now populated on every MM boot**, not only when the save editor window inits. Verified safe: `MM_gItemSlots` is exactly 77 entries (`z_inventory.c:235`) and every entry is a real slot `<= SLOT_MASK_FIERCE_DEITY` (0x2F) — no `SLOT_NONE` (0xFF) — so the `safeItemsForInventorySlot[slot]` writes are all in bounds for the `SLOT_MASK_FIERCE_DEITY + 1` array. Without this port the table would stay empty and the trackers' `[0]` read would be UB, so the port is load-bearing, not cosmetic.
- An **idempotence guard** is added (upstream leaned on `GuiElement::Init`'s once-only); `RegisterWindows` is the single caller, but a re-run must not duplicate entries.

Provenance is commented at the definition: if upstream 2S2H changes `initSafeItemsForInventorySlot`, re-sync this copy.

## Rebase note

Rebased onto `main` after #447, #450, #452, #461, #466. Two interactions checked explicitly: #452's `S2H::` menu-namespace split (no menu-adjacent symbol enters this link — `Menu.obj` stays elided), and #461's new `cvar-classification` source scan (this PR's `gWindows.*` literals are MM-only window CVars; OoT is on `gOpenWindows.*`). Interleave with #461's `test_runner.cpp` additions is purely additive.
