### PR TITLE
Lock the non-arrival MM entry paths' IS_RANDO hook arm-state (#439 follow-up)

### DIFF
--- a/CMake/SingleExecutable.cmake
+++ b/CMake/SingleExecutable.cmake
@@ -452,6 +452,22 @@ if(BUILD_TESTING)
         TIMEOUT 180
         ENVIRONMENT "SDL_AUDIODRIVER=dummy;RSBS_DISABLE_OTR_INIT=1")
 
+    # #439 follow-up: MMPairSwitchEntry locks the cross-game arrival convergence;
+    # this row locks the OTHER paths into MM gameplay the arrival fix does not
+    # touch. The IS_RANDO COND_HOOKs (Rando.h: saveType == SAVETYPE_RANDO, re-
+    # evaluated on every OnSaveLoad) must match the save at every convergence:
+    # the file-select LOAD must RE-ARM after the boot chain's disarming
+    # OnSaveLoad (the disarm-then-rearm ordering #439 got wrong on the arrival
+    # path, and the ordering the owl-save reload relies on), and an in-session
+    # reload (Song of Time / cycle reset / DayTelop) must leave a live rando
+    # session's armed hooks untouched. Reads arm state through
+    # S2H::GameHooks::CountForTest<OnFlagSet>. Same display requirement, hence
+    # the same label/env.
+    redship_add_test(NAME MMReloadArmState COMMAND redship --test mm-reload-arm-state
+        LABEL rando
+        TIMEOUT 180
+        ENVIRONMENT "SDL_AUDIODRIVER=dummy;RSBS_DISABLE_OTR_INIT=1")
+
     # ========================================================================
     # Lane B — unified seed -> paired world (Phase 3.0)
     #

--- a/games/mm/2s2h/mm_rando_gen_test.cpp
+++ b/games/mm/2s2h/mm_rando_gen_test.cpp
@@ -1112,22 +1112,40 @@ extern "C" int MM_Rando_HeadlessReloadArmState(void) {
 
     // ----------------------------------------------------------------------
     // Phase 4 — vanilla direction: a file-select LOAD of a VANILLA save
-    // DISARMS again. The hooks track the loaded save, not stale registry
-    // state, so rando overrides can never leak into a non-rando file loaded
-    // after a rando one.
+    // DISARMS the rando overrides, so the hooks track the loaded save and can
+    // never leak into a non-rando file loaded after a rando one.
+    //
+    // Probed through a VB verdict, NOT the OnFlagSet count: COND_HOOK's
+    // Unregister is DEFERRED (mm_game_hooks.h — the id is queued and only erased
+    // by FlushPendingUnregistrations at the next Execute of that hook type), so
+    // CountForTest lags a disarm and still shows the not-yet-flushed hook even
+    // though it can no longer fire. GameInteractor_Should dispatches
+    // Execute<ShouldVanillaBehavior>, which applies that flush, so the verdict
+    // reflects the disarm immediately. The give override is
+    // COND_VB_SHOULD(VB_GIVE_ITEM_FROM_GREAT_FAIRY, IS_RANDO, { *should=false }),
+    // re-evaluated on the same OnSaveLoad chain (ShipInit::Init("IS_RANDO")) and
+    // headless-safe — its body touches no play state. MMRandoGen uses the same
+    // probe for its vanilla direction.
     // ----------------------------------------------------------------------
+    // Armed baseline (the rando save is still live from Phases 2-3): the
+    // IS_RANDO give override suppresses the vanilla great-fairy give.
+    if (GameInteractor_Should(VB_GIVE_ITEM_FROM_GREAT_FAIRY, true)) {
+        fprintf(stderr, "[MM-RELOAD-ARM] FAIL(7): the armed rando save did not suppress the give VB — the "
+                        "arm-state probe premise is broken\n");
+        return 7;
+    }
     memset(&gSaveContext, 0, sizeof(gSaveContext));
     MM_Sram_InitNewSave();
     GameInteractor_ExecuteOnSaveLoad(gSaveContext.fileNum);
-    const size_t reDisarmed = S2H::GameHooks::CountForTest<GameInteractor::OnFlagSet>();
-    if (reDisarmed >= armed) {
-        fprintf(stderr,
-                "[MM-RELOAD-ARM] FAIL(7): loading a vanilla save left the IS_RANDO hooks armed (OnFlagSet %zu; "
-                "rando-armed was %zu) — rando overrides leaked into a non-rando file\n",
-                reDisarmed, armed);
-        return 7;
+    // The override must be gone: the caller's verdict passes through in BOTH
+    // polarities (true stays true, false stays false).
+    if (!GameInteractor_Should(VB_GIVE_ITEM_FROM_GREAT_FAIRY, true) ||
+        GameInteractor_Should(VB_GIVE_ITEM_FROM_GREAT_FAIRY, false)) {
+        fprintf(stderr, "[MM-RELOAD-ARM] FAIL(8): a vanilla-save LOAD left the rando give override armed — rando "
+                        "overrides leaked into a non-rando file\n");
+        return 8;
     }
-    fprintf(stderr, "[MM-RELOAD-ARM] vanilla-direction LOAD disarmed the hooks (OnFlagSet %zu)\n", reDisarmed);
+    fprintf(stderr, "[MM-RELOAD-ARM] vanilla-direction LOAD disarmed the rando overrides (give VB passes through)\n");
 
     // Leave clean global state for later dispatches in the same process.
     ComboContext_Init();

--- a/games/mm/2s2h/mm_rando_gen_test.cpp
+++ b/games/mm/2s2h/mm_rando_gen_test.cpp
@@ -974,4 +974,171 @@ extern "C" int MM_Rando_HeadlessPairSwitchEntry(void) {
     return 0;
 }
 
+// ============================================================================
+// Non-arrival entry-path arm-state lock (#439 follow-up)
+// ============================================================================
+/**
+ * MMPairSwitchEntry above locks the CROSS-GAME arrival convergence
+ * (MM_Play_ConsumeStartupEntrance re-dispatching OnSaveLoad). This row locks
+ * the OTHER convergence points into MM gameplay the #439 follow-up audit
+ * enumerated — the ones the arrival fix deliberately does NOT touch — against
+ * the same failure the arrival path had: a save reaching a live PlayState with
+ * the IS_RANDO COND_HOOKs in the wrong arm state.
+ *
+ * IS_RANDO (Rando.h) is `gSaveContext.save.shipSaveInfo.saveType ==
+ * SAVETYPE_RANDO`, re-evaluated on every GameInteractor_ExecuteOnSaveLoad
+ * (Rando.cpp OnSaveLoadHandler -> MiscBehavior::OnFileLoad et al.). Arm state
+ * is read through S2H::GameHooks::CountForTest<OnFlagSet> — the same probe
+ * MMPairSwitchEntry uses; the OnFlagSet COND_HOOK (MiscBehavior.cpp) registers
+ * iff IS_RANDO at the last dispatch.
+ *
+ * Two production convergence points, each modeled through its real dispatch:
+ *
+ *  1. The MM file-select LOAD path (FileSelect_LoadGame,
+ *     z_file_choose_NES.c): MM_Sram_OpenSave memcpy's the save from flash,
+ *     THEN OnSaveLoad fires (z_file_choose_NES.c:2250). The cold boot chain
+ *     (TitleSetup_SetupTitleScreen, z_opening.c:32) authored a VANILLA
+ *     bootstrap and its OnSaveLoad DISARMED the hooks first, so this dispatch
+ *     must RE-ARM against the loaded rando save. That disarm-then-rearm
+ *     ordering is exactly what #439 got wrong on the arrival path, and it is
+ *     the convergence the owl-save reload leans on (owl-save-and-quit ->
+ *     TitleSetup disarm -> title -> file-select LOAD re-arm; z_message.c
+ *     MSGMODE_OWL_SAVE + z_play.c:806 -> MM_TitleSetup_Init). A LOADED rando
+ *     save is modeled the way MM_Sram_OpenSave produces one — a plain new-file
+ *     image with saveType stamped SAVETYPE_RANDO — because the LOAD path loads
+ *     bytes, it does NOT re-run generation (that is the CREATE path, and
+ *     MMRandoGen covers it).
+ *
+ *  2. The in-session reload paths (Song of Time / cycle reset, DayTelop):
+ *     these re-enter MM_Play_Init WITHOUT a startup entrance, so
+ *     MM_Play_ConsumeStartupEntrance early-returns (z_play.c:2282) and NOTHING
+ *     re-dispatches OnSaveLoad. That is correct precisely because these paths
+ *     do NOT run the boot chain's disarming dispatch — a live rando session's
+ *     armed hooks must simply survive. Locked here so a future change that
+ *     either routes a cycle reset through the boot chain, or drops a stray
+ *     disarming dispatch into the consumption early-return, fails loudly
+ *     instead of shipping a paired world that silently plays vanilla after the
+ *     first Song of Time.
+ *
+ * Returns 0 on success, a distinct nonzero step code otherwise.
+ */
+extern "C" int MM_Rando_HeadlessReloadArmState(void) {
+    auto ctx = Ship::Context::GetInstance();
+    if (ctx == nullptr || ctx->GetConsoleVariables() == nullptr) {
+        fprintf(stderr, "[MM-RELOAD-ARM] FAIL(1): Ship::Context not live\n");
+        return 1;
+    }
+
+    MM_Rando_Init();
+    if (Rando::Logic::Regions.empty()) {
+        fprintf(stderr, "[MM-RELOAD-ARM] FAIL(2): Logic/Regions graph empty — rando surface elided or InitAll not "
+                        "run\n");
+        return 2;
+    }
+    if (gRegEditor == NULL) {
+        static RegEditor sReloadRegEditor = {};
+        gRegEditor = &sReloadRegEditor;
+    }
+
+    // Clean cross-game state: no pairing, no pending arrival, no frozen save.
+    // This row is purely about the save-shape -> hook arm-state relationship;
+    // the paired-world producer is MMPairSwitchEntry's job.
+    ComboContext_Init();
+    Combo_ClearForeignPlacements();
+    Combo_ClearFrozenState("mm");
+    Combo_ClearStartupEntrance();
+
+    // ----------------------------------------------------------------------
+    // Phase 1 — the boot chain authors a VANILLA bootstrap and DISARMS.
+    // Exactly TitleSetup_SetupTitleScreen (z_opening.c): a plain new file,
+    // then OnSaveLoad against it. The IS_RANDO COND_HOOKs unregister here.
+    // ----------------------------------------------------------------------
+    memset(&gSaveContext, 0, sizeof(gSaveContext));
+    MM_Sram_InitNewSave();
+    if (gSaveContext.save.shipSaveInfo.saveType == SAVETYPE_RANDO) {
+        fprintf(stderr, "[MM-RELOAD-ARM] FAIL(3): a plain new file came up rando — vanilla-bootstrap premise "
+                        "broken\n");
+        return 3;
+    }
+    GameInteractor_ExecuteOnSaveLoad(gSaveContext.fileNum);
+    const size_t disarmed = S2H::GameHooks::CountForTest<GameInteractor::OnFlagSet>();
+
+    // ----------------------------------------------------------------------
+    // Phase 2 — the file-select LOAD of a RANDO save RE-ARMS after the disarm.
+    // FileSelect_LoadGame: MM_Sram_OpenSave populates gSaveContext from flash
+    // (modeled here as a new-file image stamped SAVETYPE_RANDO, the way a
+    // loaded rando save reads), THEN GameInteractor_ExecuteOnSaveLoad
+    // (z_file_choose_NES.c:2250) — the "fires AFTER the save is populated, not
+    // before" contract this audit had to confirm.
+    // ----------------------------------------------------------------------
+    memset(&gSaveContext, 0, sizeof(gSaveContext));
+    MM_Sram_InitNewSave();
+    gSaveContext.save.shipSaveInfo.saveType = SAVETYPE_RANDO; // what OpenSave loads for a rando file
+    GameInteractor_ExecuteOnSaveLoad(gSaveContext.fileNum);
+    const size_t armed = S2H::GameHooks::CountForTest<GameInteractor::OnFlagSet>();
+    if (armed == 0 || armed <= disarmed) {
+        fprintf(stderr,
+                "[MM-RELOAD-ARM] FAIL(4): the file-select LOAD dispatch did not re-arm the IS_RANDO hooks after "
+                "the boot chain's disarm (OnFlagSet %zu -> %zu) — a loaded rando save would play with vanilla "
+                "behavior\n",
+                disarmed, armed);
+        return 4;
+    }
+    fprintf(stderr, "[MM-RELOAD-ARM] file-select LOAD re-armed after the boot-chain disarm (OnFlagSet %zu -> %zu)\n",
+            disarmed, armed);
+
+    // ----------------------------------------------------------------------
+    // Phase 3 — an in-session reload (Song of Time / cycle reset / DayTelop)
+    // PRESERVES the armed state. Those reloads reach MM_Play_Init with no
+    // startup entrance, so MM_Play_ConsumeStartupEntrance early-returns and
+    // must not disturb the hooks. Drive that exact consumption with the rando
+    // save live and the pending arrival cleared.
+    // ----------------------------------------------------------------------
+    Combo_ClearStartupEntrance(); // in-session reloads carry no pending arrival
+    MM_Play_ConsumeStartupEntrance();
+    const size_t afterReload = S2H::GameHooks::CountForTest<GameInteractor::OnFlagSet>();
+    if (afterReload != armed) {
+        fprintf(stderr,
+                "[MM-RELOAD-ARM] FAIL(5): an in-session reload disturbed the IS_RANDO hooks (OnFlagSet %zu -> %zu) "
+                "— a cycle reset must never silently re-arm/disarm a paired world\n",
+                armed, afterReload);
+        return 5;
+    }
+    if (gSaveContext.save.shipSaveInfo.saveType != SAVETYPE_RANDO) {
+        fprintf(stderr, "[MM-RELOAD-ARM] FAIL(6): the in-session reload no-op mutated the live save type\n");
+        return 6;
+    }
+    fprintf(stderr, "[MM-RELOAD-ARM] in-session reload preserved the armed hooks (OnFlagSet %zu)\n", afterReload);
+
+    // ----------------------------------------------------------------------
+    // Phase 4 — vanilla direction: a file-select LOAD of a VANILLA save
+    // DISARMS again. The hooks track the loaded save, not stale registry
+    // state, so rando overrides can never leak into a non-rando file loaded
+    // after a rando one.
+    // ----------------------------------------------------------------------
+    memset(&gSaveContext, 0, sizeof(gSaveContext));
+    MM_Sram_InitNewSave();
+    GameInteractor_ExecuteOnSaveLoad(gSaveContext.fileNum);
+    const size_t reDisarmed = S2H::GameHooks::CountForTest<GameInteractor::OnFlagSet>();
+    if (reDisarmed >= armed) {
+        fprintf(stderr,
+                "[MM-RELOAD-ARM] FAIL(7): loading a vanilla save left the IS_RANDO hooks armed (OnFlagSet %zu; "
+                "rando-armed was %zu) — rando overrides leaked into a non-rando file\n",
+                reDisarmed, armed);
+        return 7;
+    }
+    fprintf(stderr, "[MM-RELOAD-ARM] vanilla-direction LOAD disarmed the hooks (OnFlagSet %zu)\n", reDisarmed);
+
+    // Leave clean global state for later dispatches in the same process.
+    ComboContext_Init();
+    Combo_ClearForeignPlacements();
+    Combo_ClearFrozenState("mm");
+    Combo_ClearStartupEntrance();
+    memset(&gSaveContext, 0, sizeof(gSaveContext));
+
+    fprintf(stderr, "[MM-RELOAD-ARM] PASS: file-select LOAD re-arms after a boot-chain disarm; in-session reload "
+                    "preserves; vanilla LOAD disarms\n");
+    return 0;
+}
+
 #endif // RSBS_SINGLE_EXECUTABLE

--- a/src/common/test_runner.cpp
+++ b/src/common/test_runner.cpp
@@ -442,6 +442,35 @@ TestResult Test_MMPairSwitchEntry(void) {
     return rc == 0 ? TEST_PASS : TEST_FAIL;
 }
 
+// Non-arrival entry-path arm-state lock (#439 follow-up). MMPairSwitchEntry
+// covers the cross-game arrival convergence; this row covers the OTHER paths
+// into MM gameplay that the arrival fix does not touch — the file-select LOAD
+// re-arm after the boot chain's disarm (the ordering the owl-save reload
+// relies on) and the in-session reload (Song of Time / cycle reset / DayTelop)
+// that must leave a live rando session's armed hooks alone. Reads arm state
+// through S2H::GameHooks::CountForTest<OnFlagSet>. Bridge body in
+// games/mm/2s2h/mm_rando_gen_test.cpp. Needs a display, same as mm-rando-gen,
+// so `--test all` skips it.
+extern "C" int MM_Rando_HeadlessReloadArmState(void);
+
+TestResult Test_MMReloadArmState(void) {
+    printf("[TEST] mm-reload-arm-state: IS_RANDO hooks match the save on the non-arrival entry paths (#439)\n");
+
+    auto ctx = CreateHarnessStyleContext();
+    if (!ctx) {
+        printf("[TEST] FAIL: could not create Ship::Context singleton\n");
+        return TEST_FAIL;
+    }
+
+    static char arg0[] = "redship";
+    static char* fakeArgv[] = { arg0, nullptr };
+    InitOTRForMMFirstBoot(1, fakeArgv);
+
+    int rc = MM_Rando_HeadlessReloadArmState();
+    printf("[TEST] %s: reload arm-state rc=%d\n", rc == 0 ? "PASS" : "FAIL", rc);
+    return rc == 0 ? TEST_PASS : TEST_FAIL;
+}
+
 TestResult Test_BootMM(void) {
     printf("[TEST] boot-mm: MM-first bring-up prerequisites (#330)\n");
     sTargetGame = GAME_MM;
@@ -1020,6 +1049,12 @@ const TestDescriptor gTests[] = {
     // Same display requirement as mm-rando-gen, so `--test all` skips it.
     {"mm-pair-switch-entry", "Paired MM world activates via switch-entry; existing saves untouched (#439)",
      Test_MMPairSwitchEntry},
+    // #439 follow-up: the OTHER entry paths into MM gameplay (file-select LOAD,
+    // Song of Time / cycle reset, DayTelop) must also reach a live PlayState
+    // with the IS_RANDO hooks matching the save. Same display requirement as
+    // mm-rando-gen, so `--test all` skips it.
+    {"mm-reload-arm-state", "IS_RANDO hooks match the save on MM's non-arrival entry paths (#439)",
+     Test_MMReloadArmState},
     {"boot-oot", "Shared-context bring-up leaves no null subsystems (#329)", Test_BootOoT},
     {"boot-mm", "MM-first bring-up prerequisites on the shared context (#330)", Test_BootMM},
     {"switch-oot-mm", "Test game switch OoT -> MM", Test_SwitchOoTMM},
@@ -1153,7 +1188,8 @@ int TestRunner_Run(const char* testName) {
             // this display-free suite, where they would hang the 60s timeout.
             if (strcmp(gTests[i].name, "rando-gen") == 0 || strcmp(gTests[i].name, "rando-determinism") == 0 ||
                 strcmp(gTests[i].name, "mm-rando-gen") == 0 ||
-                strcmp(gTests[i].name, "mm-pair-switch-entry") == 0) {
+                strcmp(gTests[i].name, "mm-pair-switch-entry") == 0 ||
+                strcmp(gTests[i].name, "mm-reload-arm-state") == 0) {
                 printf("\n--- Skipping: %s (needs display; runs as a rando-label CTest) ---\n", gTests[i].name);
                 continue;
             }


### PR DESCRIPTION
Follow-up to #439 / PR #447 (merged as d075aeaf).

## The question

#447 closed the cross-game **arrival** gap: MM's cold gamestate-chain boot dispatches `OnSaveLoad` from `TitleSetup_SetupTitleScreen` (z_opening.c:32) against a **vanilla** bootstrap authored by `MM_Sram_InitNewSave()`, which unregisters every `IS_RANDO` COND_HOOK. The fix re-dispatches `OnSaveLoad` at `MM_Play_ConsumeStartupEntrance` once the real save is known. That covered the switch-entry path only.

This audits whether any **other** path into MM gameplay can reach a live `PlayState` with the `IS_RANDO` hooks (`saveType == SAVETYPE_RANDO`, re-evaluated on every `OnSaveLoad`) in the wrong arm state.

## Audit result — every path already converges correctly

| Path | Why it's safe |
|---|---|
| **`.redsave` load** (`rsbs::SaveManager::Load`) | Writes `gComboCtx` + the **shadow copies only** — never the live `gSaveContext`, never `OnSaveLoad`. The live MM save is re-hydrated at the next OoT→MM switch, where `MM_Play_ConsumeStartupEntrance` re-dispatches (the #447 fix). It never reaches a live MM `PlayState` on its own. |
| **MM file-select LOAD** (`FileSelect_LoadGame`) | `MM_Sram_OpenSave` populates `gSaveContext` (z_file_choose_NES.c:2201), **then** `OnSaveLoad` fires (:2250) — after the save is populated, not before. |
| **Song of Time / cycle reset / DayTelop** | Reload via a **direct** `MM_Play_Init` transition (z_play.c:809‑811, z_daytelop.c) — they do **not** run the boot chain, don't dispatch, and don't change `saveType`; `MM_Play_ConsumeStartupEntrance` early-returns (z_play.c:2282, no startup entrance). The armed hooks are retained. |
| **Owl-save reload** | Owl-save-and-quit routes `GAMEMODE_OWL_SAVE` → `MM_TitleSetup_Init` (disarm) → title → **file-select LOAD** (re-arms) before gameplay. |
| **WarpPoint / SkipToFileSelect** | WarpPoint's `BootToWarpPoint` explicitly dispatches `OnSaveInit` + `OnSaveLoad` after authoring; SkipToFileSelect routes to file select, which re-arms on LOAD. |

**No production re-dispatch is warranted** — every route already ends on a dispatch (or a no-op that preserves the already-correct state) matching the save that reaches gameplay; adding another would double-fire. What was missing is a regression lock for the two convergences the arrival fix does not touch.

## The lock

New `MMReloadArmState` CTest (rando label, ROM-free), mirroring `MMPairSwitchEntry`'s `S2H::GameHooks::CountForTest<OnFlagSet>` probe and driving the real dispatch bridges:

1. **boot-chain disarm** (vanilla bootstrap + `OnSaveLoad`) → **file-select LOAD** of a rando save must **re-arm** — the disarm-then-rearm ordering the owl-save reload relies on, and the mirror of the #439 arrival bug;
2. an **in-session reload** (`MM_Play_ConsumeStartupEntrance` early-return) must leave a live rando session's armed hooks **untouched** — a cycle reset can never silently disarm a paired world;
3. a **vanilla-direction LOAD** must **disarm** again — hooks track the loaded save, not stale registry state.

The cross-game arrival path itself is untouched (fixed and locked by `MMPairSwitchEntry`).

Files: `games/mm/2s2h/mm_rando_gen_test.cpp` (bridge), `src/common/test_runner.cpp` (dispatch + registration), `CMake/SingleExecutable.cmake` (CTest row).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ef9YHCTNoEizmGWKMypDpu

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ef9YHCTNoEizmGWKMypDpu)_

<!--- section:artifacts:start -->
### Build Artifacts
  - [rsbs-windows.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/8507830812.zip)
  - [rsbs-linux.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/8507546799.zip)
<!--- section:artifacts:end -->