### PR TITLE
Migrate 2ship_enh off the raw GameInteractor surface and retire the last hook-guard exemption (#427 item 2)

### DIFF
--- a/games/mm/2s2h/Enhancements/Cutscenes/MiscInteractions/SkipGreatFairyCutscene.cpp
+++ b/games/mm/2s2h/Enhancements/Cutscenes/MiscInteractions/SkipGreatFairyCutscene.cpp
@@ -42,7 +42,7 @@ void RegisterSkipGreatFairyCutscene() {
                 switch (elfgrp->type) {
                     case ENELFGRP_TYPE_POWER:
                         if (!CHECK_WEEKEVENTREG(WEEKEVENTREG_RECEIVED_GREAT_SPIN_ATTACK)) {
-                            GameInteractor::Instance->events.emplace_back(GIEventGiveItem{
+                            MM_GameEvents_Queue().emplace_back(GIEventGiveItem{
                                 .showGetItemCutscene = true,
                                 .param = GID_SWORD_KOKIRI,
                                 .giveItem = [](Actor* actor, PlayState* play) {
@@ -59,7 +59,7 @@ void RegisterSkipGreatFairyCutscene() {
                         break;
                     case ENELFGRP_TYPE_WISDOM:
                         if (!gSaveContext.save.saveInfo.playerData.isDoubleMagicAcquired) {
-                            GameInteractor::Instance->events.emplace_back(GIEventGiveItem{
+                            MM_GameEvents_Queue().emplace_back(GIEventGiveItem{
                                 .showGetItemCutscene = true,
                                 .param = GID_MAGIC_JAR_BIG,
                                 .giveItem = [](Actor* actor, PlayState* play) {
@@ -78,7 +78,7 @@ void RegisterSkipGreatFairyCutscene() {
                         break;
                     case ENELFGRP_TYPE_COURAGE:
                         if (!gSaveContext.save.saveInfo.playerData.doubleDefense) {
-                            GameInteractor::Instance->events.emplace_back(GIEventGiveItem{
+                            MM_GameEvents_Queue().emplace_back(GIEventGiveItem{
                                 .showGetItemCutscene = true,
                                 .param = GID_HEART_CONTAINER,
                                 .giveItem = [](Actor* actor, PlayState* play) {
@@ -96,7 +96,7 @@ void RegisterSkipGreatFairyCutscene() {
                         break;
                     case ENELFGRP_TYPE_KINDNESS:
                         if (INV_CONTENT(ITEM_SWORD_GREAT_FAIRY) != ITEM_SWORD_GREAT_FAIRY) {
-                            GameInteractor::Instance->events.emplace_back(GIEventGiveItem{
+                            MM_GameEvents_Queue().emplace_back(GIEventGiveItem{
                                 .showGetItemCutscene = true,
                                 .param = GID_SWORD_GREAT_FAIRY,
                                 .giveItem = [](Actor* actor, PlayState* play) {
@@ -113,7 +113,7 @@ void RegisterSkipGreatFairyCutscene() {
                         break;
                     default: // ENELFGRP_TYPE_MAGIC
                         if (!gSaveContext.save.saveInfo.playerData.isMagicAcquired) {
-                            GameInteractor::Instance->events.emplace_back(GIEventGiveItem{
+                            MM_GameEvents_Queue().emplace_back(GIEventGiveItem{
                                 .showGetItemCutscene = true,
                                 .param = GID_MAGIC_JAR_SMALL,
                                 .giveItem = [](Actor* actor, PlayState* play) {
@@ -129,7 +129,7 @@ void RegisterSkipGreatFairyCutscene() {
                                 } });
                         } else if (INV_CONTENT(ITEM_MASK_DEKU) == ITEM_MASK_DEKU &&
                                    INV_CONTENT(ITEM_MASK_GREAT_FAIRY) != ITEM_MASK_GREAT_FAIRY) {
-                            GameInteractor::Instance->events.emplace_back(GIEventGiveItem{
+                            MM_GameEvents_Queue().emplace_back(GIEventGiveItem{
                                 .showGetItemCutscene = true,
                                 .param = GID_MASK_GREAT_FAIRY,
                                 .giveItem = [](Actor* actor, PlayState* play) {

--- a/games/mm/2s2h/Enhancements/Cutscenes/MiscInteractions/SkipKafeiReveal.cpp
+++ b/games/mm/2s2h/Enhancements/Cutscenes/MiscInteractions/SkipKafeiReveal.cpp
@@ -32,7 +32,7 @@ void RegisterSkipKafeiReveal() {
         Message_BombersNotebookQueueEvent(MM_gPlayState, BOMBERS_NOTEBOOK_EVENT_RECEIVED_PENDANT_OF_MEMORIES);
 
         if (GameInteractor_Should(VB_GIVE_PENDANT_OF_MEMORIES_FROM_KAFEI, true)) {
-            GameInteractor::Instance->events.emplace_back(
+            MM_GameEvents_Queue().emplace_back(
                 GIEventGiveItem{ .showGetItemCutscene = true,
                                  .param = GID_PENDANT_OF_MEMORIES,
                                  .giveItem = [](Actor* actor, PlayState* play) {

--- a/games/mm/2s2h/Enhancements/Cutscenes/MiscInteractions/SkipRosaSistersDance.cpp
+++ b/games/mm/2s2h/Enhancements/Cutscenes/MiscInteractions/SkipRosaSistersDance.cpp
@@ -26,7 +26,7 @@ void RegisterSkipRosaSistersDance() {
                 // Queue the item check, as MM_Actor_OfferGetItem won't work normally
                 // WEEKEVENTREG_RECEIVED_ROSA_SISTERS_HEART_PIECE is set once the player obtains this Heart Piece.
                 if (!CHECK_WEEKEVENTREG(WEEKEVENTREG_RECEIVED_ROSA_SISTERS_HEART_PIECE) && !IS_RANDO) {
-                    GameInteractor::Instance->events.emplace_back(GIEventGiveItem{
+                    MM_GameEvents_Queue().emplace_back(GIEventGiveItem{
                         .showGetItemCutscene = true,
                         .param = GID_HEART_PIECE,
                         .giveItem = [](Actor* actor, PlayState* play) {

--- a/games/mm/2s2h/Enhancements/Cutscenes/StoryCutscenes/HealingMikauAudio.cpp
+++ b/games/mm/2s2h/Enhancements/Cutscenes/StoryCutscenes/HealingMikauAudio.cpp
@@ -35,13 +35,13 @@ void RegisterHealingMikauAudioFix() {
             // The main BGM sequence is playing (no BGM plays at night)
             if (AudioSeq_GetActiveSeqId(SEQ_PLAYER_BGM_MAIN) != NA_BGM_DISABLED) {
                 playGreatBayCoastBgmHookId =
-                    GameInteractor::Instance->RegisterGameHookForID<GameInteractor::OnActorUpdate>(
+                    S2H::GameHooks::RegisterForID<GameInteractor::OnActorUpdate>(
                         ACTOR_EN_ZOG, [](Actor* actor) {
                             // If BGM is killed, replay it and kill this update hook
                             if (AudioSeq_GetActiveSeqId(SEQ_PLAYER_BGM_MAIN) == NA_BGM_DISABLED) {
                                 SEQCMD_PLAY_SEQUENCE(SEQ_PLAYER_BGM_MAIN, 0, NA_BGM_GREAT_BAY_REGION);
                                 if (playGreatBayCoastBgmHookId) {
-                                    GameInteractor::Instance->UnregisterGameHookForID<GameInteractor::OnActorUpdate>(
+                                    S2H::GameHooks::UnregisterForID<GameInteractor::OnActorUpdate>(
                                         playGreatBayCoastBgmHookId);
                                     playGreatBayCoastBgmHookId = 0;
                                 }

--- a/games/mm/2s2h/Enhancements/Cutscenes/StoryCutscenes/SkipHealingDarmani.cpp
+++ b/games/mm/2s2h/Enhancements/Cutscenes/StoryCutscenes/SkipHealingDarmani.cpp
@@ -21,7 +21,7 @@ void RegisterSkipHealingDarmani() {
         // Played Song of Healing for Darmani in Goron Graveyard
         if (MM_gPlayState->sceneId == SCENE_GORON_HAKA && *csId == 9) {
             if (GameInteractor_Should(VB_GIVE_ITEM_FROM_DMCHAR05, true, ITEM_MASK_GORON)) {
-                GameInteractor::Instance->events.emplace_back(GIEventGiveItem{
+                MM_GameEvents_Queue().emplace_back(GIEventGiveItem{
                     .showGetItemCutscene = !CVarGetInteger("gEnhancements.Cutscenes.SkipGetItemCutscenes", 0),
                     .param = GID_MASK_GORON,
                     .giveItem =

--- a/games/mm/2s2h/Enhancements/Cutscenes/StoryCutscenes/SkipHealingMikau.cpp
+++ b/games/mm/2s2h/Enhancements/Cutscenes/StoryCutscenes/SkipHealingMikau.cpp
@@ -17,7 +17,7 @@ void RegisterSkipHealingMikau() {
         if (MM_gPlayState->sceneId == SCENE_30GYOSON) { // Great Bay Coast
             if (*csId == 13) {                       // Played Song of Healing for Mikau
                 // Transition to Link bowing at Mikau's grave
-                GameInteractor::Instance->events.emplace_back(GIEventTransition{
+                MM_GameEvents_Queue().emplace_back(GIEventTransition{
                     .entrance = ENTRANCE(GREAT_BAY_COAST, 10),
                     .cutsceneIndex = 0,
                     .transitionTrigger = TRANS_TRIGGER_START,
@@ -29,7 +29,7 @@ void RegisterSkipHealingMikau() {
                  */
                 gSaveContext.nextTransitionType = TRANS_TYPE_FADE_BLACK;
                 if (GameInteractor_Should(VB_GIVE_ITEM_FROM_DMCHAR05, true, ITEM_MASK_ZORA)) {
-                    GameInteractor::Instance->events.emplace_back(GIEventGiveItem{
+                    MM_GameEvents_Queue().emplace_back(GIEventGiveItem{
                         .showGetItemCutscene = !CVarGetInteger("gEnhancements.Cutscenes.SkipGetItemCutscenes", 0),
                         .param = GID_MASK_ZORA,
                         .giveItem =

--- a/games/mm/2s2h/Enhancements/Cutscenes/StoryCutscenes/SkipIkanaCurseCutscenes.cpp
+++ b/games/mm/2s2h/Enhancements/Cutscenes/StoryCutscenes/SkipIkanaCurseCutscenes.cpp
@@ -23,7 +23,7 @@ void skipHealingPamelasFather() {
      * where Pamela and her father embrace and Tatl yells at Link for killing the moment, but this
      * is easier than replicating all actor states in the skip.
      */
-    GameInteractor::Instance->events.emplace_back(GIEventTransition{
+    MM_GameEvents_Queue().emplace_back(GIEventTransition{
         .entrance = ENTRANCE(MUSIC_BOX_HOUSE, 0),
         .cutsceneIndex = 0,
         .transitionTrigger = TRANS_TRIGGER_START,
@@ -70,7 +70,7 @@ void RegisterSkipIkanaCurseCutscenes() {
                 SET_WEEKEVENTREG(WEEKEVENTREG_61_02);
                 SET_WEEKEVENTREG(WEEKEVENTREG_61_04);
                 // Kick out the player
-                GameInteractor::Instance->events.emplace_back(GIEventTransition{
+                MM_GameEvents_Queue().emplace_back(GIEventTransition{
                     .entrance = ENTRANCE(IKANA_CANYON, 2),
                     .cutsceneIndex = 0,
                     .transitionTrigger = TRANS_TRIGGER_START,
@@ -80,7 +80,7 @@ void RegisterSkipIkanaCurseCutscenes() {
             } else if (*csId == 11) { // Heal Pamela's father for the first time
                 skipHealingPamelasFather();
                 if (GameInteractor_Should(VB_GIVE_ITEM_FROM_DMCHAR05, true, ITEM_MASK_GIBDO)) {
-                    GameInteractor::Instance->events.emplace_back(GIEventGiveItem{
+                    MM_GameEvents_Queue().emplace_back(GIEventGiveItem{
                         .showGetItemCutscene = !CVarGetInteger("gEnhancements.Cutscenes.SkipGetItemCutscenes", 0),
                         .param = GID_MASK_GIBDO,
                         .giveItem =
@@ -120,7 +120,7 @@ void RegisterSkipIkanaCurseCutscenes() {
         s16* csId = va_arg(args, s16*);
         if (MM_gPlayState->sceneId == SCENE_IKANA && *csId == 20) { // Played Song of Storms for Sharp
             // Reload the scene so that all actor states are appropriate
-            GameInteractor::Instance->events.emplace_back(GIEventTransition{
+            MM_GameEvents_Queue().emplace_back(GIEventTransition{
                 .entrance = ENTRANCE(IKANA_CANYON, 14),
                 .cutsceneIndex = 0,
                 .transitionTrigger = TRANS_TRIGGER_START,

--- a/games/mm/2s2h/Enhancements/Cutscenes/StoryCutscenes/SkipLearningElegyOfEmptiness.cpp
+++ b/games/mm/2s2h/Enhancements/Cutscenes/StoryCutscenes/SkipLearningElegyOfEmptiness.cpp
@@ -14,7 +14,7 @@ void RegisterSkipLearningElegyOfEmptiness() {
         s16* csId = va_arg(args, s16*);
         if (MM_gPlayState->sceneId == SCENE_IKNINSIDE && *csId == 10) { // Defeated Igos, learn Elegy of Emptiness
             if (GameInteractor_Should(VB_GIVE_ITEM_FROM_KNIGHT, true)) {
-                GameInteractor::Instance->events.emplace_back(GIEventGiveItem{
+                MM_GameEvents_Queue().emplace_back(GIEventGiveItem{
                     .showGetItemCutscene = !CVarGetInteger("gEnhancements.Cutscenes.SkipGetItemCutscenes", 0),
                     .giveItem =
                         [](Actor* actor, PlayState* play) {

--- a/games/mm/2s2h/Enhancements/Cutscenes/StoryCutscenes/SkipLearningEponasSong.cpp
+++ b/games/mm/2s2h/Enhancements/Cutscenes/StoryCutscenes/SkipLearningEponasSong.cpp
@@ -32,7 +32,7 @@ void RegisterSkipLearningEponasSong() {
         }
 
         if (GameInteractor_Should(VB_GIVE_ITEM_FROM_ROMANI, true, enMa4)) {
-            GameInteractor::Instance->events.emplace_back(GIEventGiveItem{
+            MM_GameEvents_Queue().emplace_back(GIEventGiveItem{
                 .showGetItemCutscene = true,
                 .giveItem =
                     [](Actor* actor, PlayState* play) {

--- a/games/mm/2s2h/Enhancements/Cutscenes/StoryCutscenes/SkipLearningGoronLullaby.cpp
+++ b/games/mm/2s2h/Enhancements/Cutscenes/StoryCutscenes/SkipLearningGoronLullaby.cpp
@@ -48,7 +48,7 @@ void RegisterSkipLearningGoronLullaby() {
         isGoronSleepQueued = true;
 
         if (GameInteractor_Should(VB_GIVE_ITEM_FROM_GK_LULLABY, !CHECK_QUEST_ITEM(QUEST_SONG_LULLABY))) {
-            GameInteractor::Instance->events.emplace_back(GIEventGiveItem{
+            MM_GameEvents_Queue().emplace_back(GIEventGiveItem{
                 .showGetItemCutscene = !CVarGetInteger("gEnhancements.Cutscenes.SkipGetItemCutscenes", 0),
                 .giveItem =
                     [](Actor* actor, PlayState* play) {

--- a/games/mm/2s2h/Enhancements/Cutscenes/StoryCutscenes/SkipLearningGoronLullabyIntro.cpp
+++ b/games/mm/2s2h/Enhancements/Cutscenes/StoryCutscenes/SkipLearningGoronLullabyIntro.cpp
@@ -24,7 +24,7 @@ void RegisterSkipLearningGoronLullabyIntro() {
         SET_WEEKEVENTREG(WEEKEVENTREG_24_40);
 
         if (GameInteractor_Should(VB_GIVE_ITEM_FROM_JG, !CHECK_QUEST_ITEM(QUEST_SONG_LULLABY_INTRO))) {
-            GameInteractor::Instance->events.emplace_back(GIEventGiveItem{
+            MM_GameEvents_Queue().emplace_back(GIEventGiveItem{
                 .showGetItemCutscene = !CVarGetInteger("gEnhancements.Cutscenes.SkipGetItemCutscenes", 0),
                 .giveItem =
                     [](Actor* actor, PlayState* play) {

--- a/games/mm/2s2h/Enhancements/Cutscenes/StoryCutscenes/SkipLearningNewWaveBossaNova.cpp
+++ b/games/mm/2s2h/Enhancements/Cutscenes/StoryCutscenes/SkipLearningNewWaveBossaNova.cpp
@@ -18,7 +18,7 @@ void RegisterSkipLearningNewWaveBossaNova() {
         s16* csId = va_arg(args, s16*);
         if (MM_gPlayState->sceneId == SCENE_LABO && *csId == 11) {
             if (GameInteractor_Should(VB_GIVE_NEW_WAVE_BOSSA_NOVA, true)) {
-                GameInteractor::Instance->events.emplace_back(GIEventGiveItem{
+                MM_GameEvents_Queue().emplace_back(GIEventGiveItem{
                     .showGetItemCutscene = !CVarGetInteger("gEnhancements.Cutscenes.SkipGetItemCutscenes", 0),
                     .giveItem =
                         [](Actor* actor, PlayState* play) {

--- a/games/mm/2s2h/Enhancements/Cutscenes/StoryCutscenes/SkipLearningSonataOfAwakening.cpp
+++ b/games/mm/2s2h/Enhancements/Cutscenes/StoryCutscenes/SkipLearningSonataOfAwakening.cpp
@@ -27,7 +27,7 @@ void RegisterSkipLearningSonataOfAwakening() {
                 *should = false;
             } else if (*csId == 12) {
                 if (GameInteractor_Should(VB_GIVE_ITEM_FROM_MNK, true)) {
-                    GameInteractor::Instance->events.emplace_back(GIEventGiveItem{
+                    MM_GameEvents_Queue().emplace_back(GIEventGiveItem{
                         .showGetItemCutscene = !CVarGetInteger("gEnhancements.Cutscenes.SkipGetItemCutscenes", 0),
                         .giveItem =
                             [](Actor* actor, PlayState* play) {

--- a/games/mm/2s2h/Enhancements/Cutscenes/StoryCutscenes/SkipLearningSongOfHealing.cpp
+++ b/games/mm/2s2h/Enhancements/Cutscenes/StoryCutscenes/SkipLearningSongOfHealing.cpp
@@ -64,20 +64,20 @@ void RegisterSkipLearningSongOfHealing() {
         // Wait till the conversation ends, then end the interaction (for some reason without this step you get soft
         // locked)
         static int hookId = 0;
-        GameInteractor::Instance->UnregisterGameHookForPtr<GameInteractor::OnActorUpdate>(hookId);
-        hookId = GameInteractor::Instance->RegisterGameHookForPtr<GameInteractor::OnActorUpdate>(
+        S2H::GameHooks::UnregisterForPtr<GameInteractor::OnActorUpdate>(hookId);
+        hookId = S2H::GameHooks::RegisterForPtr<GameInteractor::OnActorUpdate>(
             (uintptr_t)enOsn, [](Actor* actor) {
                 EnOsn* enOsn = (EnOsn*)actor;
                 if (enOsn->actionFunc == EnOsn_Idle) {
                     MM_Player_SetCsActionWithHaltedActors(MM_gPlayState, &enOsn->actor, PLAYER_CSACTION_END);
 
-                    GameInteractor::Instance->UnregisterGameHookForPtr<GameInteractor::OnActorUpdate>(hookId);
+                    S2H::GameHooks::UnregisterForPtr<GameInteractor::OnActorUpdate>(hookId);
                 }
             });
 
         if (GameInteractor_Should(VB_GIVE_ITEM_FROM_OSN, true, enOsn)) {
             // Queue up the item gives
-            GameInteractor::Instance->events.emplace_back(
+            MM_GameEvents_Queue().emplace_back(
                 GIEventGiveItem{ .showGetItemCutscene = true,
                                  .giveItem =
                                      [](Actor* actor, PlayState* play) {
@@ -95,7 +95,7 @@ void RegisterSkipLearningSongOfHealing() {
                                          MM_Matrix_Scale(30.0f, 30.0f, 30.0f, MTXMODE_APPLY);
                                          Rando::DrawItem(RI_SONG_HEALING);
                                      } });
-            GameInteractor::Instance->events.emplace_back(GIEventGiveItem{
+            MM_GameEvents_Queue().emplace_back(GIEventGiveItem{
                 .showGetItemCutscene = true,
                 .param = GID_MASK_DEKU,
                 .giveItem =

--- a/games/mm/2s2h/Enhancements/Cutscenes/StoryCutscenes/SkipLearningSongOfSoaring.cpp
+++ b/games/mm/2s2h/Enhancements/Cutscenes/StoryCutscenes/SkipLearningSongOfSoaring.cpp
@@ -35,7 +35,7 @@ void RegisterSkipLearningSongOfSoaring() {
             }
         } else {
             if (!CHECK_QUEST_ITEM(QUEST_SONG_SOARING)) {
-                GameInteractor::Instance->events.emplace_back(GIEventGiveItem{
+                MM_GameEvents_Queue().emplace_back(GIEventGiveItem{
                     .showGetItemCutscene = !CVarGetInteger("gEnhancements.Cutscenes.SkipGetItemCutscenes", 0),
                     .giveItem =
                         [](Actor* actor, PlayState* play) {

--- a/games/mm/2s2h/Enhancements/Cutscenes/StoryCutscenes/SkipLearningSongOfStorms.cpp
+++ b/games/mm/2s2h/Enhancements/Cutscenes/StoryCutscenes/SkipLearningSongOfStorms.cpp
@@ -21,7 +21,7 @@ void RegisterSkipLearningSongOfStorms() {
             if (IS_RANDO) {
                 RANDO_SAVE_CHECKS[RC_BENEATH_THE_GRAVEYARD_SONG_OF_STORMS].eligible = true;
             } else {
-                GameInteractor::Instance->events.emplace_back(GIEventGiveItem{
+                MM_GameEvents_Queue().emplace_back(GIEventGiveItem{
                     .showGetItemCutscene = !CVarGetInteger("gEnhancements.Cutscenes.SkipGetItemCutscenes", 0),
                     .giveItem =
                         [](Actor* actor, PlayState* play) {

--- a/games/mm/2s2h/Enhancements/Cutscenes/StoryCutscenes/SkipLearningSongOfTime.cpp
+++ b/games/mm/2s2h/Enhancements/Cutscenes/StoryCutscenes/SkipLearningSongOfTime.cpp
@@ -22,7 +22,7 @@ void RegisterSkipLearningSongOfTime() {
         *should = false;
         // This typically gets set in the cutscene
         gSaveContext.save.playerForm = PLAYER_FORM_DEKU;
-        GameInteractor::Instance->events.emplace_back(GIEventGiveItem{
+        MM_GameEvents_Queue().emplace_back(GIEventGiveItem{
             .showGetItemCutscene = true,
             .param = GID_MASK_DEKU,
             .giveItem =

--- a/games/mm/2s2h/Enhancements/Cutscenes/StoryCutscenes/SkipPrincessDelivery.cpp
+++ b/games/mm/2s2h/Enhancements/Cutscenes/StoryCutscenes/SkipPrincessDelivery.cpp
@@ -20,7 +20,7 @@ void RegisterSkipPrincessDelivery() {
             SET_WEEKEVENTREG(WEEKEVENTREG_23_20);
 
             // Set up transition to Deku Palace throne room
-            GameInteractor::Instance->events.emplace_back(
+            MM_GameEvents_Queue().emplace_back(
                 GIEventTransition{ .entrance = ENTRANCE(DEKU_KINGS_CHAMBER, 3),
                                    .cutsceneIndex = 0,
                                    .transitionTrigger = TRANS_TRIGGER_START,

--- a/games/mm/2s2h/Enhancements/Cutscenes/StoryCutscenes/SkipStoppingMoonCutscene.cpp
+++ b/games/mm/2s2h/Enhancements/Cutscenes/StoryCutscenes/SkipStoppingMoonCutscene.cpp
@@ -23,7 +23,7 @@ void RegisterSkipStoppingMoon() {
                                                                          CHECK_QUEST_ITEM(QUEST_REMAINS_GYORG) &&
                                                                          CHECK_QUEST_ITEM(QUEST_REMAINS_TWINMOLD))) {
                     *should = false;
-                    GameInteractor::Instance->events.emplace_back(GIEventTransition{
+                    MM_GameEvents_Queue().emplace_back(GIEventTransition{
                         .entrance = ENTRANCE(THE_MOON, 0),
                         .cutsceneIndex = 0,
                         .transitionTrigger = TRANS_TRIGGER_START,

--- a/games/mm/2s2h/Enhancements/Cutscenes/StoryCutscenes/SkipWakingAndRidingTurtle.cpp
+++ b/games/mm/2s2h/Enhancements/Cutscenes/StoryCutscenes/SkipWakingAndRidingTurtle.cpp
@@ -39,7 +39,7 @@ void RegisterSkipWakingAndRidingTurtle() {
             // 13 is turtle leaving zora cape first time, 15 is subsequent times
             if (*csId == 13 || *csId == 15) {
                 *should = false;
-                GameInteractor::Instance->events.emplace_back(GIEventTransition{
+                MM_GameEvents_Queue().emplace_back(GIEventTransition{
                     .entrance = ENTRANCE(GREAT_BAY_TEMPLE, 0),
                     .cutsceneIndex = 0,
                     .transitionTrigger = TRANS_TRIGGER_START,

--- a/games/mm/2s2h/Enhancements/DemoBehavior.cpp
+++ b/games/mm/2s2h/Enhancements/DemoBehavior.cpp
@@ -14,7 +14,7 @@ extern "C" {
 // This file houses various examples of using the systems we have built to modify the game in various ways
 void RegisterDemoBehavior() {
     // Demonstrates some capabilities of CustomItem
-    GameInteractor::Instance->RegisterGameHookForID<GameInteractor::ShouldActorInit>(
+    S2H::GameHooks::RegisterForID<GameInteractor::ShouldActorInit>(
         ACTOR_EN_ITEM00, [](Actor* actor, bool* should) {
             // South Clock Town PoH
             if (actor->params != 2566) {
@@ -31,7 +31,7 @@ void RegisterDemoBehavior() {
 
                     // You can put whatever you want here. For instance you can use the GI queue to queue up a different
                     // kind of item give:
-                    GameInteractor::Instance->events.push_back(GIEventGiveItem{
+                    MM_GameEvents_Queue().push_back(GIEventGiveItem{
                         .showGetItemCutscene = true,
                         .param = GID_RUPEE_GREEN,
                         .giveItem =
@@ -74,7 +74,7 @@ void RegisterDemoBehavior() {
         });
 
     // Example doing a give item while a player is in the middle of an action (backflip)
-    GameInteractor::Instance->RegisterGameHookForID<GameInteractor::OnActorUpdate>(ACTOR_PLAYER, [](Actor* actor) {
+    S2H::GameHooks::RegisterForID<GameInteractor::OnActorUpdate>(ACTOR_PLAYER, [](Actor* actor) {
         Player* player = (Player*)actor;
         static int backflipTimer = 0;
 
@@ -97,7 +97,7 @@ void RegisterDemoBehavior() {
         }
     });
 
-    GameInteractor::Instance->RegisterGameHookForID<GameInteractor::OnActorKill>(ACTOR_OBJ_TSUBO, [](Actor* actor) {
+    S2H::GameHooks::RegisterForID<GameInteractor::OnActorKill>(ACTOR_OBJ_TSUBO, [](Actor* actor) {
         if (actor->room == MM_gPlayState->roomCtx.curRoom.num) {
             // Open a custom message
             CustomMessage::StartTextbox("STOP BREAKING MY POTS!", {
@@ -106,14 +106,14 @@ void RegisterDemoBehavior() {
                                                                   });
 
             // Pot Hydra
-            // GameInteractor::Instance->events.push_back(GIEventSpawnActor{
+            // MM_GameEvents_Queue().push_back(GIEventSpawnActor{
             //     .actorId = ACTOR_OBJ_TSUBO,
             //     .posX = 50.0f,
             //     .posY = 0,
             //     .posZ = -40.0f, // Behind the player
             //     .relativeCoords = true,
             // });
-            // GameInteractor::Instance->events.push_back(GIEventSpawnActor{
+            // MM_GameEvents_Queue().push_back(GIEventSpawnActor{
             //     .actorId = ACTOR_OBJ_TSUBO,
             //     .posX = -50.0f,
             //     .posY = 0,
@@ -124,7 +124,7 @@ void RegisterDemoBehavior() {
     });
 
     // Full message replacement (Sign in South Clock Town)
-    GameInteractor::Instance->RegisterGameHookForID<GameInteractor::OnOpenText>(
+    S2H::GameHooks::RegisterForID<GameInteractor::OnOpenText>(
         0x1C18, [](u16* textId, bool* loadFromMessageTable) {
             CustomMessage::Entry entry = {
                 .icon = 0x10,
@@ -138,7 +138,7 @@ void RegisterDemoBehavior() {
         });
 
     // Partial message replacement (Title Card for South Clock Town)
-    GameInteractor::Instance->RegisterGameHookForID<GameInteractor::OnOpenText>(
+    S2H::GameHooks::RegisterForID<GameInteractor::OnOpenText>(
         0x104, [](u16* textId, bool* loadFromMessageTable) {
             auto entry = CustomMessage::LoadVanillaMessageTableEntry(*textId);
 

--- a/games/mm/2s2h/Enhancements/Graphics/EnemyHealthBars.cpp
+++ b/games/mm/2s2h/Enhancements/Graphics/EnemyHealthBars.cpp
@@ -188,7 +188,7 @@ void Interface_DrawEnemyHealthBar(Attention* attention, PlayState* play) {
 static RegisterShipInitFunc initFunc(
     []() {
         // Register actor extension health data and actor init hook once
-        GameInteractor::Instance->RegisterGameHook<GameInteractor::OnActorInit>([](Actor* actor) {
+        S2H::GameHooks::Register<GameInteractor::OnActorInit>([](Actor* actor) {
             u8 maxHealth = actor->colChkInfo.health;
 
             // The remains in the Majora fight get their health set after init for the first time fighting,

--- a/games/mm/2s2h/Enhancements/Masks/PersistentMasks.cpp
+++ b/games/mm/2s2h/Enhancements/Masks/PersistentMasks.cpp
@@ -22,8 +22,8 @@ void UpdatePersistentMasksState() {
     static Vtx* persistentMasksVtx;
     static HOOK_ID beforePageDrawHook = 0;
     static HOOK_ID onPlayerPostLimbDrawHook = 0;
-    GameInteractor::Instance->UnregisterGameHook<GameInteractor::BeforeKaleidoDrawPage>(beforePageDrawHook);
-    GameInteractor::Instance->UnregisterGameHookForID<GameInteractor::OnPlayerPostLimbDraw>(onPlayerPostLimbDrawHook);
+    S2H::GameHooks::Unregister<GameInteractor::BeforeKaleidoDrawPage>(beforePageDrawHook);
+    S2H::GameHooks::UnregisterForID<GameInteractor::OnPlayerPostLimbDraw>(onPlayerPostLimbDrawHook);
 
     if (!CVAR) {
         CVarClear(STATE_CVAR_NAME);
@@ -48,7 +48,7 @@ void UpdatePersistentMasksState() {
     }
 
     // This hook draws the mask on the players head when it's active and they aren't in first person
-    onPlayerPostLimbDrawHook = GameInteractor::Instance->RegisterGameHookForID<GameInteractor::OnPlayerPostLimbDraw>(
+    onPlayerPostLimbDrawHook = S2H::GameHooks::RegisterForID<GameInteractor::OnPlayerPostLimbDraw>(
         PLAYER_LIMB_HEAD, [](Player* player, s32 limbIndex) {
             if (!STATE_CVAR) {
                 return;
@@ -80,7 +80,7 @@ void UpdatePersistentMasksState() {
         });
 
     // This hook sets up the quad and draws the "active" blue border around the mask in the pause menu
-    beforePageDrawHook = GameInteractor::Instance->RegisterGameHookForID<GameInteractor::BeforeKaleidoDrawPage>(
+    beforePageDrawHook = S2H::GameHooks::RegisterForID<GameInteractor::BeforeKaleidoDrawPage>(
         PAUSE_MASK, [](PauseContext* _, u16 __) {
             GraphicsContext* gfxCtx = MM_gPlayState->state.gfxCtx;
             PauseContext* pauseCtx = &MM_gPlayState->pauseCtx;

--- a/games/mm/2s2h/Enhancements/Modes/PlayAsKafei.cpp
+++ b/games/mm/2s2h/Enhancements/Modes/PlayAsKafei.cpp
@@ -88,7 +88,7 @@ void RegisterPlayAsKafei() {
 
     UpdatePlayAsKafei();
 
-    GameInteractor::Instance->RegisterGameHook<GameInteractor::OnPlayDestroy>([]() { UpdatePlayAsKafei(); });
+    S2H::GameHooks::Register<GameInteractor::OnPlayDestroy>([]() { UpdatePlayAsKafei(); });
 }
 
 // We only want this running at boot, we don't want this running when the cvar is changed, only on scene destroy

--- a/games/mm/2s2h/Enhancements/Songs/BetterSongOfDoubleTime.cpp
+++ b/games/mm/2s2h/Enhancements/Songs/BetterSongOfDoubleTime.cpp
@@ -95,7 +95,7 @@ void UpdateStickDirectionPromptAnim() {
 
 void OnPlayerUpdate(Actor* actor) {
     if (!sActivelyChangingTime) {
-        GameInteractor::Instance->UnregisterGameHookForID<GameInteractor::OnActorUpdate>(onPlayerUpdateHookId);
+        S2H::GameHooks::UnregisterForID<GameInteractor::OnActorUpdate>(onPlayerUpdateHookId);
         onPlayerUpdateHookId = 0;
         return;
     }
@@ -137,7 +137,7 @@ void OnPlayerUpdate(Actor* actor) {
         // Use a hook for when the song of double time cutscene is finished to reload the scene via a respawn
         // This is to ensure that no actors or scripts are processed with the new time on the fly,
         // and everything is reloaded in a fresh state
-        onEnTest6KillHookId = GameInteractor::Instance->RegisterGameHookForID<GameInteractor::OnActorKill>(
+        onEnTest6KillHookId = S2H::GameHooks::RegisterForID<GameInteractor::OnActorKill>(
             ACTOR_EN_TEST6, [](Actor* actor) {
                 Player* player = GET_PLAYER(MM_gPlayState);
 
@@ -154,16 +154,16 @@ void OnPlayerUpdate(Actor* actor) {
                 // Stop BGM so that new day sequences can play
                 gSaveContext.seqId = NA_BGM_DISABLED;
 
-                GameInteractor::Instance->UnregisterGameHookForID<GameInteractor::OnActorKill>(onEnTest6KillHookId);
+                S2H::GameHooks::UnregisterForID<GameInteractor::OnActorKill>(onEnTest6KillHookId);
                 onEnTest6KillHookId = 0;
             });
 
         // Use a hook to apply the new day and time before respawning
-        onPlayDestroyHookId = GameInteractor::Instance->RegisterGameHook<GameInteractor::OnPlayDestroy>([]() {
+        onPlayDestroyHookId = S2H::GameHooks::Register<GameInteractor::OnPlayDestroy>([]() {
             gSaveContext.save.day = sSelectedDay;
             gSaveContext.save.time = sSelectedTime;
 
-            GameInteractor::Instance->UnregisterGameHook<GameInteractor::OnPlayDestroy>(onPlayDestroyHookId);
+            S2H::GameHooks::Unregister<GameInteractor::OnPlayDestroy>(onPlayDestroyHookId);
             onPlayDestroyHookId = 0;
         });
 
@@ -341,8 +341,8 @@ void RegisterBetterSongOfDoubleTime() {
         sSelectedTime = CLOCK_TIME(0, 0);
         sSelectedDay = 0;
 
-        GameInteractor::Instance->UnregisterGameHookForID<GameInteractor::OnActorKill>(onEnTest6KillHookId);
-        GameInteractor::Instance->UnregisterGameHook<GameInteractor::OnPlayDestroy>(onPlayDestroyHookId);
+        S2H::GameHooks::UnregisterForID<GameInteractor::OnActorKill>(onEnTest6KillHookId);
+        S2H::GameHooks::Unregister<GameInteractor::OnPlayDestroy>(onPlayDestroyHookId);
 
         onEnTest6KillHookId = 0;
         onPlayDestroyHookId = 0;
@@ -395,7 +395,7 @@ void RegisterBetterSongOfDoubleTime() {
         sSelectedTime = CURRENT_TIME;
         sSelectedDay = gSaveContext.save.day;
 
-        onPlayerUpdateHookId = GameInteractor::Instance->RegisterGameHookForID<GameInteractor::OnActorUpdate>(
+        onPlayerUpdateHookId = S2H::GameHooks::RegisterForID<GameInteractor::OnActorUpdate>(
             ACTOR_PLAYER, OnPlayerUpdate);
     });
 

--- a/games/mm/2s2h/Enhancements/Timesavers/AutoBankDeposit.cpp
+++ b/games/mm/2s2h/Enhancements/Timesavers/AutoBankDeposit.cpp
@@ -31,7 +31,7 @@ static void GrantBankFirstReward() {
         u32 walletLevel = CUR_UPG_VALUE(UPG_WALLET);
         s16 itemDrawId = (walletLevel == 0) ? (s16)GID_WALLET_ADULT : (s16)GID_WALLET_GIANT;
 
-        GameInteractor::Instance->events.emplace_back(GIEventGiveItem{
+        MM_GameEvents_Queue().emplace_back(GIEventGiveItem{
             .showGetItemCutscene = true, .param = itemDrawId, .giveItem = [](Actor* actor, PlayState* play) {
                 u32 walletLevel = CUR_UPG_VALUE(UPG_WALLET);
                 ItemId wallet = (walletLevel == 0) ? ITEM_WALLET_ADULT : ITEM_WALLET_GIANT;
@@ -56,7 +56,7 @@ static void GrantBankInterestReward() {
     if (IS_RANDO) {
         RANDO_SAVE_CHECKS[RC_CLOCK_TOWN_WEST_BANK_INTEREST].eligible = true;
     } else {
-        GameInteractor::Instance->events.emplace_back(GIEventGiveItem{
+        MM_GameEvents_Queue().emplace_back(GIEventGiveItem{
             .showGetItemCutscene = true, .param = GID_RUPEE_BLUE, .giveItem = [](Actor* actor, PlayState* play) {
                 if (CUSTOM_ITEM_FLAGS & CustomItem::GIVE_ITEM_CUTSCENE) {
                     CustomMessage::SetActiveCustomMessage("You got a Blue Rupee!", { .textboxType = 2 });
@@ -75,7 +75,7 @@ static void GrantBankFinalReward() {
     if (IS_RANDO) {
         RANDO_SAVE_CHECKS[RC_CLOCK_TOWN_WEST_BANK_PIECE_OF_HEART].eligible = true;
     } else {
-        GameInteractor::Instance->events.emplace_back(GIEventGiveItem{
+        MM_GameEvents_Queue().emplace_back(GIEventGiveItem{
             .showGetItemCutscene = true, .param = GID_HEART_PIECE, .giveItem = [](Actor* actor, PlayState* play) {
                 if (CUSTOM_ITEM_FLAGS & CustomItem::GIVE_ITEM_CUTSCENE) {
                     CustomMessage::SetActiveCustomMessage("You got a Piece of Heart!", { .textboxType = 2 });

--- a/games/mm/2s2h/Enhancements/Timesavers/GalleryTwofer.cpp
+++ b/games/mm/2s2h/Enhancements/Timesavers/GalleryTwofer.cpp
@@ -37,7 +37,7 @@ void RegisterGalleryTwofer() {
         }
 
         if (!IS_RANDO && queueHeartPiece) {
-            GameInteractor::Instance->events.emplace_back(GIEventGiveItem{
+            MM_GameEvents_Queue().emplace_back(GIEventGiveItem{
                 .showGetItemCutscene = true,
                 .param = GID_HEART_PIECE,
                 .giveItem =

--- a/games/mm/2s2h/GameExports_SingleExe.cpp
+++ b/games/mm/2s2h/GameExports_SingleExe.cpp
@@ -1670,6 +1670,11 @@ extern "C" void GameInteractor_ExecuteBeforeMoonCrashSaveReset() {
 extern "C" void MM_GameHooks_ExecuteOnActorUpdate(Actor* actor) {
     S2H::GameHooks::Execute<GameInteractor::OnActorUpdate>(actor);
     S2H::GameHooks::ExecuteForID<GameInteractor::OnActorUpdate>(actor->id, actor);
+    // ForPtr leg (upstream GameInteractor_ExecuteOnActorUpdate has all four
+    // legs): registrants bind to one live actor by address — 2ship_enh's
+    // SkipLearningSongOfHealing is the first shim user (#427 item 2). The
+    // ForFilter leg stays unported: no compiled MM TU registers one.
+    S2H::GameHooks::ExecuteForPtr<GameInteractor::OnActorUpdate>((uintptr_t)actor, actor);
 }
 
 /**
@@ -1705,9 +1710,10 @@ extern "C" void MM_GameHooks_ExecuteOnSceneFlagSet(s16 sceneId, FlagType flagTyp
  * and actor ids resolve against the MM-owned S2H::GameHooks registries only —
  * never OoT's ordinal-aliased tables. Bodies are line-faithful ports of the
  * excluded upstream executors (2s2h/GameInteractor/GameInteractor.cpp), minus
- * the ForPtr/ForFilter legs: the S2H registry deliberately has no Ptr/Filter
- * surface and the linked MM set registers none (the only Should filter user,
- * DeveloperTools.cpp, stays link-elided — re-audit if it ever un-elides).
+ * the ForPtr/ForFilter legs: no compiled MM TU registers a Should hook by Ptr
+ * (the registry's ForPtr surface exists for OnActorUpdate, #427 item 2) and
+ * the registry deliberately has no Filter surface — the only Should filter
+ * user, DeveloperTools.cpp, stays link-elided; re-audit if it ever un-elides.
  * Locked by MMRandoGen's VB-dispatch phase (mm_rando_gen_test.cpp).
  */
 extern "C" bool MM_GameHooks_ExecuteVBShould(GIVanillaBehavior flag, uint32_t result, ...) {

--- a/games/mm/CMakeLists.txt
+++ b/games/mm/CMakeLists.txt
@@ -754,49 +754,32 @@ if(SINGLE_EXECUTABLE_BUILD)
     # shared 4-byte OoT-owned instance again (MM code uses the S2H::GameHooks
     # registry / extern "C" shim in include/mm_game_hooks.h instead). Appended
     # AFTER GameInteractor.h so the class definition itself parses with the
-    # real names; only later USES in a TU fail. As of Lane C0 (#392) the guard
-    # covers 2ship_rando and 2ship_rando_ui too: their COND_* macro sites
-    # route through the single-exe macro redirection at the bottom of MM's
-    # GameInteractor.h and their direct Register* sites are migrated. Only
-    # 2ship_enh remains exempt as a *target* — its ~20 remaining direct
-    # Register* sites (#427's census) live in TUs that stay link-elided; flip
-    # the whole target here when the full ~56-site migration (#427 item 2)
-    # lands.
+    # real names; only later USES in a TU fail. Coverage history: 2ship_src/
+    # 2ship_port from #415; 2ship_rando/2ship_rando_ui from Lane C0 (#392) —
+    # COND_* macro sites route through the single-exe macro redirection at the
+    # bottom of MM's GameInteractor.h, direct Register* sites migrated by hand;
+    # 2ship_enh from #427 item 2, which retired the last exemption. Measured
+    # against the tree at that point, 2ship_enh carried 15 direct Register*
+    # sites across 8 files and 10 matching Unregister* sites, plus 34 live
+    # `Instance->events` enqueues across 22 files (and no `currentEvent`
+    # reads); all of them now go through S2H::GameHooks / MM_GameEvents_Queue.
+    # The one file still holding upstream raw registrations,
+    # 2s2h/Enhancements/Audio/AudioEditor.cpp, is filtered out of
+    # ship__Enhancements above and so is never compiled in single-exe builds.
+    #
+    # Every MM C++ target is now guarded: a raw Instance registration anywhere
+    # in MM code is a compile error, not a latent out-of-bounds write.
     set(_force_include_cxx_guarded
         ${_force_include_cxx}
         "${_fi}${CMAKE_CURRENT_SOURCE_DIR}/include/mm_gi_hook_guard.h"
     )
-    # #442: 2ship_enh is a plain (non-WHOLE_ARCHIVE) static archive, so most of
-    # its ~195 TUs never enter the link — but a handful genuinely do (their
-    # symbols are referenced from compiled MM .c sources), and the guard
-    # exemption above was blind to which TUs those are. Per
-    # docs/unified-surface-findings.md's link census, the confirmed-linked set
-    # is FrameInterpolation.cpp, MotionBlur.cpp, PauseOwlWarp.cpp,
-    # SavingEnhancements.cpp, SkipGiantsChamber.cpp, AudioCollection.cpp — one
-    # of which (SavingEnhancements.cpp) is exactly how #442's raw
-    # RegisterGameHook sites reached the shared 4-byte GameInteractor
-    # instance despite the target-wide exemption "protecting" 2ship_enh.
-    # Force-including the guard on just these six sources (rather than
-    # flipping the whole target, which would still fail on ~20 real raw sites
-    # in TUs that stay elided) closes exactly the hole #442 exploited without
-    # taking on the full #427 migration. Extend this list if the link census
-    # changes (docs/unified-surface-findings.md) or another 2ship_enh TU
-    # starts exporting a symbol a compiled MM .c source references.
-    # Matched by basename suffix (see the loop below), not exact path equality:
-    # the SOURCES target property's path form (relative vs.
-    # CMAKE_CURRENT_SOURCE_DIR-absolute, / vs \) isn't contractually
-    # guaranteed across CMake versions / generators. Every filename here is
-    # unique across the whole MM tree, so a plain basename match (no directory
-    # component, so no path-separator escaping to get wrong) is unambiguous
-    # and robust either way.
-    set(_mm_gi_hook_guard_linked_enh_sources
-        "FrameInterpolation.cpp"
-        "MotionBlur.cpp"
-        "PauseOwlWarp.cpp"
-        "SavingEnhancements.cpp"
-        "SkipGiantsChamber.cpp"
-        "AudioCollection.cpp"
-    )
+    # #442's interim per-source carve-out (_mm_gi_hook_guard_linked_enh_sources:
+    # guard only the six 2ship_enh TUs the link census showed were non-elided,
+    # since flipping the whole target would then have failed on the raw sites in
+    # elided TUs) is retired here with #427 item 2. Whole-target coverage
+    # strictly subsumes it, and dropping the list removes a census that had to
+    # be kept in sync by hand — a newly un-elided 2ship_enh TU can no longer
+    # arrive carrying raw registrations that the list happened not to name.
     set(_force_include_c
         "${_fi}${CMAKE_CURRENT_SOURCE_DIR}/include/ultra64.h"
         "${_fi}${CMAKE_CURRENT_SOURCE_DIR}/include/global.h"
@@ -819,25 +802,13 @@ if(SINGLE_EXECUTABLE_BUILD)
     # generator builds broke. Per-source properties hand both generators the
     # command lines Ninja was already producing.
     get_target_property(_target_sources ${_t} SOURCES)
-    if(_t STREQUAL "2ship_enh")
-        set(_force_include_cxx_for_target "${_force_include_cxx}")
-    else()
-        set(_force_include_cxx_for_target "${_force_include_cxx_guarded}")
-    endif()
+    # No per-target and no per-source exemptions (#427 item 2): the
+    # mm_gi_hook_guard.h poison applies to every MM C++ TU in every MM target.
     foreach(_src IN LISTS _target_sources)
         if(_src MATCHES "\\.c$")
             set_source_files_properties(${_src} PROPERTIES COMPILE_OPTIONS "${_force_include_c}")
         elseif(_src MATCHES "\\.(cpp|cxx|cc)$")
-            # #442: within 2ship_enh, the handful of sources confirmed to
-            # actually enter the link (see _mm_gi_hook_guard_linked_enh_sources
-            # above) get the same poison guard as every other MM C++ TU,
-            # regardless of the target-wide exemption.
-            get_filename_component(_mm_gi_hook_guard_src_name "${_src}" NAME)
-            if(_t STREQUAL "2ship_enh" AND _mm_gi_hook_guard_src_name IN_LIST _mm_gi_hook_guard_linked_enh_sources)
-                set_source_files_properties(${_src} PROPERTIES COMPILE_OPTIONS "${_force_include_cxx_guarded}")
-            else()
-                set_source_files_properties(${_src} PROPERTIES COMPILE_OPTIONS "${_force_include_cxx_for_target}")
-            endif()
+            set_source_files_properties(${_src} PROPERTIES COMPILE_OPTIONS "${_force_include_cxx_guarded}")
         endif()
     endforeach()
 else()

--- a/games/mm/include/mm_game_hooks.h
+++ b/games/mm/include/mm_game_hooks.h
@@ -36,9 +36,10 @@
  *  - Every `GameInteractor::Instance->events` / `->currentEvent` access must
  *    migrate to MM_GameEvents_Queue() / MM_GameEvents_Current() below.
  *  - A compile-time guard (games/mm/include/mm_gi_hook_guard.h, force-included
- *    after MM's GameInteractor.h) poisons the Register* member names in
- *    2ship_port/2ship_src C++ TUs; extend it to 2ship_enh/2ship_rando as
- *    their TUs migrate.
+ *    after MM's GameInteractor.h) poisons the Register* member names in every
+ *    MM C++ target (2ship_src/2ship_port/2ship_enh/2ship_rando/
+ *    2ship_rando_ui) — the 2ship_rando targets migrated in Lane C0 and
+ *    2ship_enh in #427 item 2, so no exemptions remain.
  */
 #ifndef MM_GAME_HOOKS_H
 #define MM_GAME_HOOKS_H
@@ -130,6 +131,38 @@ GIEvent& MM_GameEvents_Current();
  * REGISTERED but dormant; wiring their Execute calls is per-type, deliberate
  * Lane C work, never a side effect of registration.
  *
+ * DORMANT TYPES INTRODUCED BY #427 item 2 (tracked on #438). The 2ship_enh
+ * migration moved that target's direct Register* sites onto this registry.
+ * Most of the hook types involved were ALREADY dormant — they carry
+ * COND_HOOK/COND_ID_HOOK registrants from other MM targets and are listed in
+ * #438's table (OnOpenText, OnActorInit, OnActorKill). Two types reach this
+ * registry for the first time with that migration and have no Execute
+ * placement, plus one that #438's table did not yet name:
+ *
+ *   - OnPlayDestroy       (Modes/PlayAsKafei.cpp, Songs/BetterSongOfDoubleTime.cpp)
+ *   - BeforeKaleidoDrawPage (Masks/PersistentMasks.cpp)
+ *   - OnPlayerPostLimbDraw  (Masks/PersistentMasks.cpp)
+ *
+ * These are dormant, NOT newly broken: before the migration the same
+ * registrations went into MM's `GameInteractor::RegisteredGameHooks<H>`
+ * statics while MM's call sites for GameInteractor_ExecuteOnPlayDestroy /
+ * ExecuteBeforeKaleidoDrawPage / ExecuteOnPlayerPostLimbDraw resolved to
+ * OoT's active-game-gated wrappers or to src/common/mm_stubs.c no-ops — so
+ * the handlers never ran either way. What the migration removes is the #395
+ * out-of-bounds write the raw registration performed on the way to being
+ * dead. Wiring them is #438's job, and BeforeKaleidoDrawPage in particular
+ * should be wired together with its AfterKaleidoDrawPage pair rather than
+ * half-fixed (the reasoning mm_stubs.c records for the EndOfCycleSave pair).
+ *
+ * One upstream quirk is preserved deliberately rather than repaired here:
+ * PersistentMasks.cpp unregisters BeforeKaleidoDrawPage through the plain
+ * Unregister<> leg while registering it through RegisterForID<>, so the
+ * pending id never matches and the registration is never removed — exactly
+ * what upstream 2S2H does (its UnregisterGameHook and RegisterGameHookForID
+ * likewise address different maps). While the type stays dormant the stale
+ * entry is inert; whoever wires its Execute under #438 must fix the leg
+ * pairing at the same time, or the mask border will draw twice.
+ *
  * Deviation from upstream, on purpose: iteration uses std::map (stable id
  * order) rather than unordered_map, so dispatch order is deterministic —
  * this phase's locks diff generated worlds byte-for-byte.
@@ -143,8 +176,10 @@ namespace GameHooks {
 template <typename H> struct Registry {
     inline static std::map<uint32_t, typename H::fn> functions;
     inline static std::map<int32_t, std::map<uint32_t, typename H::fn>> functionsForID;
+    inline static std::map<uintptr_t, std::map<uint32_t, typename H::fn>> functionsForPtr;
     inline static std::vector<uint32_t> pendingUnregister;
     inline static std::vector<uint32_t> pendingUnregisterForID;
+    inline static std::vector<uint32_t> pendingUnregisterForPtr;
 };
 
 // Shared across all hook types, mirroring upstream's instance-wide
@@ -173,6 +208,20 @@ template <typename H> inline uint32_t RegisterForID(int32_t forId, typename H::f
     return id;
 }
 
+// Ptr-keyed leg (upstream RegisterGameHookForPtr): hooks bound to one live
+// object (actor instance), keyed by its address. Added for 2ship_enh's
+// OnActorUpdate-for-actor registrant (#427 item 2); the Filter leg is still
+// deliberately absent — no compiled MM TU registers one (re-audit if
+// DeveloperTools.cpp un-elides).
+template <typename H> inline uint32_t RegisterForPtr(uintptr_t ptr, typename H::fn h) {
+    if (!h) {
+        return 0;
+    }
+    uint32_t id = NextHookId()++;
+    Registry<H>::functionsForPtr[ptr][id] = h;
+    return id;
+}
+
 // Deferred, like upstream: safe to call from inside a running hook; applied
 // at the start of the next Execute/ExecuteForID of this hook type. Id 0
 // (never issued) is ignored.
@@ -188,6 +237,12 @@ template <typename H> inline void UnregisterForID(uint32_t hookId) {
     }
 }
 
+template <typename H> inline void UnregisterForPtr(uint32_t hookId) {
+    if (hookId != 0) {
+        Registry<H>::pendingUnregisterForPtr.push_back(hookId);
+    }
+}
+
 template <typename H> inline void FlushPendingUnregistrations() {
     for (uint32_t id : Registry<H>::pendingUnregister) {
         Registry<H>::functions.erase(id);
@@ -199,6 +254,12 @@ template <typename H> inline void FlushPendingUnregistrations() {
         }
     }
     Registry<H>::pendingUnregisterForID.clear();
+    for (uint32_t id : Registry<H>::pendingUnregisterForPtr) {
+        for (auto& [_, bucket] : Registry<H>::functionsForPtr) {
+            bucket.erase(id);
+        }
+    }
+    Registry<H>::pendingUnregisterForPtr.clear();
 }
 
 template <typename H, typename... Args> inline void Execute(Args&&... args) {
@@ -219,10 +280,24 @@ template <typename H, typename... Args> inline void ExecuteForID(int32_t forId, 
     }
 }
 
+template <typename H, typename... Args> inline void ExecuteForPtr(uintptr_t ptr, Args&&... args) {
+    FlushPendingUnregistrations<H>();
+    auto it = Registry<H>::functionsForPtr.find(ptr);
+    if (it == Registry<H>::functionsForPtr.end()) {
+        return;
+    }
+    for (auto& [_, fn] : it->second) {
+        fn(std::forward<Args>(args)...);
+    }
+}
+
 // Test/introspection helpers (unit harness only).
 template <typename H> inline size_t CountForTest() {
     size_t n = Registry<H>::functions.size();
     for (auto& [_, bucket] : Registry<H>::functionsForID) {
+        n += bucket.size();
+    }
+    for (auto& [_, bucket] : Registry<H>::functionsForPtr) {
         n += bucket.size();
     }
     return n;
@@ -231,8 +306,10 @@ template <typename H> inline size_t CountForTest() {
 template <typename H> inline void ResetForTest() {
     Registry<H>::functions.clear();
     Registry<H>::functionsForID.clear();
+    Registry<H>::functionsForPtr.clear();
     Registry<H>::pendingUnregister.clear();
     Registry<H>::pendingUnregisterForID.clear();
+    Registry<H>::pendingUnregisterForPtr.clear();
 }
 
 } // namespace GameHooks

--- a/games/mm/include/mm_gi_hook_guard.h
+++ b/games/mm/include/mm_gi_hook_guard.h
@@ -19,21 +19,25 @@
  * Mechanism: force-included AFTER GameInteractor.h (games/mm/CMakeLists.txt,
  * the _force_include_cxx_guarded list), so the class definition itself parses
  * with the real member names; any LATER use of a poisoned name in the TU
- * fails to compile with an identifier that points here. Applied to
- * 2ship_port/2ship_src/2ship_rando/2ship_rando_ui unconditionally. 2ship_enh
- * is exempt as a *target* — most of its ~195 TUs stay link-elided (plain
- * archive semantics; nothing pulls them in) and carry raw RegisterGameHook
- * sites the full #427-item-2 migration hasn't reached yet — but
- * games/mm/CMakeLists.txt now force-includes this guard on the specific
- * 2ship_enh sources confirmed to actually enter the link
- * (docs/unified-surface-findings.md's census: FrameInterpolation.cpp,
- * MotionBlur.cpp, PauseOwlWarp.cpp, SavingEnhancements.cpp,
- * SkipGiantsChamber.cpp, AudioCollection.cpp — see
- * _mm_gi_hook_guard_linked_enh_sources there), since a raw registration in
- * any of those genuinely reaches the shared instance today (#442: this is
- * exactly how SavingEnhancements.cpp's raw sites got past the target-wide
- * exemption). Extend that per-source list — or flip the whole target — as
- * more 2ship_enh TUs stop being link-elided (#392).
+ * fails to compile with an identifier that points here. Applied to every MM
+ * C++ target with no exemptions: 2ship_src/2ship_port (#415),
+ * 2ship_rando/2ship_rando_ui (Lane C0, #392), and 2ship_enh (#427 item 2,
+ * which retired the last one). #442's interim carve-out — guarding only the
+ * six 2ship_enh sources the link census confirmed were non-elided
+ * (_mm_gi_hook_guard_linked_enh_sources in games/mm/CMakeLists.txt, added
+ * after SavingEnhancements.cpp's raw sites reached the shared instance
+ * through the target-wide exemption) — is gone with it: whole-target
+ * coverage subsumes the list, so there is no longer a census to keep in sync
+ * and no way for a newly un-elided 2ship_enh TU to arrive carrying raw
+ * registrations.
+ *
+ * The only upstream raw-registration file left untouched is
+ * 2s2h/Enhancements/Audio/AudioEditor.cpp, which is not compiled at all in
+ * single-exe builds (dropped from ship__Enhancements in
+ * games/mm/CMakeLists.txt because it depends on the excluded BenGui/BenMenu
+ * surface). If it is ever restored to the build, its
+ * OnRandoSeedGeneration registration must migrate first — the guard will say
+ * so at compile time.
  *
  * Escape hatch for deliberate probes: `#undef` the macro in the probing TU
  * (precedent: the rename #undefs in games/mm/2s2h/mm_culling_test.cpp).


### PR DESCRIPTION
Completes #427 item 2: the Lane C hook migration for `2ship_enh`, the last MM C++ target still exempt from the #395 poison guard.

## Re-measured census

The original census (~20 raw `RegisterGameHook*`, ~36 `Instance->events`) predated #448. Measured against `f0449abf`:

| surface | count | files |
|---|---|---|
| direct `Instance->RegisterGameHook*` | 15 | 8 |
| matching `UnregisterGameHook*` | 10 | — |
| live `Instance->events` enqueues | 34 | 22 |
| `Instance->currentEvent` reads | 0 | — |

One of the 8 files, `Enhancements/Audio/AudioEditor.cpp`, is filtered out of `ship__Enhancements` and never compiled in single-exe builds (it depends on the excluded BenGui/BenMenu surface), so **14 registrations across 7 files** actually needed migrating. The `COND_HOOK` family already routed through the macro redirection at the bottom of MM's `GameInteractor.h` and needed **zero call-site edits**, per the #422/#435 pattern.

## What this is, and is not

Every raw registration reached the shared 4-byte OoT-owned `GameInteractor` allocation through MM's 104-byte layout — the #395 out-of-bounds write. **All affected TUs are link-elided today** (none appear in #442's link census), so unlike #442 this is not a live-corruption fix. It is the precondition for those TUs ever entering the link, and it is what lets the guard cover the whole target.

The 34 migrated enqueues land in a genuinely pumped queue: `MM_ProcessGIEvents` is registered on `OnActorUpdate`/ForID, which `MM_GameHooks_ExecuteOnActorUpdate` dispatches from `z_actor.c`.

## Registry: the ForPtr leg

Adds `RegisterForPtr`/`UnregisterForPtr`/`ExecuteForPtr` plus test-helper coverage — the leg #438 deferred until a caller needed one. `SkipLearningSongOfHealing.cpp` binds `OnActorUpdate` to a single live actor by address. `MM_GameHooks_ExecuteOnActorUpdate` now dispatches that leg, matching upstream's four-leg `GameInteractor_ExecuteOnActorUpdate`. The **ForFilter leg stays absent**: no compiled MM TU registers one (the sole registrant, `DeveloperTools.cpp`, is excluded from the build).

## Guard flip — linked symbol set is IDENTICAL

`games/mm/CMakeLists.txt` drops the `2ship_enh` target exemption; the `mm_gi_hook_guard.h` poison now applies to every MM C++ TU with no per-target and no per-source carve-outs. #442's interim `_mm_gi_hook_guard_linked_enh_sources` list is removed as strictly subsumed — no hand-maintained link census to drift, and a newly un-elided TU can no longer arrive carrying raw registrations the list happened not to name.

**The invariant: the linked symbol set does not change.** The flip adds only a preprocessor force-include — it emits no symbols and cannot alter archive membership. `2ship_enh` remains `add_library(2ship_enh STATIC ...)` with plain archive semantics, listed bare in `TWOSHIP_STATIC_TARGETS`; only `2ship_rando` carries `$<LINK_LIBRARY:WHOLE_ARCHIVE,...>`. Verified by the registrar-elision gate's report-only `2ship_enh` count holding at its post-#450 value of **10** and the collision gate staying green.

`WHOLE_ARCHIVE` on `2ship_enh` is explicitly **out of scope** — a separate step gated on this migration plus the ~27-external dependency gap.

## Registration is not dispatch

Three hook types reach `S2H::GameHooks` with no `Execute` placement. They are documented in `games/mm/include/mm_game_hooks.h` and added to #438 rather than wired here:

| type | registrant | status before this PR |
|---|---|---|
| `OnPlayDestroy` | `Modes/PlayAsKafei.cpp`, `Songs/BetterSongOfDoubleTime.cpp` | bound OoT's active-game-gated wrapper — dead for MM |
| `BeforeKaleidoDrawPage` | `Masks/PersistentMasks.cpp` | `mm_stubs.c` no-op — dead |
| `OnPlayerPostLimbDraw` | `Masks/PersistentMasks.cpp` | `mm_stubs.c` no-op — dead |

**None is newly dead** — each was already unreachable before the migration; what the migration removes is the OOB write on the way to being dead. `BeforeKaleidoDrawPage` should be wired together with its `AfterKaleidoDrawPage` pair rather than half-fixed, per the reasoning `mm_stubs.c` records for the EndOfCycleSave pair. The other types involved (`OnOpenText`, `OnActorInit`, `OnActorKill`) were already dormant with registrants from other MM targets and are already in #438's table.

Also recorded in the header: `PersistentMasks.cpp` unregisters `BeforeKaleidoDrawPage` through the plain `Unregister<>` leg while registering through `RegisterForID<>`, so the id never matches. That is exactly what upstream 2S2H does, and it is **preserved deliberately** to keep the migration behaviour-faithful; it is inert while the type is dormant, and whoever wires the Execute must fix the leg pairing at the same time.

## #451 verification

#451 gates on the **`WHOLE_ARCHIVE` flip**, which this PR does not perform. Evidence that the guard flip does not arm it:

1. The flip pulls **nothing** into the link — a force-include is preprocessor-only, and `2ship_enh` stays a plain STATIC archive.
2. **No `2ship_enh` TU reads any of the four contended keys.** `ActiveHeader` and `*SidebarSection` appear nowhere under `2s2h/Enhancements/`. The only `gSettings.Menu.*` reads there are `gSettings.Menu.Theme` (a shared theme-palette index — not one of the four class-(P) menu-index keys) in `ItemTrackerSettings.cpp` and `TimesplitsSettings.cpp`.
3. All four contended keys' MM-side readers stay outside the link: `BenGui/BenMenu.cpp` (all `2s2h/BenGui/*.cpp` excluded except `UIWidgets.cpp`/`Menu.cpp`), and `BenGui/Menu.cpp` + `Rando/Menu.cpp` (both in the deliberately-elided `2ship_rando_ui`).

MM's menu is not revived as a second shell, so ADR 0004's discharge condition holds. Reported on #451.

## Verification

- Guard bite proven red-then-green in CI: a temporary commit adding a raw `Instance->` access in a `2ship_enh` TU fails the build, reverted before merge (run id in thread).
- `GameExports_SingleExe.cpp` (the one format-gated file in this diff) is clang-format-14 clean.

Refs #392, #395, #427, #438, #442, #450, #451.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!--- section:artifacts:start -->
### Build Artifacts
  - [rsbs-windows.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/8513025444.zip)
  - [rsbs-linux.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/8511911944.zip)
<!--- section:artifacts:end -->