### PR TITLE
Netplay 1a: per-source grant cursors make retransmit vs second-gift decidable (ADR 0005, #460)

### DIFF
--- a/CMake/SingleExecutable.cmake
+++ b/CMake/SingleExecutable.cmake
@@ -313,6 +313,13 @@ if(BUILD_TESTING)
     # blocker (#460): a stale sharedItemsTagged carries another player's grants
     # from a dead room into a fresh seed.
     redship_add_test(NAME SessionInvalidation COMMAND redship --test session-invalidation)
+    # Netplay 1a (ADR 0005, #460): sourced-grant model locks — cursor
+    # idempotency, switch-free received-order redemption, loud overflow with
+    # redeemed-slot reclamation, and .redsave durability + reset atomicity.
+    redship_add_test(NAME GrantIdempotency COMMAND redship --test grant-idempotency)
+    redship_add_test(NAME GrantRedeemNoSwitch COMMAND redship --test grant-redeem-no-switch)
+    redship_add_test(NAME GrantOverflow COMMAND redship --test grant-overflow)
+    redship_add_test(NAME GrantPersistence COMMAND redship --test grant-persistence)
     redship_add_test(NAME ArchiveHotswapLogic COMMAND redship --test archive-hotswap-logic)
     # Unified save (.redsave) headless tests — Phase 2 T6 (#35)
     redship_add_test(NAME SaveRoundtripTiers COMMAND redship --test save-roundtrip-tiers)

--- a/docs/adr/0005-sourced-grant-cursors.md
+++ b/docs/adr/0005-sourced-grant-cursors.md
@@ -88,8 +88,21 @@ source; it is a bug surfaced early.
 
 `RSBS_GRANT_SOURCE_CAP` is 8: an AP server is *one* source regardless of room
 size, P2P co-op is one per peer. Exhaustion is explicit
-(`RSBS_GRANT_NO_SOURCE_SLOT`), never silent. Growing the table later is a
-legal reserved[] carve.
+(`RSBS_GRANT_NO_SOURCE_SLOT`), never silent.
+
+More cursor capacity later is reachable, but **not by bumping
+`RSBS_GRANT_SOURCE_CAP`**. `sharedItemOverflowCount` sits immediately after
+`grantCursors` at offset 736 — a shipped offset the moment this lands — so
+widening the array in place shifts it (and every field carved after it) and
+silently reinterprets every existing `.redsave`. That is a format break, not a
+carve. The legal move is to carve a *second*, separate cursor block from the
+front of the remaining `reserved[]` and have the lookup consult both; each
+appended block keeps zero == unset and leaves prior offsets fixed. The
+static-assert chain pins `sharedItemOverflowCount` relative to
+`RSBS_GRANT_SOURCE_CAP`, so it will follow a bump rather than break the
+build — the assert proves contiguity, it cannot prove the bytes did not move.
+This is the one place the growth contract is easy to violate while appearing
+to honor it.
 
 ### 2. The two producer classes never share an idempotency domain
 

--- a/docs/adr/0005-sourced-grant-cursors.md
+++ b/docs/adr/0005-sourced-grant-cursors.md
@@ -1,0 +1,292 @@
+# ADR 0005: Sourced item grants are idempotent by per-source cursor, not by content
+
+- Status: **Accepted** (2026-07-21)
+- For: #460 (netplay increment 1a), building on the spike merged in #444
+  (`docs/netplay-increment-1-spike.md`)
+- Depends on: ADR 0002 (origin-tagged `SharedItem`, the ComboContext growth
+  contract), Lane A1's stage/record/redeem machinery (#419/#420), Lane C1's
+  give path (#428)
+- Composes with (does **not** fix): #440 (cross-game state invalidation on
+  reset/new game)
+
+This is the contract the 1b transport work builds against. The seam is
+`Combo_SubmitSourcedGrant` and friends in `src/common/shared_items.h`; nothing
+in this ADR opens a socket, declares `BUILD_REMOTE_CONTROL`, or picks a
+transport.
+
+## Context
+
+The `SharedItem` grant machinery (ADR 0002, Lane A1) is correct today only
+because every producer is in-process. The netplay spike (#444 §3) identified
+four gaps that any remote grant hits on arrival:
+
+1. `Combo_RecordSharedItem` de-dups by content — an un-redeemed
+   `(originGame, id)` match merges. Right for a re-fired in-process producer;
+   for a network feed it collapses two peers' identical gifts into one item,
+   and makes a retransmit indistinguishable from a genuine second gift.
+2. `SharedItem` is 4 bytes with size and member offsets static-asserted as
+   `.redsave` format. There is no room for a grant/sequence id in the entry.
+3. Redemption fires only at the presence-gated switch-arrival points. A grant
+   for the game you are already in waits for a switch that may never come.
+4. The 64-slot array drops on overflow with only a `stderr` line — silent loss
+   of a peer's gift — and, because entries were never cleared, 64 was a
+   lifetime cap per save, not a working-set cap.
+
+Constraints: the ADR 0002 growth contract is absolute (carve from
+`reserved[]`, append-only, zero == unset, offsets pinned by static_assert,
+dual C/C++ views, no untagged cross-game ids); existing `.redsave` files must
+keep loading; everything must be lockable ROM-free in the `redship` CTest
+tier.
+
+## Decision
+
+### 1. Grant identity is a per-source monotonic cursor, persisted in gComboCtx
+
+A **source** is a producer with its own identity and its own delivery stream —
+a network peer, an Archipelago server, a loopback test feed. Each source
+numbers its grants with a dense, 1-based sequence. The save persists one
+cursor per source:
+
+```c
+typedef struct {
+    uint32_t sourceKey; // transport-assigned nonzero source identity; 0 = empty slot
+    uint32_t lastSeq;   // highest accepted sequence number from this source; 0 = none
+} ComboGrantSourceCursor;
+// gComboCtx.grantCursors[RSBS_GRANT_SOURCE_CAP /* 8 */]
+```
+
+`Combo_SubmitSourcedGrant(sourceKey, seq, originGame, id)` accepts **strictly
+in order**: `seq == lastSeq + 1` records the item and advances the cursor;
+`seq <= lastSeq` is `RSBS_GRANT_DUPLICATE` (a retransmit — dropped,
+idempotent success); `seq > lastSeq + 1` is `RSBS_GRANT_GAP` (predecessors
+missing — the source must resend in order; nothing moves). Every non-accepted
+outcome leaves `gComboCtx` untouched.
+
+This makes retransmit-vs-second-gift decidable without widening `SharedItem`:
+identity lives in the *stream position*, not in the entry. Two peers gifting
+the same item are two sources with independent cursors — two accepts, two
+entries. One peer resending is the same `(sourceKey, seq)` — one accept, ever,
+across save/load, because the cursor rides the `.redsave`.
+
+**Why a cursor and not a per-entry grantId:** (a) the `SharedItem` layout is
+pinned format with no spare field, and a parallel seen-`grantId` set is
+unbounded state that would itself need serializing; (b) a cursor is O(1)
+durable state per source and one comparison per submit; (c) it hosts an
+**externally owned cursor directly** — Archipelago's `ReceivedItems` is
+server-authoritative with a monotonic `index`; an AP transport maps index `i`
+to `seq i + 1`, hands `Combo_GetGrantCursor(key)` to `Sync` as its resume
+point, and the spike's resync trap (a full re-delivery being silently eaten by
+content de-dup) becomes the *designed* path: the already-seen prefix returns
+`DUPLICATE` by cursor, the novel tail records. A grantId-set design cannot
+host a foreign cursor; this one is a superset of it.
+
+Strict in-order acceptance is deliberate: it is what makes received order
+well-defined (§4), turns message loss into a visible `GAP` instead of silent
+reordering, and matches both planned source shapes (AP's index is dense;
+a P2P feed numbers per-sender). A source that cannot replay in order is not a
+source; it is a bug surfaced early.
+
+`RSBS_GRANT_SOURCE_CAP` is 8: an AP server is *one* source regardless of room
+size, P2P co-op is one per peer. Exhaustion is explicit
+(`RSBS_GRANT_NO_SOURCE_SLOT`), never silent. Growing the table later is a
+legal reserved[] carve.
+
+### 2. The two producer classes never share an idempotency domain
+
+- **In-process producers** (Lane C1's give path, the staged/commit path) keep
+  `Combo_RecordSharedItem` and its content de-dup unchanged — a re-fired local
+  event is the same event.
+- **Sourced producers** go through `Combo_SubmitSourcedGrant` only, which
+  appends **without** content de-dup.
+
+Entries recorded by the sourced path carry a new flag bit,
+`RSBS_SHARED_ITEM_SOURCED` (0x02), and content de-dup **skips** flagged
+entries. Without this, a peer's pending gift of item X would swallow a genuine
+local pickup of X (the merge would eat the local event). Zero == unset holds:
+every legacy entry was in-process, which is exactly what a zero bit says.
+
+### 3. Overflow: reclaim redeemed entries; refuse loudly; backpressure sources
+
+When the array is full, recording first **reclaims the oldest REDEEMED
+entry**: the array compacts (preserving relative order — occupied entries
+always form a prefix, so slot order stays acceptance order) and the freed tail
+slot takes the new record. A redeemed entry is an informational record of a
+completed crossing; an un-redeemed entry is an undelivered item. Only the
+former is evictable; the latter is **never dropped**.
+
+> **Amendment to A1's contract:** shared_items' previous "entries are never
+> cleared; they remain as the durable record of the crossing" weakens to
+> "…until capacity pressure reclaims redeemed entries, oldest first". Nothing
+> in the tree reads redeemed entries as a history (verified: consumers filter
+> them out; tests use them transiently), and single-use never depended on the
+> entry's continued presence — an evicted entry cannot re-award because
+> re-recording it requires a fresh producer event by definition. Slot indices
+> returned by record APIs are therefore transient; callers must not store
+> them (no caller does).
+
+If every entry is un-redeemed, the record is **refused loudly**:
+
+- `gComboCtx.sharedItemOverflowCount` (new, serialized, zero == unset)
+  increments — a durable, tracker-surfaceable signal that capacity refused
+  work; it survives save/load and resets only with the world.
+- For a **sourced** grant the refusal is `RSBS_GRANT_RETRY_FULL` and the
+  cursor does **not** advance: the grant remains owed by the source, and its
+  later retransmit of the same seq is *accepted*, not treated as a duplicate.
+  Backpressure, not loss.
+- For an **in-process** record the refusal (return -1) *is* a lost item — the
+  pickup already happened in-game. The counter is what makes that loss
+  diagnosable instead of a `stderr` line nobody sees. With reclamation, this
+  requires 64 simultaneously *undelivered* items, which the working set can
+  no longer reach by mere accumulation.
+
+This is the honest middle the increment asked for: the game never blocks, no
+peer's gift is silently lost (sourced grants are retried by contract), and the
+one genuinely lossy corner (in-process producer against a fully-undelivered
+array) is durable-signaled and CI-locked.
+
+### 4. Redemption safe points — "next switch only" generalizes to "next safe point"
+
+`Combo_RedeemSharedItemsForGame` is the **single** redemption entry and is
+safe wherever all of the following hold for the target game: it is the active
+game, on the game thread; a save is loaded and normal gameplay has been
+reached (so the award callback's give machinery is valid); the caller passes
+that game's real award callback. `RSBS_SHARED_ITEM_REDEEMED` makes redemption
+idempotent under any interleaving of safe points, and awards fire in slot
+order == acceptance order (**received-order redemption is a contract**: the
+give paths resolve progressives against the live save, so order changes what
+the player gets; reclamation preserves it).
+
+Safe points, precisely:
+
+1. The two presence-gated startup-entrance consumption points
+   (`OoT_ConsumeSharedItems`, `MM_ConsumeSharedItems`) — wired today,
+   unchanged.
+2. A gameplay-gated frame tick (`OnGameFrameUpdate`-class, gated on "save
+   loaded and in normal gameplay") — **defined here, wired by 1b** together
+   with the first producer that can target the active game mid-session.
+   Deliberately not wired now: every in-process producer records for the game
+   being *left*, so today a tick would have nothing to redeem, and its gate
+   ("normal gameplay") is game-side state that only an in-game path exercises
+   — dead code with ROM-only risk. The model side — that redemption needs no
+   switch machinery whatsoever — is what this increment locks in CI.
+
+Plain-load semantics are unchanged for everything wired today and the header
+now states the general rule: un-redeemed entries persist and are awarded at
+the next safe point. Redeem-at-load remains forbidden for the same reason as
+before — the give machinery is not yet valid.
+
+### 5. Save-format delta rides the ADR 0002 growth contract; no version bump
+
+Carved from the FRONT of `reserved[332]`, which shrinks to `reserved[264]`:
+
+| Field | Offset | Size |
+|---|---|---|
+| `grantCursors[8]` | 672 | 64 |
+| `sharedItemOverflowCount` | 736 | 4 |
+
+Offsets pinned by the `context.h` static-assert chain (contiguous with
+`foreignPlacements`); zero == unset for every member ("no source has ever
+delivered; no refusal has ever happened" — exactly what a zero-extended
+pre-netplay record must mean). `sizeof(ComboContext)` stays 1004 ≤ the fixed
+1024-byte Tier-1 record, so `RSBS_SAVE_VERSION` stays 2 and
+`COMBO_CONTEXT_VERSION` stays 1 (nothing old needs distinguishing, only
+extending). Migration is locked by a crafted pre-carve record test in the
+`test_save_roundtrip.c` style (`Test_GrantPersistence` part b).
+
+### 6. Composition with #440 (not a fix for it)
+
+Cursors live in the same Tier-1 record as the item array **on purpose**:
+`ComboContext_Init` — the invalidation primitive #440's fix will invoke on
+reset/new-game — retires items, cursors, and the overflow count in one memset.
+That atomicity is load-bearing in both directions: a surviving cursor without
+its items would refuse re-delivery into the world that lost them
+(`DUPLICATE`); surviving items without their cursor would re-accept a dead
+room's stream. After invalidation, a dead-room retransmit is a `GAP` (new
+sources must start at seq 1), never a silent acceptance — locked in
+`Test_GrantPersistence` part c. #440 itself (making reset/new-game actually
+*call* the invalidation) stays with its own fix; when it lands, remotely
+sourced grants are covered by the same call this ADR's tests already pin.
+
+### 7. The seam a transport writes against
+
+```c
+ComboGrantResult Combo_SubmitSourcedGrant(uint32_t sourceKey, uint32_t seq,
+                                          GameId originGame, uint16_t id);
+uint32_t Combo_GetGrantCursor(uint32_t sourceKey); // resume point: deliver from cursor+1
+int      Combo_CountGrantSources(void);
+uint32_t Combo_GetSharedItemOverflowCount(void);
+```
+
+Contract highlights for 1b:
+
+- **Game thread only.** A transport receiving off-thread marshals to the game
+  thread before submitting. (The vendored Anchor client's
+  network-thread-mutation hazard — spike §6 — must not be reproduced against
+  this seam.)
+- `sourceKey` is a nonzero identity *within the current world/session*; the
+  transport derives it (e.g. hash of room id + peer slot; an AP server is one
+  source). Cross-session collisions are handled by invalidation (§6), not by
+  key hygiene.
+- `seq` is dense and 1-based per source. On reconnect or after a `.redsave`
+  load, resume from `Combo_GetGrantCursor(key) + 1`; on `GAP`, resync/resend
+  in order; on `RETRY_FULL`, re-offer later — delivery is the source's
+  obligation until `ACCEPTED` or `DUPLICATE`.
+- Delivery of a grant to the *player* still happens via
+  `Combo_RedeemSharedItemsForGame` at a safe point (§4); the transport never
+  awards anything itself.
+
+## Rationale
+
+1. **Idempotency must be decidable at the API, not probable at the wire.**
+   Retransmits are a fact of any transport; second gifts are a fact of
+   multiworld. Any design that cannot tell them apart locally is wrong under
+   exactly the load netplay creates.
+2. **Own as little identity as possible.** The cursor stores one u32 per
+   source and no per-grant identity, which is why an external
+   server-authoritative cursor (AP) can *be* the identity. Designs that stamp
+   every entry force a mapping layer under every transport forever.
+3. **Losing data loudly beats both losing it silently and blocking.** The
+   durable counter + non-advancing cursor is the smallest mechanism where
+   every loss is either prevented (sourced) or signaled (in-process).
+4. **The wrong producer path should be structurally awkward.** Sourced
+   producers get their own entry point and their entries are flagged; content
+   de-dup cannot reach them even if someone routes wrongly later.
+
+## Consequences
+
+- `sizeof(ComboContext)` stays 1004; `reserved` headroom drops 332 → 264.
+- New CI locks (all ROM-free, registered as CTest rows): `GrantIdempotency`,
+  `GrantRedeemNoSwitch`, `GrantOverflow`, `GrantPersistence`.
+- `shared_items.h` is the seam's documentation of record; its file header now
+  defines the producer classes, safe points, capacity policy, and threading
+  rule stated here.
+- The spike's §8 loopback-pair row ("two in-process client objects over an
+  in-memory channel") becomes 1b's first test: it needs a transport object,
+  which is exactly the piece this ADR deliberately does not build. Everything
+  semantic beneath it is locked here.
+- A1's "never cleared" note is amended per §3; ADR 0002 is otherwise
+  untouched and its growth contract fully honored.
+
+## Alternatives considered
+
+- **Widen `SharedItem` with a grantId/sender/seq.** Rejected: the 4-byte
+  layout with pinned offsets is shipped `.redsave` format (ADR 0002); a
+  parallel wide array duplicates the store and still needs the cursor logic
+  for external sources.
+- **A persisted seen-`grantId` set.** Rejected: unbounded, needs its own
+  eviction policy (which reintroduces the duplicate window it exists to
+  close), and cannot host a server-authoritative cursor.
+- **RAM-only cursors.** Rejected: a save/reload re-opens the duplicate
+  window — the spike called this trap out explicitly for the AP resync case.
+- **Out-of-order acceptance (advance cursor past gaps, or track a bitmap).**
+  Rejected: silently reorders progressive-item resolution, turns message loss
+  into undetectable item loss (jump) or unbounded state (bitmap), and no
+  planned source needs it.
+- **Growing `RSBS_SHARED_ITEM_CAP` instead of reclaiming.** Rejected as the
+  *primary* fix: any fixed cap without reclamation is a lifetime cap per
+  save; reclamation makes the cap a working-set bound. Raising the cap later
+  remains a legal, compatible carve if the working set ever demands it.
+- **Wiring the redemption tick now.** Rejected for this increment: no
+  producer can target the active game yet, so the wiring would be untestable
+  dead code in the ROM-gated tier; the safe-point contract it must obey is
+  defined and locked instead.

--- a/src/common/context.cpp
+++ b/src/common/context.cpp
@@ -218,11 +218,16 @@ void ComboContext_Init(void) {
     gComboCtx.sourceIsRando = false;
     gComboCtx.sharedRandoSeed = 0;
     gComboCtx.sharedRandoSettingsHash = 0;  // Lane B (ADR 0002 §3): 0 == no profile recorded
-    // sharedItemsTagged and the remaining reserved[] headroom are covered by
-    // the memset above: all-zero IS the initialized state (every slot unset,
-    // originGame == GAME_NONE). That equivalence is load-bearing — it is what
-    // makes a zero-extended legacy .redsave record indistinguishable from a
-    // fresh init (ADR 0002 growth contract).
+    // sharedItemsTagged, foreignPlacements, grantCursors,
+    // sharedItemOverflowCount, and the remaining reserved[] headroom are
+    // covered by the memset above: all-zero IS the initialized state (every
+    // slot unset, originGame == GAME_NONE, no source has ever delivered).
+    // That equivalence is load-bearing — it is what makes a zero-extended
+    // legacy .redsave record indistinguishable from a fresh init (ADR 0002
+    // growth contract). It is ALSO the invalidation atomicity the sourced-
+    // grant model requires (ADR 0005 / #440): one memset retires items and
+    // their delivery cursors together, so a dead session can neither replay
+    // its grants nor block a fresh session's deliveries.
 }
 
 void ComboContext_RequestSwitch(GameId target, uint16_t entrance) {

--- a/src/common/context.h
+++ b/src/common/context.h
@@ -171,8 +171,16 @@ void Context_UpdateShadowCopy(GameId game, const void* saveContext, size_t size)
  * distinct GRANT SOURCES can hold a delivery cursor at once. A source is one
  * remote authority feeding Combo_SubmitSourcedGrant — an Archipelago server
  * counts as ONE source regardless of room size, and a P2P co-op session uses
- * one source per peer, so 8 is generous for every planned topology. Growing
- * later is legal under the growth contract (carve more of reserved[]).
+ * one source per peer, so 8 is generous for every planned topology.
+ *
+ * DO NOT BUMP THIS CONSTANT to get more capacity. sharedItemOverflowCount is
+ * carved immediately after grantCursors, so widening the array in place moves
+ * that field (and anything carved after it) off the offset every shipped
+ * .redsave stored it at — a format break that the static asserts below CANNOT
+ * catch, because they pin the offset relative to RSBS_GRANT_SOURCE_CAP and so
+ * simply follow the bump. To add capacity, carve a SECOND cursor block from
+ * the front of reserved[] and consult both in the lookup: append-only, prior
+ * offsets fixed, zero still unset. See ADR 0005 §1.
  */
 #define RSBS_GRANT_SOURCE_CAP 8u
 

--- a/src/common/context.h
+++ b/src/common/context.h
@@ -148,12 +148,33 @@ void Context_UpdateShadowCopy(GameId game, const void* saveContext, size_t size)
 #define RSBS_SHARED_ITEM_REDEEMED 0x01u
 
 /**
+ * SharedItem.flags bit: this entry was recorded by an identified SOURCE
+ * through Combo_SubmitSourcedGrant (ADR 0005), not by an in-process producer.
+ * The bit keeps the two producer classes' idempotency domains disjoint:
+ * Combo_RecordSharedItem's content de-dup skips sourced entries, so a local
+ * pickup can never be silently merged into (and lost against) a peer's gift
+ * of the same item. Zero == unset holds: every legacy entry was recorded
+ * in-process, which is exactly what a zero bit means.
+ */
+#define RSBS_SHARED_ITEM_SOURCED 0x02u
+
+/**
  * Capacity of ComboContext.foreignPlacements (Lane C1, #392). The MVP pins ~4
  * OoT progression items into MM checks; 8 slots leave headroom without
  * spending reserved[] bytes we would rather keep (growing later is legal under
  * the growth contract).
  */
 #define RSBS_FOREIGN_PLACEMENT_CAP 8u
+
+/**
+ * Capacity of ComboContext.grantCursors (ADR 0005, netplay 1a #460): how many
+ * distinct GRANT SOURCES can hold a delivery cursor at once. A source is one
+ * remote authority feeding Combo_SubmitSourcedGrant — an Archipelago server
+ * counts as ONE source regardless of room size, and a P2P co-op session uses
+ * one source per peer, so 8 is generous for every planned topology. Growing
+ * later is legal under the growth contract (carve more of reserved[]).
+ */
+#define RSBS_GRANT_SOURCE_CAP 8u
 
 /**
  * One cross-game item, tagged with the game whose id-space `id` belongs to.
@@ -211,6 +232,36 @@ RSBS_CTX_STATIC_ASSERT(sizeof(ComboForeignPlacement) == 6,
                        "format");
 RSBS_CTX_STATIC_ASSERT(offsetof(ComboForeignPlacement, mmCheckId) == 0 && offsetof(ComboForeignPlacement, item) == 2,
                        "ComboForeignPlacement member offsets are .redsave format and must not move");
+
+/**
+ * One grant source's delivery cursor (ADR 0005, netplay 1a #460).
+ *
+ * A SOURCE is a producer of item grants with its own identity and its own
+ * monotonic sequence numbering — an in-process cross-game hand-off is NOT a
+ * source (it keeps using Combo_RecordSharedItem's content de-dup); a network
+ * peer or an Archipelago server is. `lastSeq` is the highest sequence number
+ * this save has ACCEPTED from the source: a retransmitted grant (seq <=
+ * lastSeq) is decidably a duplicate, a fresh grant (seq == lastSeq + 1) is
+ * decidably new — even when both carry the same (originGame, id). Persisting
+ * the cursor in the .redsave is what keeps that decision correct across a
+ * save/load: a reload can never re-open a duplicate-delivery window.
+ *
+ * Zero means unset for every member (growth contract): a slot is occupied iff
+ * sourceKey != 0, and an occupied slot always has lastSeq >= 1 (a cursor is
+ * only created by accepting seq 1). A zero-extended legacy record therefore
+ * reads as "no sources have ever delivered", which is correct.
+ */
+typedef struct {
+    uint32_t sourceKey; // transport-assigned nonzero source identity; 0 = empty slot
+    uint32_t lastSeq;   // highest accepted sequence number from this source; 0 = none
+} ComboGrantSourceCursor;
+
+RSBS_CTX_STATIC_ASSERT(sizeof(ComboGrantSourceCursor) == 8,
+                       "ComboGrantSourceCursor is serialized raw inside the .redsave Tier-1 record; its layout is "
+                       "format");
+RSBS_CTX_STATIC_ASSERT(offsetof(ComboGrantSourceCursor, sourceKey) == 0 &&
+                           offsetof(ComboGrantSourceCursor, lastSeq) == 4,
+                       "ComboGrantSourceCursor member offsets are .redsave format and must not move");
 
 typedef struct {
     char magic[8];        // "OoT+MM<3"
@@ -275,14 +326,34 @@ typedef struct {
     // the accessors; raw entries must always carry the origin tag (ADR 0002).
     ComboForeignPlacement foreignPlacements[RSBS_FOREIGN_PLACEMENT_CAP];
 
+    // Netplay 1a (ADR 0005, #460): per-source grant-delivery cursors, written
+    // by Combo_SubmitSourcedGrant when it accepts a grant, read to decide
+    // retransmit-vs-new. Carved from the FRONT of the old reserved[332] under
+    // the growth contract: all-zero = no sources have ever delivered, which is
+    // exactly what a zero-extended pre-netplay record must read as. Lives in
+    // the SAME Tier-1 record as sharedItemsTagged on purpose: the array and
+    // the cursors must be saved, loaded, and invalidated (#440) atomically —
+    // a cursor without its items refuses re-delivery of lost grants, items
+    // without their cursor re-accept duplicates.
+    ComboGrantSourceCursor grantCursors[RSBS_GRANT_SOURCE_CAP];
+
+    // Netplay 1a (ADR 0005, #460): durable count of shared-item records
+    // REFUSED for capacity (array full even after reclaiming redeemed slots).
+    // The anti-silent-loss signal: for the in-process producer a refusal is a
+    // genuinely lost item; for a sourced grant it marks backpressure (the
+    // grant stays owed by the source because its cursor did not advance).
+    // Zero == unset (no refusal has ever happened), per the growth contract.
+    uint32_t sharedItemOverflowCount;
+
     // Headroom. Carve new fields from the FRONT of this array (as
-    // sharedItemsTagged, sharedRandoSettingsHash, and foreignPlacements were)
-    // so the struct stays inside RSBS_COMBO_CONTEXT_RECORD_SIZE; the on-disk
-    // record size does not change either way, so old saves keep loading.
-    // Zeroed by ComboContext_Init, which is what makes a zero-extended legacy
-    // record indistinguishable from a freshly-initialized one — every field
-    // carved from here must keep "zero means unset".
-    uint8_t reserved[332];
+    // sharedItemsTagged, sharedRandoSettingsHash, foreignPlacements, and the
+    // grant cursors were) so the struct stays inside
+    // RSBS_COMBO_CONTEXT_RECORD_SIZE; the on-disk record size does not change
+    // either way, so old saves keep loading. Zeroed by ComboContext_Init,
+    // which is what makes a zero-extended legacy record indistinguishable from
+    // a freshly-initialized one — every field carved from here must keep
+    // "zero means unset".
+    uint8_t reserved[264];
 } ComboContext;
 
 /**
@@ -327,13 +398,25 @@ RSBS_CTX_STATIC_ASSERT(offsetof(ComboContext, foreignPlacements) ==
                                sizeof(uint32_t),
                        "foreignPlacements must be carved from the FRONT of the old reserved[] "
                        "(contiguous with the settings digest); moving it changes .redsave format");
-RSBS_CTX_STATIC_ASSERT(offsetof(ComboContext, reserved) ==
+// grantCursors is the next carve from the front of the old reserved[]: it must
+// sit immediately after the foreign-placement table with no gap, occupying
+// bytes every shipped .redsave stored as zero (unset).
+RSBS_CTX_STATIC_ASSERT(offsetof(ComboContext, grantCursors) ==
                            RSBS_COMBO_CONTEXT_PRECARVE_SIZE + RSBS_SHARED_ITEM_CAP * sizeof(SharedItem) +
                                sizeof(uint32_t) +
                                RSBS_FOREIGN_PLACEMENT_CAP * sizeof(ComboForeignPlacement),
-                       "the tagged-item array, the settings digest, the foreign-placement table, and "
-                       "the remaining headroom must stay contiguous (no padding, no fields slipped "
-                       "between them)");
+                       "grantCursors must be carved from the FRONT of the old reserved[] (contiguous "
+                       "with the foreign-placement table); moving it changes .redsave format");
+RSBS_CTX_STATIC_ASSERT(offsetof(ComboContext, sharedItemOverflowCount) ==
+                           offsetof(ComboContext, grantCursors) +
+                               RSBS_GRANT_SOURCE_CAP * sizeof(ComboGrantSourceCursor),
+                       "sharedItemOverflowCount must sit immediately after the grant cursors; moving "
+                       "it changes .redsave format");
+RSBS_CTX_STATIC_ASSERT(offsetof(ComboContext, reserved) ==
+                           offsetof(ComboContext, sharedItemOverflowCount) + sizeof(uint32_t),
+                       "the tagged-item array, the settings digest, the foreign-placement table, the "
+                       "grant cursors, the overflow count, and the remaining headroom must stay "
+                       "contiguous (no padding, no fields slipped between them)");
 
 #ifdef __cplusplus
 // The raw-assignment-fails proof (ADR 0002). In C this is a constraint

--- a/src/common/shared_items.c
+++ b/src/common/shared_items.c
@@ -13,6 +13,7 @@
 
 #include "shared_items.h"
 #include <stdio.h>
+#include <string.h>
 
 // ============================================================================
 // RAM outbox for the deferred (stage -> commit-at-suspend) producer path.
@@ -32,7 +33,77 @@ static bool IsRealGame(GameId game) {
 }
 
 // ============================================================================
-// Producer
+// Slot management (ADR 0005)
+//
+// The occupied entries always form a PREFIX of the array: records append at
+// the first free slot, entries are never cleared individually, and
+// reclamation compacts. Slot order is therefore acceptance order, which is
+// what makes Combo_RedeemSharedItemsForGame's slot-order walk a received-order
+// guarantee.
+// ============================================================================
+
+static int FindFirstFreeSlot(void) {
+    for (int i = 0; i < (int)RSBS_SHARED_ITEM_CAP; i++) {
+        if (gComboCtx.sharedItemsTagged[i].originGame == (uint8_t)GAME_NONE) {
+            return i;
+        }
+    }
+    return -1;
+}
+
+// Evict the OLDEST redeemed entry by compacting everything after it down one
+// slot, freeing the tail slot for the caller. Relative order of the surviving
+// entries is preserved, so received-order redemption is unaffected. Only
+// redeemed entries are evictable: they are informational records of completed
+// crossings, while an un-redeemed entry is an undelivered item and must never
+// be dropped. Returns the freed tail slot, or -1 if nothing is redeemed.
+static int ReclaimOldestRedeemedSlot(void) {
+    for (int i = 0; i < (int)RSBS_SHARED_ITEM_CAP; i++) {
+        SharedItem* slot = &gComboCtx.sharedItemsTagged[i];
+        if (slot->originGame != (uint8_t)GAME_NONE && (slot->flags & RSBS_SHARED_ITEM_REDEEMED) != 0) {
+            memmove(&gComboCtx.sharedItemsTagged[i], &gComboCtx.sharedItemsTagged[i + 1],
+                    ((size_t)RSBS_SHARED_ITEM_CAP - 1u - (size_t)i) * sizeof(SharedItem));
+            memset(&gComboCtx.sharedItemsTagged[RSBS_SHARED_ITEM_CAP - 1], 0, sizeof(SharedItem));
+            return (int)RSBS_SHARED_ITEM_CAP - 1;
+        }
+    }
+    return -1;
+}
+
+// Append an entry with NO content de-dup (the sourced-grant path depends on
+// that: a second grant of the same item is a real second item). `flags` is 0
+// for an in-process record or RSBS_SHARED_ITEM_SOURCED for a sourced grant —
+// never RSBS_SHARED_ITEM_REDEEMED (only the consumer sets that). On a full
+// array, reclaim the oldest redeemed entry; if every entry is un-redeemed,
+// refuse LOUDLY — increment the durable overflow count and log — rather than
+// drop silently. Returns the slot written, or -1 on refusal.
+static int AppendSharedItem(GameId originGame, uint16_t id, uint8_t flags) {
+    int slot = FindFirstFreeSlot();
+    if (slot < 0) {
+        slot = ReclaimOldestRedeemedSlot();
+        if (slot >= 0) {
+            fprintf(stderr, "[SharedItem] array full: reclaimed oldest redeemed entry (origin=%s id=%u incoming)\n",
+                    Game_ToString(originGame), (unsigned)id);
+        }
+    }
+    if (slot < 0) {
+        gComboCtx.sharedItemOverflowCount++;
+        fprintf(stderr,
+                "[SharedItem] record REFUSED: all %u slots hold un-redeemed items (overflow count now %u), "
+                "origin=%s id=%u\n",
+                RSBS_SHARED_ITEM_CAP, gComboCtx.sharedItemOverflowCount, Game_ToString(originGame), (unsigned)id);
+        return -1;
+    }
+
+    SharedItem* dst = &gComboCtx.sharedItemsTagged[slot];
+    dst->originGame = (uint8_t)originGame;
+    dst->flags = flags;
+    dst->id = id;
+    return slot;
+}
+
+// ============================================================================
+// In-process producer
 // ============================================================================
 
 int Combo_RecordSharedItem(GameId originGame, uint16_t id) {
@@ -40,38 +111,27 @@ int Combo_RecordSharedItem(GameId originGame, uint16_t id) {
         return -1;
     }
 
-    // De-dup against an existing un-redeemed entry so a re-fired producer
-    // cannot create doubles (see the header). An already-redeemed match does
-    // NOT block a fresh record — the same item crossing a second time is a
-    // real, distinct hand-off.
-    int firstFree = -1;
+    // De-dup BY CONTENT against an existing un-redeemed IN-PROCESS entry so a
+    // re-fired in-process producer cannot create doubles (see the header). An
+    // already-redeemed match does NOT block a fresh record — the same item
+    // crossing a second time is a real, distinct hand-off. SOURCED entries are
+    // skipped (RSBS_SHARED_ITEM_SOURCED): a peer's pending gift of the same
+    // item must not swallow a genuine local pickup — the two producer classes'
+    // idempotency domains are disjoint by design (ADR 0005).
     for (int i = 0; i < (int)RSBS_SHARED_ITEM_CAP; i++) {
         SharedItem* slot = &gComboCtx.sharedItemsTagged[i];
-        if (slot->originGame == (uint8_t)GAME_NONE) {
-            if (firstFree < 0) {
-                firstFree = i;
-            }
-            continue;
-        }
         if (slot->originGame == (uint8_t)originGame && slot->id == id &&
-            (slot->flags & RSBS_SHARED_ITEM_REDEEMED) == 0) {
+            (slot->flags & (RSBS_SHARED_ITEM_REDEEMED | RSBS_SHARED_ITEM_SOURCED)) == 0) {
             return i; // already pending — leave it exactly as-is
         }
     }
 
-    if (firstFree < 0) {
-        fprintf(stderr, "[SharedItem] record dropped: array full (%u slots), origin=%s id=%u\n",
-                RSBS_SHARED_ITEM_CAP, Game_ToString(originGame), (unsigned)id);
-        return -1;
+    int slot = AppendSharedItem(originGame, id, 0);
+    if (slot >= 0) {
+        fprintf(stderr, "[SharedItem] recorded origin=%s id=%u in slot %d\n", Game_ToString(originGame), (unsigned)id,
+                slot);
     }
-
-    SharedItem* dst = &gComboCtx.sharedItemsTagged[firstFree];
-    dst->originGame = (uint8_t)originGame;
-    dst->flags = 0;
-    dst->id = id;
-    fprintf(stderr, "[SharedItem] recorded origin=%s id=%u in slot %d\n", Game_ToString(originGame), (unsigned)id,
-            firstFree);
-    return firstFree;
+    return slot;
 }
 
 bool Combo_StageSharedItem(GameId originGame, uint16_t id) {
@@ -96,12 +156,107 @@ int Combo_CommitStagedSharedItems(void) {
         if (Combo_RecordSharedItem((GameId)sOutbox[i].originGame, sOutbox[i].id) >= 0) {
             committed++;
         }
-        // A -1 here means the durable array is full; the staged entry is
-        // dropped (already logged by Combo_RecordSharedItem) rather than left
-        // to leak forward into a later, unrelated switch.
+        // A -1 here means the durable array is full of un-redeemed items even
+        // after reclamation; the staged entry is dropped (already logged AND
+        // counted in the durable overflow count by the record path) rather
+        // than left to leak forward into a later, unrelated switch.
     }
     sOutboxCount = 0;
     return committed;
+}
+
+// ============================================================================
+// Sourced producer (ADR 0005) — the seam a transport writes against.
+// ============================================================================
+
+ComboGrantResult Combo_SubmitSourcedGrant(uint32_t sourceKey, uint32_t seq, GameId originGame, uint16_t id) {
+    if (sourceKey == 0u || seq == 0u || !IsRealGame(originGame)) {
+        fprintf(stderr, "[SharedItem] sourced grant REJECTED (malformed): key=%u seq=%u origin=%d id=%u\n",
+                sourceKey, seq, (int)originGame, (unsigned)id);
+        return RSBS_GRANT_REJECTED;
+    }
+
+    // Locate this source's cursor; remember a free slot in case the source is
+    // new. The cursor slot must be secured BEFORE the item is recorded: an
+    // item recorded without a cursor to remember it would make the source's
+    // inevitable retransmit of the same seq record a double.
+    ComboGrantSourceCursor* cur = NULL;
+    ComboGrantSourceCursor* freeSlot = NULL;
+    for (int i = 0; i < (int)RSBS_GRANT_SOURCE_CAP; i++) {
+        ComboGrantSourceCursor* c = &gComboCtx.grantCursors[i];
+        if (c->sourceKey == sourceKey) {
+            cur = c;
+            break;
+        }
+        if (c->sourceKey == 0u && freeSlot == NULL) {
+            freeSlot = c;
+        }
+    }
+
+    const uint32_t lastSeq = (cur != NULL) ? cur->lastSeq : 0u;
+    if (seq <= lastSeq) {
+        // Retransmit of a grant this save already accepted. Deliberately not
+        // logged: this is the expected idempotent path under a resend-happy
+        // transport, not an anomaly.
+        return RSBS_GRANT_DUPLICATE;
+    }
+    if (seq != lastSeq + 1u) {
+        fprintf(stderr, "[SharedItem] sourced grant GAP: key=%u sent seq=%u but expected %u — resync the source\n",
+                sourceKey, seq, lastSeq + 1u);
+        return RSBS_GRANT_GAP;
+    }
+    if (cur == NULL && freeSlot == NULL) {
+        fprintf(stderr, "[SharedItem] sourced grant refused: all %u source-cursor slots occupied (key=%u)\n",
+                RSBS_GRANT_SOURCE_CAP, sourceKey);
+        return RSBS_GRANT_NO_SOURCE_SLOT;
+    }
+
+    // In-order and novel: record it. NO content de-dup — a second grant of the
+    // same (originGame, id) with its own seq is a real second item. The
+    // SOURCED flag keeps this entry out of Combo_RecordSharedItem's content
+    // de-dup domain.
+    if (AppendSharedItem(originGame, id, RSBS_SHARED_ITEM_SOURCED) < 0) {
+        // Backpressure, not loss: the cursor did not advance, so the source
+        // still owes this seq. A later retransmit — after redemption frees
+        // capacity — is accepted, not treated as a duplicate. AppendSharedItem
+        // already counted and logged the refusal.
+        return RSBS_GRANT_RETRY_FULL;
+    }
+
+    if (cur == NULL) {
+        cur = freeSlot;
+        cur->sourceKey = sourceKey;
+    }
+    cur->lastSeq = seq;
+    fprintf(stderr, "[SharedItem] sourced grant accepted: key=%u seq=%u origin=%s id=%u\n", sourceKey, seq,
+            Game_ToString(originGame), (unsigned)id);
+    return RSBS_GRANT_ACCEPTED;
+}
+
+uint32_t Combo_GetGrantCursor(uint32_t sourceKey) {
+    if (sourceKey == 0u) {
+        return 0u;
+    }
+    for (int i = 0; i < (int)RSBS_GRANT_SOURCE_CAP; i++) {
+        if (gComboCtx.grantCursors[i].sourceKey == sourceKey) {
+            return gComboCtx.grantCursors[i].lastSeq;
+        }
+    }
+    return 0u;
+}
+
+int Combo_CountGrantSources(void) {
+    int count = 0;
+    for (int i = 0; i < (int)RSBS_GRANT_SOURCE_CAP; i++) {
+        if (gComboCtx.grantCursors[i].sourceKey != 0u) {
+            count++;
+        }
+    }
+    return count;
+}
+
+uint32_t Combo_GetSharedItemOverflowCount(void) {
+    return gComboCtx.sharedItemOverflowCount;
 }
 
 // ============================================================================

--- a/src/common/shared_items.h
+++ b/src/common/shared_items.h
@@ -28,15 +28,68 @@
  *   - When the player next ARRIVES in the origin game, that game's consumer
  *     awards every un-redeemed entry tagged for it and marks it redeemed.
  *
- * Plain `.redsave` load without a switch (decided, documented): the consumers
- * run only at the presence-gated startup-entrance consumption points, which a
- * cold boot or a plain load never reaches. Un-redeemed items therefore persist
- * in the loaded `gComboCtx` and are awarded on the NEXT switch into their
- * origin game — an explicit "applies on next switch only" semantic. No item is
- * lost (the array is serialized and REDEEMED tracks what is done) and none is
- * double-awarded. We deliberately do NOT redeem at load time: awarding routes
- * through the game's live item-give machinery, which is only valid once the
- * game has reached gameplay — exactly what the consumption point guarantees.
+ * TWO PRODUCER CLASSES (ADR 0005, netplay 1a #460) — choosing the wrong one is
+ * a correctness bug, not a style choice:
+ *
+ *   - IN-PROCESS producers (a give path re-firing inside this process) use
+ *     Combo_RecordSharedItem / Combo_StageSharedItem. Their idempotency is
+ *     CONTENT de-dup: an identical un-redeemed (originGame, id) is the same
+ *     event re-observed, so it merges. Correct here, and ONLY here.
+ *   - SOURCED producers (anything with its own identity and its own delivery
+ *     stream: a network peer, an Archipelago server, a loopback test feed) use
+ *     Combo_SubmitSourcedGrant. Their idempotency is a per-source monotonic
+ *     CURSOR: a retransmit (seq <= cursor) is dropped, a genuinely new grant
+ *     of the same item (fresh seq) is recorded WITHOUT content de-dup — two
+ *     peers gifting you the same item is two items. A sourced producer must
+ *     never call Combo_RecordSharedItem directly: content de-dup would
+ *     silently merge distinct gifts.
+ *
+ *     The two domains never mix: sourced entries carry
+ *     RSBS_SHARED_ITEM_SOURCED, and content de-dup skips them, so a peer's
+ *     pending gift can never swallow a genuine local pickup of the same item
+ *     (nor vice versa).
+ *
+ * REDEMPTION SAFE POINTS (ADR 0005). Combo_RedeemSharedItemsForGame is safe at
+ * any point where ALL of the following hold for `arrivingGame`, not only at a
+ * game switch: (1) it is the active game, on the game thread; (2) a save is
+ * loaded and normal gameplay has been reached, so the award callback's give
+ * machinery is valid; (3) the caller passes that game's real award callback.
+ * The presence-gated startup-entrance consumption points are the two wired
+ * safe points today. A gameplay-gated frame tick is the third, DEFINED safe
+ * point — it gets wired together with the first producer that can target the
+ * active game mid-session (the 1b transport), because until such a producer
+ * exists there is nothing for a tick to redeem: every in-process producer
+ * records for the game you are leaving. Single-use is independent of the
+ * trigger: RSBS_SHARED_ITEM_REDEEMED makes redemption idempotent under any
+ * interleaving of safe points.
+ *
+ * Plain `.redsave` load without a switch: unchanged for everything wired
+ * today. Un-redeemed items persist in the loaded `gComboCtx` and are awarded
+ * at the next safe point — which, with only arrival points wired, is the next
+ * switch into their origin game. We deliberately do NOT redeem at load time:
+ * awarding routes through the game's live item-give machinery, which is only
+ * valid once the game has reached gameplay — exactly what every safe point
+ * above guarantees.
+ *
+ * CAPACITY (ADR 0005). The durable array holds RSBS_SHARED_ITEM_CAP entries.
+ * When it is full, recording first RECLAIMS the oldest REDEEMED entry (the
+ * array compacts, preserving relative order, and the freed tail slot takes
+ * the new record) — a redeemed entry is an informational record of a done
+ * crossing, an un-redeemed entry is an undelivered item; only the former may
+ * be evicted, and ADR 0005 amends A1's "entries are never cleared" note
+ * accordingly. If every entry is un-redeemed, the record is REFUSED — loudly:
+ * the durable gComboCtx.sharedItemOverflowCount increments (serialized, so
+ * the signal survives save/load) and the refusal is logged. For a sourced
+ * grant a refusal is backpressure, not loss: the cursor does not advance, so
+ * the source still owes the grant and a later retransmit is accepted. For an
+ * in-process producer a refusal IS a lost item (the pickup already happened);
+ * the counter is what keeps that loss diagnosable. Slot indices returned by
+ * the record APIs are transient (reclamation compacts the array) — never
+ * store them.
+ *
+ * THREADING: everything in this header runs on the game thread only. A
+ * transport receiving off-thread must marshal onto the game thread before
+ * calling Combo_SubmitSourcedGrant (that is part of the seam's contract).
  */
 
 #ifndef RSBS_COMMON_SHARED_ITEMS_H
@@ -59,21 +112,29 @@ extern "C" {
 typedef void (*ComboSharedItemAward)(const SharedItem* item, void* ctx);
 
 /**
- * PRODUCER (direct write). Record a cross-game item into
+ * IN-PROCESS PRODUCER (direct write). Record a cross-game item into
  * gComboCtx.sharedItemsTagged, visible immediately in the shared context and
  * persisted by the next `.redsave` save.
  *
  * @param originGame the id-space owner (GAME_OOT => `id` is RG_*, GAME_MM => RI_*)
  * @param id         the item id within originGame's id-space
  * @return the slot index used (>= 0), or -1 if originGame is not a real game or
- *         the array is full.
+ *         the array is full of un-redeemed entries (after attempting
+ *         reclamation; the refusal increments the durable overflow count).
+ *         Returned indices are transient — reclamation compacts the array —
+ *         so treat them as success/failure only, never store them.
  *
- * De-dups: if an identical (originGame, id) entry already exists and is NOT yet
- * redeemed, its slot is returned unchanged rather than duplicated — so a
- * re-fired producer (the Combo_CheckEntranceSwitch wasAlreadyPending re-entry,
- * or two suspends with no consume between them) cannot create doubles. A
- * matching entry that is already redeemed does NOT block a fresh record: the
- * same item legitimately crossing again gets a new slot.
+ * De-dups BY CONTENT: if an identical (originGame, id) entry already exists and
+ * is NOT yet redeemed, its slot is returned unchanged rather than duplicated —
+ * so a re-fired producer (the Combo_CheckEntranceSwitch wasAlreadyPending
+ * re-entry, or two suspends with no consume between them) cannot create
+ * doubles. A matching entry that is already redeemed does NOT block a fresh
+ * record: the same item legitimately crossing again gets a new slot.
+ *
+ * Content de-dup is only correct for in-process re-fired producers. A SOURCED
+ * producer (network peer, Archipelago server) must go through
+ * Combo_SubmitSourcedGrant instead, where retransmit-vs-new is decided by the
+ * source's cursor and two distinct grants of the same item both record.
  */
 int Combo_RecordSharedItem(GameId originGame, uint16_t id);
 
@@ -107,17 +168,92 @@ int Combo_CommitStagedSharedItems(void);
 
 /**
  * CONSUMER HOOK. Award every occupied, un-redeemed entry whose
- * originGame == arrivingGame via `award`, then set RSBS_SHARED_ITEM_REDEEMED on
- * each. Entries are NOT cleared: they remain as the serialized record of the
- * crossing.
+ * originGame == arrivingGame via `award`, in slot order — which is acceptance
+ * order, and reclamation preserves it — then set RSBS_SHARED_ITEM_REDEEMED on
+ * each. Received-order awarding is a contract, not an accident: the give paths
+ * resolve progressive items against the live save, so order changes WHAT the
+ * player receives. Redeemed entries stay in the array as the serialized record
+ * of the crossing until capacity pressure reclaims them (file header).
  *
- * Called from each game's presence-gated startup-entrance consumption point
+ * Wired today at each game's presence-gated startup-entrance consumption point
  * (OoT_Play_Init / MM_Play_ConsumeStartupEntrance), which run only on a switch
- * arrival. See the file header for the plain-load semantics.
+ * arrival. Safe at ANY redemption safe point (file header): it has no
+ * dependency on switch machinery, and RSBS_SHARED_ITEM_REDEEMED makes it
+ * idempotent under any interleaving of safe points.
  *
  * @return the number of entries redeemed this call.
  */
 int Combo_RedeemSharedItemsForGame(GameId arrivingGame, ComboSharedItemAward award, void* ctx);
+
+// ============================================================================
+// Sourced grants (ADR 0005, netplay 1a #460) — the producer seam a transport
+// writes against. No transport lives in this layer: the only callers today are
+// the CI locks, and the 1b transport plugs in here without this file changing.
+// ============================================================================
+
+/**
+ * Result of Combo_SubmitSourcedGrant. Everything except RSBS_GRANT_ACCEPTED
+ * leaves gComboCtx completely unchanged (no item recorded, no cursor moved).
+ */
+typedef enum {
+    RSBS_GRANT_ACCEPTED = 0,   // recorded; the source's cursor advanced to seq
+    RSBS_GRANT_DUPLICATE = 1,  // seq <= cursor: retransmit of a delivered grant; drop it (idempotent success)
+    RSBS_GRANT_GAP = 2,        // seq skips ahead: predecessors missing; resync/resend the source in order
+    RSBS_GRANT_RETRY_FULL = 3, // array full of un-redeemed items: backpressure — the source still owes this
+                               // grant (cursor unmoved) and must re-offer it later
+    RSBS_GRANT_NO_SOURCE_SLOT = 4, // all RSBS_GRANT_SOURCE_CAP cursor slots taken by other sources
+    RSBS_GRANT_REJECTED = 5,   // malformed: sourceKey 0, seq 0, or originGame not a real game
+} ComboGrantResult;
+
+/**
+ * SOURCED PRODUCER. Submit one grant from an identified source, idempotently.
+ *
+ * @param sourceKey  nonzero identity of the source WITHIN the current world /
+ *                   session (the transport derives it — e.g. a hash of room id
+ *                   + peer slot; an Archipelago server is one source). Cursor
+ *                   state is per-key and lives in gComboCtx, so #440-class
+ *                   invalidation wipes keys and items together.
+ * @param seq        the source's own monotonic sequence number for this grant,
+ *                   starting at 1 for the source's first grant, dense (no
+ *                   holes). A server-authoritative cursor maps directly: an
+ *                   Archipelago ReceivedItems index i is seq i + 1.
+ * @param originGame / @param id  exactly Combo_RecordSharedItem's parameters.
+ *
+ * Acceptance is STRICTLY in-order per source (seq must be cursor + 1; a new
+ * source must start at 1). That is what makes every case decidable: a
+ * retransmit is DUPLICATE, a genuine second gift has a fresh seq and records
+ * without content de-dup, a lost message surfaces as GAP instead of silent
+ * reordering, and a capacity refusal (RETRY_FULL) leaves the cursor unmoved so
+ * the grant is retried rather than lost. On DUPLICATE the grant was already
+ * recorded by an earlier accept; whether it has been redeemed since is the
+ * consumer's business — the producer seam never re-records it.
+ *
+ * Game thread only (file header). See ComboGrantResult for the outcomes.
+ */
+ComboGrantResult Combo_SubmitSourcedGrant(uint32_t sourceKey, uint32_t seq, GameId originGame, uint16_t id);
+
+/**
+ * The source's persisted delivery cursor: the highest seq ever ACCEPTED from
+ * sourceKey, or 0 if the source is unknown (nothing accepted yet — a source
+ * only exists once its seq 1 is accepted). A transport resumes delivery at
+ * cursor + 1 after a reconnect or a .redsave load; an Archipelago client hands
+ * this to Sync as its ReceivedItems index.
+ */
+uint32_t Combo_GetGrantCursor(uint32_t sourceKey);
+
+/**
+ * Number of occupied grant-cursor slots (read-only; trackers / tests).
+ */
+int Combo_CountGrantSources(void);
+
+/**
+ * Durable count of shared-item records refused for capacity (read-only view of
+ * gComboCtx.sharedItemOverflowCount; serialized in every .redsave). Nonzero
+ * means the array hit capacity with every slot un-redeemed: for in-process
+ * records that is a lost item, for sourced grants a backpressure event. Reset
+ * only by ComboContext_Init (fresh world / #440 invalidation).
+ */
+uint32_t Combo_GetSharedItemOverflowCount(void);
 
 /**
  * Count occupied entries whose originGame == game. When includeRedeemed is

--- a/src/common/test_runner.cpp
+++ b/src/common/test_runner.cpp
@@ -138,6 +138,14 @@ extern "C" {
 // pipeline symbols it drives are C-linkage and declared in the file.
 #include "tests/test_foreign_items.c"
 
+// Sourced-grant model locks (ADR 0005, netplay 1a #460): per-source cursor
+// idempotency, switch-free received-order redemption, loud overflow with
+// redeemed-slot reclamation, and .redsave durability including the
+// pre-netplay migration path and the #440-composing reset atomicity. FILE
+// SCOPE (compiled as C++) for rsbs::SaveManager; the grant API is C-linkage
+// via shared_items.h.
+#include "tests/test_grant_sources.c"
+
 // MM scene-command parse regression (issue #344). Included at FILE SCOPE
 // (compiled as C++): it drives MM's S2H::ResourceFactoryBinarySceneV0 directly
 // over a synthetic scene buffer — no ROM archives or display needed.
@@ -1114,6 +1122,16 @@ const TestDescriptor gTests[] = {
     // crossing awards exactly once, and the placement carve serializes.
     {"foreign-item-give", "Foreign give path tags shared structure; awards once; placements serialize (Lane C1)",
      Test_ForeignItemGive},
+    // Netplay 1a (ADR 0005, #460): the sourced-grant model, transport-free.
+    {"grant-idempotency", "Retransmit delivers once; a second gift of the same item delivers twice (ADR 0005)",
+     Test_GrantIdempotency},
+    {"grant-redeem-no-switch", "Grants redeem in received order at a safe point, no switch machinery (ADR 0005)",
+     Test_GrantRedeemNoSwitch},
+    {"grant-overflow", "Full array refuses loudly, backpressures sources, reclaims redeemed slots (ADR 0005)",
+     Test_GrantOverflow},
+    {"grant-persistence", "Cursors + overflow ride the .redsave; legacy loads unset; reset retires atomically "
+     "(ADR 0005)",
+     Test_GrantPersistence},
     {"context", "Test context/state management", Test_Context},
     // Clears all frozen states on entry and exit, so it must not run between a
     // test that freezes and one that expects that freeze to still be there.

--- a/src/common/tests/test_grant_sources.c
+++ b/src/common/tests/test_grant_sources.c
@@ -330,6 +330,20 @@ TestResult Test_GrantPersistence(void) {
     rsbs::SaveManager& mgr = rsbs::SaveManager::Instance();
     mgr.SetSaveDirectory(kGrantSaveDir);
 
+    // Save-harness precondition, NOT a grant-model dependency: SaveManager::Save
+    // serializes Tiers 2/3 from the context-layer shadow buffers and refuses
+    // outright (save.cpp: "refuse rather than write a half-empty file") if either
+    // is absent. Context_InitFrozenStates allocates both at capacity; it is
+    // idempotent, and ClearAll only zeroes them, so once initialized they stay
+    // present. GrantTestReset deliberately does not do this — the other three
+    // grant tests must prove the model needs no switch machinery — so this test
+    // states the precondition itself instead of inheriting it from whichever
+    // save test happened to run earlier in the same process. Without it,
+    // `redship --test grant-persistence` standalone fails at Save while the
+    // pooled `--test all` run passes, which is exactly how this presented.
+    Context_InitFrozenStates();
+    GS_ASSERT(Context_GetOoTSaveContext() != NULL && Context_GetMMSaveContext() != NULL);
+
     // ------------------------------------------------------------------
     // (a) Round-trip: sourced entries, cursors, and the overflow count all
     //     survive Save/Load byte-exact — and the duplicate window STAYS

--- a/src/common/tests/test_grant_sources.c
+++ b/src/common/tests/test_grant_sources.c
@@ -1,0 +1,426 @@
+/**
+ * @file test_grant_sources.c
+ * @brief ROM-free locks for the sourced-grant model (ADR 0005, netplay 1a #460).
+ *
+ * The four semantic gaps the netplay spike identified (docs/
+ * netplay-increment-1-spike.md §3) are locked here, transport-free:
+ *
+ *  (1) IDEMPOTENCY IS DECIDABLE: a retransmitted grant (same source, same seq)
+ *      delivers once; two distinct grants of the SAME item — two sources, or
+ *      one source with fresh seqs — both deliver. Content de-dup stays correct
+ *      for in-process producers and never crosses into the sourced domain.
+ *
+ *  (2) REDEMPTION NEEDS NO SWITCH: grants redeem through the ordinary
+ *      consumer at any safe point, with zero switch machinery touched, in
+ *      received order, single-use under repeated safe points.
+ *
+ *  (3) OVERFLOW CANNOT LOSE DATA SILENTLY: a full array refuses loudly (the
+ *      durable overflow count), a refused sourced grant stays owed (cursor
+ *      unmoved -> the retry is accepted, not deduped), and redeemed entries
+ *      are reclaimed oldest-first with order preserved.
+ *
+ *  (4) THE MODEL IS DURABLE: cursors + sourced entries + overflow count ride
+ *      the .redsave Tier-1 record (ADR 0002 growth contract), a reload closes
+ *      the duplicate window instead of re-opening it, a pre-netplay legacy
+ *      record loads with every new field unset, and ComboContext_Init retires
+ *      items and cursors ATOMICALLY (the #440 composition contract).
+ *
+ * Linkage note: #included into test_runner.cpp at FILE SCOPE (compiled as
+ * C++, like test_save_roundtrip.c) for the rsbs::SaveManager half; every
+ * grant symbol it drives is C-linkage via shared_items.h.
+ */
+
+#include "../context.h"
+#include "../save.h"
+#include "../shared_items.h"
+#include "../test_runner.h"
+
+#include <cstdio>
+#include <cstring>
+#include <filesystem>
+#include <fstream>
+#include <string>
+#include <vector>
+
+#define GS_ASSERT(cond)                                                                                                \
+    do {                                                                                                               \
+        if (!(cond)) {                                                                                                 \
+            printf("[TEST] FAIL: %s:%d: %s\n", __FILE__, __LINE__, #cond);                                             \
+            return TEST_FAIL;                                                                                          \
+        }                                                                                                              \
+    } while (0)
+
+namespace {
+
+const char* const kGrantSaveDir = "rsbs_test_saves_grants";
+
+// Arbitrary nonzero source keys — the model treats them opaquely.
+const uint32_t kGrantSrcA = 0xA11CE001u;
+const uint32_t kGrantSrcB = 0xB0B00002u;
+
+// Award recorder that captures the FULL award order, not just the last one:
+// received-order redemption is one of the contracts under test.
+struct GrantAwardLog {
+    int count;
+    uint16_t ids[RSBS_SHARED_ITEM_CAP];
+    uint8_t origins[RSBS_SHARED_ITEM_CAP];
+};
+
+void GrantTestAward(const SharedItem* item, void* ctx) {
+    GrantAwardLog* log = (GrantAwardLog*)ctx;
+    if (log->count < (int)RSBS_SHARED_ITEM_CAP) {
+        log->ids[log->count] = item->id;
+        log->origins[log->count] = item->originGame;
+    }
+    log->count++;
+}
+
+// Clean slate shared by every grant test. Deliberately does NOT touch frozen
+// state or the entrance table: these tests must prove the grant model has no
+// dependency on the switch machinery.
+void GrantTestReset(void) {
+    ComboContext_Init();
+    Combo_ClearSharedItemOutbox();
+}
+
+int GrantTestOccupiedTotal(void) {
+    return Combo_CountSharedItems(GAME_OOT, /*includeRedeemed=*/true) +
+           Combo_CountSharedItems(GAME_MM, /*includeRedeemed=*/true);
+}
+
+// Hand-craft a PRE-NETPLAY .redsave: the Tier-1 record truncated exactly where
+// the ADR 0005 carve begins (offsetof grantCursors — drift-locked to 672 by
+// the context.h static-assert chain), taking the bytes from the CURRENT
+// gComboCtx. That is byte-for-byte what a pre-carve build wrote, per the
+// growth contract. Mirrors test_save_roundtrip.c's SaveTestWriteCraftedSlot
+// but is kept local so this file does not reach into another test's internals.
+bool GrantTestWriteLegacySlot(const std::string& path) {
+    const uint32_t comboSize = (uint32_t)offsetof(ComboContext, grantCursors);
+    std::vector<uint8_t> payload;
+    const uint8_t* comboBytes = reinterpret_cast<const uint8_t*>(&gComboCtx);
+    payload.insert(payload.end(), comboBytes, comboBytes + comboSize);
+    payload.insert(payload.end(), OOT_SAVE_CONTEXT_SIZE, 0u);
+    payload.insert(payload.end(), MM_SAVE_CONTEXT_SIZE, 0u);
+
+    rsbs::RsbsSaveHeader h;
+    std::memset(&h, 0, sizeof(h));
+    std::memcpy(h.magic, RSBS_SAVE_MAGIC, sizeof(h.magic));
+    h.version = RSBS_SAVE_VERSION;
+    h.endian = RSBS_SAVE_ENDIAN_LE;
+    h.slot = 0;
+    h.headerSize = sizeof(rsbs::RsbsSaveHeader);
+    h.comboSize = comboSize;
+    h.ootSize = (uint32_t)OOT_SAVE_CONTEXT_SIZE;
+    h.mmSize = (uint32_t)MM_SAVE_CONTEXT_SIZE;
+    h.crc32 = rsbs::SaveManager::Crc32(payload.data(), payload.size());
+
+    std::filesystem::create_directories(kGrantSaveDir);
+    std::ofstream out(path, std::ios::binary | std::ios::trunc);
+    if (!out) {
+        return false;
+    }
+    out.write(reinterpret_cast<const char*>(&h), sizeof(h));
+    out.write(reinterpret_cast<const char*>(payload.data()), (std::streamsize)payload.size());
+    return static_cast<bool>(out);
+}
+
+} // namespace
+
+TestResult Test_GrantIdempotency(void) {
+    printf("[TEST] grant-idempotency: retransmit delivers once; a second gift of the same item delivers twice "
+           "(ADR 0005)\n");
+
+    GrantTestReset();
+
+    // Malformed submissions change nothing.
+    GS_ASSERT(Combo_SubmitSourcedGrant(0, 1, GAME_OOT, 10) == RSBS_GRANT_REJECTED);
+    GS_ASSERT(Combo_SubmitSourcedGrant(kGrantSrcA, 0, GAME_OOT, 10) == RSBS_GRANT_REJECTED);
+    GS_ASSERT(Combo_SubmitSourcedGrant(kGrantSrcA, 1, GAME_NONE, 10) == RSBS_GRANT_REJECTED);
+    GS_ASSERT(Combo_CountGrantSources() == 0 && GrantTestOccupiedTotal() == 0);
+    GS_ASSERT(Combo_GetGrantCursor(kGrantSrcA) == 0 && Combo_GetGrantCursor(0) == 0);
+
+    // A new source must start at seq 1: out-of-the-blue seq 5 is a GAP, and
+    // no cursor slot is burned for it.
+    GS_ASSERT(Combo_SubmitSourcedGrant(kGrantSrcA, 5, GAME_OOT, 10) == RSBS_GRANT_GAP);
+    GS_ASSERT(Combo_CountGrantSources() == 0 && GrantTestOccupiedTotal() == 0);
+
+    // First delivery.
+    GS_ASSERT(Combo_SubmitSourcedGrant(kGrantSrcA, 1, GAME_OOT, 10) == RSBS_GRANT_ACCEPTED);
+    GS_ASSERT(Combo_GetGrantCursor(kGrantSrcA) == 1);
+    GS_ASSERT(GrantTestOccupiedTotal() == 1);
+    GS_ASSERT((gComboCtx.sharedItemsTagged[0].flags & RSBS_SHARED_ITEM_SOURCED) != 0);
+    GS_ASSERT((gComboCtx.sharedItemsTagged[0].flags & RSBS_SHARED_ITEM_REDEEMED) == 0);
+
+    // RETRANSMIT: same source, same seq — delivers once. This used to be
+    // indistinguishable from a second gift at the record API (spike §3).
+    GS_ASSERT(Combo_SubmitSourcedGrant(kGrantSrcA, 1, GAME_OOT, 10) == RSBS_GRANT_DUPLICATE);
+    GS_ASSERT(GrantTestOccupiedTotal() == 1 && Combo_GetGrantCursor(kGrantSrcA) == 1);
+
+    // THE GAP-2 REGRESSION: a second source gifting the SAME item is a second
+    // item, not a merge.
+    GS_ASSERT(Combo_SubmitSourcedGrant(kGrantSrcB, 1, GAME_OOT, 10) == RSBS_GRANT_ACCEPTED);
+    GS_ASSERT(GrantTestOccupiedTotal() == 2);
+
+    // Same source gifting the same item again under a fresh seq: also a
+    // second item.
+    GS_ASSERT(Combo_SubmitSourcedGrant(kGrantSrcA, 2, GAME_OOT, 10) == RSBS_GRANT_ACCEPTED);
+    GS_ASSERT(GrantTestOccupiedTotal() == 3 && Combo_GetGrantCursor(kGrantSrcA) == 2);
+
+    // A skipped seq is a GAP (cursor and array unmoved); filling in order
+    // resumes delivery.
+    GS_ASSERT(Combo_SubmitSourcedGrant(kGrantSrcA, 4, GAME_OOT, 11) == RSBS_GRANT_GAP);
+    GS_ASSERT(GrantTestOccupiedTotal() == 3 && Combo_GetGrantCursor(kGrantSrcA) == 2);
+    GS_ASSERT(Combo_SubmitSourcedGrant(kGrantSrcA, 3, GAME_OOT, 11) == RSBS_GRANT_ACCEPTED);
+    GS_ASSERT(Combo_SubmitSourcedGrant(kGrantSrcA, 4, GAME_OOT, 12) == RSBS_GRANT_ACCEPTED);
+    GS_ASSERT(Combo_GetGrantCursor(kGrantSrcA) == 4 && GrantTestOccupiedTotal() == 5);
+    GS_ASSERT(Combo_SubmitSourcedGrant(kGrantSrcA, 2, GAME_OOT, 10) == RSBS_GRANT_DUPLICATE); // stale retransmit
+
+    // The in-process producer's content de-dup is UNCHANGED — and disjoint
+    // from the sourced domain: un-redeemed sourced (OOT, 10) entries exist,
+    // yet a local pickup of (OOT, 10) records fresh instead of merging.
+    int localSlot = Combo_RecordSharedItem(GAME_OOT, 10);
+    GS_ASSERT(localSlot >= 0);
+    GS_ASSERT(GrantTestOccupiedTotal() == 6);
+    GS_ASSERT(gComboCtx.sharedItemsTagged[localSlot].flags == 0); // in-process: no SOURCED bit
+    // A re-fired local pickup still merges into the local entry.
+    GS_ASSERT(Combo_RecordSharedItem(GAME_OOT, 10) == localSlot);
+    GS_ASSERT(GrantTestOccupiedTotal() == 6);
+
+    // Source-table exhaustion is explicit, not silent: fill all cursor slots,
+    // then a 9th source is refused with nothing recorded.
+    GS_ASSERT(Combo_CountGrantSources() == 2);
+    for (uint32_t i = 0; i < RSBS_GRANT_SOURCE_CAP - 2u; i++) {
+        GS_ASSERT(Combo_SubmitSourcedGrant(0xC0DE0000u + i, 1, GAME_OOT, (uint16_t)(900u + i)) ==
+                  RSBS_GRANT_ACCEPTED);
+    }
+    GS_ASSERT(Combo_CountGrantSources() == (int)RSBS_GRANT_SOURCE_CAP);
+    const int occupiedBefore = GrantTestOccupiedTotal();
+    GS_ASSERT(Combo_SubmitSourcedGrant(0xDEADBEEFu, 1, GAME_OOT, 999) == RSBS_GRANT_NO_SOURCE_SLOT);
+    GS_ASSERT(GrantTestOccupiedTotal() == occupiedBefore);
+    GS_ASSERT(Combo_CountGrantSources() == (int)RSBS_GRANT_SOURCE_CAP);
+
+    GrantTestReset();
+    printf("[TEST] PASS: retransmit vs second gift is decidable; domains disjoint; exhaustion explicit\n");
+    return TEST_PASS;
+}
+
+TestResult Test_GrantRedeemNoSwitch(void) {
+    printf("[TEST] grant-redeem-no-switch: grants redeem in received order with zero switch machinery (ADR 0005)\n");
+
+    GrantTestReset();
+    Context_InitFrozenStates();
+    Context_ClearAllFrozenStates();
+
+    // Interleave two sources; one grant is bound for the OTHER game.
+    GS_ASSERT(Combo_SubmitSourcedGrant(kGrantSrcA, 1, GAME_OOT, 101) == RSBS_GRANT_ACCEPTED);
+    GS_ASSERT(Combo_SubmitSourcedGrant(kGrantSrcB, 1, GAME_OOT, 201) == RSBS_GRANT_ACCEPTED);
+    GS_ASSERT(Combo_SubmitSourcedGrant(kGrantSrcA, 2, GAME_OOT, 102) == RSBS_GRANT_ACCEPTED);
+    GS_ASSERT(Combo_SubmitSourcedGrant(kGrantSrcB, 2, GAME_MM, 301) == RSBS_GRANT_ACCEPTED);
+
+    // Nothing switch-shaped has happened — and must not need to.
+    GS_ASSERT(!ComboContext_IsSwitchPending());
+    GS_ASSERT(!Context_HasFrozenState(GAME_OOT) && !Context_HasFrozenState(GAME_MM));
+
+    // Redeem for OoT directly — the safe-point call a mid-session tick will
+    // make. Received order across sources, only OoT-bound entries.
+    GrantAwardLog log;
+    std::memset(&log, 0, sizeof(log));
+    GS_ASSERT(Combo_RedeemSharedItemsForGame(GAME_OOT, GrantTestAward, &log) == 3);
+    GS_ASSERT(log.count == 3);
+    GS_ASSERT(log.ids[0] == 101 && log.ids[1] == 201 && log.ids[2] == 102);
+    GS_ASSERT(log.origins[0] == (uint8_t)GAME_OOT && log.origins[1] == (uint8_t)GAME_OOT &&
+              log.origins[2] == (uint8_t)GAME_OOT);
+
+    // Single-use under a repeated safe point.
+    std::memset(&log, 0, sizeof(log));
+    GS_ASSERT(Combo_RedeemSharedItemsForGame(GAME_OOT, GrantTestAward, &log) == 0);
+    GS_ASSERT(log.count == 0);
+
+    // The MM-bound grant was untouched and redeems for MM.
+    GS_ASSERT(Combo_CountSharedItems(GAME_MM, /*includeRedeemed=*/false) == 1);
+    std::memset(&log, 0, sizeof(log));
+    GS_ASSERT(Combo_RedeemSharedItemsForGame(GAME_MM, GrantTestAward, &log) == 1);
+    GS_ASSERT(log.ids[0] == 301 && log.origins[0] == (uint8_t)GAME_MM);
+
+    // A grant arriving AFTER a redemption pass redeems at the next safe point.
+    GS_ASSERT(Combo_SubmitSourcedGrant(kGrantSrcA, 3, GAME_OOT, 103) == RSBS_GRANT_ACCEPTED);
+    std::memset(&log, 0, sizeof(log));
+    GS_ASSERT(Combo_RedeemSharedItemsForGame(GAME_OOT, GrantTestAward, &log) == 1);
+    GS_ASSERT(log.ids[0] == 103);
+
+    GrantTestReset();
+    printf("[TEST] PASS: redemption is a safe-point call, in received order, single-use, no switch required\n");
+    return TEST_PASS;
+}
+
+TestResult Test_GrantOverflow(void) {
+    printf("[TEST] grant-overflow: full array refuses loudly, backpressures sources, reclaims redeemed slots "
+           "(ADR 0005)\n");
+
+    GrantTestReset();
+    GS_ASSERT(Combo_GetSharedItemOverflowCount() == 0);
+
+    // Fill the array: 62 OoT-bound grants, then 2 MM-bound, all one source.
+    for (uint32_t i = 1; i <= RSBS_SHARED_ITEM_CAP - 2u; i++) {
+        GS_ASSERT(Combo_SubmitSourcedGrant(kGrantSrcA, i, GAME_OOT, (uint16_t)(1000u + i)) == RSBS_GRANT_ACCEPTED);
+    }
+    GS_ASSERT(Combo_SubmitSourcedGrant(kGrantSrcA, RSBS_SHARED_ITEM_CAP - 1u, GAME_MM, 501) == RSBS_GRANT_ACCEPTED);
+    GS_ASSERT(Combo_SubmitSourcedGrant(kGrantSrcA, RSBS_SHARED_ITEM_CAP, GAME_MM, 502) == RSBS_GRANT_ACCEPTED);
+    GS_ASSERT(GrantTestOccupiedTotal() == (int)RSBS_SHARED_ITEM_CAP);
+
+    // Every entry is un-redeemed: the next sourced grant is BACKPRESSURED —
+    // refused loudly, cursor unmoved, durable overflow count up.
+    GS_ASSERT(Combo_SubmitSourcedGrant(kGrantSrcA, RSBS_SHARED_ITEM_CAP + 1u, GAME_OOT, 1065) ==
+              RSBS_GRANT_RETRY_FULL);
+    GS_ASSERT(Combo_GetGrantCursor(kGrantSrcA) == RSBS_SHARED_ITEM_CAP);
+    GS_ASSERT(Combo_GetSharedItemOverflowCount() == 1);
+
+    // In-process refusals are counted too (a genuine loss, made diagnosable).
+    GS_ASSERT(Combo_RecordSharedItem(GAME_OOT, 2000) == -1);
+    GS_ASSERT(Combo_GetSharedItemOverflowCount() == 2);
+    GS_ASSERT(Combo_StageSharedItem(GAME_OOT, 2001) == true);
+    GS_ASSERT(Combo_CommitStagedSharedItems() == 0);
+    GS_ASSERT(Combo_GetSharedItemOverflowCount() == 3);
+
+    // Redeem the two MM entries: capacity returns via oldest-first reclaim.
+    GrantAwardLog log;
+    std::memset(&log, 0, sizeof(log));
+    GS_ASSERT(Combo_RedeemSharedItemsForGame(GAME_MM, GrantTestAward, &log) == 2);
+    GS_ASSERT(log.ids[0] == 501 && log.ids[1] == 502);
+
+    // THE NO-SILENT-LOSS PROPERTY: the refused seq, retried after capacity
+    // returned, is ACCEPTED — the cursor never advanced past it, so the retry
+    // is not mistaken for a duplicate and the grant is not lost.
+    GS_ASSERT(Combo_SubmitSourcedGrant(kGrantSrcA, RSBS_SHARED_ITEM_CAP + 1u, GAME_OOT, 1065) ==
+              RSBS_GRANT_ACCEPTED);
+    GS_ASSERT(Combo_SubmitSourcedGrant(kGrantSrcA, RSBS_SHARED_ITEM_CAP + 2u, GAME_OOT, 1066) ==
+              RSBS_GRANT_ACCEPTED);
+    GS_ASSERT(GrantTestOccupiedTotal() == (int)RSBS_SHARED_ITEM_CAP);
+    GS_ASSERT(Combo_GetSharedItemOverflowCount() == 3); // reclaim is not a refusal
+
+    // Both redeemed entries are gone; a third grant is backpressured again.
+    GS_ASSERT(Combo_SubmitSourcedGrant(kGrantSrcA, RSBS_SHARED_ITEM_CAP + 3u, GAME_OOT, 1067) ==
+              RSBS_GRANT_RETRY_FULL);
+    GS_ASSERT(Combo_GetSharedItemOverflowCount() == 4);
+
+    // Reclamation preserved received order: the 62 originals award before the
+    // two late arrivals, all in acceptance order.
+    std::memset(&log, 0, sizeof(log));
+    GS_ASSERT(Combo_RedeemSharedItemsForGame(GAME_OOT, GrantTestAward, &log) == (int)RSBS_SHARED_ITEM_CAP);
+    GS_ASSERT(log.count == (int)RSBS_SHARED_ITEM_CAP);
+    for (uint32_t i = 0; i < RSBS_SHARED_ITEM_CAP - 2u; i++) {
+        GS_ASSERT(log.ids[i] == (uint16_t)(1000u + i + 1u));
+    }
+    GS_ASSERT(log.ids[RSBS_SHARED_ITEM_CAP - 2u] == 1065 && log.ids[RSBS_SHARED_ITEM_CAP - 1u] == 1066);
+
+    // The once-refused-then-accepted seq is now firmly a duplicate.
+    GS_ASSERT(Combo_SubmitSourcedGrant(kGrantSrcA, RSBS_SHARED_ITEM_CAP + 1u, GAME_OOT, 1065) ==
+              RSBS_GRANT_DUPLICATE);
+
+    GrantTestReset();
+    printf("[TEST] PASS: overflow refuses loudly and durably; backpressure retries deliver; order survives "
+           "reclamation\n");
+    return TEST_PASS;
+}
+
+TestResult Test_GrantPersistence(void) {
+    printf("[TEST] grant-persistence: cursors + overflow ride the .redsave; legacy loads unset; reset retires "
+           "atomically (ADR 0005)\n");
+
+    rsbs::SaveManager& mgr = rsbs::SaveManager::Instance();
+    mgr.SetSaveDirectory(kGrantSaveDir);
+
+    // ------------------------------------------------------------------
+    // (a) Round-trip: sourced entries, cursors, and the overflow count all
+    //     survive Save/Load byte-exact — and the duplicate window STAYS
+    //     closed across the reload.
+    // ------------------------------------------------------------------
+    GrantTestReset();
+    GS_ASSERT(Combo_SubmitSourcedGrant(kGrantSrcA, 1, GAME_OOT, 11) == RSBS_GRANT_ACCEPTED);
+    GS_ASSERT(Combo_SubmitSourcedGrant(kGrantSrcA, 2, GAME_MM, 22) == RSBS_GRANT_ACCEPTED);
+    GS_ASSERT(Combo_SubmitSourcedGrant(kGrantSrcB, 1, GAME_OOT, 33) == RSBS_GRANT_ACCEPTED);
+    GS_ASSERT(Combo_RedeemSharedItemsForGame(GAME_OOT, NULL, NULL) == 2);
+    gComboCtx.sharedItemOverflowCount = 7; // stand-in for a recorded refusal; serialization is what's under test
+
+    SharedItem expectedItems[RSBS_SHARED_ITEM_CAP];
+    ComboGrantSourceCursor expectedCursors[RSBS_GRANT_SOURCE_CAP];
+    std::memcpy(expectedItems, gComboCtx.sharedItemsTagged, sizeof(expectedItems));
+    std::memcpy(expectedCursors, gComboCtx.grantCursors, sizeof(expectedCursors));
+
+    mgr.DeleteSave(0);
+    GS_ASSERT(mgr.Save(0));
+
+    // Wipe, then scribble, so restored zeros are provably the loader's doing.
+    ComboContext_Init();
+    std::memset(gComboCtx.sharedItemsTagged, 0x5A, sizeof(gComboCtx.sharedItemsTagged));
+    std::memset(gComboCtx.grantCursors, 0x5A, sizeof(gComboCtx.grantCursors));
+    gComboCtx.sharedItemOverflowCount = 0xDEADBEEFu;
+
+    GS_ASSERT(mgr.Load(0));
+    GS_ASSERT(std::memcmp(expectedItems, gComboCtx.sharedItemsTagged, sizeof(expectedItems)) == 0);
+    GS_ASSERT(std::memcmp(expectedCursors, gComboCtx.grantCursors, sizeof(expectedCursors)) == 0);
+    GS_ASSERT(gComboCtx.sharedItemOverflowCount == 7);
+    // Typed spot-checks so a memcmp-passing-but-misread layout fails loudly.
+    GS_ASSERT(Combo_GetGrantCursor(kGrantSrcA) == 2 && Combo_GetGrantCursor(kGrantSrcB) == 1);
+    GS_ASSERT(Combo_CountGrantSources() == 2);
+    GS_ASSERT(gComboCtx.sharedItemsTagged[0].flags == (RSBS_SHARED_ITEM_SOURCED | RSBS_SHARED_ITEM_REDEEMED));
+    GS_ASSERT(gComboCtx.sharedItemsTagged[1].flags == RSBS_SHARED_ITEM_SOURCED); // MM grant still pending
+
+    // The reload did NOT re-open the duplicate window: every delivered seq is
+    // still a duplicate, and delivery resumes exactly at cursor + 1.
+    GS_ASSERT(Combo_SubmitSourcedGrant(kGrantSrcA, 1, GAME_OOT, 11) == RSBS_GRANT_DUPLICATE);
+    GS_ASSERT(Combo_SubmitSourcedGrant(kGrantSrcA, 2, GAME_MM, 22) == RSBS_GRANT_DUPLICATE);
+    GS_ASSERT(Combo_SubmitSourcedGrant(kGrantSrcB, 1, GAME_OOT, 33) == RSBS_GRANT_DUPLICATE);
+    GS_ASSERT(Combo_SubmitSourcedGrant(kGrantSrcA, 3, GAME_OOT, 44) == RSBS_GRANT_ACCEPTED);
+    mgr.DeleteSave(0);
+
+    // ------------------------------------------------------------------
+    // (b) Migration: a PRE-NETPLAY .redsave (Tier-1 truncated at the ADR 0005
+    //     carve) loads with items intact and every new field unset.
+    // ------------------------------------------------------------------
+    GrantTestReset();
+    GS_ASSERT(Combo_RecordSharedItem(GAME_OOT, 0x00A7) >= 0); // a real legacy save holds in-process entries only
+    GS_ASSERT(Combo_RecordSharedItem(GAME_MM, 0x0042) >= 0);
+    GS_ASSERT(Combo_RedeemSharedItemsForGame(GAME_OOT, NULL, NULL) == 1);
+    GS_ASSERT(GrantTestWriteLegacySlot(mgr.SlotPath(0)));
+
+    ComboContext_Init();
+    std::memset(gComboCtx.grantCursors, 0x5A, sizeof(gComboCtx.grantCursors));
+    gComboCtx.sharedItemOverflowCount = 0xDEADBEEFu;
+
+    GS_ASSERT(mgr.Load(0));
+    GS_ASSERT(Combo_CountSharedItems(GAME_OOT, /*includeRedeemed=*/true) == 1);
+    GS_ASSERT(Combo_CountSharedItems(GAME_MM, /*includeRedeemed=*/false) == 1);
+    GS_ASSERT(Combo_CountGrantSources() == 0);              // no source ever delivered to a legacy save
+    GS_ASSERT(Combo_GetSharedItemOverflowCount() == 0);     // and it never overflowed
+    for (uint32_t i = 0; i < RSBS_GRANT_SOURCE_CAP; i++) {
+        GS_ASSERT(gComboCtx.grantCursors[i].sourceKey == 0 && gComboCtx.grantCursors[i].lastSeq == 0);
+    }
+    // A legacy world accepts its first sourced delivery like any fresh one.
+    GS_ASSERT(Combo_SubmitSourcedGrant(kGrantSrcA, 1, GAME_OOT, 55) == RSBS_GRANT_ACCEPTED);
+    mgr.DeleteSave(0);
+
+    // ------------------------------------------------------------------
+    // (c) Reset invalidation (the #440 composition contract): one
+    //     ComboContext_Init retires items AND cursors AND the overflow count
+    //     together, so a dead session can neither replay its grants into a
+    //     fresh world nor block that world's own deliveries.
+    // ------------------------------------------------------------------
+    GS_ASSERT(Combo_SubmitSourcedGrant(kGrantSrcA, 2, GAME_MM, 66) == RSBS_GRANT_ACCEPTED);
+    GS_ASSERT(Combo_CountGrantSources() == 1 && GrantTestOccupiedTotal() > 0);
+
+    ComboContext_Init();
+    GS_ASSERT(Combo_CountGrantSources() == 0);
+    GS_ASSERT(GrantTestOccupiedTotal() == 0);
+    GS_ASSERT(Combo_GetSharedItemOverflowCount() == 0);
+    // A dead-room retransmit is NOT silently accepted into the fresh world...
+    GS_ASSERT(Combo_SubmitSourcedGrant(kGrantSrcA, 2, GAME_MM, 66) == RSBS_GRANT_GAP);
+    GS_ASSERT(GrantTestOccupiedTotal() == 0);
+    // ...while a fresh session's own delivery stream starts cleanly.
+    GS_ASSERT(Combo_SubmitSourcedGrant(kGrantSrcA, 1, GAME_OOT, 77) == RSBS_GRANT_ACCEPTED);
+
+    GrantTestReset();
+    printf("[TEST] PASS: durable across save/load; legacy records read unset; reset retires items + cursors "
+           "atomically\n");
+    return TEST_PASS;
+}


### PR DESCRIPTION
Supersedes #463 (same work, rebased onto current main after a power failure interrupted the original branch).

Implements the netplay **foundation** layer — the local grant model, designed against the full multiworld/co-op target so nothing needs retrofitting later. No networking, no transport, no build option: this is all local and fully CI-lockable.

Closes the four gaps that were invisible while the only grant producer was in-process:
- **De-dup could not distinguish a retransmit from a genuine second gift** — two peers gifting the same item before redemption yielded one item. Per-source cursors make it decidable.
- **No grant identity** — `SharedItem` is 4 bytes with offsets static-asserted as save format, so there was nowhere to put one.
- **Redemption only fired on a game switch** — now redeems at safe points.
- **The 64-slot array dropped silently** — overflow is now loud, with redeemed-slot reclamation.

Also lands a producer **seam** so the relay lane has a defined contract to build against, plus ADR 0005.

Four new ROM-free locks: `GrantIdempotency`, `GrantRedeemNoSwitch`, `GrantOverflow`, `GrantPersistence`. The last one failed on the original branch; the fix (a save-harness shadow-buffer precondition) is included, along with a follow-up commit closing a format landmine around bumping `RSBS_GRANT_SOURCE_CAP`.

Rebase note: the only conflict was additive in the CTest registration block — main's `SessionInvalidation` row (#440) and this branch's `Grant*` rows; both kept.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!--- section:artifacts:start -->
### Build Artifacts
  - [rsbs-windows.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/8509086800.zip)
  - [rsbs-linux.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/8508130323.zip)
<!--- section:artifacts:end -->