### PR TITLE
Invalidate cross-game session state on soft reset and new game (#440)

### DIFF
--- a/CMake/SingleExecutable.cmake
+++ b/CMake/SingleExecutable.cmake
@@ -288,6 +288,13 @@ if(BUILD_TESTING)
     # shared structure, the crossing awards exactly once on the OoT side, and
     # gComboCtx.foreignPlacements round-trips through the .redsave record.
     redship_add_test(NAME ForeignItemGive COMMAND redship --test foreign-item-give)
+    # Cross-game session invalidation (#440). A soft reset or a new game must
+    # retire the previous session's frozen blobs, shadows and gComboCtx
+    # crossings — while a cross-game arrival and a legitimate existing-slot
+    # load must still restore. Also the single-player half of the netplay
+    # blocker (#460): a stale sharedItemsTagged carries another player's grants
+    # from a dead room into a fresh seed.
+    redship_add_test(NAME SessionInvalidation COMMAND redship --test session-invalidation)
     redship_add_test(NAME ArchiveHotswapLogic COMMAND redship --test archive-hotswap-logic)
     # Unified save (.redsave) headless tests — Phase 2 T6 (#35)
     redship_add_test(NAME SaveRoundtripTiers COMMAND redship --test save-roundtrip-tiers)

--- a/games/oot/soh/SaveManager.cpp
+++ b/games/oot/soh/SaveManager.cpp
@@ -165,12 +165,27 @@ SaveManager::SaveManager() {
     });
 
     GameInteractor::Instance->RegisterGameHook<GameInteractor::OnLoadFile>([](int32_t fileNum) {
-        // Only pull the cross-game half if a .redsave already exists for
-        // this slot. A vanilla OoT save with no companion unified file is
-        // legal — we leave gComboCtx + MM shadow untouched in that case.
+        // Clear-and-reload (#440). The .redsave is per-OoT-slot
+        // (redship_slot{0,1,2}.redsave) but gComboCtx and both shadows are
+        // process singletons, so loading a slot has to REPLACE the resident
+        // cross-game state, never merge with it.
+        //
+        // This hook used to be load-if-present with no clear, which quietly
+        // made "this slot has no .redsave" mean "keep whatever the previous
+        // session left resident" — the previous seed's crossings, foreign
+        // placements and frozen blobs got adopted by an unrelated slot. That
+        // is the same leak as the operator's #440 repro arriving by the load
+        // path instead of the new-game path.
+        //
+        // Clearing unconditionally and reloading only if a file exists gives
+        // both halves the right meaning: a slot WITH a .redsave gets exactly
+        // its own state, and a slot WITHOUT one gets none. A vanilla OoT save
+        // with no companion unified file stays perfectly legal — it just no
+        // longer inherits a stranger's session.
         if (fileNum < 0 || fileNum >= RSBS_SAVE_MAX_SLOTS) {
             return;
         }
+        Context_InvalidateSessionOnSlotLoad();
         if (RsbsSave_HasSave(fileNum)) {
             RsbsSave_Load(fileNum);
         }

--- a/games/oot/src/code/title_setup.c
+++ b/games/oot/src/code/title_setup.c
@@ -1,8 +1,26 @@
 #include "global.h"
 
+// Cross-game session invalidation (#440). Declared locally rather than by
+// including src/common/context.h: games/oot/src/**.c does not have src/common
+// on its include path, and this is the same convention z_play.c uses for the
+// Combo_* entry points. Self-suppresses on a cross-game arrival — see
+// context.h.
+extern int Context_InvalidateSessionOnReturnToTitle(void);
+
 void TitleSetup_InitImpl(GameState* gameState) {
     osSyncPrintf("ゼルダ共通データ初期化\n"); // "Zelda common data initalization"
     OoT_SaveContext_Init();
+    // Retire the cross-game session as well as OoT's own SaveContext (#440).
+    // OoT_SaveContext_Init above wipes gSaveContext, which is the game's OWN
+    // reset inverse; the cross-game frozen blobs, both shadows, and gComboCtx
+    // are process-global and had NO inverse at all, so a soft reset left them
+    // fully intact for the next session to inherit. This is the single call
+    // site of OoT_SaveContext_Init, and every soft-reset route reaches it:
+    // the debug-console "reset" command that the Ctrl+R menu item dispatches
+    // (-> OoT_TitleSetup_Init) and the N64 reset-button emulation (-> PreNMI,
+    // which restarts the boot chain). A cold boot reaches it too, where the
+    // clear is a harmless no-op on already-zero state.
+    Context_InvalidateSessionOnReturnToTitle();
     gameState->running = false;
     SET_NEXT_GAMESTATE(gameState, Title_Init, TitleContext);
 }

--- a/games/oot/src/code/z_sram.c
+++ b/games/oot/src/code/z_sram.c
@@ -16,6 +16,11 @@ void Save_LoadFile(void);
 
 void BossRush_InitSave(void);
 
+// Cross-game session invalidation (#440). Declared locally: games/oot/src/**.c
+// does not have src/common on its include path (same convention z_play.c uses
+// for the Combo_* entry points). See src/common/context.h for the contract.
+extern void Context_InvalidateSessionOnNewGame(int isRandoFile);
+
 /**
  *  Initialize new save.
  *  This save has an empty inventory with 3 hearts and single magic.
@@ -261,7 +266,31 @@ void OoT_Sram_InitSave(FileChooseContext* fileChooseCtx) {
 
     u8 currentQuest = fileChooseCtx->questType[fileChooseCtx->buttonIndex];
 
-    if (currentQuest == QUEST_RANDOMIZER && (Randomizer_IsSeedGenerated() || Randomizer_IsSpoilerLoaded())) {
+    u8 isRandoFile =
+        (currentQuest == QUEST_RANDOMIZER && (Randomizer_IsSeedGenerated() || Randomizer_IsSpoilerLoaded()));
+
+    // Retire the previous cross-game session before this file exists (#440).
+    // Creating a file is the strongest possible statement that the old session
+    // is over, and nothing used to act on it: the operator started a NEW seed
+    // on slot 1 after a soft reset and MM came up on the PREVIOUS seed's clock
+    // with its stray fairies already collected, because the dead session's
+    // frozen MM blob was still sitting there for the first consume.
+    //
+    // Ordered BEFORE Randomizer_InitSaveFile() and Save_SaveFile() below so
+    // that (a) nothing this new file authors is wiped by the clear, and (b) the
+    // Save_SaveFile() -> OnSaveFile -> RsbsSave_Save at the end of this
+    // function writes a .redsave for the new slot that already reflects the
+    // cleared state, instead of persisting the dead session's crossings into
+    // the new file's very first save.
+    //
+    // isRandoFile is exactly the condition the branch below uses, so the seed
+    // stamp is kept precisely when generation has already authored it for this
+    // file and dropped for a vanilla file (where a surviving stamp would leave
+    // Combo_ForeignPairingActive() reporting a paired world that does not
+    // exist).
+    Context_InvalidateSessionOnNewGame(isRandoFile);
+
+    if (isRandoFile) {
         gSaveContext.ship.quest.id = QUEST_RANDOMIZER;
 
         Randomizer_InitSaveFile();

--- a/src/common/context.cpp
+++ b/src/common/context.cpp
@@ -7,6 +7,13 @@
  */
 
 #include "context.h"
+// Context_InvalidateSessionState also has to drain the RAM-only shared-item
+// staging outbox, which lives in shared_items.c. Included here (a .cpp) rather
+// than from context.h so the header keeps its no-dependency shape.
+#include "shared_items.h"
+// Combo_HasStartupEntrance() — the discriminator that keeps the return-to-title
+// hook from eating a cross-game arrival's blob.
+#include "entrance.h"
 #include <cstdio>
 #include <cstring>
 #include <vector>
@@ -251,6 +258,80 @@ void Context_RequestSwitch(GameId target, uint16_t entrance) {
 
 bool Context_HasPendingSwitch(void) {
     return ComboContext_IsSwitchPending();
+}
+
+// ----------------------------------------------------------------------------
+// Session invalidation (#440). See context.h for the contract and the operator
+// repro this exists to close.
+// ----------------------------------------------------------------------------
+
+void Context_InvalidateSessionState(ComboSeedStampPolicy seedPolicy) {
+    // Snapshot the Lane B stamp BEFORE the re-init below wipes it. This is the
+    // only part of gComboCtx that can legitimately outlive the session, and
+    // only in the KEEP case — see ComboSeedStampPolicy.
+    const bool savedSourceIsRando = gComboCtx.sourceIsRando;
+    const uint32_t savedSeed = gComboCtx.sharedRandoSeed;
+    const uint32_t savedSettingsHash = gComboCtx.sharedRandoSettingsHash;
+
+    // Frozen blobs and shadow copies in one call — they are the same storage
+    // (FrozenStateManager::ClearFrozenState memsets the buffer AND clears
+    // hasBeenFrozen). This is the half that fixes the operator's symptom: the
+    // dead session's MM blob no longer survives to be consumed by the next
+    // session's first Happy Mask Shop entry.
+    Context_ClearAllFrozenStates();
+
+    // Pickups staged but never committed when the session died. Committed ones
+    // live in sharedItemsTagged and go with the ComboContext_Init below; this
+    // outbox is RAM-only and would otherwise drain into the NEXT session's
+    // array at its first suspend.
+    Combo_ClearSharedItemOutbox();
+
+    // Every remaining field of gComboCtx is session state, so the initializer
+    // IS the invalidator — there is no per-field clear to drift out of sync
+    // with the struct. Fields carved from reserved[] in the future are covered
+    // automatically, which is the growth contract's "zero means unset" rule
+    // doing exactly what it was written for. Re-stamps magic/version too.
+    ComboContext_Init();
+
+    if (seedPolicy == RSBS_SEED_STAMP_KEEP) {
+        gComboCtx.sourceIsRando = savedSourceIsRando;
+        gComboCtx.sharedRandoSeed = savedSeed;
+        gComboCtx.sharedRandoSettingsHash = savedSettingsHash;
+    }
+
+    fprintf(stderr, "[Context] Session state invalidated (seed stamp %s: rando=%d seed=%u settings=%08X)\n",
+            (seedPolicy == RSBS_SEED_STAMP_KEEP) ? "kept" : "dropped", (int)gComboCtx.sourceIsRando,
+            (unsigned)gComboCtx.sharedRandoSeed, (unsigned)gComboCtx.sharedRandoSettingsHash);
+}
+
+int Context_InvalidateSessionOnReturnToTitle(void) {
+    // The arrival guard. See the header: a cross-game arrival walks the SAME
+    // title chain, so without this the hook would eat the blob that arrival is
+    // about to consume. Untagged (not ...ForGame) on purpose — any pending
+    // cross-game entrance, for either game, means a switch is in flight and
+    // this pass through the title is boot chain, not a player-visible reset.
+    if (Combo_HasStartupEntrance()) {
+        fprintf(stderr, "[Context] Return-to-title invalidation skipped: cross-game arrival in flight\n");
+        return 0;
+    }
+    fprintf(stderr, "[Context] Return to title: retiring cross-game session state\n");
+    Context_InvalidateSessionState(RSBS_SEED_STAMP_DROP);
+    return 1;
+}
+
+void Context_InvalidateSessionOnNewGame(int isRandoFile) {
+    fprintf(stderr, "[Context] New file (rando=%d): retiring cross-game session state\n", isRandoFile);
+    // A rando file's stamp was authored by generation minutes ago and belongs
+    // to the file being created, not to the session being discarded.
+    Context_InvalidateSessionState(isRandoFile ? RSBS_SEED_STAMP_KEEP : RSBS_SEED_STAMP_DROP);
+}
+
+void Context_InvalidateSessionOnSlotLoad(void) {
+    fprintf(stderr, "[Context] Slot load: clearing before reload\n");
+    // Always DROP: whatever this slot legitimately owns arrives from its own
+    // .redsave immediately after. A slot with no .redsave must read as "no
+    // cross-game state", not as "whatever the last session happened to leave".
+    Context_InvalidateSessionState(RSBS_SEED_STAMP_DROP);
 }
 
 void Context_SetCurrentGame(GameId game) {

--- a/src/common/context.h
+++ b/src/common/context.h
@@ -380,6 +380,169 @@ void Context_RequestSwitch(GameId target, uint16_t entrance);
  */
 bool Context_HasPendingSwitch(void);
 
+// ============================================================================
+// Session invalidation (#440)
+// ============================================================================
+//
+// THE TRANSITION MATRIX. What survives, and what the next first-MM-entry does.
+//
+// "Pairs?" is MM_Rando_PairOnCrossGameArrival's decision
+// (games/mm/2s2h/GameExports_SingleExe.cpp, #447/d075aeaf). It reads exactly
+// two things, both of them src/common state: Combo_ForeignPairingActive() and
+// whether Combo_ConsumeFrozenState returned a blob. That is why a stale blob
+// is not merely cosmetic post-#447 — it answers "this MM save already exists"
+// for a save that does not, and the new seed DECLINES TO PAIR. Fixing the
+// invalidation restores pairing with no change to that guard.
+//
+//   transition          | frozen blobs | shadows  | crossings | seed stamp | pairs?
+//   --------------------+--------------+----------+-----------+------------+--------
+//   cold boot           | none (init)  | zeroed   | none      | none       | n/a until a seed exists
+//   reset -> same slot  | DROPPED      | reloaded | reloaded  | reloaded   | yes, from that slot's .redsave
+//   reset -> diff slot  | DROPPED      | reloaded | reloaded  | reloaded   | yes, from that slot's .redsave
+//   reset -> new file   | DROPPED      | zeroed   | DROPPED   | kept iff   | YES for a rando file (the
+//                       |              |          |           | rando file | operator's case); declines
+//                       |              |          |           |            | with no-paired-oot-world for
+//                       |              |          |           |            | a vanilla file, correctly
+//   cross-game arrival  | PRESERVED    | preserved| preserved | preserved  | declines (existing save) —
+//                       |              |          |           |            | correct: it IS the player's
+//                       |              |          |           |            | own restored MM session
+//
+// Note the last row: an arrival walks the SAME OoT title chain a soft reset
+// does, so Context_InvalidateSessionOnReturnToTitle self-suppresses on a
+// pending startup entrance. Without that guard this fix would eat the blob
+// every return leg is on its way to consume — a strictly worse bug.
+//
+// "reset -> same slot" and "reset -> diff slot" are deliberately identical:
+// the .redsave is per-OoT-slot but these globals are process singletons, so
+// the only safe rule is clear-then-reload for BOTH. Treating "same slot" as a
+// fast path that skips the clear is precisely how a slot with no companion
+// .redsave would keep inheriting the previous session.
+
+/**
+ * What Context_InvalidateSessionState does with the Lane B seed stamp
+ * (sourceIsRando / sharedRandoSeed / sharedRandoSettingsHash).
+ *
+ * The stamp is the one part of gComboCtx that is NOT authored by the session
+ * being torn down: Playthrough_Init writes it at GENERATION time, which for a
+ * new file happens BEFORE the file is created (generate a seed in the menu,
+ * then name the file). So the new-file call site must keep a stamp that
+ * generation just authored, while a return-to-title must drop one that nothing
+ * stands behind. Making that an explicit argument rather than a hidden policy
+ * means every call site has to state which situation it is in.
+ */
+typedef enum {
+    /**
+     * Drop the stamp. Correct wherever no generation stands behind it: a soft
+     * reset to title, and a NON-rando new file. A surviving stamp is not inert
+     * — Combo_ForeignPairingActive() is literally
+     * `sourceIsRando && sharedRandoSettingsHash != 0`, so a dead session's
+     * stamp makes MM believe a paired world exists for a seed that is gone.
+     */
+    RSBS_SEED_STAMP_DROP = 0,
+    /**
+     * Keep the stamp. Correct ONLY where generation has already authored it
+     * for the file now being created (OoT_Sram_InitSave on a randomizer file).
+     */
+    RSBS_SEED_STAMP_KEEP = 1,
+} ComboSeedStampPolicy;
+
+/**
+ * Retire every trace of the cross-game session that just ended (#440).
+ *
+ * This is the missing INVERSE of the freeze machinery. Cross-game session state
+ * is process-global — the frozen blobs, both shadow copies, and every session
+ * field of gComboCtx — and before this existed nothing invalidated any of it on
+ * a soft reset or a new game. PR #400 made Combo_ConsumeFrozenState retire the
+ * blob it hands over, which stops a blob being consumed TWICE, but a dead
+ * session's blob was still sitting there for the FIRST consume of the next
+ * session. That is the operator's #440 repro exactly: play a seed on slot 3,
+ * soft reset, start a NEW seed on slot 1, walk into the Happy Mask Shop, and
+ * MM comes up on the previous seed's clock with its stray fairies collected.
+ *
+ * Clears, in order:
+ *   - both frozen blobs AND both shadow copies. In FrozenStateManager these are
+ *     the SAME storage: Context_UpdateShadowCopy writes the bytes without
+ *     setting hasBeenFrozen, and Context_ClearFrozenState memsets the buffer as
+ *     well as clearing the flag. So one ClearAll covers both halves of the
+ *     issue's "frozen blobs both directions, both shadows".
+ *   - the RAM-only shared-item staging outbox (shared_items.c), which holds
+ *     pickups staged but not yet committed when the session died.
+ *   - every session field of gComboCtx: the switch request, source game and
+ *     entrance, sharedFlags, the retired-in-place sharedItems/saveSlot, and —
+ *     the two the netplay spike (#460) cares about — sharedItemsTagged and
+ *     foreignPlacements. A stale sharedItemsTagged is how another player's
+ *     grants from a dead room would reach a fresh seed.
+ *
+ * The seed stamp is governed by @p seedPolicy; see ComboSeedStampPolicy.
+ *
+ * Deliberately does NOT touch gCurrentGame (which game is running right now is
+ * still true) and does NOT arm a frozen blob from anything. Arming is the
+ * exclusive job of a real freeze, which keeps the "a plain .redsave load
+ * applies on the next switch only" semantics from #419/#420 intact.
+ */
+void Context_InvalidateSessionState(ComboSeedStampPolicy seedPolicy);
+
+// ---- Call-site-shaped entry points ---------------------------------------
+// The three transitions that end a session, each named for the thing that
+// happens rather than for the policy it selects. Game-side call sites are plain
+// C in games/oot/src/**, which do NOT have src/common on their include path and
+// so declare these locally as `extern` (the same convention z_play.c uses for
+// Combo_*). That is why none of them take ComboSeedStampPolicy: an enum
+// re-declared by hand in another TU is an ABI hazard for no benefit. Keeping
+// the policy here also means the "is this really a session end?" judgement is
+// written once, in a TU the headless tests link.
+
+/**
+ * Return to the title screen (soft reset, or a cold boot's first pass).
+ *
+ * SUPPRESSED when a cross-game startup entrance is pending, and that guard is
+ * the whole subtlety of this hook. A cross-game arrival ALSO passes through
+ * OoT's title chain — TitleSetup -> Title (which fast-forwards on
+ * Combo_HasStartupEntranceForGame) -> Opening -> Play_Init, which is where
+ * Combo_ConsumeFrozenState finally applies the blob. Invalidating
+ * unconditionally here would destroy the very blob the arrival is on its way to
+ * consume, turning every return leg into a lost session. rsbs/src/main.cpp sets
+ * the startup entrance BEFORE GameRunner_SwitchTo, so it is reliably visible by
+ * the time the target's title chain runs — for entrance switches and for F10
+ * hot-swap returns alike.
+ *
+ * Uses RSBS_SEED_STAMP_DROP: at the title no file is active, so nothing stands
+ * behind a stamp. A seed generated afterwards re-stamps via Playthrough_Init;
+ * an existing slot re-stamps from its .redsave on load.
+ *
+ * @return 1 if the session was invalidated, 0 if suppressed for an arrival.
+ */
+int Context_InvalidateSessionOnReturnToTitle(void);
+
+/**
+ * A new OoT file is being created (OoT_Sram_InitSave).
+ *
+ * @param isRandoFile non-zero iff the file being created is a randomizer file
+ *        whose seed has already been generated. That is the ONLY case where the
+ *        seed stamp is kept: generation ran moments ago, in the menu, and
+ *        authored the stamp FOR this file. A vanilla new file passes 0 and the
+ *        stamp goes with the rest of the dead session — otherwise
+ *        Combo_ForeignPairingActive() would still report a paired world.
+ */
+void Context_InvalidateSessionOnNewGame(int isRandoFile);
+
+/**
+ * An existing slot is being loaded, BEFORE its .redsave is read back.
+ *
+ * The clear half of the issue's clear-and-reload semantics, and it matters most
+ * in the case that looks like it needs it least: the .redsave is per-OoT-slot
+ * (redship_slot{0,1,2}.redsave) while these globals are process singletons, so
+ * loading a slot that has NO companion .redsave used to leave the previous
+ * session's gComboCtx and shadows in place and silently adopt them as if they
+ * belonged to the slot. Clearing first makes "no .redsave" mean "no cross-game
+ * state", which is the truth.
+ *
+ * Does NOT arm a frozen blob — the caller's RsbsSave_Load repopulates gComboCtx
+ * and both shadows, and arming stays the exclusive job of a real freeze so the
+ * #419/#420 "applies on next switch only" plain-load semantics survive.
+ */
+void Context_InvalidateSessionOnSlotLoad(void);
+
 // Context_ProcessSwitch() / Context_IsSwitchInProgress() used to be declared
 // here. Their implementations were removed from switch.cpp (zero callers, and
 // they depended on TUs excluded from the single-exe link); the dangling

--- a/src/common/test_runner.cpp
+++ b/src/common/test_runner.cpp
@@ -107,6 +107,12 @@ extern "C" {
 #include "tests/test_hotswap_freeze.c"
 }
 
+// Cross-game session invalidation on soft reset / new game (issue #440).
+// Included at FILE SCOPE (compiled as C++): it drives the C++-linkage
+// rsbs::SaveManager to prove a legitimate existing-slot load still restores,
+// and the C++-linkage Entrance_* API to stage the arrival negative control.
+#include "tests/test_session_invalidation.c"
+
 // Archive hot-swap regression test (issue #263). Included at FILE SCOPE (not
 // inside an extern "C" block): it is compiled as C++ and uses the C++-linkage
 // Entrance_* API for setup. Its cross-TU ArchiveHotswap_* helpers are wrapped
@@ -1043,6 +1049,13 @@ const TestDescriptor gTests[] = {
     // test that freezes and one that expects that freeze to still be there.
     {"hotswap-freeze", "F10 hot swap freezes the departing game; frozen state is single-use (#364)",
      Test_HotSwapFreeze},
+    // #440: the inverse #400 never got. Retiring a blob ON CONSUME stops it
+    // being consumed twice; it does nothing about a dead session's blob still
+    // being there for the NEXT session's first consume. Like hotswap-freeze
+    // this clears all frozen states on entry and exit, so it must not run
+    // between a test that freezes and one expecting that freeze to persist.
+    {"session-invalidation", "Soft reset / new game retire cross-game session state; loads still restore (#440)",
+     Test_SessionInvalidation},
     {"lifecycle", "Game lifecycle unit tests", Test_Lifecycle},
     // Unified save (.redsave) headless coverage (issue #35, Phase 2 T6).
     {"save-roundtrip-tiers", "Unified .redsave preserves ComboContext + both SaveContexts (#35)", Test_SaveRoundtripTiers},

--- a/src/common/tests/test_session_invalidation.c
+++ b/src/common/tests/test_session_invalidation.c
@@ -1,0 +1,396 @@
+/**
+ * @file test_session_invalidation.c
+ * @brief Cross-game session invalidation on reset / new game — issue #440
+ *
+ * The operator's repro, headlessly: play a rando on OoT slot 3, SOFT RESET
+ * (no process restart), start a NEW rando on slot 1, walk into the Happy Mask
+ * Shop — and MM came up carrying the PREVIOUS session's state, in-game clock
+ * where the old session left it and the Laundry Pool stray fairy still
+ * collected. "The gamestate didn't reset at all."
+ *
+ * Root cause: cross-game session state is process-global and had no
+ * invalidation inverse. The frozen blobs, both shadow copies (the SAME storage
+ * inside FrozenStateManager) and every session field of gComboCtx survived a
+ * soft reset untouched. PR #400 made Combo_ConsumeFrozenState retire the blob
+ * it hands over, which stops a blob being consumed TWICE — but a dead session's
+ * blob was still sitting there for the FIRST consume of the next session, which
+ * is exactly what the operator hit.
+ *
+ * It is also cross-seed contamination, and that is why the netplay spike
+ * (#460) is blocked on it: a stale sharedItemsTagged carries another player's
+ * grants from a dead room into a fresh seed.
+ *
+ * What this file locks, in the order a session actually ends:
+ *
+ *   1. Session A really is resident — the precondition the whole bug needs.
+ *   2. A cross-game ARRIVAL must NOT invalidate. The negative control, and the
+ *      most dangerous way to "fix" this bug: an arrival walks the same title
+ *      chain as a reset, so an unguarded hook would eat the blob the arrival is
+ *      on its way to consume and turn every return leg into a lost session.
+ *   3. Soft reset to title retires the blobs, the shadows and gComboCtx.
+ *   4. Entering MM after the reset finds NOTHING to consume — the operator's
+ *      symptom, asserted directly.
+ *  4b. The COMPOSED regression, and post-#447 the headline one: session A
+ *      frozen -> reset -> new game on a different slot -> first MM entry must
+ *      PAIR, not merely be fresh. #447 (d075aeaf) made MM's arrival guard key
+ *      off Combo_ConsumeFrozenState's return value to answer "does this MM save
+ *      already exist?" — so a dead session's blob tells a brand-new seed that
+ *      it does, and the paired world is never generated at all. The dependency
+ *      is one-directional: invalidating the blob restores correct pairing with
+ *      no change to the guard.
+ *   5. New game keeps a generated seed stamp and drops everything else.
+ *   6. A NON-rando new file drops the seed stamp too, or
+ *      Combo_ForeignPairingActive() would keep reporting a paired world.
+ *   7. A legitimate existing-slot load STILL restores that slot's .redsave.
+ *      The do-not-break case: fixing the leak by breaking restore would be a
+ *      worse bug than the leak.
+ *   8. Loading a slot with NO .redsave yields no cross-game state rather than
+ *      inheriting the previous session's.
+ *
+ * Included at FILE SCOPE (compiled as C++, NOT inside an extern "C" block) so
+ * it can drive the C++-linkage rsbs::SaveManager for cases 7 and 8, the same
+ * way test_save_roundtrip.c does. Everything else it touches is C-linkage and
+ * declared through the headers below.
+ */
+
+#include "../context.h"
+#include "../entrance.h"
+#include "../foreign_items.h"
+#include "../game.h"
+#include "../save.h"
+#include "../shared_items.h"
+#include "../test_runner.h"
+
+#include <cstddef>
+#include <cstdint>
+#include <cstdio>
+#include <cstring>
+#include <filesystem>
+#include <string>
+#include <vector>
+
+// The consume side of the freeze machinery (src/common/switch.cpp). Declared
+// locally for the same reason test_hotswap_freeze.c does: the switch policy has
+// no header of its own.
+extern "C" int Combo_ConsumeFrozenState(const char* gameId, void* saveContext, size_t size);
+
+#define SESSION_ASSERT(cond)                                                                                           \
+    do {                                                                                                               \
+        if (!(cond)) {                                                                                                 \
+            printf("  FAIL: %s:%d: %s\n", __FILE__, __LINE__, #cond);                                                  \
+            return TEST_FAIL;                                                                                          \
+        }                                                                                                              \
+    } while (0)
+
+namespace {
+
+const char* const kSessionTestDir = "rsbs_test_session";
+
+// A slice of a SaveContext is enough: Context_FreezeState/RestoreState clamp to
+// min(size, per-game capacity), so a short buffer round-trips exactly. Same
+// trick test_hotswap_freeze.c uses.
+const size_t kSessionBuf = 512;
+
+// Byte fills standing in for "session A" and "session B" MM saves. In the
+// operator's terms, kSessionAByte is the old seed's clock and stray-fairy bits.
+const uint8_t kSessionAByte = 0xA5;
+const uint8_t kSessionBByte = 0x5B;
+
+// Put a recognizable, fully-populated session into every global the bug leaks
+// through: both frozen blobs, both shadows, the seed stamp, the crossing
+// tables, and a staged-but-uncommitted pickup in the RAM outbox.
+void SeedSessionA(uint32_t seed, uint32_t settingsHash) {
+    Context_InitFrozenStates();
+    Context_ClearAllFrozenStates();
+    ComboContext_Init();
+
+    std::vector<uint8_t> blob(kSessionBuf, kSessionAByte);
+    Context_FreezeState(GAME_MM, MM_ENTR_SOUTH_CLOCK_TOWN_0, blob.data(), blob.size());
+    Context_FreezeState(GAME_OOT, OOT_ENTR_MARKET_FROM_MASK_SHOP, blob.data(), blob.size());
+
+    gComboCtx.sourceGame = GAME_OOT;
+    gComboCtx.sourceEntrance = OOT_ENTR_HAPPY_MASK_SHOP;
+    gComboCtx.sharedFlags[3] = 0xDEADBEEFu;
+    gComboCtx.sourceIsRando = true;
+    gComboCtx.sharedRandoSeed = seed;
+    gComboCtx.sharedRandoSettingsHash = settingsHash;
+
+    // The two fields the netplay grant model composes with (#460).
+    Combo_RecordSharedItem(GAME_OOT, 42);
+    SharedItem foreign;
+    foreign.originGame = (uint8_t)GAME_OOT;
+    foreign.flags = 0;
+    foreign.id = 77;
+    Combo_SetForeignPlacement(/*mmCheckId=*/9, foreign);
+
+    // Staged but never committed — the session died mid-pickup.
+    Combo_StageSharedItem(GAME_OOT, 43);
+}
+
+// What MM's cross-game arrival decides once #447 (d075aeaf) merged.
+//
+// The authoritative copy is MM_Rando_PairOnCrossGameArrival in
+// games/mm/2s2h/GameExports_SingleExe.cpp; this mirrors its decision because
+// BOTH of its inputs are src/common state — Combo_ForeignPairingActive() and
+// Combo_ConsumeFrozenState()'s return value. That is exactly why #440 was able
+// to change the guard's answer without a line of pairing logic being wrong:
+// the guard asks "does this MM save already exist?", and a dead session's blob
+// answers "yes" for a save that does not exist. So post-#447 this bug does not
+// merely leak the old clock and stray fairies into the new seed — it makes the
+// new seed DECLINE TO PAIR AT ALL, suppressing the headline feature.
+//
+// Mirrored rather than called: the real guard needs gSaveContext and MM's
+// SAVETYPE_RANDO, which a headless src/common test has no business booting.
+// MMPairSwitchEntry (games/mm/2s2h/mm_rando_gen_test.cpp) covers the dispatch
+// itself; what belongs HERE is that the inputs the guard reads are correct.
+enum PairDecision {
+    PAIR_DECLINE_NO_WORLD,       // Combo_ForeignPairingActive() == false
+    PAIR_DECLINE_EXISTING_SAVE,  // hadFrozenState != 0 — the #440 failure
+    PAIR_PROCEED,                // dispatches OnSaveInit; the paired world activates
+};
+
+PairDecision ArrivalPairDecision(int hadFrozenState) {
+    if (!Combo_ForeignPairingActive()) {
+        return PAIR_DECLINE_NO_WORLD;
+    }
+    if (hadFrozenState) {
+        return PAIR_DECLINE_EXISTING_SAVE;
+    }
+    return PAIR_PROCEED;
+}
+
+// Stamp the seed fields the way Playthrough_Init does at generation time —
+// which for a new file happens BEFORE the file is created.
+void StampGeneratedSeed(uint32_t seed, uint32_t settingsHash) {
+    gComboCtx.sourceIsRando = true;
+    gComboCtx.sharedRandoSeed = seed;
+    gComboCtx.sharedRandoSettingsHash = settingsHash;
+}
+
+// Every session field must read as freshly initialized.
+bool SessionIsClear(bool expectSeedStamp) {
+    if (Context_HasFrozenState(GAME_OOT) || Context_HasFrozenState(GAME_MM)) {
+        return false;
+    }
+    if (gComboCtx.switchRequested || gComboCtx.sourceGame != GAME_NONE || gComboCtx.sourceEntrance != 0) {
+        return false;
+    }
+    if (gComboCtx.sharedFlags[3] != 0) {
+        return false;
+    }
+    if (Combo_CountSharedItems(GAME_OOT, /*includeRedeemed=*/true) != 0) {
+        return false;
+    }
+    if (Combo_CountForeignPlacements() != 0) {
+        return false;
+    }
+    if (expectSeedStamp != gComboCtx.sourceIsRando) {
+        return false;
+    }
+    return true;
+}
+
+}  // namespace
+
+TestResult Test_SessionInvalidation(void) {
+    printf("[TEST] session-invalidation: soft reset / new game retire cross-game session state (#440)\n");
+
+    Entrance_ClearStartupEntrance();
+
+    // ---- 1. Session A is resident ----------------------------------------
+    // The precondition. If this ever stops holding, every assertion below
+    // passes vacuously and the test stops being a lock at all.
+    SeedSessionA(0x1234u, 0xABCDu);
+    SESSION_ASSERT(Context_HasFrozenState(GAME_MM) == 1);
+    SESSION_ASSERT(Context_HasFrozenState(GAME_OOT) == 1);
+    SESSION_ASSERT(Combo_CountSharedItems(GAME_OOT, true) == 1);
+    SESSION_ASSERT(Combo_CountForeignPlacements() == 1);
+    SESSION_ASSERT(Combo_ForeignPairingActive());
+
+    // ---- 2. NEGATIVE CONTROL: an arrival must not invalidate --------------
+    // A cross-game arrival passes through the SAME OoT title chain a soft reset
+    // does (TitleSetup -> Title fast-forward -> Opening -> Play_Init, where the
+    // blob is finally consumed). An unguarded return-to-title hook would clear
+    // the blob mid-flight and every return leg would silently lose its session
+    // — a strictly worse bug than the one being fixed. main.cpp sets the
+    // startup entrance BEFORE GameRunner_SwitchTo, so it is visible here.
+    Entrance_SetStartupEntrance(MM_ENTR_SOUTH_CLOCK_TOWN_0, GAME_MM);
+    SESSION_ASSERT(Context_InvalidateSessionOnReturnToTitle() == 0);
+    SESSION_ASSERT(Context_HasFrozenState(GAME_MM) == 1);
+    SESSION_ASSERT(Combo_CountForeignPlacements() == 1);
+    Entrance_ClearStartupEntrance();
+
+    // ---- 3. Soft reset to title retires the session -----------------------
+    SESSION_ASSERT(Context_InvalidateSessionOnReturnToTitle() == 1);
+    SESSION_ASSERT(SessionIsClear(/*expectSeedStamp=*/false));
+    // The seed stamp goes too: at the title no file is active, so nothing
+    // stands behind it, and Combo_ForeignPairingActive() is literally
+    // `sourceIsRando && sharedRandoSettingsHash != 0`.
+    SESSION_ASSERT(gComboCtx.sharedRandoSeed == 0);
+    SESSION_ASSERT(gComboCtx.sharedRandoSettingsHash == 0);
+    SESSION_ASSERT(!Combo_ForeignPairingActive());
+    // The shadows are the same storage as the blobs and must be wiped with
+    // them, or a tracker (or a .redsave written afterwards) would still be
+    // reading the dead session's bytes.
+    {
+        const uint8_t* mmShadow = static_cast<const uint8_t*>(Context_GetMMSaveContext());
+        const uint8_t* ootShadow = static_cast<const uint8_t*>(Context_GetOoTSaveContext());
+        SESSION_ASSERT(mmShadow != nullptr && ootShadow != nullptr);
+        SESSION_ASSERT(mmShadow[0] == 0x00 && mmShadow[kSessionBuf - 1] == 0x00);
+        SESSION_ASSERT(ootShadow[0] == 0x00 && ootShadow[kSessionBuf - 1] == 0x00);
+    }
+
+    // ---- 4. THE OPERATOR'S SYMPTOM ----------------------------------------
+    // Start the new seed and walk into the Happy Mask Shop. MM's arrival calls
+    // Combo_ConsumeFrozenState — which before the fix found session A's blob
+    // and restored its clock and its collected stray fairies onto a brand new
+    // file. It must now find nothing, leaving MM's bootstrap save untouched.
+    {
+        std::vector<uint8_t> arriving(kSessionBuf, kSessionBByte);
+        SESSION_ASSERT(Combo_ConsumeFrozenState("mm", arriving.data(), arriving.size()) == 0);
+        SESSION_ASSERT(arriving[0] == kSessionBByte);                 // not session A's clock
+        SESSION_ASSERT(arriving[kSessionBuf - 1] == kSessionBByte);   // not session A's fairy flags
+        SESSION_ASSERT(arriving[0] != kSessionAByte);
+    }
+
+    // ---- 4b. COMPOSED REGRESSION: the new seed must still PAIR -------------
+    // Post-#447 (d075aeaf) this is the headline consequence, and it is the one
+    // a player would actually notice. MM's arrival guard decides whether to
+    // generate the paired world from two src/common inputs; a stale blob makes
+    // it answer "this MM save already exists" for a save that does not, so the
+    // brand-new seed declines to pair and MM plays vanilla.
+    //
+    // First, prove the failure shape is real — that this test would CATCH a
+    // regression rather than pass vacuously. Session A's blob resident, new
+    // seed stamped: the guard declines.
+    SeedSessionA(0x1234u, 0xABCDu);
+    StampGeneratedSeed(0x99999999u, 0x5555u);
+    {
+        std::vector<uint8_t> arriving(kSessionBuf, kSessionBByte);
+        const int hadFrozen = Combo_ConsumeFrozenState("mm", arriving.data(), arriving.size());
+        SESSION_ASSERT(hadFrozen == 1);
+        SESSION_ASSERT(ArrivalPairDecision(hadFrozen) == PAIR_DECLINE_EXISTING_SAVE);
+    }
+
+    // Now the real sequence: session A resident, soft reset, generate the new
+    // seed, create the new file on a DIFFERENT slot, then first MM entry.
+    SeedSessionA(0x1234u, 0xABCDu);
+    SESSION_ASSERT(Context_InvalidateSessionOnReturnToTitle() == 1);
+    StampGeneratedSeed(0x99999999u, 0x5555u);
+    Context_InvalidateSessionOnNewGame(/*isRandoFile=*/1);
+    {
+        std::vector<uint8_t> arriving(kSessionBuf, kSessionBByte);
+        const int hadFrozen = Combo_ConsumeFrozenState("mm", arriving.data(), arriving.size());
+        // No stale blob, so the guard is told the truth: this MM save does not
+        // exist yet.
+        SESSION_ASSERT(hadFrozen == 0);
+        // The new seed's stamp survived, so a paired OoT world is still visible.
+        SESSION_ASSERT(Combo_ForeignPairingActive());
+        // Therefore the arrival dispatches OnSaveInit and the paired world
+        // activates. Invalidation restores correct pairing with NO change to
+        // #447's guard — it was asking the right question all along.
+        SESSION_ASSERT(ArrivalPairDecision(hadFrozen) == PAIR_PROCEED);
+    }
+
+    // ---- 5. New RANDO file: keep the seed stamp, drop the session ----------
+    // Generation runs BEFORE the file is created (generate a seed in the menu,
+    // then name the file), so Playthrough_Init has already stamped these fields
+    // FOR this file. Dropping them here would unpair a world that was just
+    // generated — which is the same "declines to pair" symptom arriving from
+    // the opposite direction, and why the stamp is the ONE field invalidation
+    // can be asked to preserve.
+    SeedSessionA(0x1234u, 0xABCDu);
+    StampGeneratedSeed(0x99999999u, 0x5555u);
+    Context_InvalidateSessionOnNewGame(/*isRandoFile=*/1);
+    SESSION_ASSERT(SessionIsClear(/*expectSeedStamp=*/true));
+    SESSION_ASSERT(gComboCtx.sharedRandoSeed == 0x99999999u);
+    SESSION_ASSERT(gComboCtx.sharedRandoSettingsHash == 0x5555u);
+    // The dead session's crossings must not reach the new seed. This is the
+    // assertion the netplay agents' grant model composes with (#460): a stale
+    // sharedItemsTagged is another player's grants from a dead room.
+    SESSION_ASSERT(Combo_CountSharedItems(GAME_OOT, true) == 0);
+    SESSION_ASSERT(Combo_CountForeignPlacements() == 0);
+    // ...including the staged-but-uncommitted outbox, which would otherwise
+    // drain into the NEW seed's array at its first suspend.
+    SESSION_ASSERT(Combo_CommitStagedSharedItems() == 0);
+    SESSION_ASSERT(Combo_CountSharedItems(GAME_OOT, true) == 0);
+
+    // ---- 6. New VANILLA file: the seed stamp goes too ----------------------
+    SeedSessionA(0x1234u, 0xABCDu);
+    Context_InvalidateSessionOnNewGame(/*isRandoFile=*/0);
+    SESSION_ASSERT(SessionIsClear(/*expectSeedStamp=*/false));
+    SESSION_ASSERT(gComboCtx.sharedRandoSeed == 0);
+    SESSION_ASSERT(gComboCtx.sharedRandoSettingsHash == 0);
+    // A surviving stamp would leave MM believing a paired world exists for a
+    // seed that no longer does — the arrival must decline, and for the RIGHT
+    // reason (no paired world, not "the save already exists").
+    SESSION_ASSERT(!Combo_ForeignPairingActive());
+    SESSION_ASSERT(ArrivalPairDecision(/*hadFrozenState=*/0) == PAIR_DECLINE_NO_WORLD);
+
+    // ---- 7. DO NOT BREAK RESTORE: an existing slot reloads its .redsave ----
+    // Fixing the leak by making loads stop restoring would be a worse bug than
+    // the leak. Write slot 1 from session A, invalidate, load slot 1 back, and
+    // require that slot's own state to return.
+    {
+        std::error_code ec;
+        std::filesystem::remove_all(kSessionTestDir, ec);
+        std::filesystem::create_directories(kSessionTestDir, ec);
+        rsbs::SaveManager& mgr = rsbs::SaveManager::Instance();
+        mgr.SetSaveDirectory(kSessionTestDir);
+
+        SeedSessionA(0x2468u, 0x1357u);
+        std::vector<uint8_t> mmLive(MM_SAVE_CONTEXT_SIZE, kSessionAByte);
+        Context_UpdateShadowCopy(GAME_MM, mmLive.data(), mmLive.size());
+        SESSION_ASSERT(mgr.Save(1));
+
+        // Something else entirely happens (a reset), then the player loads
+        // slot 1 through the OnLoadFile path: clear, then reload.
+        Context_InvalidateSessionOnReturnToTitle();
+        SESSION_ASSERT(SessionIsClear(false));
+
+        Context_InvalidateSessionOnSlotLoad();
+        SESSION_ASSERT(mgr.HasSave(1));
+        SESSION_ASSERT(mgr.Load(1));
+
+        // Slot 1's own cross-game state is back, byte-exact.
+        SESSION_ASSERT(gComboCtx.sharedRandoSeed == 0x2468u);
+        SESSION_ASSERT(gComboCtx.sharedRandoSettingsHash == 0x1357u);
+        SESSION_ASSERT(gComboCtx.sourceIsRando);
+        SESSION_ASSERT(gComboCtx.sharedFlags[3] == 0xDEADBEEFu);
+        SESSION_ASSERT(Combo_CountSharedItems(GAME_OOT, true) == 1);
+        SESSION_ASSERT(Combo_CountForeignPlacements() == 1);
+        SESSION_ASSERT(Combo_GetForeignPlacementForCheck(9) != nullptr);
+        {
+            const uint8_t* mmShadow = static_cast<const uint8_t*>(Context_GetMMSaveContext());
+            SESSION_ASSERT(mmShadow != nullptr);
+            SESSION_ASSERT(mmShadow[0] == kSessionAByte);
+            SESSION_ASSERT(mmShadow[MM_SAVE_CONTEXT_SIZE - 1] == kSessionAByte);
+        }
+        // A plain load must NOT arm a frozen blob. Restores stay the exclusive
+        // job of a real freeze, which is what keeps the #419/#420 "applies on
+        // the next switch only" plain-load semantics intact.
+        SESSION_ASSERT(Context_HasFrozenState(GAME_MM) == 0);
+        SESSION_ASSERT(Context_HasFrozenState(GAME_OOT) == 0);
+
+        // ---- 8. A slot with NO .redsave inherits nothing ------------------
+        // The .redsave is per-OoT-slot but these globals are process
+        // singletons. Slot 2 was never written, so loading it must leave no
+        // cross-game state — not slot 1's, which is still resident right now.
+        SESSION_ASSERT(!mgr.HasSave(2));
+        Context_InvalidateSessionOnSlotLoad();
+        SESSION_ASSERT(SessionIsClear(false));
+        SESSION_ASSERT(gComboCtx.sharedRandoSeed == 0);
+        SESSION_ASSERT(!Combo_ForeignPairingActive());
+
+        std::filesystem::remove_all(kSessionTestDir, ec);
+    }
+
+    printf("[TEST] PASS: a dead session's frozen blobs, shadows and gComboCtx crossings do not "
+           "survive a soft reset or a new game; arrivals and existing-slot loads still restore\n");
+
+    // Leave global state clean for any subsequent test.
+    Context_ClearAllFrozenStates();
+    ComboContext_Init();
+    Entrance_ClearStartupEntrance();
+    return TEST_PASS;
+}


### PR DESCRIPTION
Fixes #440.

## Root cause

Cross-game session state is **process-global and had no invalidation inverse**. The frozen blobs, both shadow copies, and every session field of `gComboCtx` survived a soft reset and a new game untouched.

PR #400 made `Combo_ConsumeFrozenState` retire the blob it hands over. That stops a blob being consumed **twice** — it does nothing about a dead session's blob still being there for the **first** consume of the next session. That is the operator's repro exactly: rando on OoT slot 3, soft reset, new rando on slot 1, Happy Mask Shop, and MM comes up on the previous seed's clock with its Laundry Pool stray fairy still collected.

One structural detail worth stating, because it makes the fix smaller than it looks: inside `FrozenStateManager` the **shadow copy and the frozen blob are the same storage**. `Context_UpdateShadowCopy` writes the bytes without setting `hasBeenFrozen`; `Context_ClearFrozenState` memsets the buffer *and* clears the flag. So one `Context_ClearAllFrozenStates()` covers the issue's "frozen blobs both directions, both shadows".

## Severity after #447

`MM_Rando_PairOnCrossGameArrival` (merged in #447, `d075aeaf`) keys off `Combo_ConsumeFrozenState`'s return value to answer *"does this MM save already exist?"*. Given a live session that is correct. Under #440 the blob describes a **dead** session, so a brand-new seed's first MM entry is told the save exists, logs

```
[MM] pairing: skipped-because-existing-mm-save
```

and **declines to pair at all**. So this is no longer just "old clock/flags leak in" — it suppresses the paired world, the headline feature.

The dependency is one-directional and clean: **no change to #447's guard**. It was asking the right question and being given a stale answer. Making the stale blob not be there restores correct pairing by itself.

## The transition matrix

"Pairs?" is `MM_Rando_PairOnCrossGameArrival`'s decision on the next first-MM-entry.

| transition | frozen blobs | shadows | crossings | seed stamp | pairs? |
|---|---|---|---|---|---|
| **cold boot** | none (init) | zeroed | none | none | n/a until a seed exists |
| **reset -> same slot** | DROPPED | reloaded | reloaded | reloaded | **yes**, from that slot's `.redsave` |
| **reset -> different slot** | DROPPED | reloaded | reloaded | reloaded | **yes**, from that slot's `.redsave` |
| **reset -> new file** | DROPPED | zeroed | DROPPED | kept iff rando file | **yes** for a rando file (the operator's case); declines with `no-paired-oot-world` for a vanilla file, correctly |
| *(cross-game arrival)* | **PRESERVED** | preserved | preserved | preserved | declines (`existing-mm-save`) — correct, it **is** the player's own restored session |

Same-slot and different-slot are deliberately identical. The `.redsave` is per-OoT-slot (`redship_slot{0,1,2}.redsave`) but these globals are process singletons, so the only safe rule is **clear-then-reload for both**. Treating "same slot" as a fast path that skips the clear is precisely how a slot with no companion `.redsave` keeps inheriting the previous session.

That last row is the trap. A cross-game arrival walks the **same OoT title chain** a soft reset does (`TitleSetup` -> `Title` fast-forward -> `Opening` -> `Play_Init`, where the blob is finally consumed). An unguarded return-to-title hook would eat the blob every return leg is on its way to consume — a strictly worse bug than the one being fixed. `Context_InvalidateSessionOnReturnToTitle` self-suppresses on a pending startup entrance; `main.cpp` sets it *before* `GameRunner_SwitchTo`, so it is reliably visible, for entrance switches and F10 returns alike.

## Per-field fate on invalidation

| field | fate | why |
|---|---|---|
| `magic`, `version` | re-stamped | struct identity, not session state |
| `switchRequested`, `targetGame`, `targetEntrance` | cleared | a pending switch belongs to the dead session |
| `sourceGame`, `sourceEntrance` | cleared | "last game played" is the dead session's |
| `sharedFlags[64]` | cleared | cross-game event bits are session state |
| `sharedItems[32]`, `saveSlot` | cleared / `-1` | retired-in-place; kept consistent with `ComboContext_Init` |
| `sharedItemsTagged[64]` | **cleared** | **the netplay one** — another player's grants from a dead room must not reach a fresh seed |
| `foreignPlacements[8]` | **cleared** | a dead seed's cross-game placements must not survive |
| `sourceIsRando`, `sharedRandoSeed`, `sharedRandoSettingsHash` | **policy-controlled** | see below |
| `reserved[332]` | cleared | growth contract: zero means unset |
| *(RAM outbox, `shared_items.c`)* | cleared | staged-but-uncommitted pickups would otherwise drain into the next session |

Every field is session state, so `ComboContext_Init()` **is** the invalidator — there is no hand-written per-field clear to drift out of sync with the struct, and fields carved from `reserved[]` later are covered automatically.

**The seed stamp is the one exception, and it needs care.** `Playthrough_Init` writes it at *generation* time, which for a new file happens **before** the file is created (generate a seed in the menu, then name the file). So a blanket wipe at `OoT_Sram_InitSave` would unpair a world that had just been generated — the same "declines to pair" symptom from the opposite direction. Hence `ComboSeedStampPolicy`, and an explicit argument rather than a hidden rule so every call site states which situation it is in:

- **new rando file** -> `KEEP` (generation authored it for *this* file)
- **new vanilla file** -> `DROP` (`Combo_ForeignPairingActive()` is literally `sourceIsRando && sharedRandoSettingsHash != 0`, so a surviving stamp reports a paired world that does not exist)
- **return to title** -> `DROP` (no file is active; a later generation re-stamps, a later load re-stamps from disk)
- **slot load** -> `DROP` (the slot's own `.redsave` supplies the truth immediately after)

## Call sites

- **return to title** — `TitleSetup_InitImpl`, the single call site of `OoT_SaveContext_Init`. Every soft-reset route reaches it: the debug-console `reset` command the Ctrl+R menu item dispatches, and the N64 reset-button emulation via PreNMI restarting the boot chain. A cold boot reaches it too, where the clear is a no-op on already-zero state.
- **new file** — `OoT_Sram_InitSave`, ordered *before* `Randomizer_InitSaveFile()` and `Save_SaveFile()` so nothing the new file authors is wiped, and so the `OnSaveFile` -> `RsbsSave_Save` at the end of that function writes a `.redsave` already reflecting the cleared state instead of persisting the dead session's crossings into the new file's very first save.
- **existing-slot load** — `OnLoadFile`, now clear-then-reload instead of load-if-present.

## What is deliberately *not* changed

Invalidation never **arms** a frozen blob. Arming stays the exclusive job of a real freeze, so #419/#420's "a plain `.redsave` load applies on the next switch only" semantics are untouched. `gCurrentGame` is also left alone — which game is running right now is still true.

Per the note on #440, the fix stays confined to the reset/new-file boundary: `MM_Play_ConsumeStartupEntrance` is presence-gated on `Combo_HasStartupEntranceForGame("mm")` and the startup entrance is cleared per switch, so the consumption point correctly treats the next MM entry as a first entry with no reach-in needed.

## Lock

New `SessionInvalidation` CTest (`redship`-tier, headless — no SDL, no ROMs, no boot):

1. session A really is resident (or every assertion below passes vacuously)
2. **negative control** — a pending startup entrance suppresses invalidation; the arrival's blob survives
3. soft reset retires blobs, shadows *and* `gComboCtx`
4. **the operator's symptom** — entering MM after the reset finds nothing to consume, and the arriving buffer keeps its own bytes
5. **the composed regression** — session A -> reset -> new seed -> new file on a *different* slot -> first MM entry **PAIRS**. Includes a proof that the pre-fix shape *declines*, so the test cannot pass vacuously
6. new rando file keeps the generated stamp, drops everything else including the staged outbox
7. new vanilla file drops the stamp too, and the arrival declines for the *right* reason
8. **do not break restore** — an existing slot still reloads its own `.redsave` byte-exact, and a plain load still does not arm a blob
9. a slot with **no** `.redsave` inherits nothing rather than adopting the resident session

The pairing decision is mirrored from `MM_Rando_PairOnCrossGameArrival` rather than called (the real guard needs `gSaveContext` and MM's `SAVETYPE_RANDO`, which a headless `src/common` test has no business booting). `MMPairSwitchEntry` covers the dispatch itself; what belongs here is that the inputs the guard reads are correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!--- section:artifacts:start -->
### Build Artifacts
  - [rsbs-windows.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/8506774767.zip)
  - [rsbs-linux.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/8506443243.zip)
<!--- section:artifacts:end -->