### PR TITLE
Converge MM's volume and tunic CVars onto OoT's keys, add ConfigVersion7Updater + classification lock (#34)

### DIFF
--- a/CMake/SingleExecutable.cmake
+++ b/CMake/SingleExecutable.cmake
@@ -74,6 +74,10 @@ set(REDSHIP_COMMON_HEADERS
     ${CMAKE_SOURCE_DIR}/src/common/game_lifecycle.h
     ${CMAKE_SOURCE_DIR}/src/common/SharedGraphics.h
     ${CMAKE_SOURCE_DIR}/src/common/save.h
+    # The cross-game CVar classification manifest (ADR 0003 + the
+    # enhancement-classification inventory), consumed by OoT's version-7
+    # config updater, the 2Ship importer, and the classification lock.
+    ${CMAKE_SOURCE_DIR}/src/common/cvar_shared_keys.h
 )
 
 # ============================================================================
@@ -106,6 +110,13 @@ target_link_libraries(redship_common PUBLIC
 
 # Define COMBO_BUILDING_DLL so SharedGraphics exports symbols with __declspec(dllexport)
 target_compile_definitions(redship_common PRIVATE COMBO_BUILDING_DLL)
+
+# The CVar classification lock (--test cvar-classification, #34) scans games/
+# for retired and must-stay-distinct key literals, so it needs to find the
+# source tree at runtime. The test degrades to a loud WARNING (not a silent
+# pass) when the path is absent, which is what happens if the binary is run
+# from a relocated artifact rather than its build tree.
+target_compile_definitions(redship_common PRIVATE RSBS_SOURCE_DIR="${CMAKE_SOURCE_DIR}")
 
 set_target_properties(redship_common PROPERTIES
     CXX_STANDARD 20
@@ -276,6 +287,13 @@ if(BUILD_TESTING)
     # write pointer (WRITE AV at 0xA7, first HUD-visible MM frame — caught by
     # int-gameplay-roundtrip on the OoT->MM leg).
     redship_add_test(NAME CosmeticGfxStub COMMAND redship --test cosmetic-gfx-stub)
+    # Cross-game CVar classification lock (#34). Keeps ADR 0003 and
+    # docs/enhancement-classification.md from decaying into prose: fails when a
+    # converged key diverges again, OR when a key the inventory marks per-game
+    # gets merged because the names looked equivalent. The second direction is
+    # the dangerous one — merging OoT's 1-5x text-speed slider with MM's
+    # boolean yields a control that persists a value and does nothing.
+    redship_add_test(NAME CVarClassification COMMAND redship --test cvar-classification)
     redship_add_test(NAME Roundtrip COMMAND redship --test roundtrip)
     redship_add_test(NAME RoundtripIntegrity COMMAND redship --test roundtrip-integrity)
     redship_add_test(NAME SharedRoundtrip COMMAND redship --test shared-roundtrip)

--- a/games/mm/2s2h/BenGui/BenMenu.cpp
+++ b/games/mm/2s2h/BenGui/BenMenu.cpp
@@ -395,63 +395,88 @@ void BenMenu::AddSettings() {
     path.sidebarName = "Audio";
     path.column = SECTION_COLUMN_1;
     AddSidebarEntry("Settings", "Audio", 3);
-    AddWidget(path, "Master Volume: %.0f%%", WIDGET_CVAR_SLIDER_FLOAT)
-        .CVar("gSettings.Audio.MasterVolume")
-        .Options(FloatSliderOptions()
+    // RSBS: these six sliders drive the SAME CVars OoT's Settings > Audio menu
+    // drives (ADR 0003 §5.1) — one setting, one key, both games. That means
+    // adopting OoT's representation as well as its spelling: integer percent
+    // 0-100 on an int slider, not float 0..1, because libultraship returns the
+    // default on a CVar type mismatch and a float reader against OoT's integer
+    // key would never see the user's value. Canonical spellings and defaults
+    // live in src/common/cvar_shared_keys.h.
+    AddWidget(path, "Master Volume: %d%%", WIDGET_CVAR_SLIDER_INT)
+        .CVar("gSettings.Volume.Master")
+        .Options(IntSliderOptions()
                      .Tooltip("Adjust the overall sound volume.")
                      .ShowAdjustmentButtons(false)
                      .Format("")
-                     .IsPercentage());
-    AddWidget(path, "Main Music Volume: %.0f%%", WIDGET_CVAR_SLIDER_FLOAT)
-        .CVar("gSettings.Audio.MainMusicVolume")
+                     .Min(0)
+                     .Max(100)
+                     .DefaultValue(40));
+    AddWidget(path, "Main Music Volume: %d%%", WIDGET_CVAR_SLIDER_INT)
+        .CVar("gSettings.Volume.MainMusic")
         .Callback([](WidgetInfo& info) {
-            AudioSeq_SetPortVolumeScale(SEQ_PLAYER_BGM_MAIN, CVarGetFloat("gSettings.Audio.MainMusicVolume", 1.0f));
+            AudioSeq_SetPortVolumeScale(SEQ_PLAYER_BGM_MAIN,
+                                        (float)CVarGetInteger("gSettings.Volume.MainMusic", 100) / 100.0f);
         })
-        .Options(FloatSliderOptions()
+        .Options(IntSliderOptions()
                      .Tooltip("Adjust the background music volume.")
                      .ShowAdjustmentButtons(false)
                      .Format("")
-                     .IsPercentage());
-    AddWidget(path, "Sub Music Volume: %.0f%%", WIDGET_CVAR_SLIDER_FLOAT)
-        .CVar("gSettings.Audio.SubMusicVolume")
+                     .Min(0)
+                     .Max(100)
+                     .DefaultValue(100));
+    AddWidget(path, "Sub Music Volume: %d%%", WIDGET_CVAR_SLIDER_INT)
+        .CVar("gSettings.Volume.SubMusic")
         .Callback([](WidgetInfo& info) {
-            AudioSeq_SetPortVolumeScale(SEQ_PLAYER_BGM_SUB, CVarGetFloat("gSettings.Audio.SubMusicVolume", 1.0f));
+            AudioSeq_SetPortVolumeScale(SEQ_PLAYER_BGM_SUB,
+                                        (float)CVarGetInteger("gSettings.Volume.SubMusic", 100) / 100.0f);
         })
-        .Options(FloatSliderOptions()
+        .Options(IntSliderOptions()
                      .Tooltip("Adjust the sub music volume.")
                      .ShowAdjustmentButtons(false)
                      .Format("")
-                     .IsPercentage());
-    AddWidget(path, "Sound Effects Volume: %.0f%%", WIDGET_CVAR_SLIDER_FLOAT)
-        .CVar("gSettings.Audio.SoundEffectsVolume")
+                     .Min(0)
+                     .Max(100)
+                     .DefaultValue(100));
+    AddWidget(path, "Sound Effects Volume: %d%%", WIDGET_CVAR_SLIDER_INT)
+        .CVar("gSettings.Volume.SFX")
         .Callback([](WidgetInfo& info) {
-            AudioSeq_SetPortVolumeScale(SEQ_PLAYER_SFX, CVarGetFloat("gSettings.Audio.SoundEffectsVolume", 1.0f));
+            AudioSeq_SetPortVolumeScale(SEQ_PLAYER_SFX, (float)CVarGetInteger("gSettings.Volume.SFX", 100) / 100.0f);
         })
-        .Options(FloatSliderOptions()
+        .Options(IntSliderOptions()
                      .Tooltip("Adjust the sound effects volume.")
                      .ShowAdjustmentButtons(false)
                      .Format("")
-                     .IsPercentage());
-    AddWidget(path, "Fanfare Volume: %.0f%%", WIDGET_CVAR_SLIDER_FLOAT)
-        .CVar("gSettings.Audio.FanfareVolume")
+                     .Min(0)
+                     .Max(100)
+                     .DefaultValue(100));
+    AddWidget(path, "Fanfare Volume: %d%%", WIDGET_CVAR_SLIDER_INT)
+        .CVar("gSettings.Volume.Fanfare")
         .Callback([](WidgetInfo& info) {
-            AudioSeq_SetPortVolumeScale(SEQ_PLAYER_FANFARE, CVarGetFloat("gSettings.Audio.FanfareVolume", 1.0f));
+            AudioSeq_SetPortVolumeScale(SEQ_PLAYER_FANFARE,
+                                        (float)CVarGetInteger("gSettings.Volume.Fanfare", 100) / 100.0f);
         })
-        .Options(FloatSliderOptions()
+        .Options(IntSliderOptions()
                      .Tooltip("Adjust the fanfare volume.")
                      .ShowAdjustmentButtons(false)
                      .Format("")
-                     .IsPercentage());
-    AddWidget(path, "Ambience Volume: %.0f%%", WIDGET_CVAR_SLIDER_FLOAT)
-        .CVar("gSettings.Audio.AmbienceVolume")
+                     .Min(0)
+                     .Max(100)
+                     .DefaultValue(100));
+    // No OoT twin — OoT has no ambience channel — but spelled into the same
+    // family so OoT can adopt the key if it ever gains one.
+    AddWidget(path, "Ambience Volume: %d%%", WIDGET_CVAR_SLIDER_INT)
+        .CVar("gSettings.Volume.Ambience")
         .Callback([](WidgetInfo& info) {
-            AudioSeq_SetPortVolumeScale(SEQ_PLAYER_AMBIENCE, CVarGetFloat("gSettings.Audio.AmbienceVolume", 1.0f));
+            AudioSeq_SetPortVolumeScale(SEQ_PLAYER_AMBIENCE,
+                                        (float)CVarGetInteger("gSettings.Volume.Ambience", 100) / 100.0f);
         })
-        .Options(FloatSliderOptions()
+        .Options(IntSliderOptions()
                      .Tooltip("Adjust the ambient sound volume.")
                      .ShowAdjustmentButtons(false)
                      .Format("")
-                     .IsPercentage());
+                     .Min(0)
+                     .Max(100)
+                     .DefaultValue(100));
     AddWidget(path, "Audio API", WIDGET_AUDIO_BACKEND);
 
     // Graphics Settings
@@ -2028,7 +2053,9 @@ void BenMenu::InitElement() {
         { DISABLE_FOR_MOTION_BLUR_OFF,
           { [](disabledInfo& info) -> bool { return !R_MOTION_BLUR_ENABLED; }, "Motion Blur is disabled" } },
         { DISABLE_FOR_FRAME_ADVANCE_OFF,
-          { [](disabledInfo& info) -> bool { return !(MM_gPlayState != nullptr && MM_gPlayState->frameAdvCtx.enabled); },
+          { [](disabledInfo& info) -> bool {
+               return !(MM_gPlayState != nullptr && MM_gPlayState->frameAdvCtx.enabled);
+           },
             "Frame Advance is Disabled" } },
         { DISABLE_FOR_INTRO_SKIP_OFF,
           { [](disabledInfo& info) -> bool { return !CVarGetInteger("gEnhancements.Cutscenes.SkipIntroSequence", 0); },

--- a/games/mm/2s2h/BenPort.cpp
+++ b/games/mm/2s2h/BenPort.cpp
@@ -488,7 +488,7 @@ void OTRAudio_Thread() {
         s16 audio_buffer[SAMPLES_HIGH * NUM_AUDIO_CHANNELS * 3];
         for (int i = 0; i < AUDIO_FRAMES_PER_UPDATE; i++) {
             MM_AudioMgr_CreateNextAudioBuffer(audio_buffer + i * (num_audio_samples * NUM_AUDIO_CHANNELS),
-                                           num_audio_samples);
+                                              num_audio_samples);
         }
 
         AudioPlayer_Play((u8*)audio_buffer,
@@ -1839,21 +1839,25 @@ Color_RGB8 GetColorForControllerLED() {
         LEDColorSource source =
             static_cast<LEDColorSource>(CVarGetInteger("gLedColorSource", LED_SOURCE_TUNIC_ORIGINAL));
         bool criticalOverride = CVarGetInteger("gLedCriticalOverride", 1);
+        // RSBS: MM was stranded on OoT's PRE-MIGRATION spelling (Link_XTunic),
+        // which OoT retired in its own v3 config table — so the user's OoT
+        // tunic colours never reached MM. Converged onto OoT's live spelling
+        // per ADR 0003 §5.1; canonical keys in src/common/cvar_shared_keys.h.
         if (MM_gPlayState && (source == LED_SOURCE_TUNIC_ORIGINAL || source == LED_SOURCE_TUNIC_COSMETICS)) {
             switch (CUR_EQUIP_VALUE(EQUIP_TUNIC) - 1) {
                 case PLAYER_TUNIC_KOKIRI:
                     color = source == LED_SOURCE_TUNIC_COSMETICS
-                                ? CVarGetColor24("gCosmetics.Link_KokiriTunic.Value", kokiriColor)
+                                ? CVarGetColor24("gCosmetics.Link.KokiriTunic.Value", kokiriColor)
                                 : kokiriColor;
                     break;
                 case PLAYER_TUNIC_GORON:
                     color = source == LED_SOURCE_TUNIC_COSMETICS
-                                ? CVarGetColor24("gCosmetics.Link_GoronTunic.Value", goronColor)
+                                ? CVarGetColor24("gCosmetics.Link.GoronTunic.Value", goronColor)
                                 : goronColor;
                     break;
                 case PLAYER_TUNIC_ZORA:
                     color = source == LED_SOURCE_TUNIC_COSMETICS
-                                ? CVarGetColor24("gCosmetics.Link_ZoraTunic.Value", zoraColor)
+                                ? CVarGetColor24("gCosmetics.Link.ZoraTunic.Value", zoraColor)
                                 : zoraColor;
                     break;
             }
@@ -2175,8 +2179,8 @@ static void MM_InitFirstEntrySaveContext(ComboContext* ctx) {
         gSaveContext.save.isFirstCycle = true;
 
         // Set required flags for rando start (Tatl acquired, etc.)
-        SET_WEEKEVENTREG(WEEKEVENTREG_59_04);  // Tatl flag 1
-        SET_WEEKEVENTREG(WEEKEVENTREG_31_04);  // Tatl flag 2
+        SET_WEEKEVENTREG(WEEKEVENTREG_59_04); // Tatl flag 1
+        SET_WEEKEVENTREG(WEEKEVENTREG_31_04); // Tatl flag 2
 
         // Happy Mask Salesman cutscene flag
         gSaveContext.save.saveInfo.permanentSceneFlags[SCENE_INSIDETOWER].switch0 |= (1 << 0);
@@ -2222,8 +2226,7 @@ void MM_FreezeState(ComboContext* ctx) {
         ctx->sharedRandoSeed = gSaveContext.save.shipSaveInfo.rando.finalSeed;
     }
 
-    fprintf(stderr, "[MM] State frozen, return entrance: 0x%04X, isRando: %d\n",
-            returnEntrance, ctx->sourceIsRando);
+    fprintf(stderr, "[MM] State frozen, return entrance: 0x%04X, isRando: %d\n", returnEntrance, ctx->sourceIsRando);
 }
 
 /**

--- a/games/mm/src/audio/lib/playback.c
+++ b/games/mm/src/audio/lib/playback.c
@@ -110,7 +110,11 @@ void AudioPlayback_InitSampleState(Note* note, NoteSampleState* sampleState, Not
     velocity = 0.0f > velocity ? 0.0f : velocity;
     velocity = 1.0f < velocity ? 1.0f : velocity;
 
-    float master_vol = CVarGetFloat("gSettings.Audio.MasterVolume", 1.0f);
+    // RSBS: one master volume for both games (ADR 0003 §5.1). OoT stores this
+    // key as integer percent, so read it the way OoT's audio_playback.c does —
+    // CVarGetFloat on an Integer-typed CVar returns the default and the slider
+    // would silently never apply. Canonical spelling: src/common/cvar_shared_keys.h
+    float master_vol = (float)CVarGetInteger("gSettings.Volume.Master", 40) / 100.0f;
     sampleState->targetVolLeft = (s32)((velocity * volLeft) * (0x1000 - 0.001f)) * master_vol;
     sampleState->targetVolRight = (s32)((velocity * volRight) * (0x1000 - 0.001f)) * master_vol;
 

--- a/games/mm/src/code/audio_thread_manager.c
+++ b/games/mm/src/code/audio_thread_manager.c
@@ -123,11 +123,17 @@ void MM_AudioMgr_Init(AudioMgr* audioMgr, void* stack, OSPri pri, OSId id, Sched
     MM_Audio_InitSound();
     MM_osSendMesg(&audioMgr->lockQueue, OS_MESG_PTR(NULL), OS_MESG_BLOCK);
 
-    AudioSeq_SetPortVolumeScale(SEQ_PLAYER_BGM_MAIN, CVarGetFloat("gSettings.Audio.MainMusicVolume", 1.0f));
-    AudioSeq_SetPortVolumeScale(SEQ_PLAYER_BGM_SUB, CVarGetFloat("gSettings.Audio.SubMusicVolume", 1.0f));
-    AudioSeq_SetPortVolumeScale(SEQ_PLAYER_SFX, CVarGetFloat("gSettings.Audio.SoundEffectsVolume", 1.0f));
-    AudioSeq_SetPortVolumeScale(SEQ_PLAYER_FANFARE, CVarGetFloat("gSettings.Audio.FanfareVolume", 1.0f));
-    AudioSeq_SetPortVolumeScale(SEQ_PLAYER_AMBIENCE, CVarGetFloat("gSettings.Audio.AmbienceVolume", 1.0f));
+    // RSBS: the volume sliders are one setting across both games (ADR 0003
+    // §5.1), spelled OoT-style and stored as integer percent. Reading these
+    // with CVarGetFloat would return the default forever, because libultraship
+    // returns the default on a CVar type mismatch. Canonical spellings live in
+    // src/common/cvar_shared_keys.h. Ambience has no OoT twin but keeps the
+    // family spelling so OoT can adopt it if it ever gains the channel.
+    AudioSeq_SetPortVolumeScale(SEQ_PLAYER_BGM_MAIN, (float)CVarGetInteger("gSettings.Volume.MainMusic", 100) / 100.0f);
+    AudioSeq_SetPortVolumeScale(SEQ_PLAYER_BGM_SUB, (float)CVarGetInteger("gSettings.Volume.SubMusic", 100) / 100.0f);
+    AudioSeq_SetPortVolumeScale(SEQ_PLAYER_SFX, (float)CVarGetInteger("gSettings.Volume.SFX", 100) / 100.0f);
+    AudioSeq_SetPortVolumeScale(SEQ_PLAYER_FANFARE, (float)CVarGetInteger("gSettings.Volume.Fanfare", 100) / 100.0f);
+    AudioSeq_SetPortVolumeScale(SEQ_PLAYER_AMBIENCE, (float)CVarGetInteger("gSettings.Volume.Ambience", 100) / 100.0f);
 
     // MM_osCreateThread(&audioMgr->thread, id, MM_AudioMgr_ThreadEntry, audioMgr, stack, pri);
     // MM_osStartThread(&audioMgr->thread);

--- a/games/oot/soh/OTRGlobals.cpp
+++ b/games/oot/soh/OTRGlobals.cpp
@@ -1739,7 +1739,7 @@ static void InitOTRImpl(int argc, char* argv[], bool runExtract) {
     // through the same convergence table version 7 uses. Must run AFTER the
     // version updates so the imported keys land in their converged spelling
     // and cannot be re-migrated. No-op when there is nothing to import.
-    SOH::ImportTwoShipConfig(conf);
+    SOH::ImportTwoShipConfig(conf.get());
 
     // The SoH GUI windows load OoT game assets while they initialize
     // (Plandomizer/ItemTracker icons, cosmetics Gfx patches), and LUS's

--- a/games/oot/soh/OTRGlobals.cpp
+++ b/games/oot/soh/OTRGlobals.cpp
@@ -135,6 +135,7 @@
 #include "soh/resource/importer/BackgroundFactory.h"
 
 #include "soh/config/ConfigUpdaters.h"
+#include "soh/config/TwoShipImport.h"
 #include "soh/ShipInit.hpp"
 
 // Runtime feature flags for debugging - set env var to "1" to disable subsystem
@@ -1729,7 +1730,16 @@ static void InitOTRImpl(int argc, char* argv[], bool runExtract) {
     conf->RegisterVersionUpdater(std::make_shared<SOH::ConfigVersion4Updater>());
     conf->RegisterVersionUpdater(std::make_shared<SOH::ConfigVersion5Updater>());
     conf->RegisterVersionUpdater(std::make_shared<SOH::ConfigVersion6Updater>());
+    // RSBS: cross-game key convergence — MM moves onto OoT's spelling for
+    // settings both games mean identically (ADR 0003 §5.1).
+    conf->RegisterVersionUpdater(std::make_shared<SOH::ConfigVersion7Updater>());
     conf->RunVersionUpdates();
+
+    // RSBS: one-shot import of an existing 2Ship2Harkinian config, mapped
+    // through the same convergence table version 7 uses. Must run AFTER the
+    // version updates so the imported keys land in their converged spelling
+    // and cannot be re-migrated. No-op when there is nothing to import.
+    SOH::ImportTwoShipConfig(conf);
 
     // The SoH GUI windows load OoT game assets while they initialize
     // (Plandomizer/ItemTracker icons, cosmetics Gfx patches), and LUS's

--- a/games/oot/soh/config/ConfigMigrators.h
+++ b/games/oot/soh/config/ConfigMigrators.h
@@ -8,6 +8,25 @@ namespace SOH {
 enum class MigrationAction {
     Rename,
     Remove,
+    /**
+     * RSBS (ADR 0003 §6.3). Like Rename, but the destination wins a conflict.
+     *
+     * Plain Rename is CVarCopy-then-CVarClear, and CVarCopy overwrites
+     * unconditionally. That is correct when `from` is a spelling this port
+     * itself retired, because only one of the two keys can ever have held a
+     * user's value. It is WRONG for the cross-game convergence in
+     * version7Migrations: a config can legitimately hold both
+     * gSettings.Volume.Master (written by OoT's live menu) and
+     * gSettings.Audio.MasterVolume (hand-edited, or imported from a 2Ship
+     * preset), and a plain Rename would let the MM-spelled value clobber the
+     * OoT one.
+     *
+     * RenameIfAbsent adopts `from` only when `to` does not already exist. The
+     * OoT-spelled value is the one the user could actually have set through a
+     * live menu, so it is the one they last saw take effect. `from` is cleared
+     * either way — the legacy spelling retires regardless of who won.
+     */
+    RenameIfAbsent,
 };
 
 struct Migration {
@@ -1538,5 +1557,36 @@ std::vector<Migration> version6Migrations = {
     { MigrationAction::Remove, "gSettings.WalkModifier.SwimMapping1" },
     { MigrationAction::Remove, "gSettings.WalkModifier.SwimMapping2" },
     { MigrationAction::Remove, "gSettings.WalkModifier.Mod2Btn" },
+};
+
+/**
+ * RSBS version 7 — cross-game key convergence (ADR 0003 §5.1 / §6.2).
+ *
+ * MM moves onto OoT's spelling for settings both games mean identically. Only
+ * the character-colour rows live here: they are pure renames, so the
+ * declarative table expresses them completely.
+ *
+ * The SIX audio-volume rows are deliberately NOT in this table. They are not
+ * renames — OoT stores volume as integer percent (0-100) while MM stored float
+ * (0..1), and libultraship returns the DEFAULT on a CVar type mismatch, so a
+ * CVarCopy across one of them produces a key the reader silently ignores.
+ * Those rows need a value transform and are applied imperatively in
+ * ConfigVersion7Updater::Update, exactly as ConfigVersion3Updater already does
+ * for OoT's own float-to-percent volume migration.
+ *
+ * Both halves are driven by ONE manifest — RSBS::kConvergedKeys in
+ * src/common/cvar_shared_keys.h, which the 2Ship importer also consumes so the
+ * updater and the importer cannot drift. `--test cvar-classification` asserts
+ * this table still agrees with the manifest.
+ *
+ * These three are issue #453: MM reads OoT's PRE-MIGRATION underscore spelling,
+ * which OoT's own version-3 table renames away (see line ~482 above). MM was
+ * never updated, so after any OoT migration MM's tunic colours read a key
+ * nothing writes and fall back to hardcoded defaults permanently.
+ */
+std::vector<Migration> version7Migrations = {
+    { MigrationAction::RenameIfAbsent, "gCosmetics.Link_KokiriTunic.Value", "gCosmetics.Link.KokiriTunic.Value" },
+    { MigrationAction::RenameIfAbsent, "gCosmetics.Link_GoronTunic.Value", "gCosmetics.Link.GoronTunic.Value" },
+    { MigrationAction::RenameIfAbsent, "gCosmetics.Link_ZoraTunic.Value", "gCosmetics.Link.ZoraTunic.Value" },
 };
 } // namespace SOH

--- a/games/oot/soh/config/ConfigUpdaters.cpp
+++ b/games/oot/soh/config/ConfigUpdaters.cpp
@@ -2,6 +2,11 @@
 #include "ConfigMigrators.h"
 #include "soh/Enhancements/audio/AudioCollection.h"
 
+// src/common — the cross-game CVar classification manifest (ADR 0003 / the
+// enhancement-classification inventory). Version 7's convergence rows and the
+// 2Ship importer both read kConvergedKeys from here.
+#include "cvar_shared_keys.h"
+
 namespace SOH {
 ConfigVersion1Updater::ConfigVersion1Updater() : ConfigVersionUpdater(1) {
 }
@@ -14,6 +19,8 @@ ConfigVersion4Updater::ConfigVersion4Updater() : ConfigVersionUpdater(4) {
 ConfigVersion5Updater::ConfigVersion5Updater() : ConfigVersionUpdater(5) {
 }
 ConfigVersion6Updater::ConfigVersion6Updater() : ConfigVersionUpdater(6) {
+}
+ConfigVersion7Updater::ConfigVersion7Updater() : ConfigVersionUpdater(7) {
 }
 
 void ConfigVersion1Updater::Update(Ship::Config* conf) {
@@ -140,6 +147,73 @@ void ConfigVersion6Updater::Update(Ship::Config* conf) {
             CVarCopy(migration.from.c_str(), migration.to.value().c_str());
         }
         CVarClear(migration.from.c_str());
+    }
+}
+
+// ============================================================================
+// Version 7 — cross-game key convergence (ADR 0003 §5.1, §6.2-6.3)
+// ============================================================================
+
+/**
+ * Is this CVar set at all?
+ *
+ * NOT `CVarExists` — libultraship declares that in consolevariablebridge.h and
+ * never defines it anywhere, so calling it is a link error rather than a
+ * presence check. `CVarGet` is the real accessor and is what the bridge's own
+ * Register* paths use to test presence.
+ */
+static bool CVarPresent(const char* name) {
+    return CVarGet(name) != nullptr;
+}
+
+bool ShouldAdoptLegacyValue(bool legacyPresent, bool canonicalPresent) {
+    // Nothing to adopt, or OoT's value already stands. Either way the legacy
+    // key is cleared by the caller — the retired spelling goes away regardless
+    // of who won, so this migration is not re-runnable and cannot oscillate.
+    return legacyPresent && !canonicalPresent;
+}
+
+int32_t VolumePercentFromFloatScale(float scale) {
+    if (!(scale > 0.0f)) { // also catches NaN, which compares false everywhere
+        return 0;
+    }
+    if (scale > 1.0f) {
+        return 100;
+    }
+    return (int32_t)(scale * 100.0f);
+}
+
+void ConfigVersion7Updater::Update(Ship::Config* conf) {
+    // Character colours: pure renames, so the declarative table covers them.
+    for (Migration migration : version7Migrations) {
+        if (migration.action == MigrationAction::RenameIfAbsent) {
+            if (ShouldAdoptLegacyValue(CVarPresent(migration.from.c_str()),
+                                       CVarPresent(migration.to.value().c_str()))) {
+                CVarCopy(migration.from.c_str(), migration.to.value().c_str());
+            }
+        } else if (migration.action == MigrationAction::Rename) {
+            CVarCopy(migration.from.c_str(), migration.to.value().c_str());
+        }
+        CVarClear(migration.from.c_str());
+    }
+
+    // Audio volume: a rename AND a representation change. MM stored a float
+    // scale; OoT stores integer percent, and every reader of the canonical key
+    // calls CVarGetInteger. Copying the Float-typed CVar across would leave a
+    // value that libultraship's type check rejects, so the slider would read
+    // its default forever — the same silent-no-op this whole convergence
+    // exists to remove. Same conflict rule as above: OoT's value wins.
+    //
+    // Driven by the shared manifest rather than a local list, so the importer
+    // and this updater cannot disagree about what maps to what.
+    for (const RSBS::ConvergedKey& key : RSBS::kConvergedKeys) {
+        if (!key.scaledPercent) {
+            continue; // handled by version7Migrations above
+        }
+        if (ShouldAdoptLegacyValue(CVarPresent(key.legacy), CVarPresent(key.canonical))) {
+            CVarSetInteger(key.canonical, VolumePercentFromFloatScale(CVarGetFloat(key.legacy, 1.0f)));
+        }
+        CVarClear(key.legacy);
     }
 }
 } // namespace SOH

--- a/games/oot/soh/config/ConfigUpdaters.h
+++ b/games/oot/soh/config/ConfigUpdaters.h
@@ -38,4 +38,50 @@ class ConfigVersion6Updater final : public Ship::ConfigVersionUpdater {
     ConfigVersion6Updater();
     void Update(Ship::Config* conf);
 };
+
+/**
+ * RSBS version 7 — cross-game key convergence (ADR 0003 §5.1, §6.2-6.3).
+ *
+ * Moves MM onto OoT's spelling for settings both games mean identically, so a
+ * volume slider or a tunic colour set in one game is the same setting in the
+ * other. Zero-loss: every row copies before it clears, and a row whose legacy
+ * key is absent is a no-op.
+ */
+class ConfigVersion7Updater final : public Ship::ConfigVersionUpdater {
+  public:
+    ConfigVersion7Updater();
+    void Update(Ship::Config* conf);
+};
+
+/**
+ * @brief The ADR 0003 §6.3 conflict rule, as a pure predicate.
+ *
+ * A config can legitimately hold BOTH spellings of a converged setting: the
+ * OoT one written by OoT's live menu, and the MM one hand-edited or imported
+ * from a 2Ship preset. They can disagree. CVarCopy overwrites unconditionally,
+ * so the plain rename pattern would let the MM-spelled value clobber the OoT
+ * one — the wrong winner.
+ *
+ * Rule: **OoT's value wins.** The MM-spelled value is adopted only when the
+ * OoT key is absent. The OoT-spelled value is the one the user could have set
+ * through a live menu, so it is the one they last saw take effect.
+ *
+ * Factored out (rather than inlined into Update) so the ROM-free CTest tier can
+ * exercise the decision itself — the same shape as the sequence-map bound
+ * functions #371/#378 pulled out for `--test seq-map-bounds`.
+ *
+ * @return true if the legacy value should be adopted into the canonical key.
+ */
+bool ShouldAdoptLegacyValue(bool legacyPresent, bool canonicalPresent);
+
+/**
+ * @brief Float scale (0..1) to OoT's integer percent (0-100), clamped.
+ *
+ * MM stored volumes as a float scale; OoT stores integer percent. Converging
+ * the key without converting the value would leave a Float-typed CVar under a
+ * key whose readers all call CVarGetInteger — and libultraship returns the
+ * DEFAULT on a type mismatch, so the user's imported volume would silently
+ * never apply. Clamped because a hand-edited config can hold anything.
+ */
+int32_t VolumePercentFromFloatScale(float scale);
 } // namespace SOH

--- a/games/oot/soh/config/TwoShipImport.cpp
+++ b/games/oot/soh/config/TwoShipImport.cpp
@@ -1,0 +1,240 @@
+#include "TwoShipImport.h"
+#include "ConfigUpdaters.h"
+
+// src/common — the cross-game CVar classification manifest. The importer and
+// ConfigVersion7Updater read the SAME table, so they cannot disagree about
+// what maps to what (ADR 0003 §6.4).
+#include "cvar_shared_keys.h"
+
+#include <cstdint>
+#include <filesystem>
+#include <fstream>
+#include <string>
+#include <vector>
+
+#include <nlohmann/json.hpp>
+#include <spdlog/spdlog.h>
+
+namespace SOH {
+
+const char* const kTwoShipImportStampKey = "TwoShipImport.Completed";
+
+namespace {
+
+constexpr const char* kTwoShipAppShortName = "2ship";
+constexpr const char* kTwoShipConfigFileName = "2ship2harkinian.json";
+
+/**
+ * Walk a dotted CVar name through 2Ship's NESTED config json.
+ *
+ * `gSettings.Audio.MasterVolume` is stored as
+ * `CVars > gSettings > Audio > MasterVolume`, so the lookup is a segment walk
+ * rather than a flat map hit. Returns nullptr when any segment is missing.
+ */
+const nlohmann::json* FindNested(const nlohmann::json& cvars, const std::string& dottedKey) {
+    const nlohmann::json* node = &cvars;
+    std::size_t start = 0;
+
+    while (start <= dottedKey.size()) {
+        const std::size_t dot = dottedKey.find('.', start);
+        const std::string segment = dottedKey.substr(start, dot == std::string::npos ? std::string::npos : dot - start);
+
+        if (!node->is_object() || !node->contains(segment)) {
+            return nullptr;
+        }
+        node = &(*node)[segment];
+
+        if (dot == std::string::npos) {
+            return node;
+        }
+        start = dot + 1;
+    }
+    return nullptr;
+}
+
+/**
+ * 2Ship's own config migrations, replayed against an imported json.
+ *
+ * ADR 0003 §6.4's ordering hazard: a legacy `2ship2harkinian.json` must be
+ * brought up to 2Ship's own config version BEFORE key mapping, or a pre-v1
+ * file imports mis-keyed. `Ben::ConfigVersion1Updater` cannot be reused for
+ * this — it mutates the LIVE CVar store through CVarCopy/CVarClear, which is
+ * the wrong target for a file we are only reading — so its key mapping is
+ * replayed here against the parsed json instead.
+ *
+ * None of 2Ship's v1 rows currently intersect the convergence table (v1 renames
+ * `gFixes.FixAmmoCountEnvColor` and reshapes `gDisplayOverlay`, neither of which
+ * is a converged key), so today this is a no-op for everything we import. It
+ * exists so that a future 2Ship version that DOES touch a converged key is
+ * handled at the correct point in the pipeline rather than silently mis-keyed.
+ */
+void ApplyTwoShipVersionUpdates(nlohmann::json& cvars, uint32_t sourceVersion) {
+    struct SourceMigration {
+        uint32_t introducedIn;
+        const char* from;
+        const char* to;
+    };
+    static constexpr SourceMigration kSourceMigrations[] = {
+        { 1, "gFixes.FixAmmoCountEnvColor", "gFixes.FixButtonEnvColor" },
+    };
+
+    for (const SourceMigration& migration : kSourceMigrations) {
+        if (sourceVersion >= migration.introducedIn) {
+            continue; // the source file already applied this one
+        }
+        const nlohmann::json* value = FindNested(cvars, migration.from);
+        if (value == nullptr) {
+            continue;
+        }
+        // Write through the flat pointer form so intermediate objects are
+        // created as needed, matching how the destination store nests keys.
+        std::string pointer = "/";
+        for (char c : std::string(migration.to)) {
+            pointer += (c == '.') ? '/' : c;
+        }
+        cvars[nlohmann::json::json_pointer(pointer)] = *value;
+    }
+}
+
+/** Is this CVar already set in the LIVE store? See ConfigUpdaters.cpp. */
+bool CVarPresent(const char* name) {
+    return CVarGet(name) != nullptr;
+}
+
+/**
+ * Adopt one imported value into the live store under its canonical spelling.
+ *
+ * Applies ADR 0003 §6.3's conflict rule: OoT's value wins, so an imported
+ * value lands only where the canonical key is currently unset. A 2Ship user
+ * who has also been playing RSBS keeps what they set in RSBS's own menu.
+ */
+bool AdoptImportedValue(const RSBS::ConvergedKey& key, const nlohmann::json& value) {
+    if (!ShouldAdoptLegacyValue(/*legacyPresent=*/true, CVarPresent(key.canonical))) {
+        return false;
+    }
+
+    if (key.scaledPercent) {
+        // 2Ship stored volume as a float scale; OoT stores integer percent and
+        // every reader calls CVarGetInteger. Importing the raw float would
+        // produce a key whose readers all fall back to their default.
+        if (!value.is_number()) {
+            return false;
+        }
+        CVarSetInteger(key.canonical, VolumePercentFromFloatScale(value.get<float>()));
+        return true;
+    }
+
+    // Colours serialize as a nested {R,G,B,Type} object, not a scalar.
+    if (value.is_object() && value.contains("R") && value.contains("G") && value.contains("B")) {
+        Color_RGB8 color;
+        color.r = (uint8_t)value["R"].get<uint32_t>();
+        color.g = (uint8_t)value["G"].get<uint32_t>();
+        color.b = (uint8_t)value["B"].get<uint32_t>();
+        CVarSetColor24(key.canonical, color);
+        return true;
+    }
+
+    if (value.is_number_integer() || value.is_boolean()) {
+        CVarSetInteger(key.canonical, value.get<int32_t>());
+        return true;
+    }
+    if (value.is_number_float()) {
+        CVarSetFloat(key.canonical, value.get<float>());
+        return true;
+    }
+    if (value.is_string()) {
+        CVarSetString(key.canonical, value.get<std::string>().c_str());
+        return true;
+    }
+    return false;
+}
+
+/** Where a standalone 2Ship install would have left its config. */
+std::vector<std::string> CandidateSourcePaths() {
+    std::vector<std::string> paths;
+    paths.push_back(Ship::Context::GetPathRelativeToAppDirectory(kTwoShipConfigFileName, kTwoShipAppShortName));
+    // Portable installs keep the json beside the executable rather than in the
+    // per-app data directory.
+    paths.push_back(std::string("./") + kTwoShipConfigFileName);
+    return paths;
+}
+
+} // namespace
+
+bool ImportTwoShipConfig(Ship::Config* conf) {
+    if (conf == nullptr) {
+        return false;
+    }
+
+    // Run-once. Stamped even when there was nothing to import, so a user
+    // without a 2Ship install does not re-probe the filesystem every boot.
+    if (conf->GetBool(kTwoShipImportStampKey, false)) {
+        return false;
+    }
+
+    std::string sourcePath;
+    for (const std::string& candidate : CandidateSourcePaths()) {
+        std::error_code ec;
+        if (!candidate.empty() && std::filesystem::exists(candidate, ec) && !ec) {
+            sourcePath = candidate;
+            break;
+        }
+    }
+
+    if (sourcePath.empty()) {
+        // Nothing to import. Stamp anyway — see above.
+        conf->SetBool(kTwoShipImportStampKey, true);
+        conf->Save();
+        return false;
+    }
+
+    nlohmann::json source;
+    try {
+        std::ifstream file(sourcePath);
+        if (!file.is_open()) {
+            SPDLOG_WARN("2Ship config import: cannot open {}, skipping", sourcePath);
+            return false;
+        }
+        file >> source;
+    } catch (const std::exception& e) {
+        // A malformed source file is the user's problem to fix, not a reason to
+        // fail RSBS's boot. Do NOT stamp: a corrupt file they later repair
+        // should still get imported.
+        SPDLOG_WARN("2Ship config import: {} is not valid JSON ({}), skipping", sourcePath, e.what());
+        return false;
+    }
+
+    if (!source.contains("CVars") || !source["CVars"].is_object()) {
+        conf->SetBool(kTwoShipImportStampKey, true);
+        conf->Save();
+        return false;
+    }
+
+    nlohmann::json cvars = source["CVars"];
+    const uint32_t sourceVersion = source.value("ConfigVersion", 0u);
+    ApplyTwoShipVersionUpdates(cvars, sourceVersion);
+
+    int imported = 0;
+    int skipped = 0;
+    for (const RSBS::ConvergedKey& key : RSBS::kConvergedKeys) {
+        const nlohmann::json* value = FindNested(cvars, key.legacy);
+        if (value == nullptr) {
+            continue;
+        }
+        if (AdoptImportedValue(key, *value)) {
+            imported++;
+        } else {
+            skipped++;
+        }
+    }
+
+    conf->SetBool(kTwoShipImportStampKey, true);
+    conf->Save();
+    Ship::Context::GetInstance()->GetConsoleVariables()->Save();
+
+    SPDLOG_INFO("2Ship config import from {} (source version {}): {} setting(s) adopted, {} already set in RSBS",
+                sourcePath, sourceVersion, imported, skipped);
+    return imported > 0;
+}
+
+} // namespace SOH

--- a/games/oot/soh/config/TwoShipImport.h
+++ b/games/oot/soh/config/TwoShipImport.h
@@ -1,0 +1,49 @@
+#pragma once
+
+#include "libultraship/libultraship.h"
+
+namespace SOH {
+
+/**
+ * @brief One-shot import of an existing 2Ship2Harkinian config (issue #34).
+ *
+ * A user arriving from a standalone 2Ship install has their settings in
+ * `2ship2harkinian.json` under 2Ship's own app directory. RSBS runs from
+ * `shipofharkinian.json`, so without this those settings are simply invisible.
+ *
+ * Scope, per ADR 0003 §6.4: this imports the CONVERGED keys only — the
+ * settings where MM's spelling moved onto OoT's — mapped through the same
+ * `RSBS::kConvergedKeys` manifest that `ConfigVersion7Updater` uses, so the
+ * updater and the importer cannot drift. Keys MM still owns outright are
+ * already spelled identically in both files and need no mapping; keys the
+ * classification marks per-game or disputed are deliberately not touched.
+ *
+ * Guarantees:
+ *   - **Runs at most once.** Stamped by a flag in the destination config.
+ *   - **Never overwrites a value OoT could have written.** Same conflict rule
+ *     as version 7: the OoT-spelled value wins; the imported value is adopted
+ *     only where the OoT key is absent.
+ *   - **No-op** when the source file is missing, unreadable, or malformed.
+ *     A user with no 2Ship install pays nothing and sees nothing.
+ *   - **Read-only on the source.** `2ship2harkinian.json` is never modified,
+ *     so a standalone 2Ship install keeps working unchanged.
+ *
+ * Must be called AFTER `RunVersionUpdates()`, so imported values land in their
+ * converged spelling and are not re-migrated by a version updater that has
+ * already run.
+ *
+ * @param conf The destination (RSBS) config — used for the run-once stamp.
+ * @return true if an import was performed on this call.
+ */
+bool ImportTwoShipConfig(Ship::Config* conf);
+
+/**
+ * @brief The run-once stamp key, exposed for tests and diagnostics.
+ *
+ * Lives in the destination config rather than beside the CVars so that a user
+ * clearing their CVars does not silently re-arm a second import over settings
+ * they have since changed.
+ */
+extern const char* const kTwoShipImportStampKey;
+
+} // namespace SOH

--- a/src/common/cvar_shared_keys.h
+++ b/src/common/cvar_shared_keys.h
@@ -1,0 +1,359 @@
+/**
+ * @file cvar_shared_keys.h
+ * @brief The checked-in CVar classification manifest — the executable form of
+ *        ADR 0003 + ADR 0004's classification inventory.
+ *
+ * RedShipBlueShip runs both games in one process against ONE CVar store backed
+ * by ONE config file (`shipofharkinian.json`). Two documents govern that
+ * keyspace, and this header is where they become something CI can enforce:
+ *
+ *   - `docs/adr/0003-settings-namespace.md` — the policy (unify by default,
+ *     one key both games read, converge MM onto OoT).
+ *   - `docs/enhancement-classification.md` — the per-setting inventory, which
+ *     classified at individual-setting level with per-key verification.
+ *     **Where the two disagree, the inventory wins**, because it verified each
+ *     key's type, range, and implementation rather than its name.
+ *
+ * `--test cvar-classification` (src/common/tests/test_cvar_classification.c)
+ * fails the build when the tree drifts away from the tables below.
+ *
+ * The three settled premises, restated so nobody has to go find the ADR:
+ *
+ *   1. Settings are UNIFIED BY DEFAULT. "In general, this is conceptually one
+ *      game. If something applying to both makes sense, it should."
+ *   2. One CVar, read directly by both ports. No fan-out layer, no per-game
+ *      shadow keys, no gCore/gOoT/gMM partition.
+ *   3. Where both games mean the same thing under different key names, MM
+ *      moves to OoT's key. SoH is the host port owning the config.
+ *
+ * ============================================================================
+ * READ THIS BEFORE "FIXING" A SHARED KEY
+ * ============================================================================
+ *
+ * A key read by both games is NOT a bug by itself. The inventory measured 35
+ * exact collisions and found 33 of them CORRECT AND DELIBERATE. The five
+ * `gCheats.*` keys below are the ones most likely to be mistaken for a
+ * collision defect: they are shared on purpose, and the inventory verified
+ * per-key that the two implementations genuinely match. Turning on infinite
+ * health is a statement about how the user wants to play RSBS, not about
+ * which of the two games happens to be in front. Namespacing them would be a
+ * regression, and this lock will fail if you try.
+ *
+ * ============================================================================
+ * AND READ THIS BEFORE CONVERGING A KEY BECAUSE THE NAMES LOOK EQUIVALENT
+ * ============================================================================
+ *
+ * Names are not semantics. `kMustStayDistinct` below holds pairs that read as
+ * obvious renames and are not — merging them produces a control that silently
+ * does nothing, or drops a setting on one side. The canonical example is text
+ * speed: OoT's is a 1-5x integer multiplier, MM's is a boolean, and writing
+ * MM's `1` into OoT's key means "1x = no speedup". The toggle would appear in
+ * the menu, respond to clicks, persist its value, and have no effect.
+ */
+
+#ifndef RSBS_CVAR_SHARED_KEYS_H
+#define RSBS_CVAR_SHARED_KEYS_H
+
+/* ==========================================================================
+ * Converged keys — canonical OoT spellings.
+ *
+ * MM used to spell these differently, so the setting silently did not cross
+ * the game boundary. The RSBS_CVAR_LEGACY_* spellings are what MM read before
+ * this change; they are retired and must not reappear anywhere in games/.
+ * ========================================================================== */
+
+/* Audio volume. OoT stores these as INTEGER PERCENT (0-100), not float 0..1 —
+ * see the representation note below, which is the correction this work made to
+ * ADR 0003 §5.1. */
+#define RSBS_CVAR_VOLUME_MASTER "gSettings.Volume.Master"
+#define RSBS_CVAR_VOLUME_MAIN_MUSIC "gSettings.Volume.MainMusic"
+#define RSBS_CVAR_VOLUME_SUB_MUSIC "gSettings.Volume.SubMusic"
+#define RSBS_CVAR_VOLUME_SFX "gSettings.Volume.SFX"
+#define RSBS_CVAR_VOLUME_FANFARE "gSettings.Volume.Fanfare"
+/* No OoT twin: OoT has no ambience channel. Spelled OoT-style anyway so the
+ * family stays consistent and OoT can adopt the key if it ever gains one. */
+#define RSBS_CVAR_VOLUME_AMBIENCE "gSettings.Volume.Ambience"
+
+#define RSBS_CVAR_LEGACY_VOLUME_MASTER "gSettings.Audio.MasterVolume"
+#define RSBS_CVAR_LEGACY_VOLUME_MAIN_MUSIC "gSettings.Audio.MainMusicVolume"
+#define RSBS_CVAR_LEGACY_VOLUME_SUB_MUSIC "gSettings.Audio.SubMusicVolume"
+#define RSBS_CVAR_LEGACY_VOLUME_SFX "gSettings.Audio.SoundEffectsVolume"
+#define RSBS_CVAR_LEGACY_VOLUME_FANFARE "gSettings.Audio.FanfareVolume"
+#define RSBS_CVAR_LEGACY_VOLUME_AMBIENCE "gSettings.Audio.AmbienceVolume"
+
+/* Character colour — issue #453, inventory §3.3 BUG 1 / §4 row P4.
+ *
+ * Not a collision: a STALE-KEY DESYNC. OoT reads the dot form and its own v3
+ * migrator actively renames the underscore form away, so the key MM reads is
+ * one OoT has already migrated out of existence. After any OoT config
+ * migration runs, MM's tunic colours read a key nothing writes and fall back
+ * to hardcoded defaults permanently, with no UI to correct it. MM applies
+ * these to the Deku/Goron/Zora forms where OoT applies them to the tunics:
+ * different garment, same user intent. Converge as a FIX, not a plain rename. */
+#define RSBS_CVAR_COLOR_KOKIRI_TUNIC "gCosmetics.Link.KokiriTunic.Value"
+#define RSBS_CVAR_COLOR_GORON_TUNIC "gCosmetics.Link.GoronTunic.Value"
+#define RSBS_CVAR_COLOR_ZORA_TUNIC "gCosmetics.Link.ZoraTunic.Value"
+
+#define RSBS_CVAR_LEGACY_COLOR_KOKIRI_TUNIC "gCosmetics.Link_KokiriTunic.Value"
+#define RSBS_CVAR_LEGACY_COLOR_GORON_TUNIC "gCosmetics.Link_GoronTunic.Value"
+#define RSBS_CVAR_LEGACY_COLOR_ZORA_TUNIC "gCosmetics.Link_ZoraTunic.Value"
+
+/* ==========================================================================
+ * OoT's defaults for the converged volume family.
+ *
+ * These are the values OoT's menu and read sites already use
+ * (SohMenuSettings.cpp, audio_playback.c, audioMgr.c). MM adopts them: a
+ * converged setting has to have ONE default too, or a fresh config still
+ * sounds different in the two games.
+ * ========================================================================== */
+#define RSBS_VOLUME_DEFAULT_MASTER 40
+#define RSBS_VOLUME_DEFAULT_OTHER 100
+
+/* Percent -> linear scale, the expression OoT's own read sites use. */
+#define RSBS_VOLUME_SCALE(percent) ((float)(percent) / 100.0f)
+
+#ifdef __cplusplus
+
+#include <cstddef>
+
+namespace RSBS {
+
+/** One converged setting: the retired MM spelling and the canonical OoT one. */
+struct ConvergedKey {
+    const char* legacy;    ///< MM's pre-convergence spelling. Retired.
+    const char* canonical; ///< OoT's spelling. The single source of truth.
+    /// True when the two sides also disagreed about REPRESENTATION, not just
+    /// spelling — OoT stores integer percent, MM stored float 0..1. libultraship
+    /// returns the DEFAULT on a CVar type mismatch, so a plain CVarCopy across
+    /// one of these is a type-punned no-op: the version-7 updater must convert
+    /// rather than rename, and MM's read sites must read integers.
+    bool scaledPercent;
+};
+
+/**
+ * The convergence set landed by this work. The single table the version-7
+ * config updater and the 2Ship importer both consume, so the two cannot drift.
+ *
+ * SCOPE NOTE — this is not the whole convergence backlog. ADR 0003 §5.1 scoped
+ * "tier 1" to these 9 keys; ADR 0004's inventory §5.3 independently found 26
+ * more convergence rows. The two sets are very nearly DISJOINT, not nested:
+ * the inventory classified MM's `gEnhancements.*`/`gCheats.*` categories and
+ * the 35-key collision set, while the audio-volume family below is in neither
+ * (MM and OoT spell it differently, so it is not a collision, and it is not an
+ * enhancement). They intersect only on the three tunic keys. The inventory's
+ * 26 rows are tracked separately and are NOT attempted here — four of them are
+ * parked on unanswered taxonomy questions (see kMustStayDistinct).
+ */
+inline constexpr ConvergedKey kConvergedKeys[] = {
+    { RSBS_CVAR_LEGACY_VOLUME_MASTER, RSBS_CVAR_VOLUME_MASTER, true },
+    { RSBS_CVAR_LEGACY_VOLUME_MAIN_MUSIC, RSBS_CVAR_VOLUME_MAIN_MUSIC, true },
+    { RSBS_CVAR_LEGACY_VOLUME_SUB_MUSIC, RSBS_CVAR_VOLUME_SUB_MUSIC, true },
+    { RSBS_CVAR_LEGACY_VOLUME_SFX, RSBS_CVAR_VOLUME_SFX, true },
+    { RSBS_CVAR_LEGACY_VOLUME_FANFARE, RSBS_CVAR_VOLUME_FANFARE, true },
+    { RSBS_CVAR_LEGACY_VOLUME_AMBIENCE, RSBS_CVAR_VOLUME_AMBIENCE, true },
+    { RSBS_CVAR_LEGACY_COLOR_KOKIRI_TUNIC, RSBS_CVAR_COLOR_KOKIRI_TUNIC, false },
+    { RSBS_CVAR_LEGACY_COLOR_GORON_TUNIC, RSBS_CVAR_COLOR_GORON_TUNIC, false },
+    { RSBS_CVAR_LEGACY_COLOR_ZORA_TUNIC, RSBS_CVAR_COLOR_ZORA_TUNIC, false },
+};
+
+/**
+ * Key prefixes a converged family owns. Once a family converges, a NEW sibling
+ * appearing on MM's abandoned prefix is the same defect all over again, so the
+ * lock rejects the whole prefix rather than only the literals we happened to
+ * fix.
+ */
+inline constexpr const char* kRetiredKeyPrefixes[] = {
+    "gSettings.Audio.",
+    "gCosmetics.Link_",
+};
+
+/**
+ * A pair the lock must keep APART.
+ *
+ * These look like rename candidates and are not. The test asserts MM's key is
+ * still read somewhere under `games/mm/`; converging it makes the literal
+ * vanish and turns this table into a red build that names the row and the
+ * reason. That is the whole point — the failure mode being prevented
+ * (a control that persists a value and has no effect) is invisible at runtime.
+ */
+struct DistinctPair {
+    const char* row;    ///< Inventory row id, for the failure message.
+    const char* mmKey;  ///< MM's key. Must remain present in games/mm/.
+    const char* ootKey; ///< OoT's counterpart, for context in the message.
+    const char* why;    ///< Why merging is wrong. Printed on failure.
+};
+
+/**
+ * Inventory §4 rows (P1-P7, minus the ones with no single representative key)
+ * plus §5.3's four PARKED rows, which are real convergence candidates blocked
+ * on maintainer answers rather than settled non-merges.
+ */
+inline constexpr DistinctPair kMustStayDistinct[] = {
+    { "P1 text speed", "gEnhancements.Dialogue.FastText", "gEnhancements.TextSpeed",
+      "Units are incompatible: OoT is a 1-5x integer multiplier, MM is a boolean. Merging writes 1 = "
+      "'no speedup', so the control silently does nothing. MM's FastText also bundles hold-B-to-advance, "
+      "which OoT exposes as the SEPARATE key gEnhancements.SkipText — one control cannot express both "
+      "decompositions." },
+    { "P2 infinite sword glitch", "gEnhancements.Restorations.TatlISG", "gCheats.EasyISG",
+      "Taxonomy conflict: OoT treats ISG as a cheat to grant, MM treats restoring Navi-ISG via Tatl as "
+      "authenticity. Different menu sections, different framing. Needs a maintainer call." },
+    { "P3 camera axis decomposition", "gEnhancements.Camera.FirstPerson.InvertX",
+      "gSettings.Controls.InvertAimingXAxis",
+      "Different axis decomposition: OoT splits by context (free-look / aiming / shield / Z-aim), MM by "
+      "input device (right stick / gyro / first-person). No 1:1 mapping — OoT has no gyro axis, MM has no "
+      "shield-aim axis. Merging drops settings on both sides." },
+    { "P6 ocarina d-pad input", "gEnhancements.Playback.DpadOcarina", "gSettings.OcarinaControl.Dpad",
+      "Split across different top-level namespaces with different member sets: MM adds right-stick "
+      "ocarina, OoT adds a custom-mapping layer. Structurally parallel, not identical." },
+    { "P7 shield aim inversion", "gEnhancements.Equipment.InvertShieldY",
+      "gSettings.Controls.InvertShieldAimingYAxis",
+      "Different namespace AND different axis coverage: OoT has X+Y, MM has Y only. Merging loses OoT's "
+      "X axis." },
+    { "Autosave interval (inventory §5.3 group A caveat)", "gEnhancements.Saving.AutosaveInterval",
+      "(none — OoT hardcodes THREE_MINUTES_IN_UNIX)",
+      "The Autosave ENABLE flag is genuinely shared-intent, but OoT's interval is hardcoded with no CVar. "
+      "The interval is MM-only and must NOT ride along with an Autosave rename." },
+    { "PARKED: infinite ammo scope", "gCheats.InfiniteConsumables", "gCheats.InfiniteAmmo",
+      "MM's 'consumables' scope may be wider than OoT's 'ammo'. Pending a maintainer answer; do not "
+      "converge until it lands." },
+    { "PARKED: item restriction gate", "gCheats.UnrestrictedItems", "gCheats.NoRestrictItems",
+      "Same intent (drop item gating) but DIFFERENT GATE: OoT ignores age restrictions, MM lets all forms "
+      "use all items. Pending a maintainer answer; do not converge until it lands." },
+};
+
+/**
+ * Casing hazard, inventory §5.1. MM uses `gEnhancements.Timesavers.*`
+ * (lowercase s, 9 keys), OoT uses `gEnhancements.TimeSavers.*` (capital S, 16
+ * keys). They do NOT collide, but they are one keystroke apart in a
+ * case-sensitive store. Any rename touching this family must be explicit about
+ * which spelling wins; until that is decided, MM's spelling stays put and the
+ * lock asserts it.
+ */
+inline constexpr const char* kParkedCasingPrefixMM = "gEnhancements.Timesavers.";
+
+/**
+ * Inventory §3.1 + §3.2: shared spelling, shared meaning, KEEP AS IS. Zero
+ * migration. This list exists so that "these are deliberate" is a thing the
+ * build asserts rather than a thing a comment claims.
+ *
+ * `gInputViewer.` is a shared macro PREFIX — CVAR_INPUT_VIEWER(var) is defined
+ * identically in both trees, so its ~60 keys collide by construction and count
+ * as one entry.
+ */
+inline constexpr const char* kSharedIntentKeys[] = {
+    // Cheats. Deliberate, and verified per-key by the inventory. See the
+    // banner at the top of this file.
+    "gCheats.EasyFrameAdvance",
+    "gCheats.InfiniteHealth",
+    "gCheats.InfiniteMagic",
+    "gCheats.MoonJumpOnL",
+    "gCheats.NoClip",
+    // Developer tooling. NOTE: gDeveloperTools.DebugSaveFileMode is
+    // deliberately ABSENT — see kDisputedClassificationKeys.
+    "gDeveloperTools.DebugEnabled",
+    "gDeveloperTools.FrameAdvanceTick",
+    "gDeveloperTools.LogLevel",
+    // Graphics enhancements that describe the renderer, not the game.
+    "gEnhancements.Graphics.IncreaseActorDrawDistance",
+    "gEnhancements.Graphics.ActorCullingAccountsForWidescreen",
+    // Audio editor behaviour.
+    "gAudioEditor.EnemyBGMDisable",
+    "gAudioEditor.LowHpAlarm",
+    "gAudioEditor.SeqNameNotification",
+    "gAudioEditor.SeqNameNotificationDuration",
+    // Port-level: one SDL window, one input stack, one menu shell, one Gui.
+    "gSettings.CursorVisibility",
+    "gSettings.DisableChanges",
+    "gSettings.Menu.Theme",
+    "gSettings.Menu.Popout",
+    "gSettings.Menu.PoppedWidth",
+    "gSettings.Menu.PoppedHeight",
+    "gSettings.Menu.PoppedPos.x",
+    "gSettings.Menu.PoppedPos.y",
+    "gSettings.Menu.SearchAutofocus",
+    "gSettings.Menu.SidebarSearch",
+    // Shared macro prefix, identical in both trees.
+    "gInputViewer.",
+};
+
+/**
+ * The five cheat keys, called out separately so the lock can assert they are
+ * still read by MM under the SHARED spelling. If a future change namespaces
+ * MM's cheats, this is the assertion that names the mistake.
+ */
+inline constexpr const char* kDeliberateSharedCheatKeys[] = {
+    "gCheats.EasyFrameAdvance", "gCheats.InfiniteHealth", "gCheats.InfiniteMagic",
+    "gCheats.MoonJumpOnL",      "gCheats.NoClip",
+};
+
+/**
+ * Keys the two governing documents classify DIFFERENTLY. Recorded, not
+ * reconciled, so neither document silently overrides the other — and asserted
+ * on by nothing, because asserting either reading would prejudge the issue.
+ *
+ * `gDeveloperTools.DebugSaveFileMode`: ADR 0003 §4.1 calls it (S) — "value
+ * spaces align, only the unwritten fallback differs, acceptable". The
+ * inventory §3.3 BUG 2 takes the more conservative (P) line: the DEFAULTS
+ * disagree (OoT 1 = "vanilla debug save", MM 0 = "empty save"), so the first
+ * game to write the key silently changes the other's debug-save behaviour away
+ * from its own default. No rename either way, so the disagreement is narrow
+ * and safe. **Issue #454 decides it.** Do not converge, split, or re-default
+ * this key as a side effect of other work.
+ */
+inline constexpr const char* kDisputedClassificationKeys[] = {
+    "gDeveloperTools.DebugSaveFileMode",
+};
+
+/**
+ * Menu-index keys: shared spelling, and the value names or indexes into a
+ * menu. **Issue #451 decides these.**
+ *
+ * ADR 0003 §4.2 classifies them (P) — OoT's SohMenu and MM's BenMenu have
+ * different section sets, so one game's persisted index selects an unrelated
+ * or out-of-range entry in the other. ADR 0004 §3.1 argues the opposite for
+ * the same keys: under its single-shell decision there is only ONE menu, so
+ * sharing is correct — with an explicit caveat that this holds *only* while MM
+ * has no second shell.
+ *
+ * The lock does not pick a winner. It asserts the one thing true under BOTH
+ * readings: these keys are never swept into the convergence set. They are not
+ * renamed, not merged with a differently-spelled MM key, and not touched as a
+ * side effect of convergence work.
+ */
+inline constexpr const char* kMenuIndexKeys[] = {
+    "gSettings.Menu.ActiveHeader",
+    "gSettings.Menu.SettingsSidebarSection",
+    "gSettings.Menu.EnhancementsSidebarSection",
+    "gSettings.Menu.DevToolsSidebarSection",
+};
+
+inline constexpr std::size_t kConvergedKeyCount = sizeof(kConvergedKeys) / sizeof(kConvergedKeys[0]);
+inline constexpr std::size_t kRetiredKeyPrefixCount = sizeof(kRetiredKeyPrefixes) / sizeof(kRetiredKeyPrefixes[0]);
+inline constexpr std::size_t kMustStayDistinctCount = sizeof(kMustStayDistinct) / sizeof(kMustStayDistinct[0]);
+inline constexpr std::size_t kSharedIntentKeyCount = sizeof(kSharedIntentKeys) / sizeof(kSharedIntentKeys[0]);
+inline constexpr std::size_t kDeliberateSharedCheatKeyCount =
+    sizeof(kDeliberateSharedCheatKeys) / sizeof(kDeliberateSharedCheatKeys[0]);
+inline constexpr std::size_t kDisputedClassificationKeyCount =
+    sizeof(kDisputedClassificationKeys) / sizeof(kDisputedClassificationKeys[0]);
+inline constexpr std::size_t kMenuIndexKeyCount = sizeof(kMenuIndexKeys) / sizeof(kMenuIndexKeys[0]);
+
+// ADR 0003 §5.1 summarises tier 1 as "8 renames across 9 literal sites"; its
+// own sub-counts say 6 audio + 3 colour. Both describe this 9-entry table: 8 of
+// the 9 land on a key OoT already reads, and the 9th (Volume.Ambience) is an
+// adoption rather than a rename because OoT has no ambience channel to collide
+// with. Nine keys either way.
+static_assert(kConvergedKeyCount == 9, "tier 1 converges 9 keys (8 onto an existing OoT key + Ambience)");
+
+// ADR 0003 Appendix B measured 26 class-(S) collisions. This table carries 25:
+// DebugSaveFileMode was pulled out into kDisputedClassificationKeys because the
+// inventory reclassified it (P) and #454 has not settled it. Pinning the count
+// makes a silent drop a compile error rather than a quietly weaker lock.
+static_assert(kSharedIntentKeyCount == 25,
+              "ADR 0003 Appendix B's 26 class-(S) keys, less DebugSaveFileMode (disputed, #454)");
+static_assert(kMenuIndexKeyCount == 4, "four menu-index keys — #451");
+
+} // namespace RSBS
+
+#endif // __cplusplus
+
+#endif // RSBS_CVAR_SHARED_KEYS_H

--- a/src/common/test_runner.cpp
+++ b/src/common/test_runner.cpp
@@ -135,6 +135,13 @@ extern "C" {
 // MAX_AUTHENTIC_SEQID). Pure arithmetic — no audio subsystem, no archives.
 #include "tests/test_seq_map_bounds.c"
 
+// Cross-game CVar classification lock (#34, ADR 0003 §6.5 + the
+// enhancement-classification inventory). Manifest self-consistency, the
+// migrator's pure decision rules, and a source scan over games/ that catches
+// drift in BOTH directions — a converged key diverging again, and a per-game
+// key being merged because the names looked equivalent.
+#include "tests/test_cvar_classification.c"
+
 // Active-thread-queue contract (issue #385). soh/stubs.c's empty-bodied
 // __osGetActiveQueue fed a return register to the crash handler's thread walk
 // (fault.c:537). Included at FILE SCOPE like the rest; declares the C-linkage
@@ -1029,6 +1036,8 @@ const TestDescriptor gTests[] = {
      Test_SaveTaggedItems},
     {"mm-scene-parse", "MM scene commands parse via the S2H factory (#344)", Test_MMSceneParse},
     {"seq-map-bounds", "Sequence-map capacity covers the id range + custom slack (#371, #378)", Test_SeqMapBounds},
+    {"cvar-classification", "Cross-game CVar classification matches ADR 0003 + the inventory (#34)",
+     Test_CVarClassification},
     {"active-queue", "__osGetActiveQueue returns a walkable list, not a return register (#385)", Test_ActiveQueue},
     {"oot-audio-init-guard", "OoT synth no-ops while gAudioContextInitalized == false (#365)", Test_OoTAudioInitGuard},
     {"gp-watchdog", "Gameplay round-trip watchdog is wall-clock budgeted, can fire before the timeout (#376)",

--- a/src/common/tests/test_cvar_classification.c
+++ b/src/common/tests/test_cvar_classification.c
@@ -1,0 +1,347 @@
+/**
+ * CVar classification lock (issue #34, ADR 0003 §6.5).
+ *
+ * ADR 0003 and `docs/enhancement-classification.md` decide, per setting,
+ * whether the two games share one CVar or keep their own. That decision is
+ * prose, and prose decays on the first upstream sync. This test is the piece
+ * that stops it decaying: it makes the classification a build-time invariant,
+ * so a change that contradicts it is a red build NAMING THE KEY rather than a
+ * silent behavioural merge discovered by a player months later.
+ *
+ * Both failure directions are locked, because both are real:
+ *
+ *   1. **A converged key diverges again.** Someone reintroduces MM's retired
+ *      spelling, or adds a new sibling on a retired prefix. The setting
+ *      silently stops crossing the game boundary — the exact defect that made
+ *      OoT's master volume slider never apply to MM.
+ *
+ *   2. **A per-game key gets converged.** Someone sees two similar names and
+ *      "fixes" the collision. This is the more dangerous direction, because it
+ *      is invisible at runtime: merging OoT's 1-5x text-speed slider with MM's
+ *      boolean produces a control that appears in the menu, responds to
+ *      clicks, persists its value, and does nothing. The inventory's §4 rows
+ *      each say why one control would be wrong; kMustStayDistinct carries them
+ *      so a merge cannot land quietly.
+ *
+ * Plus the guard the ADR asks for explicitly: the deliberate `gCheats.*`
+ * sharing must survive. 26 of the 30 measured collisions were correct and the
+ * documents warn repeatedly against "fixing" them; this asserts it.
+ *
+ * ROM-free and cheap: a manifest self-consistency pass, a pure-function pass
+ * over the migrator's decision rules, and a source scan over `games/`. No
+ * archives, no window, no audio.
+ *
+ * Included at FILE SCOPE by test_runner.cpp (compiled as C++), like the other
+ * files in this directory.
+ */
+
+#include <cstdio>
+#include <cstring>
+#include <filesystem>
+#include <fstream>
+#include <string>
+#include <vector>
+
+#include "cvar_shared_keys.h"
+
+// Defined in games/oot/soh/config/ConfigUpdaters.cpp. Declared here rather than
+// included so redship_common does not take a header dependency on OoT's config
+// layer — same approach as test_seq_map_bounds.c.
+namespace SOH {
+bool ShouldAdoptLegacyValue(bool legacyPresent, bool canonicalPresent);
+int32_t VolumePercentFromFloatScale(float scale);
+} // namespace SOH
+
+#define CVARCLASS_CHECK(cond, msg)                     \
+    do {                                               \
+        if (!(cond)) {                                 \
+            printf("[TEST] FAIL: %s\n", (msg));        \
+            return TEST_FAIL;                          \
+        }                                              \
+    } while (0)
+
+#ifdef RSBS_SOURCE_DIR
+namespace {
+
+/// Source extensions worth scanning. Matches the extraction in ADR 0003's
+/// Appendix A so the lock and the measurement agree about what "the tree" is.
+bool CvarClassIsSourceFile(const std::filesystem::path& p) {
+    const std::string ext = p.extension().string();
+    return ext == ".c" || ext == ".cpp" || ext == ".h" || ext == ".hpp";
+}
+
+/// Every source file under `root`, slurped once. The scan asks a few dozen
+/// substring questions, so reading each file once and reusing the text beats
+/// re-walking the tree per key.
+std::vector<std::string> CvarClassSlurpTree(const std::filesystem::path& root, bool& ok) {
+    std::vector<std::string> contents;
+    std::error_code ec;
+
+    if (!std::filesystem::exists(root, ec) || ec) {
+        ok = false;
+        return contents;
+    }
+    ok = true;
+
+    for (std::filesystem::recursive_directory_iterator it(root, std::filesystem::directory_options::skip_permission_denied, ec),
+         end;
+         it != end; it.increment(ec)) {
+        if (ec) {
+            ec.clear();
+            continue;
+        }
+        if (!it->is_regular_file(ec) || ec) {
+            ec.clear();
+            continue;
+        }
+        if (!CvarClassIsSourceFile(it->path())) {
+            continue;
+        }
+        std::ifstream file(it->path(), std::ios::binary);
+        if (!file.is_open()) {
+            continue;
+        }
+        contents.emplace_back((std::istreambuf_iterator<char>(file)), std::istreambuf_iterator<char>());
+    }
+    return contents;
+}
+
+/// Does any scanned file contain this quoted key literal?
+bool CvarClassTreeContainsLiteral(const std::vector<std::string>& tree, const char* key) {
+    const std::string needle = std::string("\"") + key;
+    for (const std::string& text : tree) {
+        if (text.find(needle) != std::string::npos) {
+            return true;
+        }
+    }
+    return false;
+}
+
+} // namespace
+#endif // RSBS_SOURCE_DIR
+
+TestResult Test_CVarClassification(void) {
+    printf("[TEST] cvar-classification: cross-game CVar classification matches ADR 0003 + the inventory (#34)\n");
+
+    // ------------------------------------------------------------------
+    // (1) Manifest self-consistency.
+    //
+    // The tables are hand-maintained. Before trusting them to police the tree,
+    // check they are not internally contradictory — a manifest that disagrees
+    // with itself would police nothing.
+    // ------------------------------------------------------------------
+    for (std::size_t i = 0; i < RSBS::kConvergedKeyCount; i++) {
+        const RSBS::ConvergedKey& a = RSBS::kConvergedKeys[i];
+        CVARCLASS_CHECK(a.legacy != nullptr && a.canonical != nullptr, "converged row has a null key");
+        CVARCLASS_CHECK(strcmp(a.legacy, a.canonical) != 0, "converged row maps a key onto itself");
+
+        for (std::size_t j = i + 1; j < RSBS::kConvergedKeyCount; j++) {
+            const RSBS::ConvergedKey& b = RSBS::kConvergedKeys[j];
+            CVARCLASS_CHECK(strcmp(a.legacy, b.legacy) != 0, "duplicate legacy key in the convergence table");
+            CVARCLASS_CHECK(strcmp(a.canonical, b.canonical) != 0,
+                            "two legacy keys converge onto the SAME canonical key — that silently merges two "
+                            "distinct settings into one");
+        }
+
+        // A canonical target must not be a key some other row is retiring:
+        // that would be a two-step rename the updater applies in one pass, and
+        // the result depends on table order.
+        for (std::size_t j = 0; j < RSBS::kConvergedKeyCount; j++) {
+            CVARCLASS_CHECK(strcmp(a.canonical, RSBS::kConvergedKeys[j].legacy) != 0,
+                            "a convergence target is itself being retired by another row (chained rename)");
+        }
+    }
+
+    // The four menu-index keys (#451) and the disputed key (#454) must never be
+    // swept into convergence. Both are decided by their own issues, and both
+    // readings of each agree on this much.
+    for (std::size_t i = 0; i < RSBS::kConvergedKeyCount; i++) {
+        for (std::size_t m = 0; m < RSBS::kMenuIndexKeyCount; m++) {
+            CVARCLASS_CHECK(strcmp(RSBS::kConvergedKeys[i].canonical, RSBS::kMenuIndexKeys[m]) != 0 &&
+                                strcmp(RSBS::kConvergedKeys[i].legacy, RSBS::kMenuIndexKeys[m]) != 0,
+                            "a menu-index key (#451) leaked into the convergence table — those are decided "
+                            "separately and must never be merged by a rename pass");
+        }
+        for (std::size_t d = 0; d < RSBS::kDisputedClassificationKeyCount; d++) {
+            CVARCLASS_CHECK(strcmp(RSBS::kConvergedKeys[i].canonical, RSBS::kDisputedClassificationKeys[d]) != 0 &&
+                                strcmp(RSBS::kConvergedKeys[i].legacy, RSBS::kDisputedClassificationKeys[d]) != 0,
+                            "a disputed-classification key (#454) leaked into the convergence table");
+        }
+    }
+
+    // Every retired spelling must fall under a retired PREFIX, so the
+    // prefix-level source scan below actually covers the whole convergence set
+    // rather than a subset someone forgot to extend.
+    for (std::size_t i = 0; i < RSBS::kConvergedKeyCount; i++) {
+        bool covered = false;
+        for (std::size_t p = 0; p < RSBS::kRetiredKeyPrefixCount; p++) {
+            const char* prefix = RSBS::kRetiredKeyPrefixes[p];
+            if (strncmp(RSBS::kConvergedKeys[i].legacy, prefix, strlen(prefix)) == 0) {
+                covered = true;
+                break;
+            }
+        }
+        CVARCLASS_CHECK(covered, "a retired key is not covered by any retired prefix — the source scan would miss "
+                                 "new siblings in its family");
+    }
+
+    // ------------------------------------------------------------------
+    // (2) The migrator's decision rules (ADR 0003 §6.3).
+    //
+    // Pure functions, so the ROM-free tier can exercise the actual rules
+    // rather than a restatement of them.
+    // ------------------------------------------------------------------
+
+    // OoT's value wins. The MM-spelled value is adopted ONLY when the OoT key
+    // is absent — it is the one the user could have set through a live menu,
+    // so it is the one they last saw take effect.
+    CVARCLASS_CHECK(SOH::ShouldAdoptLegacyValue(true, false), "legacy value must be adopted when OoT's key is unset");
+    CVARCLASS_CHECK(!SOH::ShouldAdoptLegacyValue(true, true),
+                    "OoT's value must WIN when both spellings are present — adopting MM's would clobber the only "
+                    "value a user could have set through a live menu");
+    CVARCLASS_CHECK(!SOH::ShouldAdoptLegacyValue(false, false), "nothing to adopt when neither key is present");
+    CVARCLASS_CHECK(!SOH::ShouldAdoptLegacyValue(false, true), "nothing to adopt when only OoT's key is present");
+
+    // Float scale -> integer percent. The conversion exists because OoT stores
+    // volume as integer percent while MM stored a float scale, and
+    // libultraship returns the DEFAULT on a CVar type mismatch: copying the
+    // float across unconverted would leave a key every reader ignores.
+    CVARCLASS_CHECK(SOH::VolumePercentFromFloatScale(1.0f) == 100, "full scale must convert to 100%");
+    CVARCLASS_CHECK(SOH::VolumePercentFromFloatScale(0.0f) == 0, "silence must convert to 0%");
+    CVARCLASS_CHECK(SOH::VolumePercentFromFloatScale(0.5f) == 50, "half scale must convert to 50%");
+    // Hand-edited configs can hold anything; the conversion must clamp rather
+    // than produce an out-of-range percent the slider cannot represent.
+    CVARCLASS_CHECK(SOH::VolumePercentFromFloatScale(4.0f) == 100, "over-unity scale must clamp to 100%");
+    CVARCLASS_CHECK(SOH::VolumePercentFromFloatScale(-1.0f) == 0, "negative scale must clamp to 0%");
+
+    // ------------------------------------------------------------------
+    // (3) Source scan — the drift detector.
+    // ------------------------------------------------------------------
+#ifdef RSBS_SOURCE_DIR
+    const std::filesystem::path sourceRoot(RSBS_SOURCE_DIR);
+    bool mmOk = false;
+    bool ootOk = false;
+    const std::vector<std::string> mmTree = CvarClassSlurpTree(sourceRoot / "games" / "mm", mmOk);
+    const std::vector<std::string> ootTree = CvarClassSlurpTree(sourceRoot / "games" / "oot", ootOk);
+
+    if (!mmOk || !ootOk) {
+        // Running from a relocated build (an artifact run, say). The manifest
+        // and migrator halves above still ran and still passed; only the tree
+        // scan is unavailable. Say so loudly rather than reporting a clean
+        // pass that checked less than it looks like it did.
+        printf("[TEST] WARNING: source tree not found at %s — manifest and migrator checks passed, but the\n"
+               "[TEST]          source-drift scan was SKIPPED. In CI this path must not be taken.\n",
+               RSBS_SOURCE_DIR);
+    } else {
+        CVARCLASS_CHECK(!mmTree.empty(), "scanned games/mm and found no source files at all — the scan would "
+                                         "vacuously pass, which is worse than not running it");
+        CVARCLASS_CHECK(!ootTree.empty(), "scanned games/oot and found no source files at all");
+
+        // (3a) Retired spellings must be GONE. Direction 1: a converged
+        // setting silently diverging again.
+        for (std::size_t i = 0; i < RSBS::kConvergedKeyCount; i++) {
+            const RSBS::ConvergedKey& key = RSBS::kConvergedKeys[i];
+            if (CvarClassTreeContainsLiteral(mmTree, key.legacy)) {
+                printf("[TEST] FAIL: MM still reads the retired key \"%s\".\n"
+                       "[TEST]       It converged onto \"%s\"; reintroducing the old spelling means the setting\n"
+                       "[TEST]       silently stops crossing the game boundary. Use the canonical key\n"
+                       "[TEST]       (src/common/cvar_shared_keys.h), and note that the volume family also\n"
+                       "[TEST]       changed representation: integer percent, read with CVarGetInteger.\n",
+                       key.legacy, key.canonical);
+                return TEST_FAIL;
+            }
+        }
+
+        // (3b) The whole retired FAMILY stays retired. A new sibling on an
+        // abandoned prefix is the same defect with a different leaf name.
+        for (std::size_t p = 0; p < RSBS::kRetiredKeyPrefixCount; p++) {
+            const char* prefix = RSBS::kRetiredKeyPrefixes[p];
+            if (CvarClassTreeContainsLiteral(mmTree, prefix)) {
+                printf("[TEST] FAIL: MM has a key on the retired prefix \"%s\".\n"
+                       "[TEST]       That family converged onto OoT's spelling. A new sibling here diverges\n"
+                       "[TEST]       again — add it under the canonical prefix instead, and add a row to\n"
+                       "[TEST]       RSBS::kConvergedKeys + the version-7 migration if it needs migrating.\n",
+                       prefix);
+                return TEST_FAIL;
+            }
+        }
+
+        // (3c) Direction 2 — the dangerous one. Pairs that look like renames
+        // and must NOT be merged. If MM's key vanished, someone converged it.
+        for (std::size_t i = 0; i < RSBS::kMustStayDistinctCount; i++) {
+            const RSBS::DistinctPair& pair = RSBS::kMustStayDistinct[i];
+            if (!CvarClassTreeContainsLiteral(mmTree, pair.mmKey)) {
+                printf("[TEST] FAIL: MM no longer reads \"%s\" (inventory row: %s).\n"
+                       "[TEST]       This key must stay DISTINCT from OoT's \"%s\".\n"
+                       "[TEST]       Why: %s\n"
+                       "[TEST]       If this removal is deliberate and correct, update\n"
+                       "[TEST]       RSBS::kMustStayDistinct and docs/enhancement-classification.md together.\n",
+                       pair.mmKey, pair.row, pair.ootKey, pair.why);
+                return TEST_FAIL;
+            }
+        }
+
+        // (3d) The casing hazard. MM's Timesavers (lowercase s) is one
+        // keystroke from OoT's TimeSavers in a case-sensitive store, and which
+        // spelling wins is undecided.
+        if (!CvarClassTreeContainsLiteral(mmTree, RSBS::kParkedCasingPrefixMM)) {
+            printf("[TEST] FAIL: MM no longer reads the \"%s\" family.\n"
+                   "[TEST]       OoT spells it \"gEnhancements.TimeSavers.\" (capital S) — the two do NOT\n"
+                   "[TEST]       collide, but they are one keystroke apart. Which spelling wins is an open\n"
+                   "[TEST]       question; converging this family needs an explicit decision first.\n",
+                   RSBS::kParkedCasingPrefixMM);
+            return TEST_FAIL;
+        }
+
+        // (3e) The deliberate cheat sharing survives. Both documents warn
+        // against "fixing" this; here the warning is enforced.
+        for (std::size_t i = 0; i < RSBS::kDeliberateSharedCheatKeyCount; i++) {
+            const char* key = RSBS::kDeliberateSharedCheatKeys[i];
+            if (!CvarClassTreeContainsLiteral(mmTree, key)) {
+                printf("[TEST] FAIL: MM no longer reads the shared cheat key \"%s\".\n"
+                       "[TEST]       Cheats are SHARED INTENT and this sharing is deliberate: the inventory\n"
+                       "[TEST]       verified per-key that both implementations match. A cheat is a statement\n"
+                       "[TEST]       about how the user wants to play RSBS, not about which game is in front.\n"
+                       "[TEST]       Namespacing MM's cheats is a regression, not a collision fix.\n",
+                       key);
+                return TEST_FAIL;
+            }
+        }
+
+        // (3f) The canonical keys are actually read by OoT. Catches a typo in
+        // the manifest that would otherwise make every check above pass while
+        // pointing at a key nothing uses. Skips Volume.Ambience, which is an
+        // adoption rather than a rename — OoT has no ambience channel.
+        for (std::size_t i = 0; i < RSBS::kConvergedKeyCount; i++) {
+            const char* canonical = RSBS::kConvergedKeys[i].canonical;
+            if (strcmp(canonical, RSBS_CVAR_VOLUME_AMBIENCE) == 0) {
+                continue;
+            }
+            // OoT reaches gSettings.* through the CVAR_SETTING macro, so match
+            // the leaf rather than the full literal for that family.
+            const char* settingPrefix = "gSettings.";
+            const char* probe = strncmp(canonical, settingPrefix, strlen(settingPrefix)) == 0
+                                    ? canonical + strlen(settingPrefix)
+                                    : canonical;
+            if (!CvarClassTreeContainsLiteral(ootTree, probe)) {
+                printf("[TEST] FAIL: OoT does not appear to read the canonical key \"%s\" (probed \"%s\").\n"
+                       "[TEST]       MM was converged onto a key OoT does not use — check the manifest for a\n"
+                       "[TEST]       typo, or the ADR's convergence direction for this row.\n",
+                       canonical, probe);
+                return TEST_FAIL;
+            }
+        }
+
+        printf("[TEST]   scanned %zu MM + %zu OoT source files\n", mmTree.size(), ootTree.size());
+    }
+#else
+    printf("[TEST] WARNING: RSBS_SOURCE_DIR undefined — source-drift scan SKIPPED.\n");
+#endif
+
+    printf("[TEST] PASS: %zu converged keys retired cleanly, %zu per-game pairs still distinct, %zu shared cheat "
+           "keys intact\n",
+           RSBS::kConvergedKeyCount, RSBS::kMustStayDistinctCount, RSBS::kDeliberateSharedCheatKeyCount);
+    return TEST_PASS;
+}
+
+#undef CVARCLASS_CHECK


### PR DESCRIPTION
Closes #34. Implements ADR 0003 §5.1/§6.2-6.5, reconciled against ADR 0004's classification inventory.

## The user-visible defects this fixes

Two settings have never crossed the game boundary, because the two games spell the key differently:

- **The master volume slider has never applied to MM.** Set it in OoT's menu, switch to MM, MM plays at its own default.
- **OoT tunic colours have never reached MM** (#453). Worse than a collision — a *stale-key desync*. OoT's own v3 migrator renames the underscore spelling away, so the key MM reads is one OoT has already migrated out of existence. After any OoT config migration, MM's colours read a key nothing writes and fall back to hardcoded defaults permanently, with no UI to correct it.

## ⚠️ ADR correction: the audio "renames" are not renames

ADR 0003 §5.1 specifies the six audio rows as literal key swaps. **Executed literally, they would not have fixed the bug.**

| | OoT | MM (before) |
|---|---|---|
| Type | `CVarGetInteger` | `CVarGetFloat` |
| Range | integer percent 0-100 | float scale 0..1 |
| Master default | 40 | 1.0 |

`ConsoleVariable::GetFloat` returns the **default** when the stored type is `Integer` (`libultraship/src/ship/config/ConsoleVariable.cpp:38-46`). So a literal rename leaves MM calling `CVarGetFloat` on an Integer-typed CVar — it would read `1.0f` forever. That converts "MM ignores OoT's volume" into "MM ignores OoT's volume, and the config no longer shows why": strictly worse for diagnosis, since the divergence would no longer be visible as two keys.

Convergence therefore adopts OoT's **representation and defaults**, not just its spelling. MM's read sites now use OoT's own expression, `(float)CVarGetInteger(key, N) / 100.0f`. The migrator converts rather than copies, which is not novel — `ConfigVersion3Updater` already does exactly this float-to-percent conversion for OoT's own legacy volume keys.

## Verified rename list (MM key -> OoT key)

Re-verified against `origin/main` before editing.

| MM (retired) | OoT (canonical) | Sites |
|---|---|---|
| `gSettings.Audio.MasterVolume` | `gSettings.Volume.Master` | `src/audio/lib/playback.c`, `BenMenu.cpp` |
| `gSettings.Audio.MainMusicVolume` | `gSettings.Volume.MainMusic` | `src/code/audio_thread_manager.c`, `BenMenu.cpp` |
| `gSettings.Audio.SubMusicVolume` | `gSettings.Volume.SubMusic` | same |
| `gSettings.Audio.SoundEffectsVolume` | `gSettings.Volume.SFX` | same |
| `gSettings.Audio.FanfareVolume` | `gSettings.Volume.Fanfare` | same |
| `gSettings.Audio.AmbienceVolume` | `gSettings.Volume.Ambience` | same — **adoption, not rename**: OoT has no ambience channel |
| `gCosmetics.Link_KokiriTunic.Value` | `gCosmetics.Link.KokiriTunic.Value` | `BenPort.cpp` |
| `gCosmetics.Link_GoronTunic.Value` | `gCosmetics.Link.GoronTunic.Value` | `BenPort.cpp` |
| `gCosmetics.Link_ZoraTunic.Value` | `gCosmetics.Link.ZoraTunic.Value` | `BenPort.cpp` |

Two of the four MM files touched (`BenMenu.cpp`, `BenPort.cpp`) are already excluded from the single-exe link, so live-code churn is two files.

**Count note:** ADR 0003 summarises tier 1 as "8 renames across 9 literal sites" while its own sub-counts say 6 + 3 = 9. Both describe this 9-row table — 8 land on a key OoT already reads, and Ambience is an adoption. Pinned by `static_assert`.

## Migrator

`ConfigVersion7Updater` — version 7 is the next free version (1-6 registered at `OTRGlobals.cpp:1726`).

**Conflict rule (ADR 0003 §6.3): OoT's value wins.** A config can hold both spellings — the OoT one from OoT's live menu, the MM one hand-edited or preset-imported. `CVarCopy` overwrites unconditionally, so the plain rename pattern would let the MM value clobber the OoT one. The OoT-spelled value is the only one a user could have set through a live menu, so it is the one they last saw take effect. Implemented as a new `MigrationAction::RenameIfAbsent`. The legacy key is cleared either way, so the migration is not re-runnable and cannot oscillate.

Zero-loss by construction: copy before clear, no-op when the legacy key is absent.

## 2Ship importer

Re-scoped per §6.4. Reads `2ship2harkinian.json` once, maps through the **same** `RSBS::kConvergedKeys` manifest the updater uses (one table, two consumers — they cannot drift), applies the same conflict rule, stamps a run-once flag.

Handles §6.4's ordering hazard: 2Ship's own config version updates are replayed against the parsed json *before* key mapping. `Ben::ConfigVersion1Updater` could not be reused — it mutates the **live** CVar store via `CVarCopy`/`CVarClear`, which is the wrong target for a file we only read — so its key mapping is replicated. None of 2Ship's v1 rows currently intersect the convergence table; the hook exists so a future version that does is handled at the right point.

Read-only on the source: a standalone 2Ship install keeps working unchanged. A malformed source file logs and skips **without** stamping, so a user who repairs it still gets imported.

## Classification lock — `--test cvar-classification`

ROM-free, in the `redship` tier. Three parts:

1. **Manifest self-consistency** — no duplicate or chained renames, no two legacy keys converging onto one canonical key, every retired key covered by a retired prefix.
2. **The migrator's decision rules as pure functions** — `ShouldAdoptLegacyValue` and `VolumePercentFromFloatScale` were factored out so the ROM-free tier can exercise the actual rules, the same shape `--test seq-map-bounds` uses.
3. **A source scan over `games/`**, catching drift in **both** directions.

Direction 2 is the one worth having. Direction 1 (a converged key diverging again) is annoying; direction 2 — a per-game key being merged because the names looked equivalent — is **invisible at runtime**. Merging OoT's 1-5x text-speed slider with MM's boolean produces a control that appears in the menu, responds to clicks, persists its value, and does nothing. `kMustStayDistinct` carries the inventory's §4 rows with their reasons, so such a merge fails CI printing the row id and why.

It also enforces the ADRs' explicit guard: the five deliberate `gCheats.*` shared keys must still be read by MM under the shared spelling. Namespacing MM's cheats is a regression, not a collision fix, and now the build says so.

## Reconciliation with ADR 0004 (per mid-task review)

**The 8/9 and the 26 are near-disjoint, not nested.** The inventory classified MM's `gEnhancements.*`/`gCheats.*` categories plus the 35-key collision set; the audio-volume family is in neither (the two games spell it differently, so it is not a collision, and it is not an enhancement). **They intersect only on the three tunic keys**, which the inventory classifies (S) CONVERGE / row P4 / BUG 1 — exactly what this PR does, and it says "converge, but as a fix, not a plain rename", which is what the representation correction above amounts to.

So the union of convergence work is roughly 35 rows, of which this PR lands 9. **Deferred, not silently dropped:**

- The inventory's **26 §5.3 rows** — 12 mechanical (MM adds a category prefix), 7 wording drift, 4 cutscene-skip, 3 free-look. Follow-up issue filed.
- **4 parked on unanswered taxonomy questions**, all asserted as must-stay-distinct so they cannot be converged before the answer lands: `InfiniteAmmo`/`InfiniteConsumables` (scope may differ), `NoRestrictItems`/`UnrestrictedItems` (the *gates* differ — age vs form), the `TimeSavers`/`Timesavers` casing split, and `Saving.AutosaveInterval` (OoT hardcodes its interval, so it must not ride along with an `Autosave` rename).

**Trap cases checked and clear.** None of P1 (text speed), P2, P3, P6, P7, the autosave interval, or the casing split appear in this rename list. All are now in `kMustStayDistinct` and enforced.

**Contested classifications left alone.**

- `gDeveloperTools.DebugSaveFileMode` (#454): ADR 0003 says (S), the inventory says (P). Pulled out of the shared-intent table into `kDisputedClassificationKeys` and asserted on by nothing — asserting either reading would prejudge the issue. The `static_assert` count drops 26 to 25 to make the removal deliberate rather than a silently weaker lock.
- The four menu-index keys (#451): ADR 0003 says (P), ADR 0004 §3.1 argues they are correct under its single-shell decision. The lock does not pick a winner; it asserts the one thing true under both readings — they are never swept into the convergence set.

## Upstream-diff surface

Nine literal sites, so per ADR §5.4 the boundary-redirect recipe (#422/#435) is the wrong tool here — "a strictly better tool at scale and a strictly worse one at nine sites". Two of the four MM files are already link-excluded. The two live decomp files take a one-line change each, and that change had to be an expression edit rather than a token swap because of the representation gap, which is itself the argument against a pure key-alias redirect for this family.

## Incidental finding

`libultraship` **declares** `bool CVarExists(const char*)` in `consolevariablebridge.h:33` and never defines it anywhere — any caller gets an unresolved-symbol link error rather than a compile error. Worked around with a local `CVarPresent()` wrapping `CVarGet(name) != nullptr`; not fixed here since it is a submodule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!--- section:artifacts:start -->
### Build Artifacts
  - [rsbs-windows.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/8506613961.zip)
  - [rsbs-linux.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/8506285202.zip)
<!--- section:artifacts:end -->