### PR TITLE
Record the MM COND_HOOK disarm audit: file select is the universal funnel (#467)

### DIFF
--- a/docs/unified-surface-findings.md
+++ b/docs/unified-surface-findings.md
@@ -38,6 +38,45 @@ thing the docs implied:
    > earlier dispatch on the same path. Any `COND_*` condition read off save
    > state needs a re-dispatch once the final save is known.
 
+   ### Why only the cross-game arrival was broken: file select is the universal funnel
+
+   The full audit of this class (#467, against `d075aeaf`) enumerated every MM entry
+   path that reaches gameplay and asked *what save is live at each `OnSaveLoad`
+   dispatch*. The result is a single structural invariant, and it is the reason #439
+   was a one-path bug rather than a dozen:
+
+   > **Every vanilla-MM route from the disarming `TitleSetup` dispatch to actual
+   > gameplay passes through `FileSelect_LoadGame`**
+   > (`z_file_choose_NES.c:2250`), which dispatches `OnSaveLoad` against the real
+   > save. Cold boot, F10 with no frozen state, owl-save-and-quit, and the
+   > `entrance == -1` bail all land on the title/attract chain and must go through
+   > file select to reach play. **The cross-game arrival is the only path that goes
+   > `TitleSetup -> MM_Play_Init` directly**, bypassing that funnel — which is
+   > exactly why it was the only one left disarmed, and why #447's re-arm belongs at
+   > `MM_Play_ConsumeStartupEntrance` rather than anywhere more general.
+
+   Corollaries worth keeping in mind before changing this area:
+
+   - **Any new path that boots straight into `MM_Play_Init` without passing file
+     select reopens #439's class**, and needs its own re-dispatch at the point the
+     final save is known. That is the tripwire to check on boot-flow changes.
+   - The paths that never dispatch at all — three-day cycle reset (`Sram_SaveEndOfCycle`
+     -> `DayTelop_Init` -> `MM_Play_Init`), death/respawn, and ordinary scene
+     transitions — are **benign**, because they never *wipe* the save either. Hooks
+     armed by file select or by the arrival re-dispatch stay armed across them. Absence
+     of a dispatch is only a bug where the save's *shape* can change.
+   - `MM_Sram_InitSave` (`z_sram_NES.c:1918`) dispatches `OnSaveInit` but **never
+     `OnSaveLoad`**, so a freshly created rando file is briefly `SAVETYPE_RANDO` with
+     every hook disarmed. Today it is masked — name entry returns to the file list, so
+     file select always follows. **Do not "fix" this by dropping an `OnSaveLoad`
+     dispatch into `MM_Sram_InitSave`**: the checksum is computed at `:1942` and the
+     save is memcpy'd to the flash buffer at `:1946`, so any handler that mutates
+     `shipSaveInfo` in between (e.g. `SavingEnhancements`' unconditional
+     `fileCreatedAt` / `lastTimeLog` stamp) writes a buffer whose checksum disagrees
+     with its bytes, and `loadRespawnData` would run against a half-built file. If this
+     ever goes live, the fix belongs at the convergence point the new path introduces,
+     not here.
+
 The ODR/linker prep is **already paid for** (#415 shim + poison guard, #422 rando
 reachability, #434 S2H UIWidgets). What remains is surface work, and it decomposes far
 better than expected: **trackers are nearly free; the settings menu is the expensive


### PR DESCRIPTION
Docs only. Records the audit filed as #467. **No behavior change** — see "What is deliberately not fixed" below, which is the substantive part of this PR.

## What was audited

#447 fixed #439's `COND_HOOK` disarm on the cross-game arrival path and flagged that other MM entry paths "likely share the shape". This is the full enumeration: every path reaching an `OnSaveLoad` dispatch (the only thing that re-evaluates `IS_RANDO` `COND_HOOK`s), traced entry point → dispatch, classified by **what save is live at the moment of dispatch**.

Six dispatch sites exist. Thirteen entry paths reach them. Full table in #467.

## Result: the shape did not replicate

**No remaining BROKEN path.** The reason is structural, and it is the actual finding:

> **File select is a universal funnel.** Every vanilla-MM route from the disarming `TitleSetup` dispatch (`z_opening.c:32`, against `MM_Sram_InitNewSave`'s vanilla bootstrap) to actual gameplay passes through `FileSelect_LoadGame` (`z_file_choose_NES.c:2250`), which dispatches `OnSaveLoad` against the real save. Cold boot, F10 with no frozen state, owl-save-and-quit, and the `entrance == -1` bail all land on the title/attract chain and **must** go through file select to reach play.
>
> The cross-game arrival is the **only** path that goes `TitleSetup → MM_Play_Init` directly, bypassing that funnel. That is why it was the only one left disarmed — and why #447's re-arm belongs at `MM_Play_ConsumeStartupEntrance` specifically rather than anywhere more general.

Worth stating plainly because it converts #447 from "we fixed one instance of a class" into a checkable invariant: **any future path that boots straight into `MM_Play_Init` without passing file select reopens #439's class.**

### The no-dispatch paths are benign

Three-day cycle reset (`Sram_SaveEndOfCycle` → `DayTelop_Init` → `MM_Play_Init`, `z_daytelop.c:87`), death/respawn (`z_game_over.c:97`), and ordinary scene transitions (`z_play.c:811/865/907/949`) never re-evaluate — but they never *wipe* the save either, so hooks armed by file select or by #447's re-dispatch stay armed across them. This is the mirror failure the audit was asked to check for, and it is **not** present: absence of a dispatch only matters where the save's *shape* can change.

## What is deliberately not fixed

`MM_Sram_InitSave` (`z_sram_NES.c:1918`) dispatches `OnSaveInit` at `:1944` but **never `OnSaveLoad`**, so a freshly created rando file is briefly `SAVETYPE_RANDO` with every hook disarmed. It is masked today: name entry returns to the file list (`CM_NAME_ENTRY_WAIT_FOR_FLASH_SAVE`), so file select always follows.

I went to fix it and **stopped**, because the obvious fix is wrong:

- The checksum is computed at `:1942`.
- `OnSaveInit` fires at `:1944`.
- The save is memcpy'd into the flash buffer at `:1946`.

Dropping an `OnSaveLoad` dispatch into that window lets any handler mutating `shipSaveInfo` — e.g. `SavingEnhancements`' **unconditional** `fileCreatedAt` / `lastTimeLog` stamp (`SavingEnhancements.cpp:240-245`) — persist a buffer whose checksum disagrees with its bytes, and runs `loadRespawnData` (`:267`) against a half-built file. That is a new bug traded for a latent one, and it would be a second mechanism in the wrong place — precisely what #447 established not to do. The doc now carries that warning inline so the next person to notice the asymmetry doesn't "fix" it.

If a future change ever boots a newly created file directly into gameplay, the fix belongs at the convergence point *that* path introduces.

## No lock in this PR, deliberately

#447's bar is that a lock must be watched to fail. There is no BROKEN path here to fail against — a test asserting the funnel invariant would only fail if someone deleted `z_file_choose_NES.c:2250`, which is already load-bearing for vanilla file loading and would fail `MMRandoGen`'s existing `OnSaveLoad` chain coverage. Adding a green-by-construction test would be the vacuous lock #447 warned about. The durable artifact here is the invariant plus the do-not-fix-this-way warning.

## Coordination

Read against PR #464 (#440). No overlap: this is docs-only, and #464's analysis of `Context_UpdateShadowCopy` vs `Context_FreezeState` (same storage, `hasBeenFrozen` the only discriminator) is consistent with what this audit found independently — recorded in #467 under "Adjacent risk" so the two analyses agree on the mechanism rather than duplicating it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
