### PR TITLE
Netplay relay client behind RSBS_NETPLAY (default OFF) — ADR 0007

### DIFF
--- a/.github/workflows/generate-builds.yml
+++ b/.github/workflows/generate-builds.yml
@@ -350,6 +350,107 @@ jobs:
           rsbs.appimage
           readme.txt
 
+  # ==========================================================================
+  # Netplay grant relay (ADR 0007, #460)
+  #
+  # A SEPARATE job rather than a flag on build-linux, deliberately: build-linux
+  # packages and uploads the released appimage, so enabling the relay there
+  # would SHIP a feature that is supposed to be off by default. Default-off has
+  # to mean shipped-off, which means the relay never enters a release artifact.
+  #
+  # This job does two things build-linux cannot:
+  #   1. builds with RSBS_NETPLAY=ON and runs the Relay* locks, which do not
+  #      exist in a default configure;
+  #   2. asserts the DEFAULT configure pulls in no netplay translation unit —
+  #      the verifiable form of "the default build is unaffected".
+  # It uploads nothing.
+  # ==========================================================================
+  netplay-relay:
+    needs: generate-rsbs-otr
+    runs-on: ubuntu-22.04
+    container:
+      image: ghcr.io/spencerduncan/redshipblueship-build:latest
+    steps:
+    - name: Git Checkout
+      uses: actions/checkout@v4
+      with:
+        submodules: true
+        fetch-depth: 1
+        fetch-tags: true
+    - name: Configure git safe directory
+      run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
+    - name: Install packaging tools
+      run: |
+        apt-get update
+        apt-get install -y imagemagick file desktop-file-utils
+    - name: Configure ccache
+      uses: hendrikmuhs/ccache-action@v1.2
+      with:
+        save: true
+        max-size: "1.5G"
+        key: ${{ runner.os }}-ccache-netplay-${{ github.ref }}
+        restore-keys: |
+          ${{ runner.os }}-ccache-netplay-${{ github.ref }}
+          ${{ runner.os }}-ccache-${{ github.ref }}
+          ${{ runner.os }}-ccache-refs/heads/main
+          ${{ runner.os }}-ccache
+    - name: Download soh.o2r
+      uses: actions/download-artifact@v4
+      with:
+        name: soh.o2r
+        path: build-cmake/soh
+    - name: Download 2ship.o2r
+      uses: actions/download-artifact@v4
+      with:
+        name: 2ship.o2r
+        path: build-cmake/mm
+    - name: Assert the DEFAULT build pulls in no netplay TU
+      # Configure-only (seconds, no compile) in the default configuration and
+      # grep the generated build system. With RSBS_NETPLAY=OFF the netplay
+      # sources are never appended to REDSHIP_COMMON_SOURCES, so no rule
+      # referencing them can exist. This is the negative control for the
+      # positive one below; without it "default OFF" is a claim about CMake
+      # that nothing checks.
+      run: |
+        cmake --no-warn-unused-cli -H. -Bbuild-default -GNinja -DCMAKE_BUILD_TYPE:STRING=Release >/dev/null
+        if grep -rq "netplay/relay_" build-default/build.ninja; then
+          echo "FAIL: default configure references a netplay source; RSBS_NETPLAY=OFF must mean absent."
+          grep -rn "netplay/relay_" build-default/build.ninja | head
+          exit 1
+        fi
+        echo "OK: default configure pulls in no netplay translation unit."
+      env:
+        CC: gcc-11
+        CXX: g++-11
+    - name: Build with RSBS_NETPLAY=ON
+      run: |
+        export PATH="/usr/lib/ccache:/usr/local/opt/ccache/libexec:$PATH"
+        cmake --no-warn-unused-cli -H. -Bbuild-cmake -GNinja -DCMAKE_BUILD_TYPE:STRING=Release -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DBUILD_REMOTE_CONTROL=1 -DRSBS_NETPLAY=1
+        cmake --build build-cmake --config Release -j10
+      env:
+        CC: gcc-11
+        CXX: g++-11
+        CCACHE_COMPILERCHECK: content
+    - name: Assert the relay actually linked
+      # Positive control. If the flag silently stopped adding the sources, the
+      # Relay* rows below would vanish and ctest's --no-tests=error would be
+      # the only thing standing between us and a vacuous green.
+      run: |
+        if ! nm -C build-cmake/redship | grep -q "Relay_Tick"; then
+          echo "FAIL: RSBS_NETPLAY=ON but Relay_Tick is not in the binary."
+          exit 1
+        fi
+        echo "OK: relay symbols linked."
+    - name: Run netplay relay locks
+      # ROM-free and display-free: the loopback ledger is in-process. See the
+      # header of src/common/tests/test_netplay_relay.c for what these prove
+      # and — equally load-bearing — what they do not.
+      run: ctest --test-dir build-cmake --output-on-failure --tests-regex "^Relay" --no-tests=error
+    - name: Run the full ROM-free tier with the relay built
+      # The relay must not perturb anything else. Same label the default
+      # build-linux job runs, so a regression here is attributable to the flag.
+      run: ctest --test-dir build-cmake --output-on-failure --label-regex "^redship$" --no-tests=error
+
   build-windows:
     # Issue #177 — investigation results (2026-06-01, runs 26731031162 / 26731511201 / 26731832242):
     #   * sccache hit rate: 99.82% (2848 hits / 2853 executed / 5 misses) — the cache works.

--- a/CMake/SingleExecutable.cmake
+++ b/CMake/SingleExecutable.cmake
@@ -59,6 +59,27 @@ if(WIN32)
     )
 endif()
 
+# ============================================================================
+# Netplay grant relay (ADR 0007, #460) — OFF by default, and OFF means ABSENT
+#
+# These sources are appended ONLY when RSBS_NETPLAY is ON. The default build
+# therefore gains no translation unit and links no new symbol, which is the
+# strongest verifiable form of "byte-unaffected" (byte-identical binaries are
+# not reproducible across toolchain nondeterminism; "no new linked symbols" is
+# checkable, and the netplay-default-off CI job checks it).
+#
+# No submodule and no transport library: the wire format is length-prefixed
+# binary over plain TCP, so a small socket shim beats putting a dependency in
+# every CI checkout for code that is inert by default (ADR 0006 §7).
+# ============================================================================
+if(RSBS_NETPLAY)
+    message(STATUS "Netplay grant relay: ENABLED (experimental, ADR 0007)")
+    list(APPEND REDSHIP_COMMON_SOURCES
+        ${CMAKE_SOURCE_DIR}/src/common/netplay/relay_protocol.c
+        ${CMAKE_SOURCE_DIR}/src/common/netplay/relay_client.c
+    )
+endif()
+
 set(REDSHIP_COMMON_HEADERS
     ${CMAKE_SOURCE_DIR}/src/common/game.h
     ${CMAKE_SOURCE_DIR}/src/common/archive_check.h
@@ -117,6 +138,14 @@ target_compile_definitions(redship_common PRIVATE COMBO_BUILDING_DLL)
 # pass) when the path is absent, which is what happens if the binary is run
 # from a relocated artifact rather than its build tree.
 target_compile_definitions(redship_common PRIVATE RSBS_SOURCE_DIR="${CMAKE_SOURCE_DIR}")
+
+# Netplay relay (ADR 0007). PUBLIC so test_runner.cpp's guarded #include of
+# tests/test_netplay_relay.c compiles in the same configuration the relay
+# sources do — a PRIVATE define here would silently drop the tests while the
+# relay itself built, which is the worst of both.
+if(RSBS_NETPLAY)
+    target_compile_definitions(redship_common PUBLIC RSBS_NETPLAY)
+endif()
 
 set_target_properties(redship_common PROPERTIES
     CXX_STANDARD 20
@@ -320,6 +349,25 @@ if(BUILD_TESTING)
     redship_add_test(NAME GrantRedeemNoSwitch COMMAND redship --test grant-redeem-no-switch)
     redship_add_test(NAME GrantOverflow COMMAND redship --test grant-overflow)
     redship_add_test(NAME GrantPersistence COMMAND redship --test grant-persistence)
+
+    # Netplay grant relay (ADR 0007, #460). Registered only when the relay is
+    # built, because with RSBS_NETPLAY=OFF the code under test does not exist —
+    # a row here would fail rather than skip. The netplay-default-off CI job
+    # builds with the flag ON and runs these; every other job stays default.
+    #
+    # What these lock, and the honest limit, is stated at the top of
+    # src/common/tests/test_netplay_relay.c: they drive the real codec and the
+    # real state machine over a mock ledger with multi-server's semantics, so
+    # they prove our SEMANTICS but not our admissibility to the real wire.
+    # Unlike the Archipelago case (ADR 0006 §2b) there is no external
+    # gatekeeper, so a framing mismatch is a defect we can fix, not a wall.
+    if(RSBS_NETPLAY)
+        redship_add_test(NAME RelayWireFormat COMMAND redship --test relay-wire-format)
+        redship_add_test(NAME RelayLoopback COMMAND redship --test relay-loopback)
+        redship_add_test(NAME RelayCatchup COMMAND redship --test relay-catchup)
+        redship_add_test(NAME RelayBackpressure COMMAND redship --test relay-backpressure)
+        redship_add_test(NAME RelaySuspendLatch COMMAND redship --test relay-suspend-latch)
+    endif()
     redship_add_test(NAME ArchiveHotswapLogic COMMAND redship --test archive-hotswap-logic)
     # Unified save (.redsave) headless tests — Phase 2 T6 (#35)
     redship_add_test(NAME SaveRoundtripTiers COMMAND redship --test save-roundtrip-tiers)

--- a/CMake/SingleExecutable.cmake
+++ b/CMake/SingleExecutable.cmake
@@ -313,6 +313,13 @@ if(BUILD_TESTING)
     # blocker (#460): a stale sharedItemsTagged carries another player's grants
     # from a dead room into a fresh seed.
     redship_add_test(NAME SessionInvalidation COMMAND redship --test session-invalidation)
+    # Netplay 1a (ADR 0005, #460): sourced-grant model locks — cursor
+    # idempotency, switch-free received-order redemption, loud overflow with
+    # redeemed-slot reclamation, and .redsave durability + reset atomicity.
+    redship_add_test(NAME GrantIdempotency COMMAND redship --test grant-idempotency)
+    redship_add_test(NAME GrantRedeemNoSwitch COMMAND redship --test grant-redeem-no-switch)
+    redship_add_test(NAME GrantOverflow COMMAND redship --test grant-overflow)
+    redship_add_test(NAME GrantPersistence COMMAND redship --test grant-persistence)
     redship_add_test(NAME ArchiveHotswapLogic COMMAND redship --test archive-hotswap-logic)
     # Unified save (.redsave) headless tests — Phase 2 T6 (#35)
     redship_add_test(NAME SaveRoundtripTiers COMMAND redship --test save-roundtrip-tiers)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,6 +17,13 @@ option(SUPPRESS_WARNINGS "Suppress warnings in LUS and src (decomp)" ON)
 option(SINGLE_EXECUTABLE_BUILD "Build single redship executable (replaces dynamic library loading)" ON)
 option(USE_LLD_LINKER "Use LLVM's lld-link instead of MSVC linker (faster linking)" OFF)
 
+# Netplay grant relay (ADR 0007, #460). Default OFF, and OFF means ABSENT: no
+# netplay source is added to any target, so the default build links no new
+# symbols — the property the `netplay-default-off` CI job asserts against main.
+# There is no auto-connect and no outbound connection in any default path even
+# when this is ON; an operator must supply a room id and connect explicitly.
+option(RSBS_NETPLAY "Build the netplay grant relay client (experimental, ADR 0007)" OFF)
+
 # Always enable position-independent code - required for shared library builds
 # This repo is specifically for the unified combo project (shared libraries only)
 # For standalone executables, use upstream SoH/2Ship repos instead

--- a/docs/adr/0005-sourced-grant-cursors.md
+++ b/docs/adr/0005-sourced-grant-cursors.md
@@ -88,8 +88,21 @@ source; it is a bug surfaced early.
 
 `RSBS_GRANT_SOURCE_CAP` is 8: an AP server is *one* source regardless of room
 size, P2P co-op is one per peer. Exhaustion is explicit
-(`RSBS_GRANT_NO_SOURCE_SLOT`), never silent. Growing the table later is a
-legal reserved[] carve.
+(`RSBS_GRANT_NO_SOURCE_SLOT`), never silent.
+
+More cursor capacity later is reachable, but **not by bumping
+`RSBS_GRANT_SOURCE_CAP`**. `sharedItemOverflowCount` sits immediately after
+`grantCursors` at offset 736 — a shipped offset the moment this lands — so
+widening the array in place shifts it (and every field carved after it) and
+silently reinterprets every existing `.redsave`. That is a format break, not a
+carve. The legal move is to carve a *second*, separate cursor block from the
+front of the remaining `reserved[]` and have the lookup consult both; each
+appended block keeps zero == unset and leaves prior offsets fixed. The
+static-assert chain pins `sharedItemOverflowCount` relative to
+`RSBS_GRANT_SOURCE_CAP`, so it will follow a bump rather than break the
+build — the assert proves contiguity, it cannot prove the bytes did not move.
+This is the one place the growth contract is easy to violate while appearing
+to honor it.
 
 ### 2. The two producer classes never share an idempotency domain
 

--- a/docs/adr/0005-sourced-grant-cursors.md
+++ b/docs/adr/0005-sourced-grant-cursors.md
@@ -1,0 +1,292 @@
+# ADR 0005: Sourced item grants are idempotent by per-source cursor, not by content
+
+- Status: **Accepted** (2026-07-21)
+- For: #460 (netplay increment 1a), building on the spike merged in #444
+  (`docs/netplay-increment-1-spike.md`)
+- Depends on: ADR 0002 (origin-tagged `SharedItem`, the ComboContext growth
+  contract), Lane A1's stage/record/redeem machinery (#419/#420), Lane C1's
+  give path (#428)
+- Composes with (does **not** fix): #440 (cross-game state invalidation on
+  reset/new game)
+
+This is the contract the 1b transport work builds against. The seam is
+`Combo_SubmitSourcedGrant` and friends in `src/common/shared_items.h`; nothing
+in this ADR opens a socket, declares `BUILD_REMOTE_CONTROL`, or picks a
+transport.
+
+## Context
+
+The `SharedItem` grant machinery (ADR 0002, Lane A1) is correct today only
+because every producer is in-process. The netplay spike (#444 §3) identified
+four gaps that any remote grant hits on arrival:
+
+1. `Combo_RecordSharedItem` de-dups by content — an un-redeemed
+   `(originGame, id)` match merges. Right for a re-fired in-process producer;
+   for a network feed it collapses two peers' identical gifts into one item,
+   and makes a retransmit indistinguishable from a genuine second gift.
+2. `SharedItem` is 4 bytes with size and member offsets static-asserted as
+   `.redsave` format. There is no room for a grant/sequence id in the entry.
+3. Redemption fires only at the presence-gated switch-arrival points. A grant
+   for the game you are already in waits for a switch that may never come.
+4. The 64-slot array drops on overflow with only a `stderr` line — silent loss
+   of a peer's gift — and, because entries were never cleared, 64 was a
+   lifetime cap per save, not a working-set cap.
+
+Constraints: the ADR 0002 growth contract is absolute (carve from
+`reserved[]`, append-only, zero == unset, offsets pinned by static_assert,
+dual C/C++ views, no untagged cross-game ids); existing `.redsave` files must
+keep loading; everything must be lockable ROM-free in the `redship` CTest
+tier.
+
+## Decision
+
+### 1. Grant identity is a per-source monotonic cursor, persisted in gComboCtx
+
+A **source** is a producer with its own identity and its own delivery stream —
+a network peer, an Archipelago server, a loopback test feed. Each source
+numbers its grants with a dense, 1-based sequence. The save persists one
+cursor per source:
+
+```c
+typedef struct {
+    uint32_t sourceKey; // transport-assigned nonzero source identity; 0 = empty slot
+    uint32_t lastSeq;   // highest accepted sequence number from this source; 0 = none
+} ComboGrantSourceCursor;
+// gComboCtx.grantCursors[RSBS_GRANT_SOURCE_CAP /* 8 */]
+```
+
+`Combo_SubmitSourcedGrant(sourceKey, seq, originGame, id)` accepts **strictly
+in order**: `seq == lastSeq + 1` records the item and advances the cursor;
+`seq <= lastSeq` is `RSBS_GRANT_DUPLICATE` (a retransmit — dropped,
+idempotent success); `seq > lastSeq + 1` is `RSBS_GRANT_GAP` (predecessors
+missing — the source must resend in order; nothing moves). Every non-accepted
+outcome leaves `gComboCtx` untouched.
+
+This makes retransmit-vs-second-gift decidable without widening `SharedItem`:
+identity lives in the *stream position*, not in the entry. Two peers gifting
+the same item are two sources with independent cursors — two accepts, two
+entries. One peer resending is the same `(sourceKey, seq)` — one accept, ever,
+across save/load, because the cursor rides the `.redsave`.
+
+**Why a cursor and not a per-entry grantId:** (a) the `SharedItem` layout is
+pinned format with no spare field, and a parallel seen-`grantId` set is
+unbounded state that would itself need serializing; (b) a cursor is O(1)
+durable state per source and one comparison per submit; (c) it hosts an
+**externally owned cursor directly** — Archipelago's `ReceivedItems` is
+server-authoritative with a monotonic `index`; an AP transport maps index `i`
+to `seq i + 1`, hands `Combo_GetGrantCursor(key)` to `Sync` as its resume
+point, and the spike's resync trap (a full re-delivery being silently eaten by
+content de-dup) becomes the *designed* path: the already-seen prefix returns
+`DUPLICATE` by cursor, the novel tail records. A grantId-set design cannot
+host a foreign cursor; this one is a superset of it.
+
+Strict in-order acceptance is deliberate: it is what makes received order
+well-defined (§4), turns message loss into a visible `GAP` instead of silent
+reordering, and matches both planned source shapes (AP's index is dense;
+a P2P feed numbers per-sender). A source that cannot replay in order is not a
+source; it is a bug surfaced early.
+
+`RSBS_GRANT_SOURCE_CAP` is 8: an AP server is *one* source regardless of room
+size, P2P co-op is one per peer. Exhaustion is explicit
+(`RSBS_GRANT_NO_SOURCE_SLOT`), never silent. Growing the table later is a
+legal reserved[] carve.
+
+### 2. The two producer classes never share an idempotency domain
+
+- **In-process producers** (Lane C1's give path, the staged/commit path) keep
+  `Combo_RecordSharedItem` and its content de-dup unchanged — a re-fired local
+  event is the same event.
+- **Sourced producers** go through `Combo_SubmitSourcedGrant` only, which
+  appends **without** content de-dup.
+
+Entries recorded by the sourced path carry a new flag bit,
+`RSBS_SHARED_ITEM_SOURCED` (0x02), and content de-dup **skips** flagged
+entries. Without this, a peer's pending gift of item X would swallow a genuine
+local pickup of X (the merge would eat the local event). Zero == unset holds:
+every legacy entry was in-process, which is exactly what a zero bit says.
+
+### 3. Overflow: reclaim redeemed entries; refuse loudly; backpressure sources
+
+When the array is full, recording first **reclaims the oldest REDEEMED
+entry**: the array compacts (preserving relative order — occupied entries
+always form a prefix, so slot order stays acceptance order) and the freed tail
+slot takes the new record. A redeemed entry is an informational record of a
+completed crossing; an un-redeemed entry is an undelivered item. Only the
+former is evictable; the latter is **never dropped**.
+
+> **Amendment to A1's contract:** shared_items' previous "entries are never
+> cleared; they remain as the durable record of the crossing" weakens to
+> "…until capacity pressure reclaims redeemed entries, oldest first". Nothing
+> in the tree reads redeemed entries as a history (verified: consumers filter
+> them out; tests use them transiently), and single-use never depended on the
+> entry's continued presence — an evicted entry cannot re-award because
+> re-recording it requires a fresh producer event by definition. Slot indices
+> returned by record APIs are therefore transient; callers must not store
+> them (no caller does).
+
+If every entry is un-redeemed, the record is **refused loudly**:
+
+- `gComboCtx.sharedItemOverflowCount` (new, serialized, zero == unset)
+  increments — a durable, tracker-surfaceable signal that capacity refused
+  work; it survives save/load and resets only with the world.
+- For a **sourced** grant the refusal is `RSBS_GRANT_RETRY_FULL` and the
+  cursor does **not** advance: the grant remains owed by the source, and its
+  later retransmit of the same seq is *accepted*, not treated as a duplicate.
+  Backpressure, not loss.
+- For an **in-process** record the refusal (return -1) *is* a lost item — the
+  pickup already happened in-game. The counter is what makes that loss
+  diagnosable instead of a `stderr` line nobody sees. With reclamation, this
+  requires 64 simultaneously *undelivered* items, which the working set can
+  no longer reach by mere accumulation.
+
+This is the honest middle the increment asked for: the game never blocks, no
+peer's gift is silently lost (sourced grants are retried by contract), and the
+one genuinely lossy corner (in-process producer against a fully-undelivered
+array) is durable-signaled and CI-locked.
+
+### 4. Redemption safe points — "next switch only" generalizes to "next safe point"
+
+`Combo_RedeemSharedItemsForGame` is the **single** redemption entry and is
+safe wherever all of the following hold for the target game: it is the active
+game, on the game thread; a save is loaded and normal gameplay has been
+reached (so the award callback's give machinery is valid); the caller passes
+that game's real award callback. `RSBS_SHARED_ITEM_REDEEMED` makes redemption
+idempotent under any interleaving of safe points, and awards fire in slot
+order == acceptance order (**received-order redemption is a contract**: the
+give paths resolve progressives against the live save, so order changes what
+the player gets; reclamation preserves it).
+
+Safe points, precisely:
+
+1. The two presence-gated startup-entrance consumption points
+   (`OoT_ConsumeSharedItems`, `MM_ConsumeSharedItems`) — wired today,
+   unchanged.
+2. A gameplay-gated frame tick (`OnGameFrameUpdate`-class, gated on "save
+   loaded and in normal gameplay") — **defined here, wired by 1b** together
+   with the first producer that can target the active game mid-session.
+   Deliberately not wired now: every in-process producer records for the game
+   being *left*, so today a tick would have nothing to redeem, and its gate
+   ("normal gameplay") is game-side state that only an in-game path exercises
+   — dead code with ROM-only risk. The model side — that redemption needs no
+   switch machinery whatsoever — is what this increment locks in CI.
+
+Plain-load semantics are unchanged for everything wired today and the header
+now states the general rule: un-redeemed entries persist and are awarded at
+the next safe point. Redeem-at-load remains forbidden for the same reason as
+before — the give machinery is not yet valid.
+
+### 5. Save-format delta rides the ADR 0002 growth contract; no version bump
+
+Carved from the FRONT of `reserved[332]`, which shrinks to `reserved[264]`:
+
+| Field | Offset | Size |
+|---|---|---|
+| `grantCursors[8]` | 672 | 64 |
+| `sharedItemOverflowCount` | 736 | 4 |
+
+Offsets pinned by the `context.h` static-assert chain (contiguous with
+`foreignPlacements`); zero == unset for every member ("no source has ever
+delivered; no refusal has ever happened" — exactly what a zero-extended
+pre-netplay record must mean). `sizeof(ComboContext)` stays 1004 ≤ the fixed
+1024-byte Tier-1 record, so `RSBS_SAVE_VERSION` stays 2 and
+`COMBO_CONTEXT_VERSION` stays 1 (nothing old needs distinguishing, only
+extending). Migration is locked by a crafted pre-carve record test in the
+`test_save_roundtrip.c` style (`Test_GrantPersistence` part b).
+
+### 6. Composition with #440 (not a fix for it)
+
+Cursors live in the same Tier-1 record as the item array **on purpose**:
+`ComboContext_Init` — the invalidation primitive #440's fix will invoke on
+reset/new-game — retires items, cursors, and the overflow count in one memset.
+That atomicity is load-bearing in both directions: a surviving cursor without
+its items would refuse re-delivery into the world that lost them
+(`DUPLICATE`); surviving items without their cursor would re-accept a dead
+room's stream. After invalidation, a dead-room retransmit is a `GAP` (new
+sources must start at seq 1), never a silent acceptance — locked in
+`Test_GrantPersistence` part c. #440 itself (making reset/new-game actually
+*call* the invalidation) stays with its own fix; when it lands, remotely
+sourced grants are covered by the same call this ADR's tests already pin.
+
+### 7. The seam a transport writes against
+
+```c
+ComboGrantResult Combo_SubmitSourcedGrant(uint32_t sourceKey, uint32_t seq,
+                                          GameId originGame, uint16_t id);
+uint32_t Combo_GetGrantCursor(uint32_t sourceKey); // resume point: deliver from cursor+1
+int      Combo_CountGrantSources(void);
+uint32_t Combo_GetSharedItemOverflowCount(void);
+```
+
+Contract highlights for 1b:
+
+- **Game thread only.** A transport receiving off-thread marshals to the game
+  thread before submitting. (The vendored Anchor client's
+  network-thread-mutation hazard — spike §6 — must not be reproduced against
+  this seam.)
+- `sourceKey` is a nonzero identity *within the current world/session*; the
+  transport derives it (e.g. hash of room id + peer slot; an AP server is one
+  source). Cross-session collisions are handled by invalidation (§6), not by
+  key hygiene.
+- `seq` is dense and 1-based per source. On reconnect or after a `.redsave`
+  load, resume from `Combo_GetGrantCursor(key) + 1`; on `GAP`, resync/resend
+  in order; on `RETRY_FULL`, re-offer later — delivery is the source's
+  obligation until `ACCEPTED` or `DUPLICATE`.
+- Delivery of a grant to the *player* still happens via
+  `Combo_RedeemSharedItemsForGame` at a safe point (§4); the transport never
+  awards anything itself.
+
+## Rationale
+
+1. **Idempotency must be decidable at the API, not probable at the wire.**
+   Retransmits are a fact of any transport; second gifts are a fact of
+   multiworld. Any design that cannot tell them apart locally is wrong under
+   exactly the load netplay creates.
+2. **Own as little identity as possible.** The cursor stores one u32 per
+   source and no per-grant identity, which is why an external
+   server-authoritative cursor (AP) can *be* the identity. Designs that stamp
+   every entry force a mapping layer under every transport forever.
+3. **Losing data loudly beats both losing it silently and blocking.** The
+   durable counter + non-advancing cursor is the smallest mechanism where
+   every loss is either prevented (sourced) or signaled (in-process).
+4. **The wrong producer path should be structurally awkward.** Sourced
+   producers get their own entry point and their entries are flagged; content
+   de-dup cannot reach them even if someone routes wrongly later.
+
+## Consequences
+
+- `sizeof(ComboContext)` stays 1004; `reserved` headroom drops 332 → 264.
+- New CI locks (all ROM-free, registered as CTest rows): `GrantIdempotency`,
+  `GrantRedeemNoSwitch`, `GrantOverflow`, `GrantPersistence`.
+- `shared_items.h` is the seam's documentation of record; its file header now
+  defines the producer classes, safe points, capacity policy, and threading
+  rule stated here.
+- The spike's §8 loopback-pair row ("two in-process client objects over an
+  in-memory channel") becomes 1b's first test: it needs a transport object,
+  which is exactly the piece this ADR deliberately does not build. Everything
+  semantic beneath it is locked here.
+- A1's "never cleared" note is amended per §3; ADR 0002 is otherwise
+  untouched and its growth contract fully honored.
+
+## Alternatives considered
+
+- **Widen `SharedItem` with a grantId/sender/seq.** Rejected: the 4-byte
+  layout with pinned offsets is shipped `.redsave` format (ADR 0002); a
+  parallel wide array duplicates the store and still needs the cursor logic
+  for external sources.
+- **A persisted seen-`grantId` set.** Rejected: unbounded, needs its own
+  eviction policy (which reintroduces the duplicate window it exists to
+  close), and cannot host a server-authoritative cursor.
+- **RAM-only cursors.** Rejected: a save/reload re-opens the duplicate
+  window — the spike called this trap out explicitly for the AP resync case.
+- **Out-of-order acceptance (advance cursor past gaps, or track a bitmap).**
+  Rejected: silently reorders progressive-item resolution, turns message loss
+  into undetectable item loss (jump) or unbounded state (bitmap), and no
+  planned source needs it.
+- **Growing `RSBS_SHARED_ITEM_CAP` instead of reclaiming.** Rejected as the
+  *primary* fix: any fixed cap without reclamation is a lifetime cap per
+  save; reclamation makes the cap a working-set bound. Raising the cap later
+  remains a legal, compatible carve if the working set ever demands it.
+- **Wiring the redemption tick now.** Rejected for this increment: no
+  producer can target the active game yet, so the wiring would be untestable
+  dead code in the ROM-gated tier; the safe-point contract it must obey is
+  defined and locked instead.

--- a/src/common/context.cpp
+++ b/src/common/context.cpp
@@ -218,11 +218,16 @@ void ComboContext_Init(void) {
     gComboCtx.sourceIsRando = false;
     gComboCtx.sharedRandoSeed = 0;
     gComboCtx.sharedRandoSettingsHash = 0;  // Lane B (ADR 0002 §3): 0 == no profile recorded
-    // sharedItemsTagged and the remaining reserved[] headroom are covered by
-    // the memset above: all-zero IS the initialized state (every slot unset,
-    // originGame == GAME_NONE). That equivalence is load-bearing — it is what
-    // makes a zero-extended legacy .redsave record indistinguishable from a
-    // fresh init (ADR 0002 growth contract).
+    // sharedItemsTagged, foreignPlacements, grantCursors,
+    // sharedItemOverflowCount, and the remaining reserved[] headroom are
+    // covered by the memset above: all-zero IS the initialized state (every
+    // slot unset, originGame == GAME_NONE, no source has ever delivered).
+    // That equivalence is load-bearing — it is what makes a zero-extended
+    // legacy .redsave record indistinguishable from a fresh init (ADR 0002
+    // growth contract). It is ALSO the invalidation atomicity the sourced-
+    // grant model requires (ADR 0005 / #440): one memset retires items and
+    // their delivery cursors together, so a dead session can neither replay
+    // its grants nor block a fresh session's deliveries.
 }
 
 void ComboContext_RequestSwitch(GameId target, uint16_t entrance) {

--- a/src/common/context.h
+++ b/src/common/context.h
@@ -171,8 +171,16 @@ void Context_UpdateShadowCopy(GameId game, const void* saveContext, size_t size)
  * distinct GRANT SOURCES can hold a delivery cursor at once. A source is one
  * remote authority feeding Combo_SubmitSourcedGrant — an Archipelago server
  * counts as ONE source regardless of room size, and a P2P co-op session uses
- * one source per peer, so 8 is generous for every planned topology. Growing
- * later is legal under the growth contract (carve more of reserved[]).
+ * one source per peer, so 8 is generous for every planned topology.
+ *
+ * DO NOT BUMP THIS CONSTANT to get more capacity. sharedItemOverflowCount is
+ * carved immediately after grantCursors, so widening the array in place moves
+ * that field (and anything carved after it) off the offset every shipped
+ * .redsave stored it at — a format break that the static asserts below CANNOT
+ * catch, because they pin the offset relative to RSBS_GRANT_SOURCE_CAP and so
+ * simply follow the bump. To add capacity, carve a SECOND cursor block from
+ * the front of reserved[] and consult both in the lookup: append-only, prior
+ * offsets fixed, zero still unset. See ADR 0005 §1.
  */
 #define RSBS_GRANT_SOURCE_CAP 8u
 

--- a/src/common/context.h
+++ b/src/common/context.h
@@ -148,12 +148,33 @@ void Context_UpdateShadowCopy(GameId game, const void* saveContext, size_t size)
 #define RSBS_SHARED_ITEM_REDEEMED 0x01u
 
 /**
+ * SharedItem.flags bit: this entry was recorded by an identified SOURCE
+ * through Combo_SubmitSourcedGrant (ADR 0005), not by an in-process producer.
+ * The bit keeps the two producer classes' idempotency domains disjoint:
+ * Combo_RecordSharedItem's content de-dup skips sourced entries, so a local
+ * pickup can never be silently merged into (and lost against) a peer's gift
+ * of the same item. Zero == unset holds: every legacy entry was recorded
+ * in-process, which is exactly what a zero bit means.
+ */
+#define RSBS_SHARED_ITEM_SOURCED 0x02u
+
+/**
  * Capacity of ComboContext.foreignPlacements (Lane C1, #392). The MVP pins ~4
  * OoT progression items into MM checks; 8 slots leave headroom without
  * spending reserved[] bytes we would rather keep (growing later is legal under
  * the growth contract).
  */
 #define RSBS_FOREIGN_PLACEMENT_CAP 8u
+
+/**
+ * Capacity of ComboContext.grantCursors (ADR 0005, netplay 1a #460): how many
+ * distinct GRANT SOURCES can hold a delivery cursor at once. A source is one
+ * remote authority feeding Combo_SubmitSourcedGrant — an Archipelago server
+ * counts as ONE source regardless of room size, and a P2P co-op session uses
+ * one source per peer, so 8 is generous for every planned topology. Growing
+ * later is legal under the growth contract (carve more of reserved[]).
+ */
+#define RSBS_GRANT_SOURCE_CAP 8u
 
 /**
  * One cross-game item, tagged with the game whose id-space `id` belongs to.
@@ -211,6 +232,36 @@ RSBS_CTX_STATIC_ASSERT(sizeof(ComboForeignPlacement) == 6,
                        "format");
 RSBS_CTX_STATIC_ASSERT(offsetof(ComboForeignPlacement, mmCheckId) == 0 && offsetof(ComboForeignPlacement, item) == 2,
                        "ComboForeignPlacement member offsets are .redsave format and must not move");
+
+/**
+ * One grant source's delivery cursor (ADR 0005, netplay 1a #460).
+ *
+ * A SOURCE is a producer of item grants with its own identity and its own
+ * monotonic sequence numbering — an in-process cross-game hand-off is NOT a
+ * source (it keeps using Combo_RecordSharedItem's content de-dup); a network
+ * peer or an Archipelago server is. `lastSeq` is the highest sequence number
+ * this save has ACCEPTED from the source: a retransmitted grant (seq <=
+ * lastSeq) is decidably a duplicate, a fresh grant (seq == lastSeq + 1) is
+ * decidably new — even when both carry the same (originGame, id). Persisting
+ * the cursor in the .redsave is what keeps that decision correct across a
+ * save/load: a reload can never re-open a duplicate-delivery window.
+ *
+ * Zero means unset for every member (growth contract): a slot is occupied iff
+ * sourceKey != 0, and an occupied slot always has lastSeq >= 1 (a cursor is
+ * only created by accepting seq 1). A zero-extended legacy record therefore
+ * reads as "no sources have ever delivered", which is correct.
+ */
+typedef struct {
+    uint32_t sourceKey; // transport-assigned nonzero source identity; 0 = empty slot
+    uint32_t lastSeq;   // highest accepted sequence number from this source; 0 = none
+} ComboGrantSourceCursor;
+
+RSBS_CTX_STATIC_ASSERT(sizeof(ComboGrantSourceCursor) == 8,
+                       "ComboGrantSourceCursor is serialized raw inside the .redsave Tier-1 record; its layout is "
+                       "format");
+RSBS_CTX_STATIC_ASSERT(offsetof(ComboGrantSourceCursor, sourceKey) == 0 &&
+                           offsetof(ComboGrantSourceCursor, lastSeq) == 4,
+                       "ComboGrantSourceCursor member offsets are .redsave format and must not move");
 
 typedef struct {
     char magic[8];        // "OoT+MM<3"
@@ -275,14 +326,34 @@ typedef struct {
     // the accessors; raw entries must always carry the origin tag (ADR 0002).
     ComboForeignPlacement foreignPlacements[RSBS_FOREIGN_PLACEMENT_CAP];
 
+    // Netplay 1a (ADR 0005, #460): per-source grant-delivery cursors, written
+    // by Combo_SubmitSourcedGrant when it accepts a grant, read to decide
+    // retransmit-vs-new. Carved from the FRONT of the old reserved[332] under
+    // the growth contract: all-zero = no sources have ever delivered, which is
+    // exactly what a zero-extended pre-netplay record must read as. Lives in
+    // the SAME Tier-1 record as sharedItemsTagged on purpose: the array and
+    // the cursors must be saved, loaded, and invalidated (#440) atomically —
+    // a cursor without its items refuses re-delivery of lost grants, items
+    // without their cursor re-accept duplicates.
+    ComboGrantSourceCursor grantCursors[RSBS_GRANT_SOURCE_CAP];
+
+    // Netplay 1a (ADR 0005, #460): durable count of shared-item records
+    // REFUSED for capacity (array full even after reclaiming redeemed slots).
+    // The anti-silent-loss signal: for the in-process producer a refusal is a
+    // genuinely lost item; for a sourced grant it marks backpressure (the
+    // grant stays owed by the source because its cursor did not advance).
+    // Zero == unset (no refusal has ever happened), per the growth contract.
+    uint32_t sharedItemOverflowCount;
+
     // Headroom. Carve new fields from the FRONT of this array (as
-    // sharedItemsTagged, sharedRandoSettingsHash, and foreignPlacements were)
-    // so the struct stays inside RSBS_COMBO_CONTEXT_RECORD_SIZE; the on-disk
-    // record size does not change either way, so old saves keep loading.
-    // Zeroed by ComboContext_Init, which is what makes a zero-extended legacy
-    // record indistinguishable from a freshly-initialized one — every field
-    // carved from here must keep "zero means unset".
-    uint8_t reserved[332];
+    // sharedItemsTagged, sharedRandoSettingsHash, foreignPlacements, and the
+    // grant cursors were) so the struct stays inside
+    // RSBS_COMBO_CONTEXT_RECORD_SIZE; the on-disk record size does not change
+    // either way, so old saves keep loading. Zeroed by ComboContext_Init,
+    // which is what makes a zero-extended legacy record indistinguishable from
+    // a freshly-initialized one — every field carved from here must keep
+    // "zero means unset".
+    uint8_t reserved[264];
 } ComboContext;
 
 /**
@@ -327,13 +398,25 @@ RSBS_CTX_STATIC_ASSERT(offsetof(ComboContext, foreignPlacements) ==
                                sizeof(uint32_t),
                        "foreignPlacements must be carved from the FRONT of the old reserved[] "
                        "(contiguous with the settings digest); moving it changes .redsave format");
-RSBS_CTX_STATIC_ASSERT(offsetof(ComboContext, reserved) ==
+// grantCursors is the next carve from the front of the old reserved[]: it must
+// sit immediately after the foreign-placement table with no gap, occupying
+// bytes every shipped .redsave stored as zero (unset).
+RSBS_CTX_STATIC_ASSERT(offsetof(ComboContext, grantCursors) ==
                            RSBS_COMBO_CONTEXT_PRECARVE_SIZE + RSBS_SHARED_ITEM_CAP * sizeof(SharedItem) +
                                sizeof(uint32_t) +
                                RSBS_FOREIGN_PLACEMENT_CAP * sizeof(ComboForeignPlacement),
-                       "the tagged-item array, the settings digest, the foreign-placement table, and "
-                       "the remaining headroom must stay contiguous (no padding, no fields slipped "
-                       "between them)");
+                       "grantCursors must be carved from the FRONT of the old reserved[] (contiguous "
+                       "with the foreign-placement table); moving it changes .redsave format");
+RSBS_CTX_STATIC_ASSERT(offsetof(ComboContext, sharedItemOverflowCount) ==
+                           offsetof(ComboContext, grantCursors) +
+                               RSBS_GRANT_SOURCE_CAP * sizeof(ComboGrantSourceCursor),
+                       "sharedItemOverflowCount must sit immediately after the grant cursors; moving "
+                       "it changes .redsave format");
+RSBS_CTX_STATIC_ASSERT(offsetof(ComboContext, reserved) ==
+                           offsetof(ComboContext, sharedItemOverflowCount) + sizeof(uint32_t),
+                       "the tagged-item array, the settings digest, the foreign-placement table, the "
+                       "grant cursors, the overflow count, and the remaining headroom must stay "
+                       "contiguous (no padding, no fields slipped between them)");
 
 #ifdef __cplusplus
 // The raw-assignment-fails proof (ADR 0002). In C this is a constraint

--- a/src/common/netplay/relay_client.c
+++ b/src/common/netplay/relay_client.c
@@ -1,0 +1,450 @@
+/**
+ * @file relay_client.c
+ * @brief Grant-relay client implementation (ADR 0007).
+ *
+ * The whole file runs on the game thread. There is no thread here to get
+ * wrong — that is salvage item 1 (ADR 0006 §5) discharged by construction.
+ */
+
+#include "relay_client.h"
+
+#include <stdio.h>
+#include <string.h>
+
+#include "../shared_items.h" // Combo_SubmitSourcedGrant, ComboGrantResult
+
+// ============================================================================
+// Room fingerprint
+// ============================================================================
+
+uint32_t Relay_SourceKeyForRoom(const uint8_t roomUuid[RSBS_RELAY_UUID_LEN]) {
+    // FNV-1a 32. Forced nonzero because ADR 0005 reserves 0 for "empty slot".
+    uint32_t h = 2166136261u;
+    for (uint32_t i = 0; i < RSBS_RELAY_UUID_LEN; ++i) {
+        h ^= (uint32_t)roomUuid[i];
+        h *= 16777619u;
+    }
+    return h == 0u ? 1u : h;
+}
+
+// ============================================================================
+// Lifecycle
+// ============================================================================
+
+void Relay_Init(RelayClient* c, const uint8_t roomUuid[RSBS_RELAY_UUID_LEN], uint8_t localSlot, uint32_t settingsHash) {
+    if (c == NULL) {
+        return;
+    }
+    memset(c, 0, sizeof(*c));
+    if (roomUuid != NULL) {
+        memcpy(c->roomUuid, roomUuid, RSBS_RELAY_UUID_LEN);
+    }
+    c->sourceKey = Relay_SourceKeyForRoom(c->roomUuid);
+    c->localSlot = localSlot;
+    c->settingsHash = settingsHash;
+    c->state = RSBS_RELAY_STATE_IDLE;
+    c->nextSeq = 1u; // ADR 0005: a new source must start at seq 1
+    c->sendSeq = 0u;
+}
+
+/**
+ * Send from `data + *offset` onward, advancing *offset by whatever the channel
+ * accepted. Returns true only when the whole buffer is out.
+ *
+ * The caller-owned offset is the point: a real socket can accept a PREFIX and
+ * then block. Restarting from zero on the next attempt would put those bytes
+ * on the wire twice and desynchronise the server's length-prefixed parser —
+ * a corruption bug that a never-blocking loopback mock would never surface.
+ */
+static bool ChannelSendFrom(RelayClient* c, const uint8_t* data, uint32_t len, uint32_t* offset) {
+    while (*offset < len) {
+        const int n = c->channel.send(c->channel.userData, data + *offset, len - *offset);
+        if (n < 0) {
+            c->state = RSBS_RELAY_STATE_FAILED;
+            return false;
+        }
+        if (n == 0) {
+            return false; // would block; resume from *offset next tick
+        }
+        *offset += (uint32_t)n;
+    }
+    return true;
+}
+
+bool Relay_Connect(RelayClient* c, const RelayChannel* channel) {
+    if (c == NULL || channel == NULL || channel->send == NULL || channel->recv == NULL) {
+        return false;
+    }
+    c->channel = *channel;
+    c->channelSet = true;
+
+    uint8_t hello[RSBS_RELAY_HELLO_LEN];
+    RelayProto_EncodeHello(hello);
+    uint32_t off = 0;
+    if (!ChannelSendFrom(c, hello, RSBS_RELAY_HELLO_LEN, &off)) {
+        return false;
+    }
+    c->state = RSBS_RELAY_STATE_HELLO;
+    return true;
+}
+
+// ============================================================================
+// Inbox (bounded, recoverable drop — salvage item 2)
+// ============================================================================
+
+static void InboxPush(RelayClient* c, const RsbsGrantPayload* g) {
+    if (c->inboxCount >= RSBS_RELAY_INBOX_CAP) {
+        // Drop WITHOUT advancing the grant cursor and flag a replay. Bounded
+        // memory costs latency, never items: the dropped grant is re-derived
+        // by the next replay-from-zero (ADR 0007 §3.3).
+        c->statInboxDropped++;
+        c->replayNeeded = true;
+        return;
+    }
+    const uint32_t slot = (c->inboxHead + c->inboxCount) % RSBS_RELAY_INBOX_CAP;
+    c->inbox[slot] = *g;
+    c->inboxCount++;
+}
+
+static bool InboxPeek(const RelayClient* c, RsbsGrantPayload* out) {
+    if (c->inboxCount == 0) {
+        return false;
+    }
+    *out = c->inbox[c->inboxHead];
+    return true;
+}
+
+static void InboxPop(RelayClient* c) {
+    if (c->inboxCount == 0) {
+        return;
+    }
+    c->inboxHead = (c->inboxHead + 1u) % RSBS_RELAY_INBOX_CAP;
+    c->inboxCount--;
+}
+
+// ============================================================================
+// Frame handling
+// ============================================================================
+
+static void HandleEntry(RelayClient* c, const RelayLedgerEntry* entry) {
+    c->statEntriesSeen++;
+
+    RsbsGrantPayload g;
+    if (!RelayProto_DecodeGrant(entry->payload, entry->payloadLen, &g)) {
+        // Foreign or malformed: skip and count, never fatal (ADR 0007 §4.3).
+        // The server's own length prefix already kept us framed.
+        c->statForeignSkipped++;
+        return;
+    }
+
+    // Self-echo and other players' grants. The real server fans OP_TRANSFER out
+    // to EVERY client on the ledger INCLUDING the sender (client.c
+    // multiClientCmdTransfer does not skip client->id — unlike the chat path,
+    // which does), so our own gifts come straight back to us and MUST be
+    // filtered here.
+    if (g.targetSlot != c->localSlot) {
+        c->statNotForUs++;
+        return;
+    }
+
+    // Advisory only — the server does not read settingsHash and a peer that
+    // wants to lie about it can (ADR 0007 §5.3). Warn once; never enforce.
+    if (!c->settingsMismatchSeen && c->settingsHash != 0u && g.settingsHash != 0u &&
+        g.settingsHash != c->settingsHash) {
+        c->settingsMismatchSeen = true;
+        fprintf(stderr, "[relay] warning: peer slot %u reports a different settings hash "
+                        "(%08x vs %08x) — you may be on different seeds\n",
+                (unsigned)g.senderSlot, (unsigned)g.settingsHash, (unsigned)c->settingsHash);
+    }
+
+    InboxPush(c, &g);
+}
+
+static bool PumpReceive(RelayClient* c) {
+    // Drain whatever the channel has, into the accumulation buffer.
+    for (;;) {
+        if (c->rxLen >= RSBS_RELAY_RX_CAP) {
+            break; // full; decode below will drain it
+        }
+        const int n = c->channel.recv(c->channel.userData, c->rx + c->rxLen, RSBS_RELAY_RX_CAP - c->rxLen);
+        if (n < 0) {
+            c->state = RSBS_RELAY_STATE_FAILED;
+            return false;
+        }
+        if (n == 0) {
+            break;
+        }
+        c->rxLen += (uint32_t)n;
+    }
+    return true;
+}
+
+static void ConsumeRx(RelayClient* c, uint32_t n) {
+    if (n == 0) {
+        return;
+    }
+    if (n >= c->rxLen) {
+        c->rxLen = 0;
+        return;
+    }
+    memmove(c->rx, c->rx + n, c->rxLen - n);
+    c->rxLen -= n;
+}
+
+static void ProcessHandshake(RelayClient* c) {
+    if (c->state == RSBS_RELAY_STATE_HELLO) {
+        if (c->rxLen < RSBS_RELAY_SVHELLO_LEN) {
+            return;
+        }
+        if (memcmp(c->rx, RSBS_RELAY_MAGIC, RSBS_RELAY_MAGIC_LEN) != 0) {
+            fprintf(stderr, "[relay] server hello has bad magic; refusing\n");
+            c->state = RSBS_RELAY_STATE_FAILED;
+            return;
+        }
+        uint32_t serverVersion = 0;
+        for (int i = 3; i >= 0; --i) {
+            serverVersion = (serverVersion << 8) | (uint32_t)c->rx[RSBS_RELAY_MAGIC_LEN + i];
+        }
+        // Refuse rather than proceed hopefully into a misparse (ADR 0007 §3.4).
+        if (RSBS_RELAY_VERSION_MAJOR(serverVersion) != RSBS_RELAY_VERSION_MAJOR(RSBS_RELAY_PROTOCOL_VERSION)) {
+            fprintf(stderr, "[relay] server protocol %08x is incompatible with ours %08x; refusing\n",
+                    (unsigned)serverVersion, (unsigned)RSBS_RELAY_PROTOCOL_VERSION);
+            c->state = RSBS_RELAY_STATE_FAILED;
+            return;
+        }
+        c->serverClientId = (uint16_t)((uint16_t)c->rx[9] | ((uint16_t)c->rx[10] << 8));
+        ConsumeRx(c, RSBS_RELAY_SVHELLO_LEN);
+        // Move to JOINING rather than sending the join inline. If the send
+        // blocks we must be able to resume it on a later tick — and by then the
+        // server hello is already consumed, so a state that means "hello done,
+        // join still owed" is the only thing that keeps the join from being
+        // dropped on the floor.
+        c->state = RSBS_RELAY_STATE_JOINING;
+        c->joinSent = 0;
+    }
+
+    if (c->state == RSBS_RELAY_STATE_JOINING) {
+        // Join at base 0, always (ADR 0007 §3.3): the grant cursor de-dups the
+        // already-delivered prefix, so we never persist a second cursor.
+        uint8_t join[RSBS_RELAY_JOIN_LEN];
+        RelayProto_EncodeJoin(c->roomUuid, 0u, join);
+        if (!ChannelSendFrom(c, join, RSBS_RELAY_JOIN_LEN, &c->joinSent)) {
+            return; // partial or blocked; resumes from c->joinSent next tick
+        }
+        // The server sends no join acknowledgement — it simply begins streaming
+        // ledger entries — so there is nothing further to await.
+        c->state = RSBS_RELAY_STATE_READY;
+    }
+}
+
+static void ProcessFrames(RelayClient* c) {
+    for (;;) {
+        uint32_t consumed = 0;
+        RelayLedgerEntry entry;
+        const RelayDecodeStatus st = RelayProto_DecodeFrame(c->rx, c->rxLen, &consumed, &entry);
+        if (st == RSBS_RELAY_DECODE_NEED_MORE) {
+            return;
+        }
+        if (st == RSBS_RELAY_DECODE_ERROR) {
+            fprintf(stderr, "[relay] undecodable frame; closing\n");
+            c->state = RSBS_RELAY_STATE_FAILED;
+            return;
+        }
+        if (st == RSBS_RELAY_DECODE_ENTRY) {
+            HandleEntry(c, &entry);
+        }
+        // NOP and MSG are consumed and ignored.
+        ConsumeRx(c, consumed);
+    }
+}
+
+static void PumpSend(RelayClient* c) {
+    while (c->outboxCount > 0) {
+        const uint32_t slot = c->outboxHead;
+        if (!ChannelSendFrom(c, c->outbox[slot], c->outboxLen[slot], &c->outboxSent)) {
+            return; // partial or blocked; resumes from c->outboxSent next tick
+        }
+        c->outboxHead = (c->outboxHead + 1u) % RSBS_RELAY_OUTBOX_CAP;
+        c->outboxCount--;
+        c->outboxSent = 0; // next frame starts from its own beginning
+    }
+}
+
+// ============================================================================
+// Applying to the ADR 0005 seam
+// ============================================================================
+
+static int ApplyInbox(RelayClient* c) {
+    int accepted = 0;
+
+    while (c->inboxCount > 0) {
+        RsbsGrantPayload g;
+        if (!InboxPeek(c, &g)) {
+            break;
+        }
+
+        const ComboGrantResult r =
+            Combo_SubmitSourcedGrant(c->sourceKey, c->nextSeq, (GameId)g.originGame, g.itemId);
+
+        switch (r) {
+            case RSBS_GRANT_ACCEPTED:
+                c->statAccepted++;
+                c->nextSeq++;
+                accepted++;
+                InboxPop(c);
+                break;
+
+            case RSBS_GRANT_DUPLICATE:
+                // Already delivered in an earlier session/run — this is the
+                // designed outcome of the replay-from-zero catch-up, not an
+                // error. Advance past it.
+                c->statDuplicate++;
+                c->nextSeq++;
+                InboxPop(c);
+                break;
+
+            case RSBS_GRANT_RETRY_FULL:
+                // Backpressure, NOT loss (ADR 0005 §3): the cursor did not
+                // advance, so the grant is still owed. Leave it at the head of
+                // the inbox and stop — re-offering the same seq later is
+                // accepted rather than deduped. Advancing past this is the one
+                // way to actually lose an item.
+                c->statRetryFull++;
+                c->replayNeeded = true;
+                return accepted;
+
+            case RSBS_GRANT_GAP:
+                // Should be unreachable: we assign nextSeq densely ourselves.
+                // If it happens, the local model and our counter disagree, and
+                // guessing would corrupt ordering. Stop and force a replay.
+                c->statGap++;
+                c->replayNeeded = true;
+                return accepted;
+
+            case RSBS_GRANT_NO_SOURCE_SLOT:
+                fprintf(stderr, "[relay] all %u grant-source slots are taken; cannot bind room\n",
+                        (unsigned)RSBS_GRANT_SOURCE_CAP);
+                c->state = RSBS_RELAY_STATE_FAILED;
+                return accepted;
+
+            case RSBS_GRANT_REJECTED:
+            default:
+                // Malformed at the seam though it passed our decode. Drop it
+                // rather than wedging the stream; it is one peer's bad grant.
+                fprintf(stderr, "[relay] seam rejected grant (game %u item %u); dropping\n",
+                        (unsigned)g.originGame, (unsigned)g.itemId);
+                InboxPop(c);
+                break;
+        }
+    }
+
+    return accepted;
+}
+
+// ============================================================================
+// Public pump
+// ============================================================================
+
+int Relay_Tick(RelayClient* c) {
+    if (c == NULL || !c->channelSet) {
+        return 0;
+    }
+    if (c->state == RSBS_RELAY_STATE_IDLE || c->state == RSBS_RELAY_STATE_FAILED) {
+        return 0;
+    }
+
+    if (!PumpReceive(c)) {
+        return 0;
+    }
+
+    ProcessHandshake(c);
+
+    if (c->state == RSBS_RELAY_STATE_READY) {
+        ProcessFrames(c);
+        PumpSend(c);
+    }
+
+    // The latch stops APPLYING only. Receiving, decoding and filing continue,
+    // so a suspended game does not stall the peer or lose ledger position
+    // (salvage item 3).
+    if (c->suspended) {
+        return 0;
+    }
+
+    return ApplyInbox(c);
+}
+
+bool Relay_SendGrant(RelayClient* c, uint8_t targetSlot, GameId originGame, uint16_t itemId) {
+    if (c == NULL || c->outboxCount >= RSBS_RELAY_OUTBOX_CAP) {
+        return false;
+    }
+    if (targetSlot == 0 || c->localSlot == 0) {
+        return false;
+    }
+
+    if (c->sendSeq == 0xFFFFu) {
+        fprintf(stderr, "[relay] outbound sequence exhausted; refusing to wrap\n");
+        return false;
+    }
+
+    RsbsGrantPayload g;
+    g.version = RSBS_GRANT_PAYLOAD_VERSION;
+    g.senderSlot = c->localSlot;
+    g.targetSlot = targetSlot;
+    g.originGame = (uint8_t)originGame;
+    g.itemId = itemId;
+    g.senderSeq = (uint16_t)(c->sendSeq + 1u);
+    g.settingsHash = c->settingsHash;
+
+    uint8_t payload[RSBS_GRANT_PAYLOAD_LEN];
+    if (!RelayProto_EncodeGrant(&g, payload)) {
+        return false;
+    }
+
+    const uint32_t slot = (c->outboxHead + c->outboxCount) % RSBS_RELAY_OUTBOX_CAP;
+    const uint32_t n =
+        RelayProto_EncodeTransfer(RelayProto_GrantKey(&g), payload, RSBS_GRANT_PAYLOAD_LEN, c->outbox[slot]);
+    if (n == 0) {
+        return false;
+    }
+    c->outboxLen[slot] = n;
+    c->outboxCount++;
+    c->sendSeq = g.senderSeq;
+    return true;
+}
+
+void Relay_OnSuspend(RelayClient* c) {
+    if (c != NULL) {
+        c->suspended = true;
+    }
+}
+
+void Relay_OnResume(RelayClient* c) {
+    if (c != NULL) {
+        c->suspended = false;
+    }
+}
+
+void Relay_ClearSessionState(RelayClient* c) {
+    if (c == NULL) {
+        return;
+    }
+    // Undelivered grants belong to the session that received them. Retiring
+    // them here — called FROM Context_InvalidateSessionState — keeps one list
+    // of "things a dead session owns" (#440 guidance on #460).
+    c->inboxHead = 0;
+    c->inboxCount = 0;
+    c->outboxHead = 0;
+    c->outboxCount = 0;
+    c->outboxSent = 0;
+    c->rxLen = 0;
+    // The cursor died with gComboCtx, so our dense counter restarts too;
+    // otherwise we would submit seq N+1 against a cursor of 0 and wedge on GAP.
+    c->nextSeq = 1u;
+    c->sendSeq = 0u;
+    c->replayNeeded = true;
+}
+
+bool Relay_ReplayNeeded(const RelayClient* c) {
+    return c != NULL && c->replayNeeded;
+}

--- a/src/common/netplay/relay_client.h
+++ b/src/common/netplay/relay_client.h
@@ -1,0 +1,201 @@
+/**
+ * @file relay_client.h
+ * @brief Grant-relay client: state machine, bounded inbox, suspend latch.
+ *        ADR 0007. No transport here — see RelayChannel.
+ *
+ * This object turns a byte stream into calls on ADR 0005's producer seam
+ * (`Combo_SubmitSourcedGrant`). It is the ONLY netplay path into the grant
+ * model; it opens no second route into `Combo_RecordSharedItem` (#460).
+ *
+ * ADR 0006 §5's salvage list is carried STRUCTURALLY, not as guidance — each
+ * item closes a verified hazard in the vendored Anchor client:
+ *
+ *   1. NO RECEIVE THREAD (Anchor hazards #1, #2). The socket is serviced only
+ *      inside Relay_Tick(), which the caller invokes on the game thread. There
+ *      is no background thread to marshal from, so ADR 0005's "game thread
+ *      only" seam contract holds by construction rather than by discipline.
+ *   2. BOUNDED INBOX WITH RECOVERABLE DROP (Anchor hazard #3). Fixed ring; on
+ *      overflow we drop WITHOUT advancing the grant cursor and set a replay
+ *      flag. Bounded memory, zero item loss — the dropped grant is re-derived
+ *      by the next §3.3 replay-from-zero.
+ *   3. EXPLICIT SUSPEND LATCH. Relay_OnSuspend() stops APPLYING; polling and
+ *      decoding continue into the inbox. Relay_OnResume() drains in received
+ *      order. The lifecycle has no implicit inverse, so the release is a
+ *      separate named action.
+ *   4. ROOM BINDING, refuse-on-mismatch — and it costs no new state, because
+ *      `sourceKey` IS the room fingerprint (ADR 0007 §4.5). A different room
+ *      derives a different key, hence a different ADR 0005 source slot, hence
+ *      a fresh seq 1. A cursor can never be applied against a room that did
+ *      not produce it.
+ *
+ * THREADING: game thread only, like the seam it feeds.
+ *
+ * SESSION SCOPE: the inbox is session-scoped RAM. Per the #440 guidance on
+ * #460, it is cleared FROM Context_InvalidateSessionState (via
+ * Relay_ClearSessionState) rather than at our own call sites, so there stays
+ * one list of "things a dead session owns".
+ */
+
+#ifndef RSBS_COMMON_NETPLAY_RELAY_CLIENT_H
+#define RSBS_COMMON_NETPLAY_RELAY_CLIENT_H
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#include "relay_protocol.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// Bounded inbox depth (salvage item 2). Sized well above a realistic burst:
+// the whole point is that exceeding it costs latency, never items.
+#define RSBS_RELAY_INBOX_CAP 64u
+
+// Receive accumulation buffer. Must exceed the largest single frame
+// (1 + 9 + 128 = 138) with room to hold a partial next frame.
+#define RSBS_RELAY_RX_CAP 1024u
+
+// Outbound staging depth for locally-produced grants awaiting a writable
+// channel.
+#define RSBS_RELAY_OUTBOX_CAP 32u
+
+/**
+ * Transport abstraction. The loopback harness and a real TCP socket implement
+ * the SAME interface, so the harness drives the identical codec and state
+ * machine a real peer would — only the syscall layer differs. That is the
+ * honest form of the loopback claim (ADR 0007 §8).
+ *
+ * Both callbacks are non-blocking:
+ *   > 0  bytes transferred
+ *   == 0 would block / nothing available
+ *   < 0  fatal channel error
+ */
+typedef struct {
+    int (*send)(void* userData, const uint8_t* data, uint32_t len);
+    int (*recv)(void* userData, uint8_t* data, uint32_t len);
+    void* userData;
+} RelayChannel;
+
+typedef enum {
+    RSBS_RELAY_STATE_IDLE = 0,   // never connected; no outbound anything
+    RSBS_RELAY_STATE_HELLO,      // hello sent, awaiting the 11-byte server hello
+    RSBS_RELAY_STATE_JOINING,    // join sent, awaiting ledger stream
+    RSBS_RELAY_STATE_READY,      // streaming
+    RSBS_RELAY_STATE_FAILED,     // terminal: version mismatch or channel error
+} RelayState;
+
+typedef struct {
+    RelayState state;
+
+    RelayChannel channel;
+    bool channelSet;
+
+    uint8_t roomUuid[RSBS_RELAY_UUID_LEN];
+    uint32_t sourceKey; // fnv1a32(roomUuid), forced nonzero — ADR 0007 §3.1
+    uint8_t localSlot;  // our slot; entries with targetSlot != this are skipped
+    uint32_t settingsHash;
+    uint16_t serverClientId;
+
+    // Receive accumulation.
+    uint8_t rx[RSBS_RELAY_RX_CAP];
+    uint32_t rxLen;
+
+    // Bounded inbox of grants addressed to us, in ledger order.
+    RsbsGrantPayload inbox[RSBS_RELAY_INBOX_CAP];
+    uint32_t inboxHead;
+    uint32_t inboxCount;
+
+    // Outbound staging.
+    uint8_t outbox[RSBS_RELAY_OUTBOX_CAP][RSBS_RELAY_MAX_PAYLOAD + 10u];
+    uint32_t outboxLen[RSBS_RELAY_OUTBOX_CAP];
+    uint32_t outboxHead;
+    uint32_t outboxCount;
+    // How much of the HEAD outbox frame has already reached the channel. A
+    // real socket can accept a prefix and then block; restarting from zero
+    // would put those bytes on the wire twice and desync the server's parser.
+    uint32_t outboxSent;
+    // Same idea for the 20-byte join, which is owed once the server hello has
+    // been consumed and so cannot simply be re-derived from the state alone.
+    uint32_t joinSent;
+
+    // The dense per-room seq we assign to entries addressed to us (§3.2). This
+    // is NOT the ledger index: we skip other players' entries, and a hole would
+    // be a permanent RSBS_GRANT_GAP.
+    uint32_t nextSeq;
+
+    // Our own outbound counter, dense and 1-based per ADR 0007 §2.
+    uint16_t sendSeq;
+
+    bool suspended;    // latch (salvage item 3)
+    bool replayNeeded; // inbox overflow or a RETRY_FULL: re-derive by rejoining
+
+    // Diagnostics — all operator-visible, none of it load-bearing.
+    uint32_t statEntriesSeen;
+    uint32_t statForeignSkipped;
+    uint32_t statNotForUs;
+    uint32_t statAccepted;
+    uint32_t statDuplicate;
+    uint32_t statGap;
+    uint32_t statRetryFull;
+    uint32_t statInboxDropped;
+    bool settingsMismatchSeen;
+} RelayClient;
+
+/**
+ * Derive the ADR 0005 sourceKey from a room UUID (FNV-1a 32, forced nonzero).
+ * Exposed because it IS the room-fingerprint binding (§4.5) and tests assert
+ * that different rooms cannot share a cursor.
+ */
+uint32_t Relay_SourceKeyForRoom(const uint8_t roomUuid[RSBS_RELAY_UUID_LEN]);
+
+/**
+ * Initialise. Does NOT connect and does NOT touch the channel: an operator
+ * action is always required (ADR 0007 §7 — no auto-connect, ever).
+ */
+void Relay_Init(RelayClient* c, const uint8_t roomUuid[RSBS_RELAY_UUID_LEN], uint8_t localSlot, uint32_t settingsHash);
+
+/**
+ * Attach a transport and begin the handshake. Sends the client hello and joins
+ * at ledgerBase 0 — always zero, per ADR 0007 §3.3: the grant cursor de-dups
+ * the already-delivered prefix, so we never persist a second cursor.
+ */
+bool Relay_Connect(RelayClient* c, const RelayChannel* channel);
+
+/**
+ * Pump the transport. Call once per frame on the GAME THREAD. Drains the
+ * socket, decodes frames, files grants addressed to us into the inbox, and —
+ * unless suspended — applies them to the ADR 0005 seam in received order.
+ *
+ * @return the number of grants ACCEPTED by the seam this call.
+ */
+int Relay_Tick(RelayClient* c);
+
+/**
+ * Queue a grant TO a peer. Local-side production: this does not touch our own
+ * grant model at all (we are giving, not receiving).
+ * @return true if staged for send.
+ */
+bool Relay_SendGrant(RelayClient* c, uint8_t targetSlot, GameId originGame, uint16_t itemId);
+
+/** Suspend latch (salvage item 3): stop applying; keep polling. */
+void Relay_OnSuspend(RelayClient* c);
+
+/** Release the latch and resume applying, in received order. */
+void Relay_OnResume(RelayClient* c);
+
+/**
+ * Retire session-scoped RAM. Called FROM Context_InvalidateSessionState so a
+ * dead session's undelivered grants cannot drain into the next session — the
+ * same treatment Combo_ClearSharedItemOutbox() gets (#440 guidance on #460).
+ */
+void Relay_ClearSessionState(RelayClient* c);
+
+/** True if the inbox overflowed or a grant was refused for capacity. */
+bool Relay_ReplayNeeded(const RelayClient* c);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // RSBS_COMMON_NETPLAY_RELAY_CLIENT_H

--- a/src/common/netplay/relay_protocol.c
+++ b/src/common/netplay/relay_protocol.c
@@ -1,0 +1,230 @@
+/**
+ * @file relay_protocol.c
+ * @brief Wire codec for the grant relay (ADR 0007 §2, §3.4). Pure bytes.
+ *
+ * Every integer is read and written a byte at a time, little-endian, rather
+ * than memcpy'd from a packed struct. The server memcpy's native structs on
+ * x86-64, so LE is the wire truth; doing it by hand means this file produces
+ * identical bytes on a big-endian host and needs no packing pragma.
+ *
+ * Nothing here allocates, blocks, or touches a socket or gComboCtx. That is
+ * what makes the golden-vector tests in test_netplay_relay.c able to pin the
+ * exact wire bytes without a transport.
+ */
+
+#include "relay_protocol.h"
+
+#include <string.h>
+
+// ============================================================================
+// Little-endian scalar helpers
+// ============================================================================
+
+static void PutU16(uint8_t* p, uint16_t v) {
+    p[0] = (uint8_t)(v & 0xFFu);
+    p[1] = (uint8_t)((v >> 8) & 0xFFu);
+}
+
+static void PutU32(uint8_t* p, uint32_t v) {
+    p[0] = (uint8_t)(v & 0xFFu);
+    p[1] = (uint8_t)((v >> 8) & 0xFFu);
+    p[2] = (uint8_t)((v >> 16) & 0xFFu);
+    p[3] = (uint8_t)((v >> 24) & 0xFFu);
+}
+
+static void PutU64(uint8_t* p, uint64_t v) {
+    for (int i = 0; i < 8; ++i) {
+        p[i] = (uint8_t)((v >> (8 * i)) & 0xFFu);
+    }
+}
+
+static uint16_t GetU16(const uint8_t* p) {
+    return (uint16_t)((uint16_t)p[0] | ((uint16_t)p[1] << 8));
+}
+
+static uint32_t GetU32(const uint8_t* p) {
+    return (uint32_t)p[0] | ((uint32_t)p[1] << 8) | ((uint32_t)p[2] << 16) | ((uint32_t)p[3] << 24);
+}
+
+static uint64_t GetU64(const uint8_t* p) {
+    uint64_t v = 0;
+    for (int i = 7; i >= 0; --i) {
+        v = (v << 8) | (uint64_t)p[i];
+    }
+    return v;
+}
+
+static bool IsRealGame(uint8_t g) {
+    return g == (uint8_t)GAME_OOT || g == (uint8_t)GAME_MM;
+}
+
+// ============================================================================
+// Grant payload
+// ============================================================================
+
+bool RelayProto_EncodeGrant(const RsbsGrantPayload* grant, uint8_t* out) {
+    if (grant == NULL || out == NULL) {
+        return false;
+    }
+    // Refuse to put a malformed grant on the wire. These are exactly the
+    // conditions the receiving seam would reject with RSBS_GRANT_REJECTED, so
+    // catching them here keeps a local bug from looking like a peer's.
+    if (grant->senderSlot == 0 || grant->targetSlot == 0 || grant->senderSeq == 0) {
+        return false;
+    }
+    if (!IsRealGame(grant->originGame)) {
+        return false;
+    }
+    if (grant->version != RSBS_GRANT_PAYLOAD_VERSION) {
+        return false;
+    }
+
+    memcpy(out, RSBS_GRANT_PAYLOAD_MAGIC, RSBS_GRANT_PAYLOAD_MAGIC_LEN);
+    out[4] = grant->version;
+    out[5] = grant->senderSlot;
+    out[6] = grant->targetSlot;
+    out[7] = grant->originGame;
+    PutU16(out + 8, grant->itemId);
+    PutU16(out + 10, grant->senderSeq);
+    PutU32(out + 12, grant->settingsHash);
+    return true;
+}
+
+bool RelayProto_DecodeGrant(const uint8_t* in, uint32_t len, RsbsGrantPayload* out) {
+    if (in == NULL || out == NULL) {
+        return false;
+    }
+    // A foreign payload is NOT an error (ADR 0007 §4.3) — the ledger is
+    // shared-format by design, so an OoTMM client's entries land in the same
+    // room. Every rejection below is "skip and count", never "disconnect".
+    if (len != RSBS_GRANT_PAYLOAD_LEN) {
+        return false;
+    }
+    if (memcmp(in, RSBS_GRANT_PAYLOAD_MAGIC, RSBS_GRANT_PAYLOAD_MAGIC_LEN) != 0) {
+        return false;
+    }
+    if (in[4] != RSBS_GRANT_PAYLOAD_VERSION) {
+        return false;
+    }
+
+    RsbsGrantPayload g;
+    g.version = in[4];
+    g.senderSlot = in[5];
+    g.targetSlot = in[6];
+    g.originGame = in[7];
+    g.itemId = GetU16(in + 8);
+    g.senderSeq = GetU16(in + 10);
+    g.settingsHash = GetU32(in + 12);
+
+    if (g.senderSlot == 0 || g.targetSlot == 0 || g.senderSeq == 0) {
+        return false;
+    }
+    if (!IsRealGame(g.originGame)) {
+        return false;
+    }
+
+    *out = g;
+    return true;
+}
+
+uint64_t RelayProto_GrantKey(const RsbsGrantPayload* grant) {
+    if (grant == NULL) {
+        return 0;
+    }
+    return ((uint64_t)grant->senderSlot << 48) | ((uint64_t)grant->senderSeq << 16) | (uint64_t)grant->itemId;
+}
+
+// ============================================================================
+// Frame encoders (client -> server)
+// ============================================================================
+
+void RelayProto_EncodeHello(uint8_t* out) {
+    memcpy(out, RSBS_RELAY_MAGIC, RSBS_RELAY_MAGIC_LEN);
+    PutU32(out + RSBS_RELAY_MAGIC_LEN, RSBS_RELAY_PROTOCOL_VERSION);
+}
+
+void RelayProto_EncodeJoin(const uint8_t roomUuid[RSBS_RELAY_UUID_LEN], uint32_t ledgerBase, uint8_t* out) {
+    memcpy(out, roomUuid, RSBS_RELAY_UUID_LEN);
+    PutU32(out + RSBS_RELAY_UUID_LEN, ledgerBase);
+}
+
+uint32_t RelayProto_EncodeTransfer(uint64_t key, const uint8_t* payload, uint32_t payloadLen, uint8_t* out) {
+    if (out == NULL || payload == NULL || payloadLen > RSBS_RELAY_MAX_PAYLOAD) {
+        return 0;
+    }
+    out[0] = RSBS_RELAY_OP_TRANSFER;
+    PutU64(out + 1, key);
+    out[9] = (uint8_t)payloadLen;
+    memcpy(out + 10, payload, payloadLen);
+    return 10u + payloadLen;
+}
+
+// ============================================================================
+// Incremental decoder (server -> client)
+// ============================================================================
+
+RelayDecodeStatus RelayProto_DecodeFrame(const uint8_t* buf, uint32_t len, uint32_t* consumed, RelayLedgerEntry* entry) {
+    if (consumed != NULL) {
+        *consumed = 0;
+    }
+    if (buf == NULL || consumed == NULL || len == 0) {
+        return RSBS_RELAY_DECODE_NEED_MORE;
+    }
+
+    switch (buf[0]) {
+        case RSBS_RELAY_OP_NONE:
+            // Keepalive. The server emits these from multiClientEventTimer
+            // whenever it has been quiet for a few ticks, so a decoder that
+            // treated a stray 0x00 as a bad opcode would drop a perfectly
+            // healthy connection after a few idle seconds.
+            *consumed = 1;
+            return RSBS_RELAY_DECODE_NOP;
+
+        case RSBS_RELAY_OP_TRANSFER: {
+            if (len < 1u + RSBS_RELAY_ENTRY_HEADER_LEN) {
+                return RSBS_RELAY_DECODE_NEED_MORE;
+            }
+            // op(1) + key(8) => the size byte is at offset 9, payload at 10.
+            const uint32_t payloadLen = buf[9];
+            if (payloadLen > RSBS_RELAY_MAX_PAYLOAD) {
+                // The server refuses to STORE an oversized entry, so it should
+                // never emit one. Treat it as a broken stream rather than
+                // guessing a resync point: the length prefix is the only thing
+                // keeping us framed, so a bad one means we are already lost.
+                return RSBS_RELAY_DECODE_ERROR;
+            }
+            const uint32_t total = 1u + RSBS_RELAY_ENTRY_HEADER_LEN + payloadLen;
+            if (len < total) {
+                return RSBS_RELAY_DECODE_NEED_MORE;
+            }
+            if (entry != NULL) {
+                entry->key = GetU64(buf + 1);
+                entry->payloadLen = payloadLen;
+                if (payloadLen > 0) {
+                    memcpy(entry->payload, buf + 10, payloadLen);
+                }
+            }
+            *consumed = total;
+            return RSBS_RELAY_DECODE_ENTRY;
+        }
+
+        case RSBS_RELAY_OP_MSG: {
+            // op + u8 size + u16 senderId + text[size]. We decode it purely to
+            // stay framed, then discard: the relay carries grants, and routing
+            // peer chat into the game is not in ADR 0007's scope.
+            if (len < 4u) {
+                return RSBS_RELAY_DECODE_NEED_MORE;
+            }
+            const uint32_t textLen = buf[1];
+            const uint32_t total = 4u + textLen;
+            if (len < total) {
+                return RSBS_RELAY_DECODE_NEED_MORE;
+            }
+            *consumed = total;
+            return RSBS_RELAY_DECODE_MSG;
+        }
+
+        default:
+            return RSBS_RELAY_DECODE_ERROR;
+    }
+}

--- a/src/common/netplay/relay_protocol.h
+++ b/src/common/netplay/relay_protocol.h
@@ -1,0 +1,221 @@
+/**
+ * @file relay_protocol.h
+ * @brief Wire codec for the grant relay (ADR 0007). Pure bytes — no sockets.
+ *
+ * This layer implements the OoTMM `multi-server` wire format
+ * (https://github.com/OoTMM/multi-server, MIT, `master` @ 2025-03-27,
+ * VERSION 0x00000200). We speak its protocol; we vendor none of its code and
+ * we ship no server. See docs/adr/0007-grant-relay-netplay.md §1.
+ *
+ * WHY WE CAN REUSE IT (ADR 0007 §1.2): the server's ledger entry is
+ * `{u64 key; u8 size; opaque payload}` and `multiLedgerWrite` never inspects
+ * the payload. There is no game identity, no slot registry, no generated
+ * world — so unlike Archipelago (ADR 0006 §1.1) there is NO admissibility
+ * check a client can fail. An unmodified multi-server relays RSBS grants
+ * today because it cannot tell them from OoTMM's.
+ *
+ * WIRE FORMAT, transcribed from the server source and pinned by golden byte
+ * vectors in test_netplay_relay.c. All multi-byte integers are LITTLE-ENDIAN
+ * (the server memcpy's native structs on x86-64 Linux), and the codec below
+ * reads/writes them byte-by-byte so a big-endian host produces the same bytes.
+ *
+ *   Handshake, client -> server (9 bytes):
+ *       "OOMM2" + u32 clientVersion
+ *   Handshake, server -> client (11 bytes):
+ *       "OOMM2" + u32 serverVersion + u16 assignedClientId
+ *   Join, client -> server (20 bytes):
+ *       u8 roomUuid[16] + u32 ledgerBase
+ *   Then a command stream in both directions:
+ *       OP_NONE     (0x00)  1 byte. Keepalive NOP — the server emits one every
+ *                           few seconds from multiClientEventTimer. MUST be
+ *                           tolerated mid-stream or the client desyncs.
+ *       OP_TRANSFER (0x01)  server->client: u64 key + u8 size + payload[size]
+ *                           client->server: u64 key + u8 size + payload[size]
+ *       OP_MSG      (0x02)  server->client: u8 size + u16 senderId + text[size]
+ *                           (chat; we decode and discard — see relay_client.c)
+ *
+ * ECHO ASYMMETRY, and it is load-bearing for the harness: `multiClientCmdTransfer`
+ * fans a new entry out to EVERY client on the ledger **including the sender**
+ * (it does not skip `client->id`), whereas `multiClientCmdMsg` explicitly does
+ * skip the sender. So a client receives its own grants back and MUST filter by
+ * targetSlot. A mock that conveniently skipped the sender would hide that —
+ * exactly the shortcut ADR 0006 §2(b) caught in the AP mock.
+ *
+ * The RSBS payload (ADR 0007 §2) is ours and opaque to the server. Foreign or
+ * malformed payloads (an OoTMM client sharing the room) are skipped, never
+ * fatal: the server's own length prefix keeps the stream framed regardless.
+ */
+
+#ifndef RSBS_COMMON_NETPLAY_RELAY_PROTOCOL_H
+#define RSBS_COMMON_NETPLAY_RELAY_PROTOCOL_H
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#include "../game.h" // GameId
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// ============================================================================
+// Server protocol constants (pinned to multi-server master @ 2025-03-27)
+// ============================================================================
+
+#define RSBS_RELAY_MAGIC "OOMM2"
+#define RSBS_RELAY_MAGIC_LEN 5u
+
+// The server's VERSION. We refuse a connection whose high 16 bits differ
+// rather than proceeding hopefully into a misparse (ADR 0007 §3.4).
+#define RSBS_RELAY_PROTOCOL_VERSION 0x00000200u
+#define RSBS_RELAY_VERSION_MAJOR(v) ((v) >> 16)
+
+#define RSBS_RELAY_HELLO_LEN 9u  // "OOMM2" + u32 version
+#define RSBS_RELAY_SVHELLO_LEN 11u // "OOMM2" + u32 version + u16 clientId
+#define RSBS_RELAY_JOIN_LEN 20u  // uuid[16] + u32 ledgerBase
+#define RSBS_RELAY_UUID_LEN 16u
+
+// Command opcodes.
+#define RSBS_RELAY_OP_NONE 0x00u
+#define RSBS_RELAY_OP_TRANSFER 0x01u
+#define RSBS_RELAY_OP_MSG 0x02u
+
+// The server disconnects a client whose OP_TRANSFER header.size exceeds this
+// (client.c: `if (header.size > 128)`). Our payload is far smaller; this is
+// here so we can never emit a frame that gets us dropped.
+#define RSBS_RELAY_MAX_PAYLOAD 128u
+
+// OP_TRANSFER wire header: u64 key + u8 size.
+#define RSBS_RELAY_ENTRY_HEADER_LEN 9u
+
+// ============================================================================
+// The RSBS grant payload (ADR 0007 §2) — ours, opaque to the server
+// ============================================================================
+
+#define RSBS_GRANT_PAYLOAD_LEN 16u
+#define RSBS_GRANT_PAYLOAD_VERSION 1u
+#define RSBS_GRANT_PAYLOAD_MAGIC "RSBS"
+#define RSBS_GRANT_PAYLOAD_MAGIC_LEN 4u
+
+/**
+ * The encoded 16-byte layout, which is the authority (the struct below holds
+ * only the 12 bytes that are DATA — the magic is a constant, not a field):
+ *
+ *   off  size  field
+ *    0    4    magic  "RSBS"
+ *    4    1    version
+ *    5    1    senderSlot
+ *    6    1    targetSlot
+ *    7    1    originGame
+ *    8    2    itemId        (LE)
+ *   10    2    senderSeq     (LE)
+ *   12    4    settingsHash  (LE)
+ *   ----------------------------
+ *              16 bytes total
+ *
+ * ADR 0007 §2's table listed a trailing `reserved[2]`, which would have made
+ * the payload 18 bytes rather than the 16 it claimed. The layout above is the
+ * correct one and the ADR is corrected to match in this change. Growth room is
+ * not lost: the server's cap is 128 bytes, so a v2 payload simply gets a new
+ * `version` byte and a longer encoding — the decoder already rejects unknown
+ * versions by returning false (skip, not fatal), so old clients degrade to
+ * "skipped a grant they could not read" rather than misparsing one.
+ */
+
+/**
+ * One grant on the wire. Decoded/encoded field-by-field (never memcpy'd over
+ * the wire bytes) so there is no packing or endianness assumption.
+ */
+typedef struct {
+    uint8_t version;       // RSBS_GRANT_PAYLOAD_VERSION
+    uint8_t senderSlot;    // 1..255, self-asserted (trust model: ADR 0007 §6)
+    uint8_t targetSlot;    // 1..255, intended recipient
+    uint8_t originGame;    // GameId — the id-space owner (ADR 0002)
+    uint16_t itemId;       // RG_* if originGame == GAME_OOT, RI_* if GAME_MM
+    uint16_t senderSeq;    // sender's own dense 1-based counter
+    uint32_t settingsHash; // ADVISORY mismatch warning only (ADR 0007 §5.3)
+} RsbsGrantPayload;
+
+/**
+ * Encode a grant payload into exactly RSBS_GRANT_PAYLOAD_LEN bytes.
+ * @return true on success; false if `out` is NULL or the grant is malformed
+ *         (slot 0, seq 0, or originGame not a real game).
+ */
+bool RelayProto_EncodeGrant(const RsbsGrantPayload* grant, uint8_t* out);
+
+/**
+ * Decode a grant payload from exactly `len` bytes.
+ *
+ * @return true if the bytes are a well-formed RSBS grant payload. Returns
+ *         FALSE — not an error, per ADR 0007 §4.3 — for a foreign payload (bad
+ *         magic, e.g. an OoTMM client in the same room), an unknown version, a
+ *         wrong length, or a malformed field. The caller skips and counts it;
+ *         it must never disconnect or desync on this.
+ */
+bool RelayProto_DecodeGrant(const uint8_t* in, uint32_t len, RsbsGrantPayload* out);
+
+/**
+ * The ledger key for a grant (ADR 0007 §2):
+ *   (senderSlot << 48) | (senderSeq << 16) | itemId
+ *
+ * Unique per (sender, sequence), so the server's keySet absorbs a sender's own
+ * retransmit — while two DIFFERENT senders gifting the same item produce
+ * different keys and both survive. That second half matters: server-side dedup
+ * collapsing two legitimate gifts would reintroduce, one layer lower, the exact
+ * bug ADR 0005 §1 exists to fix.
+ */
+uint64_t RelayProto_GrantKey(const RsbsGrantPayload* grant);
+
+// ============================================================================
+// Frame encoders (client -> server)
+// ============================================================================
+
+/** Write the 9-byte client hello. `out` must hold RSBS_RELAY_HELLO_LEN. */
+void RelayProto_EncodeHello(uint8_t* out);
+
+/** Write the 20-byte join. `out` must hold RSBS_RELAY_JOIN_LEN. */
+void RelayProto_EncodeJoin(const uint8_t roomUuid[RSBS_RELAY_UUID_LEN], uint32_t ledgerBase, uint8_t* out);
+
+/**
+ * Write an OP_TRANSFER frame: op + u64 key + u8 size + payload.
+ * `out` must hold 1 + RSBS_RELAY_ENTRY_HEADER_LEN + payloadLen.
+ * @return the number of bytes written, or 0 if payloadLen > RSBS_RELAY_MAX_PAYLOAD.
+ */
+uint32_t RelayProto_EncodeTransfer(uint64_t key, const uint8_t* payload, uint32_t payloadLen, uint8_t* out);
+
+// ============================================================================
+// Incremental decoder (server -> client)
+// ============================================================================
+
+typedef enum {
+    RSBS_RELAY_DECODE_NEED_MORE = 0, // incomplete frame; keep buffering
+    RSBS_RELAY_DECODE_NOP,           // OP_NONE keepalive consumed
+    RSBS_RELAY_DECODE_ENTRY,         // a ledger entry was decoded
+    RSBS_RELAY_DECODE_MSG,           // a chat message was consumed (discarded)
+    RSBS_RELAY_DECODE_ERROR,         // unknown opcode — the stream is unusable
+} RelayDecodeStatus;
+
+typedef struct {
+    uint64_t key;
+    uint8_t payload[RSBS_RELAY_MAX_PAYLOAD];
+    uint32_t payloadLen;
+} RelayLedgerEntry;
+
+/**
+ * Try to decode one frame from the front of `buf`.
+ *
+ * @param consumed set to the number of bytes consumed (0 when NEED_MORE).
+ * @param entry    populated only when the result is RSBS_RELAY_DECODE_ENTRY.
+ *
+ * Tolerating OP_NONE is not optional: the server emits keepalive NOPs from
+ * multiClientEventTimer whenever it has been quiet, and a decoder that treated
+ * a stray 0x00 as a bad opcode would drop a healthy connection after a few
+ * idle seconds.
+ */
+RelayDecodeStatus RelayProto_DecodeFrame(const uint8_t* buf, uint32_t len, uint32_t* consumed, RelayLedgerEntry* entry);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // RSBS_COMMON_NETPLAY_RELAY_PROTOCOL_H

--- a/src/common/shared_items.c
+++ b/src/common/shared_items.c
@@ -13,6 +13,7 @@
 
 #include "shared_items.h"
 #include <stdio.h>
+#include <string.h>
 
 // ============================================================================
 // RAM outbox for the deferred (stage -> commit-at-suspend) producer path.
@@ -32,7 +33,77 @@ static bool IsRealGame(GameId game) {
 }
 
 // ============================================================================
-// Producer
+// Slot management (ADR 0005)
+//
+// The occupied entries always form a PREFIX of the array: records append at
+// the first free slot, entries are never cleared individually, and
+// reclamation compacts. Slot order is therefore acceptance order, which is
+// what makes Combo_RedeemSharedItemsForGame's slot-order walk a received-order
+// guarantee.
+// ============================================================================
+
+static int FindFirstFreeSlot(void) {
+    for (int i = 0; i < (int)RSBS_SHARED_ITEM_CAP; i++) {
+        if (gComboCtx.sharedItemsTagged[i].originGame == (uint8_t)GAME_NONE) {
+            return i;
+        }
+    }
+    return -1;
+}
+
+// Evict the OLDEST redeemed entry by compacting everything after it down one
+// slot, freeing the tail slot for the caller. Relative order of the surviving
+// entries is preserved, so received-order redemption is unaffected. Only
+// redeemed entries are evictable: they are informational records of completed
+// crossings, while an un-redeemed entry is an undelivered item and must never
+// be dropped. Returns the freed tail slot, or -1 if nothing is redeemed.
+static int ReclaimOldestRedeemedSlot(void) {
+    for (int i = 0; i < (int)RSBS_SHARED_ITEM_CAP; i++) {
+        SharedItem* slot = &gComboCtx.sharedItemsTagged[i];
+        if (slot->originGame != (uint8_t)GAME_NONE && (slot->flags & RSBS_SHARED_ITEM_REDEEMED) != 0) {
+            memmove(&gComboCtx.sharedItemsTagged[i], &gComboCtx.sharedItemsTagged[i + 1],
+                    ((size_t)RSBS_SHARED_ITEM_CAP - 1u - (size_t)i) * sizeof(SharedItem));
+            memset(&gComboCtx.sharedItemsTagged[RSBS_SHARED_ITEM_CAP - 1], 0, sizeof(SharedItem));
+            return (int)RSBS_SHARED_ITEM_CAP - 1;
+        }
+    }
+    return -1;
+}
+
+// Append an entry with NO content de-dup (the sourced-grant path depends on
+// that: a second grant of the same item is a real second item). `flags` is 0
+// for an in-process record or RSBS_SHARED_ITEM_SOURCED for a sourced grant —
+// never RSBS_SHARED_ITEM_REDEEMED (only the consumer sets that). On a full
+// array, reclaim the oldest redeemed entry; if every entry is un-redeemed,
+// refuse LOUDLY — increment the durable overflow count and log — rather than
+// drop silently. Returns the slot written, or -1 on refusal.
+static int AppendSharedItem(GameId originGame, uint16_t id, uint8_t flags) {
+    int slot = FindFirstFreeSlot();
+    if (slot < 0) {
+        slot = ReclaimOldestRedeemedSlot();
+        if (slot >= 0) {
+            fprintf(stderr, "[SharedItem] array full: reclaimed oldest redeemed entry (origin=%s id=%u incoming)\n",
+                    Game_ToString(originGame), (unsigned)id);
+        }
+    }
+    if (slot < 0) {
+        gComboCtx.sharedItemOverflowCount++;
+        fprintf(stderr,
+                "[SharedItem] record REFUSED: all %u slots hold un-redeemed items (overflow count now %u), "
+                "origin=%s id=%u\n",
+                RSBS_SHARED_ITEM_CAP, gComboCtx.sharedItemOverflowCount, Game_ToString(originGame), (unsigned)id);
+        return -1;
+    }
+
+    SharedItem* dst = &gComboCtx.sharedItemsTagged[slot];
+    dst->originGame = (uint8_t)originGame;
+    dst->flags = flags;
+    dst->id = id;
+    return slot;
+}
+
+// ============================================================================
+// In-process producer
 // ============================================================================
 
 int Combo_RecordSharedItem(GameId originGame, uint16_t id) {
@@ -40,38 +111,27 @@ int Combo_RecordSharedItem(GameId originGame, uint16_t id) {
         return -1;
     }
 
-    // De-dup against an existing un-redeemed entry so a re-fired producer
-    // cannot create doubles (see the header). An already-redeemed match does
-    // NOT block a fresh record — the same item crossing a second time is a
-    // real, distinct hand-off.
-    int firstFree = -1;
+    // De-dup BY CONTENT against an existing un-redeemed IN-PROCESS entry so a
+    // re-fired in-process producer cannot create doubles (see the header). An
+    // already-redeemed match does NOT block a fresh record — the same item
+    // crossing a second time is a real, distinct hand-off. SOURCED entries are
+    // skipped (RSBS_SHARED_ITEM_SOURCED): a peer's pending gift of the same
+    // item must not swallow a genuine local pickup — the two producer classes'
+    // idempotency domains are disjoint by design (ADR 0005).
     for (int i = 0; i < (int)RSBS_SHARED_ITEM_CAP; i++) {
         SharedItem* slot = &gComboCtx.sharedItemsTagged[i];
-        if (slot->originGame == (uint8_t)GAME_NONE) {
-            if (firstFree < 0) {
-                firstFree = i;
-            }
-            continue;
-        }
         if (slot->originGame == (uint8_t)originGame && slot->id == id &&
-            (slot->flags & RSBS_SHARED_ITEM_REDEEMED) == 0) {
+            (slot->flags & (RSBS_SHARED_ITEM_REDEEMED | RSBS_SHARED_ITEM_SOURCED)) == 0) {
             return i; // already pending — leave it exactly as-is
         }
     }
 
-    if (firstFree < 0) {
-        fprintf(stderr, "[SharedItem] record dropped: array full (%u slots), origin=%s id=%u\n",
-                RSBS_SHARED_ITEM_CAP, Game_ToString(originGame), (unsigned)id);
-        return -1;
+    int slot = AppendSharedItem(originGame, id, 0);
+    if (slot >= 0) {
+        fprintf(stderr, "[SharedItem] recorded origin=%s id=%u in slot %d\n", Game_ToString(originGame), (unsigned)id,
+                slot);
     }
-
-    SharedItem* dst = &gComboCtx.sharedItemsTagged[firstFree];
-    dst->originGame = (uint8_t)originGame;
-    dst->flags = 0;
-    dst->id = id;
-    fprintf(stderr, "[SharedItem] recorded origin=%s id=%u in slot %d\n", Game_ToString(originGame), (unsigned)id,
-            firstFree);
-    return firstFree;
+    return slot;
 }
 
 bool Combo_StageSharedItem(GameId originGame, uint16_t id) {
@@ -96,12 +156,107 @@ int Combo_CommitStagedSharedItems(void) {
         if (Combo_RecordSharedItem((GameId)sOutbox[i].originGame, sOutbox[i].id) >= 0) {
             committed++;
         }
-        // A -1 here means the durable array is full; the staged entry is
-        // dropped (already logged by Combo_RecordSharedItem) rather than left
-        // to leak forward into a later, unrelated switch.
+        // A -1 here means the durable array is full of un-redeemed items even
+        // after reclamation; the staged entry is dropped (already logged AND
+        // counted in the durable overflow count by the record path) rather
+        // than left to leak forward into a later, unrelated switch.
     }
     sOutboxCount = 0;
     return committed;
+}
+
+// ============================================================================
+// Sourced producer (ADR 0005) — the seam a transport writes against.
+// ============================================================================
+
+ComboGrantResult Combo_SubmitSourcedGrant(uint32_t sourceKey, uint32_t seq, GameId originGame, uint16_t id) {
+    if (sourceKey == 0u || seq == 0u || !IsRealGame(originGame)) {
+        fprintf(stderr, "[SharedItem] sourced grant REJECTED (malformed): key=%u seq=%u origin=%d id=%u\n",
+                sourceKey, seq, (int)originGame, (unsigned)id);
+        return RSBS_GRANT_REJECTED;
+    }
+
+    // Locate this source's cursor; remember a free slot in case the source is
+    // new. The cursor slot must be secured BEFORE the item is recorded: an
+    // item recorded without a cursor to remember it would make the source's
+    // inevitable retransmit of the same seq record a double.
+    ComboGrantSourceCursor* cur = NULL;
+    ComboGrantSourceCursor* freeSlot = NULL;
+    for (int i = 0; i < (int)RSBS_GRANT_SOURCE_CAP; i++) {
+        ComboGrantSourceCursor* c = &gComboCtx.grantCursors[i];
+        if (c->sourceKey == sourceKey) {
+            cur = c;
+            break;
+        }
+        if (c->sourceKey == 0u && freeSlot == NULL) {
+            freeSlot = c;
+        }
+    }
+
+    const uint32_t lastSeq = (cur != NULL) ? cur->lastSeq : 0u;
+    if (seq <= lastSeq) {
+        // Retransmit of a grant this save already accepted. Deliberately not
+        // logged: this is the expected idempotent path under a resend-happy
+        // transport, not an anomaly.
+        return RSBS_GRANT_DUPLICATE;
+    }
+    if (seq != lastSeq + 1u) {
+        fprintf(stderr, "[SharedItem] sourced grant GAP: key=%u sent seq=%u but expected %u — resync the source\n",
+                sourceKey, seq, lastSeq + 1u);
+        return RSBS_GRANT_GAP;
+    }
+    if (cur == NULL && freeSlot == NULL) {
+        fprintf(stderr, "[SharedItem] sourced grant refused: all %u source-cursor slots occupied (key=%u)\n",
+                RSBS_GRANT_SOURCE_CAP, sourceKey);
+        return RSBS_GRANT_NO_SOURCE_SLOT;
+    }
+
+    // In-order and novel: record it. NO content de-dup — a second grant of the
+    // same (originGame, id) with its own seq is a real second item. The
+    // SOURCED flag keeps this entry out of Combo_RecordSharedItem's content
+    // de-dup domain.
+    if (AppendSharedItem(originGame, id, RSBS_SHARED_ITEM_SOURCED) < 0) {
+        // Backpressure, not loss: the cursor did not advance, so the source
+        // still owes this seq. A later retransmit — after redemption frees
+        // capacity — is accepted, not treated as a duplicate. AppendSharedItem
+        // already counted and logged the refusal.
+        return RSBS_GRANT_RETRY_FULL;
+    }
+
+    if (cur == NULL) {
+        cur = freeSlot;
+        cur->sourceKey = sourceKey;
+    }
+    cur->lastSeq = seq;
+    fprintf(stderr, "[SharedItem] sourced grant accepted: key=%u seq=%u origin=%s id=%u\n", sourceKey, seq,
+            Game_ToString(originGame), (unsigned)id);
+    return RSBS_GRANT_ACCEPTED;
+}
+
+uint32_t Combo_GetGrantCursor(uint32_t sourceKey) {
+    if (sourceKey == 0u) {
+        return 0u;
+    }
+    for (int i = 0; i < (int)RSBS_GRANT_SOURCE_CAP; i++) {
+        if (gComboCtx.grantCursors[i].sourceKey == sourceKey) {
+            return gComboCtx.grantCursors[i].lastSeq;
+        }
+    }
+    return 0u;
+}
+
+int Combo_CountGrantSources(void) {
+    int count = 0;
+    for (int i = 0; i < (int)RSBS_GRANT_SOURCE_CAP; i++) {
+        if (gComboCtx.grantCursors[i].sourceKey != 0u) {
+            count++;
+        }
+    }
+    return count;
+}
+
+uint32_t Combo_GetSharedItemOverflowCount(void) {
+    return gComboCtx.sharedItemOverflowCount;
 }
 
 // ============================================================================

--- a/src/common/shared_items.h
+++ b/src/common/shared_items.h
@@ -28,15 +28,68 @@
  *   - When the player next ARRIVES in the origin game, that game's consumer
  *     awards every un-redeemed entry tagged for it and marks it redeemed.
  *
- * Plain `.redsave` load without a switch (decided, documented): the consumers
- * run only at the presence-gated startup-entrance consumption points, which a
- * cold boot or a plain load never reaches. Un-redeemed items therefore persist
- * in the loaded `gComboCtx` and are awarded on the NEXT switch into their
- * origin game — an explicit "applies on next switch only" semantic. No item is
- * lost (the array is serialized and REDEEMED tracks what is done) and none is
- * double-awarded. We deliberately do NOT redeem at load time: awarding routes
- * through the game's live item-give machinery, which is only valid once the
- * game has reached gameplay — exactly what the consumption point guarantees.
+ * TWO PRODUCER CLASSES (ADR 0005, netplay 1a #460) — choosing the wrong one is
+ * a correctness bug, not a style choice:
+ *
+ *   - IN-PROCESS producers (a give path re-firing inside this process) use
+ *     Combo_RecordSharedItem / Combo_StageSharedItem. Their idempotency is
+ *     CONTENT de-dup: an identical un-redeemed (originGame, id) is the same
+ *     event re-observed, so it merges. Correct here, and ONLY here.
+ *   - SOURCED producers (anything with its own identity and its own delivery
+ *     stream: a network peer, an Archipelago server, a loopback test feed) use
+ *     Combo_SubmitSourcedGrant. Their idempotency is a per-source monotonic
+ *     CURSOR: a retransmit (seq <= cursor) is dropped, a genuinely new grant
+ *     of the same item (fresh seq) is recorded WITHOUT content de-dup — two
+ *     peers gifting you the same item is two items. A sourced producer must
+ *     never call Combo_RecordSharedItem directly: content de-dup would
+ *     silently merge distinct gifts.
+ *
+ *     The two domains never mix: sourced entries carry
+ *     RSBS_SHARED_ITEM_SOURCED, and content de-dup skips them, so a peer's
+ *     pending gift can never swallow a genuine local pickup of the same item
+ *     (nor vice versa).
+ *
+ * REDEMPTION SAFE POINTS (ADR 0005). Combo_RedeemSharedItemsForGame is safe at
+ * any point where ALL of the following hold for `arrivingGame`, not only at a
+ * game switch: (1) it is the active game, on the game thread; (2) a save is
+ * loaded and normal gameplay has been reached, so the award callback's give
+ * machinery is valid; (3) the caller passes that game's real award callback.
+ * The presence-gated startup-entrance consumption points are the two wired
+ * safe points today. A gameplay-gated frame tick is the third, DEFINED safe
+ * point — it gets wired together with the first producer that can target the
+ * active game mid-session (the 1b transport), because until such a producer
+ * exists there is nothing for a tick to redeem: every in-process producer
+ * records for the game you are leaving. Single-use is independent of the
+ * trigger: RSBS_SHARED_ITEM_REDEEMED makes redemption idempotent under any
+ * interleaving of safe points.
+ *
+ * Plain `.redsave` load without a switch: unchanged for everything wired
+ * today. Un-redeemed items persist in the loaded `gComboCtx` and are awarded
+ * at the next safe point — which, with only arrival points wired, is the next
+ * switch into their origin game. We deliberately do NOT redeem at load time:
+ * awarding routes through the game's live item-give machinery, which is only
+ * valid once the game has reached gameplay — exactly what every safe point
+ * above guarantees.
+ *
+ * CAPACITY (ADR 0005). The durable array holds RSBS_SHARED_ITEM_CAP entries.
+ * When it is full, recording first RECLAIMS the oldest REDEEMED entry (the
+ * array compacts, preserving relative order, and the freed tail slot takes
+ * the new record) — a redeemed entry is an informational record of a done
+ * crossing, an un-redeemed entry is an undelivered item; only the former may
+ * be evicted, and ADR 0005 amends A1's "entries are never cleared" note
+ * accordingly. If every entry is un-redeemed, the record is REFUSED — loudly:
+ * the durable gComboCtx.sharedItemOverflowCount increments (serialized, so
+ * the signal survives save/load) and the refusal is logged. For a sourced
+ * grant a refusal is backpressure, not loss: the cursor does not advance, so
+ * the source still owes the grant and a later retransmit is accepted. For an
+ * in-process producer a refusal IS a lost item (the pickup already happened);
+ * the counter is what keeps that loss diagnosable. Slot indices returned by
+ * the record APIs are transient (reclamation compacts the array) — never
+ * store them.
+ *
+ * THREADING: everything in this header runs on the game thread only. A
+ * transport receiving off-thread must marshal onto the game thread before
+ * calling Combo_SubmitSourcedGrant (that is part of the seam's contract).
  */
 
 #ifndef RSBS_COMMON_SHARED_ITEMS_H
@@ -59,21 +112,29 @@ extern "C" {
 typedef void (*ComboSharedItemAward)(const SharedItem* item, void* ctx);
 
 /**
- * PRODUCER (direct write). Record a cross-game item into
+ * IN-PROCESS PRODUCER (direct write). Record a cross-game item into
  * gComboCtx.sharedItemsTagged, visible immediately in the shared context and
  * persisted by the next `.redsave` save.
  *
  * @param originGame the id-space owner (GAME_OOT => `id` is RG_*, GAME_MM => RI_*)
  * @param id         the item id within originGame's id-space
  * @return the slot index used (>= 0), or -1 if originGame is not a real game or
- *         the array is full.
+ *         the array is full of un-redeemed entries (after attempting
+ *         reclamation; the refusal increments the durable overflow count).
+ *         Returned indices are transient — reclamation compacts the array —
+ *         so treat them as success/failure only, never store them.
  *
- * De-dups: if an identical (originGame, id) entry already exists and is NOT yet
- * redeemed, its slot is returned unchanged rather than duplicated — so a
- * re-fired producer (the Combo_CheckEntranceSwitch wasAlreadyPending re-entry,
- * or two suspends with no consume between them) cannot create doubles. A
- * matching entry that is already redeemed does NOT block a fresh record: the
- * same item legitimately crossing again gets a new slot.
+ * De-dups BY CONTENT: if an identical (originGame, id) entry already exists and
+ * is NOT yet redeemed, its slot is returned unchanged rather than duplicated —
+ * so a re-fired producer (the Combo_CheckEntranceSwitch wasAlreadyPending
+ * re-entry, or two suspends with no consume between them) cannot create
+ * doubles. A matching entry that is already redeemed does NOT block a fresh
+ * record: the same item legitimately crossing again gets a new slot.
+ *
+ * Content de-dup is only correct for in-process re-fired producers. A SOURCED
+ * producer (network peer, Archipelago server) must go through
+ * Combo_SubmitSourcedGrant instead, where retransmit-vs-new is decided by the
+ * source's cursor and two distinct grants of the same item both record.
  */
 int Combo_RecordSharedItem(GameId originGame, uint16_t id);
 
@@ -107,17 +168,92 @@ int Combo_CommitStagedSharedItems(void);
 
 /**
  * CONSUMER HOOK. Award every occupied, un-redeemed entry whose
- * originGame == arrivingGame via `award`, then set RSBS_SHARED_ITEM_REDEEMED on
- * each. Entries are NOT cleared: they remain as the serialized record of the
- * crossing.
+ * originGame == arrivingGame via `award`, in slot order — which is acceptance
+ * order, and reclamation preserves it — then set RSBS_SHARED_ITEM_REDEEMED on
+ * each. Received-order awarding is a contract, not an accident: the give paths
+ * resolve progressive items against the live save, so order changes WHAT the
+ * player receives. Redeemed entries stay in the array as the serialized record
+ * of the crossing until capacity pressure reclaims them (file header).
  *
- * Called from each game's presence-gated startup-entrance consumption point
+ * Wired today at each game's presence-gated startup-entrance consumption point
  * (OoT_Play_Init / MM_Play_ConsumeStartupEntrance), which run only on a switch
- * arrival. See the file header for the plain-load semantics.
+ * arrival. Safe at ANY redemption safe point (file header): it has no
+ * dependency on switch machinery, and RSBS_SHARED_ITEM_REDEEMED makes it
+ * idempotent under any interleaving of safe points.
  *
  * @return the number of entries redeemed this call.
  */
 int Combo_RedeemSharedItemsForGame(GameId arrivingGame, ComboSharedItemAward award, void* ctx);
+
+// ============================================================================
+// Sourced grants (ADR 0005, netplay 1a #460) — the producer seam a transport
+// writes against. No transport lives in this layer: the only callers today are
+// the CI locks, and the 1b transport plugs in here without this file changing.
+// ============================================================================
+
+/**
+ * Result of Combo_SubmitSourcedGrant. Everything except RSBS_GRANT_ACCEPTED
+ * leaves gComboCtx completely unchanged (no item recorded, no cursor moved).
+ */
+typedef enum {
+    RSBS_GRANT_ACCEPTED = 0,   // recorded; the source's cursor advanced to seq
+    RSBS_GRANT_DUPLICATE = 1,  // seq <= cursor: retransmit of a delivered grant; drop it (idempotent success)
+    RSBS_GRANT_GAP = 2,        // seq skips ahead: predecessors missing; resync/resend the source in order
+    RSBS_GRANT_RETRY_FULL = 3, // array full of un-redeemed items: backpressure — the source still owes this
+                               // grant (cursor unmoved) and must re-offer it later
+    RSBS_GRANT_NO_SOURCE_SLOT = 4, // all RSBS_GRANT_SOURCE_CAP cursor slots taken by other sources
+    RSBS_GRANT_REJECTED = 5,   // malformed: sourceKey 0, seq 0, or originGame not a real game
+} ComboGrantResult;
+
+/**
+ * SOURCED PRODUCER. Submit one grant from an identified source, idempotently.
+ *
+ * @param sourceKey  nonzero identity of the source WITHIN the current world /
+ *                   session (the transport derives it — e.g. a hash of room id
+ *                   + peer slot; an Archipelago server is one source). Cursor
+ *                   state is per-key and lives in gComboCtx, so #440-class
+ *                   invalidation wipes keys and items together.
+ * @param seq        the source's own monotonic sequence number for this grant,
+ *                   starting at 1 for the source's first grant, dense (no
+ *                   holes). A server-authoritative cursor maps directly: an
+ *                   Archipelago ReceivedItems index i is seq i + 1.
+ * @param originGame / @param id  exactly Combo_RecordSharedItem's parameters.
+ *
+ * Acceptance is STRICTLY in-order per source (seq must be cursor + 1; a new
+ * source must start at 1). That is what makes every case decidable: a
+ * retransmit is DUPLICATE, a genuine second gift has a fresh seq and records
+ * without content de-dup, a lost message surfaces as GAP instead of silent
+ * reordering, and a capacity refusal (RETRY_FULL) leaves the cursor unmoved so
+ * the grant is retried rather than lost. On DUPLICATE the grant was already
+ * recorded by an earlier accept; whether it has been redeemed since is the
+ * consumer's business — the producer seam never re-records it.
+ *
+ * Game thread only (file header). See ComboGrantResult for the outcomes.
+ */
+ComboGrantResult Combo_SubmitSourcedGrant(uint32_t sourceKey, uint32_t seq, GameId originGame, uint16_t id);
+
+/**
+ * The source's persisted delivery cursor: the highest seq ever ACCEPTED from
+ * sourceKey, or 0 if the source is unknown (nothing accepted yet — a source
+ * only exists once its seq 1 is accepted). A transport resumes delivery at
+ * cursor + 1 after a reconnect or a .redsave load; an Archipelago client hands
+ * this to Sync as its ReceivedItems index.
+ */
+uint32_t Combo_GetGrantCursor(uint32_t sourceKey);
+
+/**
+ * Number of occupied grant-cursor slots (read-only; trackers / tests).
+ */
+int Combo_CountGrantSources(void);
+
+/**
+ * Durable count of shared-item records refused for capacity (read-only view of
+ * gComboCtx.sharedItemOverflowCount; serialized in every .redsave). Nonzero
+ * means the array hit capacity with every slot un-redeemed: for in-process
+ * records that is a lost item, for sourced grants a backpressure event. Reset
+ * only by ComboContext_Init (fresh world / #440 invalidation).
+ */
+uint32_t Combo_GetSharedItemOverflowCount(void);
 
 /**
  * Count occupied entries whose originGame == game. When includeRedeemed is

--- a/src/common/test_runner.cpp
+++ b/src/common/test_runner.cpp
@@ -138,6 +138,14 @@ extern "C" {
 // pipeline symbols it drives are C-linkage and declared in the file.
 #include "tests/test_foreign_items.c"
 
+// Sourced-grant model locks (ADR 0005, netplay 1a #460): per-source cursor
+// idempotency, switch-free received-order redemption, loud overflow with
+// redeemed-slot reclamation, and .redsave durability including the
+// pre-netplay migration path and the #440-composing reset atomicity. FILE
+// SCOPE (compiled as C++) for rsbs::SaveManager; the grant API is C-linkage
+// via shared_items.h.
+#include "tests/test_grant_sources.c"
+
 // MM scene-command parse regression (issue #344). Included at FILE SCOPE
 // (compiled as C++): it drives MM's S2H::ResourceFactoryBinarySceneV0 directly
 // over a synthetic scene buffer — no ROM archives or display needed.
@@ -1114,6 +1122,16 @@ const TestDescriptor gTests[] = {
     // crossing awards exactly once, and the placement carve serializes.
     {"foreign-item-give", "Foreign give path tags shared structure; awards once; placements serialize (Lane C1)",
      Test_ForeignItemGive},
+    // Netplay 1a (ADR 0005, #460): the sourced-grant model, transport-free.
+    {"grant-idempotency", "Retransmit delivers once; a second gift of the same item delivers twice (ADR 0005)",
+     Test_GrantIdempotency},
+    {"grant-redeem-no-switch", "Grants redeem in received order at a safe point, no switch machinery (ADR 0005)",
+     Test_GrantRedeemNoSwitch},
+    {"grant-overflow", "Full array refuses loudly, backpressures sources, reclaims redeemed slots (ADR 0005)",
+     Test_GrantOverflow},
+    {"grant-persistence", "Cursors + overflow ride the .redsave; legacy loads unset; reset retires atomically "
+     "(ADR 0005)",
+     Test_GrantPersistence},
     {"context", "Test context/state management", Test_Context},
     // Clears all frozen states on entry and exit, so it must not run between a
     // test that freezes and one that expects that freeze to still be there.

--- a/src/common/test_runner.cpp
+++ b/src/common/test_runner.cpp
@@ -146,6 +146,21 @@ extern "C" {
 // via shared_items.h.
 #include "tests/test_grant_sources.c"
 
+// Netplay grant-relay loopback locks (ADR 0007, #460). Guarded: with
+// RSBS_NETPLAY=OFF (the default) the relay sources are not in the build at all,
+// so the code under test does not exist. The `#include "tests/..."` text is
+// still present for redship_check_test_sources(), which globs the directory and
+// greps this file — the guard hides the code from the compiler, not the file
+// from the completeness check.
+//
+// Inside its own extern "C" block: every symbol it drives (Relay_*,
+// RelayProto_*, Combo_*) is C-linkage.
+#ifdef RSBS_NETPLAY
+extern "C" {
+#include "tests/test_netplay_relay.c"
+}
+#endif
+
 // MM scene-command parse regression (issue #344). Included at FILE SCOPE
 // (compiled as C++): it drives MM's S2H::ResourceFactoryBinarySceneV0 directly
 // over a synthetic scene buffer — no ROM archives or display needed.
@@ -1132,6 +1147,21 @@ const TestDescriptor gTests[] = {
     {"grant-persistence", "Cursors + overflow ride the .redsave; legacy loads unset; reset retires atomically "
      "(ADR 0005)",
      Test_GrantPersistence},
+#ifdef RSBS_NETPLAY
+    // Netplay 1b (ADR 0007, #460): the grant relay, over a loopback ledger with
+    // multi-server's semantics. Registered only when the relay is built.
+    {"relay-wire-format", "Relay wire format matches golden vectors; foreign payloads skip (ADR 0007)",
+     Test_RelayWireFormat},
+    {"relay-loopback", "Loopback peers: retransmit delivers once, two peers' same item delivers twice, "
+     "self-echo filtered (ADR 0007)",
+     Test_RelayLoopback},
+    {"relay-catchup", "Late joiner catches up from ledger base 0; grants survive a cross-game switch (ADR 0007)",
+     Test_RelayCatchup},
+    {"relay-backpressure", "A full array backpressures the relay without losing the grant (ADR 0007)",
+     Test_RelayBackpressure},
+    {"relay-suspend-latch", "Suspend stops applying but not polling; resume drains in order (ADR 0007)",
+     Test_RelaySuspendLatch},
+#endif
     {"context", "Test context/state management", Test_Context},
     // Clears all frozen states on entry and exit, so it must not run between a
     // test that freezes and one that expects that freeze to still be there.

--- a/src/common/tests/test_grant_sources.c
+++ b/src/common/tests/test_grant_sources.c
@@ -330,6 +330,20 @@ TestResult Test_GrantPersistence(void) {
     rsbs::SaveManager& mgr = rsbs::SaveManager::Instance();
     mgr.SetSaveDirectory(kGrantSaveDir);
 
+    // Save-harness precondition, NOT a grant-model dependency: SaveManager::Save
+    // serializes Tiers 2/3 from the context-layer shadow buffers and refuses
+    // outright (save.cpp: "refuse rather than write a half-empty file") if either
+    // is absent. Context_InitFrozenStates allocates both at capacity; it is
+    // idempotent, and ClearAll only zeroes them, so once initialized they stay
+    // present. GrantTestReset deliberately does not do this — the other three
+    // grant tests must prove the model needs no switch machinery — so this test
+    // states the precondition itself instead of inheriting it from whichever
+    // save test happened to run earlier in the same process. Without it,
+    // `redship --test grant-persistence` standalone fails at Save while the
+    // pooled `--test all` run passes, which is exactly how this presented.
+    Context_InitFrozenStates();
+    GS_ASSERT(Context_GetOoTSaveContext() != NULL && Context_GetMMSaveContext() != NULL);
+
     // ------------------------------------------------------------------
     // (a) Round-trip: sourced entries, cursors, and the overflow count all
     //     survive Save/Load byte-exact — and the duplicate window STAYS

--- a/src/common/tests/test_grant_sources.c
+++ b/src/common/tests/test_grant_sources.c
@@ -1,0 +1,426 @@
+/**
+ * @file test_grant_sources.c
+ * @brief ROM-free locks for the sourced-grant model (ADR 0005, netplay 1a #460).
+ *
+ * The four semantic gaps the netplay spike identified (docs/
+ * netplay-increment-1-spike.md §3) are locked here, transport-free:
+ *
+ *  (1) IDEMPOTENCY IS DECIDABLE: a retransmitted grant (same source, same seq)
+ *      delivers once; two distinct grants of the SAME item — two sources, or
+ *      one source with fresh seqs — both deliver. Content de-dup stays correct
+ *      for in-process producers and never crosses into the sourced domain.
+ *
+ *  (2) REDEMPTION NEEDS NO SWITCH: grants redeem through the ordinary
+ *      consumer at any safe point, with zero switch machinery touched, in
+ *      received order, single-use under repeated safe points.
+ *
+ *  (3) OVERFLOW CANNOT LOSE DATA SILENTLY: a full array refuses loudly (the
+ *      durable overflow count), a refused sourced grant stays owed (cursor
+ *      unmoved -> the retry is accepted, not deduped), and redeemed entries
+ *      are reclaimed oldest-first with order preserved.
+ *
+ *  (4) THE MODEL IS DURABLE: cursors + sourced entries + overflow count ride
+ *      the .redsave Tier-1 record (ADR 0002 growth contract), a reload closes
+ *      the duplicate window instead of re-opening it, a pre-netplay legacy
+ *      record loads with every new field unset, and ComboContext_Init retires
+ *      items and cursors ATOMICALLY (the #440 composition contract).
+ *
+ * Linkage note: #included into test_runner.cpp at FILE SCOPE (compiled as
+ * C++, like test_save_roundtrip.c) for the rsbs::SaveManager half; every
+ * grant symbol it drives is C-linkage via shared_items.h.
+ */
+
+#include "../context.h"
+#include "../save.h"
+#include "../shared_items.h"
+#include "../test_runner.h"
+
+#include <cstdio>
+#include <cstring>
+#include <filesystem>
+#include <fstream>
+#include <string>
+#include <vector>
+
+#define GS_ASSERT(cond)                                                                                                \
+    do {                                                                                                               \
+        if (!(cond)) {                                                                                                 \
+            printf("[TEST] FAIL: %s:%d: %s\n", __FILE__, __LINE__, #cond);                                             \
+            return TEST_FAIL;                                                                                          \
+        }                                                                                                              \
+    } while (0)
+
+namespace {
+
+const char* const kGrantSaveDir = "rsbs_test_saves_grants";
+
+// Arbitrary nonzero source keys — the model treats them opaquely.
+const uint32_t kGrantSrcA = 0xA11CE001u;
+const uint32_t kGrantSrcB = 0xB0B00002u;
+
+// Award recorder that captures the FULL award order, not just the last one:
+// received-order redemption is one of the contracts under test.
+struct GrantAwardLog {
+    int count;
+    uint16_t ids[RSBS_SHARED_ITEM_CAP];
+    uint8_t origins[RSBS_SHARED_ITEM_CAP];
+};
+
+void GrantTestAward(const SharedItem* item, void* ctx) {
+    GrantAwardLog* log = (GrantAwardLog*)ctx;
+    if (log->count < (int)RSBS_SHARED_ITEM_CAP) {
+        log->ids[log->count] = item->id;
+        log->origins[log->count] = item->originGame;
+    }
+    log->count++;
+}
+
+// Clean slate shared by every grant test. Deliberately does NOT touch frozen
+// state or the entrance table: these tests must prove the grant model has no
+// dependency on the switch machinery.
+void GrantTestReset(void) {
+    ComboContext_Init();
+    Combo_ClearSharedItemOutbox();
+}
+
+int GrantTestOccupiedTotal(void) {
+    return Combo_CountSharedItems(GAME_OOT, /*includeRedeemed=*/true) +
+           Combo_CountSharedItems(GAME_MM, /*includeRedeemed=*/true);
+}
+
+// Hand-craft a PRE-NETPLAY .redsave: the Tier-1 record truncated exactly where
+// the ADR 0005 carve begins (offsetof grantCursors — drift-locked to 672 by
+// the context.h static-assert chain), taking the bytes from the CURRENT
+// gComboCtx. That is byte-for-byte what a pre-carve build wrote, per the
+// growth contract. Mirrors test_save_roundtrip.c's SaveTestWriteCraftedSlot
+// but is kept local so this file does not reach into another test's internals.
+bool GrantTestWriteLegacySlot(const std::string& path) {
+    const uint32_t comboSize = (uint32_t)offsetof(ComboContext, grantCursors);
+    std::vector<uint8_t> payload;
+    const uint8_t* comboBytes = reinterpret_cast<const uint8_t*>(&gComboCtx);
+    payload.insert(payload.end(), comboBytes, comboBytes + comboSize);
+    payload.insert(payload.end(), OOT_SAVE_CONTEXT_SIZE, 0u);
+    payload.insert(payload.end(), MM_SAVE_CONTEXT_SIZE, 0u);
+
+    rsbs::RsbsSaveHeader h;
+    std::memset(&h, 0, sizeof(h));
+    std::memcpy(h.magic, RSBS_SAVE_MAGIC, sizeof(h.magic));
+    h.version = RSBS_SAVE_VERSION;
+    h.endian = RSBS_SAVE_ENDIAN_LE;
+    h.slot = 0;
+    h.headerSize = sizeof(rsbs::RsbsSaveHeader);
+    h.comboSize = comboSize;
+    h.ootSize = (uint32_t)OOT_SAVE_CONTEXT_SIZE;
+    h.mmSize = (uint32_t)MM_SAVE_CONTEXT_SIZE;
+    h.crc32 = rsbs::SaveManager::Crc32(payload.data(), payload.size());
+
+    std::filesystem::create_directories(kGrantSaveDir);
+    std::ofstream out(path, std::ios::binary | std::ios::trunc);
+    if (!out) {
+        return false;
+    }
+    out.write(reinterpret_cast<const char*>(&h), sizeof(h));
+    out.write(reinterpret_cast<const char*>(payload.data()), (std::streamsize)payload.size());
+    return static_cast<bool>(out);
+}
+
+} // namespace
+
+TestResult Test_GrantIdempotency(void) {
+    printf("[TEST] grant-idempotency: retransmit delivers once; a second gift of the same item delivers twice "
+           "(ADR 0005)\n");
+
+    GrantTestReset();
+
+    // Malformed submissions change nothing.
+    GS_ASSERT(Combo_SubmitSourcedGrant(0, 1, GAME_OOT, 10) == RSBS_GRANT_REJECTED);
+    GS_ASSERT(Combo_SubmitSourcedGrant(kGrantSrcA, 0, GAME_OOT, 10) == RSBS_GRANT_REJECTED);
+    GS_ASSERT(Combo_SubmitSourcedGrant(kGrantSrcA, 1, GAME_NONE, 10) == RSBS_GRANT_REJECTED);
+    GS_ASSERT(Combo_CountGrantSources() == 0 && GrantTestOccupiedTotal() == 0);
+    GS_ASSERT(Combo_GetGrantCursor(kGrantSrcA) == 0 && Combo_GetGrantCursor(0) == 0);
+
+    // A new source must start at seq 1: out-of-the-blue seq 5 is a GAP, and
+    // no cursor slot is burned for it.
+    GS_ASSERT(Combo_SubmitSourcedGrant(kGrantSrcA, 5, GAME_OOT, 10) == RSBS_GRANT_GAP);
+    GS_ASSERT(Combo_CountGrantSources() == 0 && GrantTestOccupiedTotal() == 0);
+
+    // First delivery.
+    GS_ASSERT(Combo_SubmitSourcedGrant(kGrantSrcA, 1, GAME_OOT, 10) == RSBS_GRANT_ACCEPTED);
+    GS_ASSERT(Combo_GetGrantCursor(kGrantSrcA) == 1);
+    GS_ASSERT(GrantTestOccupiedTotal() == 1);
+    GS_ASSERT((gComboCtx.sharedItemsTagged[0].flags & RSBS_SHARED_ITEM_SOURCED) != 0);
+    GS_ASSERT((gComboCtx.sharedItemsTagged[0].flags & RSBS_SHARED_ITEM_REDEEMED) == 0);
+
+    // RETRANSMIT: same source, same seq — delivers once. This used to be
+    // indistinguishable from a second gift at the record API (spike §3).
+    GS_ASSERT(Combo_SubmitSourcedGrant(kGrantSrcA, 1, GAME_OOT, 10) == RSBS_GRANT_DUPLICATE);
+    GS_ASSERT(GrantTestOccupiedTotal() == 1 && Combo_GetGrantCursor(kGrantSrcA) == 1);
+
+    // THE GAP-2 REGRESSION: a second source gifting the SAME item is a second
+    // item, not a merge.
+    GS_ASSERT(Combo_SubmitSourcedGrant(kGrantSrcB, 1, GAME_OOT, 10) == RSBS_GRANT_ACCEPTED);
+    GS_ASSERT(GrantTestOccupiedTotal() == 2);
+
+    // Same source gifting the same item again under a fresh seq: also a
+    // second item.
+    GS_ASSERT(Combo_SubmitSourcedGrant(kGrantSrcA, 2, GAME_OOT, 10) == RSBS_GRANT_ACCEPTED);
+    GS_ASSERT(GrantTestOccupiedTotal() == 3 && Combo_GetGrantCursor(kGrantSrcA) == 2);
+
+    // A skipped seq is a GAP (cursor and array unmoved); filling in order
+    // resumes delivery.
+    GS_ASSERT(Combo_SubmitSourcedGrant(kGrantSrcA, 4, GAME_OOT, 11) == RSBS_GRANT_GAP);
+    GS_ASSERT(GrantTestOccupiedTotal() == 3 && Combo_GetGrantCursor(kGrantSrcA) == 2);
+    GS_ASSERT(Combo_SubmitSourcedGrant(kGrantSrcA, 3, GAME_OOT, 11) == RSBS_GRANT_ACCEPTED);
+    GS_ASSERT(Combo_SubmitSourcedGrant(kGrantSrcA, 4, GAME_OOT, 12) == RSBS_GRANT_ACCEPTED);
+    GS_ASSERT(Combo_GetGrantCursor(kGrantSrcA) == 4 && GrantTestOccupiedTotal() == 5);
+    GS_ASSERT(Combo_SubmitSourcedGrant(kGrantSrcA, 2, GAME_OOT, 10) == RSBS_GRANT_DUPLICATE); // stale retransmit
+
+    // The in-process producer's content de-dup is UNCHANGED — and disjoint
+    // from the sourced domain: un-redeemed sourced (OOT, 10) entries exist,
+    // yet a local pickup of (OOT, 10) records fresh instead of merging.
+    int localSlot = Combo_RecordSharedItem(GAME_OOT, 10);
+    GS_ASSERT(localSlot >= 0);
+    GS_ASSERT(GrantTestOccupiedTotal() == 6);
+    GS_ASSERT(gComboCtx.sharedItemsTagged[localSlot].flags == 0); // in-process: no SOURCED bit
+    // A re-fired local pickup still merges into the local entry.
+    GS_ASSERT(Combo_RecordSharedItem(GAME_OOT, 10) == localSlot);
+    GS_ASSERT(GrantTestOccupiedTotal() == 6);
+
+    // Source-table exhaustion is explicit, not silent: fill all cursor slots,
+    // then a 9th source is refused with nothing recorded.
+    GS_ASSERT(Combo_CountGrantSources() == 2);
+    for (uint32_t i = 0; i < RSBS_GRANT_SOURCE_CAP - 2u; i++) {
+        GS_ASSERT(Combo_SubmitSourcedGrant(0xC0DE0000u + i, 1, GAME_OOT, (uint16_t)(900u + i)) ==
+                  RSBS_GRANT_ACCEPTED);
+    }
+    GS_ASSERT(Combo_CountGrantSources() == (int)RSBS_GRANT_SOURCE_CAP);
+    const int occupiedBefore = GrantTestOccupiedTotal();
+    GS_ASSERT(Combo_SubmitSourcedGrant(0xDEADBEEFu, 1, GAME_OOT, 999) == RSBS_GRANT_NO_SOURCE_SLOT);
+    GS_ASSERT(GrantTestOccupiedTotal() == occupiedBefore);
+    GS_ASSERT(Combo_CountGrantSources() == (int)RSBS_GRANT_SOURCE_CAP);
+
+    GrantTestReset();
+    printf("[TEST] PASS: retransmit vs second gift is decidable; domains disjoint; exhaustion explicit\n");
+    return TEST_PASS;
+}
+
+TestResult Test_GrantRedeemNoSwitch(void) {
+    printf("[TEST] grant-redeem-no-switch: grants redeem in received order with zero switch machinery (ADR 0005)\n");
+
+    GrantTestReset();
+    Context_InitFrozenStates();
+    Context_ClearAllFrozenStates();
+
+    // Interleave two sources; one grant is bound for the OTHER game.
+    GS_ASSERT(Combo_SubmitSourcedGrant(kGrantSrcA, 1, GAME_OOT, 101) == RSBS_GRANT_ACCEPTED);
+    GS_ASSERT(Combo_SubmitSourcedGrant(kGrantSrcB, 1, GAME_OOT, 201) == RSBS_GRANT_ACCEPTED);
+    GS_ASSERT(Combo_SubmitSourcedGrant(kGrantSrcA, 2, GAME_OOT, 102) == RSBS_GRANT_ACCEPTED);
+    GS_ASSERT(Combo_SubmitSourcedGrant(kGrantSrcB, 2, GAME_MM, 301) == RSBS_GRANT_ACCEPTED);
+
+    // Nothing switch-shaped has happened — and must not need to.
+    GS_ASSERT(!ComboContext_IsSwitchPending());
+    GS_ASSERT(!Context_HasFrozenState(GAME_OOT) && !Context_HasFrozenState(GAME_MM));
+
+    // Redeem for OoT directly — the safe-point call a mid-session tick will
+    // make. Received order across sources, only OoT-bound entries.
+    GrantAwardLog log;
+    std::memset(&log, 0, sizeof(log));
+    GS_ASSERT(Combo_RedeemSharedItemsForGame(GAME_OOT, GrantTestAward, &log) == 3);
+    GS_ASSERT(log.count == 3);
+    GS_ASSERT(log.ids[0] == 101 && log.ids[1] == 201 && log.ids[2] == 102);
+    GS_ASSERT(log.origins[0] == (uint8_t)GAME_OOT && log.origins[1] == (uint8_t)GAME_OOT &&
+              log.origins[2] == (uint8_t)GAME_OOT);
+
+    // Single-use under a repeated safe point.
+    std::memset(&log, 0, sizeof(log));
+    GS_ASSERT(Combo_RedeemSharedItemsForGame(GAME_OOT, GrantTestAward, &log) == 0);
+    GS_ASSERT(log.count == 0);
+
+    // The MM-bound grant was untouched and redeems for MM.
+    GS_ASSERT(Combo_CountSharedItems(GAME_MM, /*includeRedeemed=*/false) == 1);
+    std::memset(&log, 0, sizeof(log));
+    GS_ASSERT(Combo_RedeemSharedItemsForGame(GAME_MM, GrantTestAward, &log) == 1);
+    GS_ASSERT(log.ids[0] == 301 && log.origins[0] == (uint8_t)GAME_MM);
+
+    // A grant arriving AFTER a redemption pass redeems at the next safe point.
+    GS_ASSERT(Combo_SubmitSourcedGrant(kGrantSrcA, 3, GAME_OOT, 103) == RSBS_GRANT_ACCEPTED);
+    std::memset(&log, 0, sizeof(log));
+    GS_ASSERT(Combo_RedeemSharedItemsForGame(GAME_OOT, GrantTestAward, &log) == 1);
+    GS_ASSERT(log.ids[0] == 103);
+
+    GrantTestReset();
+    printf("[TEST] PASS: redemption is a safe-point call, in received order, single-use, no switch required\n");
+    return TEST_PASS;
+}
+
+TestResult Test_GrantOverflow(void) {
+    printf("[TEST] grant-overflow: full array refuses loudly, backpressures sources, reclaims redeemed slots "
+           "(ADR 0005)\n");
+
+    GrantTestReset();
+    GS_ASSERT(Combo_GetSharedItemOverflowCount() == 0);
+
+    // Fill the array: 62 OoT-bound grants, then 2 MM-bound, all one source.
+    for (uint32_t i = 1; i <= RSBS_SHARED_ITEM_CAP - 2u; i++) {
+        GS_ASSERT(Combo_SubmitSourcedGrant(kGrantSrcA, i, GAME_OOT, (uint16_t)(1000u + i)) == RSBS_GRANT_ACCEPTED);
+    }
+    GS_ASSERT(Combo_SubmitSourcedGrant(kGrantSrcA, RSBS_SHARED_ITEM_CAP - 1u, GAME_MM, 501) == RSBS_GRANT_ACCEPTED);
+    GS_ASSERT(Combo_SubmitSourcedGrant(kGrantSrcA, RSBS_SHARED_ITEM_CAP, GAME_MM, 502) == RSBS_GRANT_ACCEPTED);
+    GS_ASSERT(GrantTestOccupiedTotal() == (int)RSBS_SHARED_ITEM_CAP);
+
+    // Every entry is un-redeemed: the next sourced grant is BACKPRESSURED —
+    // refused loudly, cursor unmoved, durable overflow count up.
+    GS_ASSERT(Combo_SubmitSourcedGrant(kGrantSrcA, RSBS_SHARED_ITEM_CAP + 1u, GAME_OOT, 1065) ==
+              RSBS_GRANT_RETRY_FULL);
+    GS_ASSERT(Combo_GetGrantCursor(kGrantSrcA) == RSBS_SHARED_ITEM_CAP);
+    GS_ASSERT(Combo_GetSharedItemOverflowCount() == 1);
+
+    // In-process refusals are counted too (a genuine loss, made diagnosable).
+    GS_ASSERT(Combo_RecordSharedItem(GAME_OOT, 2000) == -1);
+    GS_ASSERT(Combo_GetSharedItemOverflowCount() == 2);
+    GS_ASSERT(Combo_StageSharedItem(GAME_OOT, 2001) == true);
+    GS_ASSERT(Combo_CommitStagedSharedItems() == 0);
+    GS_ASSERT(Combo_GetSharedItemOverflowCount() == 3);
+
+    // Redeem the two MM entries: capacity returns via oldest-first reclaim.
+    GrantAwardLog log;
+    std::memset(&log, 0, sizeof(log));
+    GS_ASSERT(Combo_RedeemSharedItemsForGame(GAME_MM, GrantTestAward, &log) == 2);
+    GS_ASSERT(log.ids[0] == 501 && log.ids[1] == 502);
+
+    // THE NO-SILENT-LOSS PROPERTY: the refused seq, retried after capacity
+    // returned, is ACCEPTED — the cursor never advanced past it, so the retry
+    // is not mistaken for a duplicate and the grant is not lost.
+    GS_ASSERT(Combo_SubmitSourcedGrant(kGrantSrcA, RSBS_SHARED_ITEM_CAP + 1u, GAME_OOT, 1065) ==
+              RSBS_GRANT_ACCEPTED);
+    GS_ASSERT(Combo_SubmitSourcedGrant(kGrantSrcA, RSBS_SHARED_ITEM_CAP + 2u, GAME_OOT, 1066) ==
+              RSBS_GRANT_ACCEPTED);
+    GS_ASSERT(GrantTestOccupiedTotal() == (int)RSBS_SHARED_ITEM_CAP);
+    GS_ASSERT(Combo_GetSharedItemOverflowCount() == 3); // reclaim is not a refusal
+
+    // Both redeemed entries are gone; a third grant is backpressured again.
+    GS_ASSERT(Combo_SubmitSourcedGrant(kGrantSrcA, RSBS_SHARED_ITEM_CAP + 3u, GAME_OOT, 1067) ==
+              RSBS_GRANT_RETRY_FULL);
+    GS_ASSERT(Combo_GetSharedItemOverflowCount() == 4);
+
+    // Reclamation preserved received order: the 62 originals award before the
+    // two late arrivals, all in acceptance order.
+    std::memset(&log, 0, sizeof(log));
+    GS_ASSERT(Combo_RedeemSharedItemsForGame(GAME_OOT, GrantTestAward, &log) == (int)RSBS_SHARED_ITEM_CAP);
+    GS_ASSERT(log.count == (int)RSBS_SHARED_ITEM_CAP);
+    for (uint32_t i = 0; i < RSBS_SHARED_ITEM_CAP - 2u; i++) {
+        GS_ASSERT(log.ids[i] == (uint16_t)(1000u + i + 1u));
+    }
+    GS_ASSERT(log.ids[RSBS_SHARED_ITEM_CAP - 2u] == 1065 && log.ids[RSBS_SHARED_ITEM_CAP - 1u] == 1066);
+
+    // The once-refused-then-accepted seq is now firmly a duplicate.
+    GS_ASSERT(Combo_SubmitSourcedGrant(kGrantSrcA, RSBS_SHARED_ITEM_CAP + 1u, GAME_OOT, 1065) ==
+              RSBS_GRANT_DUPLICATE);
+
+    GrantTestReset();
+    printf("[TEST] PASS: overflow refuses loudly and durably; backpressure retries deliver; order survives "
+           "reclamation\n");
+    return TEST_PASS;
+}
+
+TestResult Test_GrantPersistence(void) {
+    printf("[TEST] grant-persistence: cursors + overflow ride the .redsave; legacy loads unset; reset retires "
+           "atomically (ADR 0005)\n");
+
+    rsbs::SaveManager& mgr = rsbs::SaveManager::Instance();
+    mgr.SetSaveDirectory(kGrantSaveDir);
+
+    // ------------------------------------------------------------------
+    // (a) Round-trip: sourced entries, cursors, and the overflow count all
+    //     survive Save/Load byte-exact — and the duplicate window STAYS
+    //     closed across the reload.
+    // ------------------------------------------------------------------
+    GrantTestReset();
+    GS_ASSERT(Combo_SubmitSourcedGrant(kGrantSrcA, 1, GAME_OOT, 11) == RSBS_GRANT_ACCEPTED);
+    GS_ASSERT(Combo_SubmitSourcedGrant(kGrantSrcA, 2, GAME_MM, 22) == RSBS_GRANT_ACCEPTED);
+    GS_ASSERT(Combo_SubmitSourcedGrant(kGrantSrcB, 1, GAME_OOT, 33) == RSBS_GRANT_ACCEPTED);
+    GS_ASSERT(Combo_RedeemSharedItemsForGame(GAME_OOT, NULL, NULL) == 2);
+    gComboCtx.sharedItemOverflowCount = 7; // stand-in for a recorded refusal; serialization is what's under test
+
+    SharedItem expectedItems[RSBS_SHARED_ITEM_CAP];
+    ComboGrantSourceCursor expectedCursors[RSBS_GRANT_SOURCE_CAP];
+    std::memcpy(expectedItems, gComboCtx.sharedItemsTagged, sizeof(expectedItems));
+    std::memcpy(expectedCursors, gComboCtx.grantCursors, sizeof(expectedCursors));
+
+    mgr.DeleteSave(0);
+    GS_ASSERT(mgr.Save(0));
+
+    // Wipe, then scribble, so restored zeros are provably the loader's doing.
+    ComboContext_Init();
+    std::memset(gComboCtx.sharedItemsTagged, 0x5A, sizeof(gComboCtx.sharedItemsTagged));
+    std::memset(gComboCtx.grantCursors, 0x5A, sizeof(gComboCtx.grantCursors));
+    gComboCtx.sharedItemOverflowCount = 0xDEADBEEFu;
+
+    GS_ASSERT(mgr.Load(0));
+    GS_ASSERT(std::memcmp(expectedItems, gComboCtx.sharedItemsTagged, sizeof(expectedItems)) == 0);
+    GS_ASSERT(std::memcmp(expectedCursors, gComboCtx.grantCursors, sizeof(expectedCursors)) == 0);
+    GS_ASSERT(gComboCtx.sharedItemOverflowCount == 7);
+    // Typed spot-checks so a memcmp-passing-but-misread layout fails loudly.
+    GS_ASSERT(Combo_GetGrantCursor(kGrantSrcA) == 2 && Combo_GetGrantCursor(kGrantSrcB) == 1);
+    GS_ASSERT(Combo_CountGrantSources() == 2);
+    GS_ASSERT(gComboCtx.sharedItemsTagged[0].flags == (RSBS_SHARED_ITEM_SOURCED | RSBS_SHARED_ITEM_REDEEMED));
+    GS_ASSERT(gComboCtx.sharedItemsTagged[1].flags == RSBS_SHARED_ITEM_SOURCED); // MM grant still pending
+
+    // The reload did NOT re-open the duplicate window: every delivered seq is
+    // still a duplicate, and delivery resumes exactly at cursor + 1.
+    GS_ASSERT(Combo_SubmitSourcedGrant(kGrantSrcA, 1, GAME_OOT, 11) == RSBS_GRANT_DUPLICATE);
+    GS_ASSERT(Combo_SubmitSourcedGrant(kGrantSrcA, 2, GAME_MM, 22) == RSBS_GRANT_DUPLICATE);
+    GS_ASSERT(Combo_SubmitSourcedGrant(kGrantSrcB, 1, GAME_OOT, 33) == RSBS_GRANT_DUPLICATE);
+    GS_ASSERT(Combo_SubmitSourcedGrant(kGrantSrcA, 3, GAME_OOT, 44) == RSBS_GRANT_ACCEPTED);
+    mgr.DeleteSave(0);
+
+    // ------------------------------------------------------------------
+    // (b) Migration: a PRE-NETPLAY .redsave (Tier-1 truncated at the ADR 0005
+    //     carve) loads with items intact and every new field unset.
+    // ------------------------------------------------------------------
+    GrantTestReset();
+    GS_ASSERT(Combo_RecordSharedItem(GAME_OOT, 0x00A7) >= 0); // a real legacy save holds in-process entries only
+    GS_ASSERT(Combo_RecordSharedItem(GAME_MM, 0x0042) >= 0);
+    GS_ASSERT(Combo_RedeemSharedItemsForGame(GAME_OOT, NULL, NULL) == 1);
+    GS_ASSERT(GrantTestWriteLegacySlot(mgr.SlotPath(0)));
+
+    ComboContext_Init();
+    std::memset(gComboCtx.grantCursors, 0x5A, sizeof(gComboCtx.grantCursors));
+    gComboCtx.sharedItemOverflowCount = 0xDEADBEEFu;
+
+    GS_ASSERT(mgr.Load(0));
+    GS_ASSERT(Combo_CountSharedItems(GAME_OOT, /*includeRedeemed=*/true) == 1);
+    GS_ASSERT(Combo_CountSharedItems(GAME_MM, /*includeRedeemed=*/false) == 1);
+    GS_ASSERT(Combo_CountGrantSources() == 0);              // no source ever delivered to a legacy save
+    GS_ASSERT(Combo_GetSharedItemOverflowCount() == 0);     // and it never overflowed
+    for (uint32_t i = 0; i < RSBS_GRANT_SOURCE_CAP; i++) {
+        GS_ASSERT(gComboCtx.grantCursors[i].sourceKey == 0 && gComboCtx.grantCursors[i].lastSeq == 0);
+    }
+    // A legacy world accepts its first sourced delivery like any fresh one.
+    GS_ASSERT(Combo_SubmitSourcedGrant(kGrantSrcA, 1, GAME_OOT, 55) == RSBS_GRANT_ACCEPTED);
+    mgr.DeleteSave(0);
+
+    // ------------------------------------------------------------------
+    // (c) Reset invalidation (the #440 composition contract): one
+    //     ComboContext_Init retires items AND cursors AND the overflow count
+    //     together, so a dead session can neither replay its grants into a
+    //     fresh world nor block that world's own deliveries.
+    // ------------------------------------------------------------------
+    GS_ASSERT(Combo_SubmitSourcedGrant(kGrantSrcA, 2, GAME_MM, 66) == RSBS_GRANT_ACCEPTED);
+    GS_ASSERT(Combo_CountGrantSources() == 1 && GrantTestOccupiedTotal() > 0);
+
+    ComboContext_Init();
+    GS_ASSERT(Combo_CountGrantSources() == 0);
+    GS_ASSERT(GrantTestOccupiedTotal() == 0);
+    GS_ASSERT(Combo_GetSharedItemOverflowCount() == 0);
+    // A dead-room retransmit is NOT silently accepted into the fresh world...
+    GS_ASSERT(Combo_SubmitSourcedGrant(kGrantSrcA, 2, GAME_MM, 66) == RSBS_GRANT_GAP);
+    GS_ASSERT(GrantTestOccupiedTotal() == 0);
+    // ...while a fresh session's own delivery stream starts cleanly.
+    GS_ASSERT(Combo_SubmitSourcedGrant(kGrantSrcA, 1, GAME_OOT, 77) == RSBS_GRANT_ACCEPTED);
+
+    GrantTestReset();
+    printf("[TEST] PASS: durable across save/load; legacy records read unset; reset retires items + cursors "
+           "atomically\n");
+    return TEST_PASS;
+}

--- a/src/common/tests/test_netplay_relay.c
+++ b/src/common/tests/test_netplay_relay.c
@@ -1,0 +1,772 @@
+/**
+ * @file test_netplay_relay.c
+ * @brief Loopback locks for the grant relay (ADR 0007). ROM-free, no sockets.
+ *
+ * WHAT THIS PROVES, and equally what it does NOT — stated here because ADR
+ * 0006 §2(b) caught the previous attempt's harness going green while real
+ * integration stayed impossible, and the honest statement is the deliverable:
+ *
+ * PROVES. Two client objects drive the REAL codec and the REAL state machine
+ * over a mock ledger implementing the same semantics as OoTMM's multi-server:
+ * append-only, u64-key dedup, `ledgerBase` replay, and — load-bearing —
+ * broadcast to EVERY client on the ledger INCLUDING the sender. Real bytes go
+ * through RelayProto_* in both directions; only the syscall layer is swapped.
+ *   - a retransmitted grant yields exactly ONE item
+ *   - two peers gifting the same item yield TWO items (the ADR 0005 §1 regression)
+ *   - received-order redemption
+ *   - grants survive a cross-game switch
+ *   - late-join catch-up delivers the whole backlog
+ *   - self-echo is filtered (the sender does not award itself its own gift)
+ *   - inbox overflow drops WITHOUT advancing the cursor, and is loud
+ *   - a foreign/malformed ledger entry is skipped without desyncing
+ *   - golden byte vectors pin the wire format
+ *
+ * DOES NOT PROVE. The mock is a re-derivation from reading multi-server's
+ * client.c/ledger.c, not the real binary — so it cannot prove our framing
+ * matches the wire. Nor does it prove real socket behaviour (partial reads,
+ * EAGAIN, mid-frame disconnect, TCP segmentation), nor that upstream still
+ * behaves as read (pinned: master @ 2025-03-27, VERSION 0x00000200).
+ *
+ * The distinction from ADR 0006's gap is real and is why this is worth
+ * locking: Archipelago's was a WALL — no client of ours could ever be
+ * admitted, because a real server validates the announced game against a
+ * generated world. multi-server's ledger never inspects the payload, so there
+ * is no admissibility check to fail and a framing mismatch is a DEFECT CLASS
+ * we can fix unilaterally. Different in kind, not merely in degree.
+ *
+ * Linkage note: #included into test_runner.cpp inside its own extern "C"
+ * block — every symbol it drives is C-linkage (relay_*, Combo_*).
+ */
+
+#include "../context.h"
+#include "../netplay/relay_client.h"
+#include "../netplay/relay_protocol.h"
+#include "../shared_items.h"
+#include "../test_runner.h"
+
+#include <stdio.h>
+#include <string.h>
+
+#define NR_ASSERT(cond)                                                                                                \
+    do {                                                                                                               \
+        if (!(cond)) {                                                                                                 \
+            printf("[TEST] FAIL: %s:%d: %s\n", __FILE__, __LINE__, #cond);                                             \
+            return TEST_FAIL;                                                                                          \
+        }                                                                                                              \
+    } while (0)
+
+// ============================================================================
+// Mock ledger server — the semantics of multi-server, in process
+// ============================================================================
+
+#define MOCK_MAX_ENTRIES 128
+#define MOCK_MAX_CLIENTS 4
+#define MOCK_PIPE_CAP 8192
+
+typedef struct {
+    uint64_t key;
+    uint8_t payload[RSBS_RELAY_MAX_PAYLOAD];
+    uint32_t payloadLen;
+} MockEntry;
+
+// A one-directional byte pipe. Deliberately a plain FIFO of bytes, not of
+// frames: the client must reassemble, which is what makes the codec's
+// incremental decoder actually exercised.
+typedef struct {
+    uint8_t buf[MOCK_PIPE_CAP];
+    uint32_t head;
+    uint32_t len;
+} MockPipe;
+
+typedef struct {
+    bool active;
+    bool ready;       // past the handshake
+    uint32_t base;    // ledgerBase: how many entries this client has been sent
+    MockPipe toClient;
+    MockPipe toServer;
+    // Server-side parse state for the client's own stream.
+    uint8_t rx[512];
+    uint32_t rxLen;
+    bool sawHello;
+    bool sawJoin;
+} MockClient;
+
+typedef struct {
+    MockEntry entries[MOCK_MAX_ENTRIES];
+    uint32_t count;
+    MockClient clients[MOCK_MAX_CLIENTS];
+    // Set to force the ledger to reject writes, to drive backpressure paths.
+    bool full;
+} MockServer;
+
+static void MockPipeWrite(MockPipe* p, const uint8_t* data, uint32_t len) {
+    for (uint32_t i = 0; i < len; ++i) {
+        if (p->len >= MOCK_PIPE_CAP) {
+            return; // drop; tests never intentionally overrun this
+        }
+        p->buf[(p->head + p->len) % MOCK_PIPE_CAP] = data[i];
+        p->len++;
+    }
+}
+
+static uint32_t MockPipeRead(MockPipe* p, uint8_t* out, uint32_t max) {
+    uint32_t n = 0;
+    while (n < max && p->len > 0) {
+        out[n++] = p->buf[p->head];
+        p->head = (p->head + 1u) % MOCK_PIPE_CAP;
+        p->len--;
+    }
+    return n;
+}
+
+static MockServer gMockServer;
+
+// --- Ledger ----------------------------------------------------------------
+
+// Append with dedup on `key`, exactly like multiLedgerWrite: an existing key
+// is silently ignored, which is the server-side half of idempotency.
+static void MockLedgerWrite(MockServer* s, uint64_t key, const uint8_t* payload, uint32_t len) {
+    if (s->full || s->count >= MOCK_MAX_ENTRIES) {
+        return;
+    }
+    for (uint32_t i = 0; i < s->count; ++i) {
+        if (s->entries[i].key == key) {
+            return; // dedup — the retransmit never fans out
+        }
+    }
+    MockEntry* e = &s->entries[s->count++];
+    e->key = key;
+    e->payloadLen = len;
+    memcpy(e->payload, payload, len);
+}
+
+// Stream every entry the client has not yet been sent. This is
+// multiClientTransferLedger: it is called both at join (catch-up from base)
+// and after every write (live tail), and it is the same code path for both.
+static void MockTransferLedger(MockServer* s, MockClient* c) {
+    if (!c->active || !c->ready) {
+        return;
+    }
+    while (c->base < s->count) {
+        const MockEntry* e = &s->entries[c->base];
+        uint8_t frame[1 + RSBS_RELAY_ENTRY_HEADER_LEN + RSBS_RELAY_MAX_PAYLOAD];
+        const uint32_t n = RelayProto_EncodeTransfer(e->key, e->payload, e->payloadLen, frame);
+        MockPipeWrite(&c->toClient, frame, n);
+        c->base++;
+    }
+}
+
+// The broadcast in multiClientCmdTransfer does NOT skip the sender (unlike the
+// chat path, which does). Reproducing that faithfully is the whole reason
+// self-echo filtering is testable here at all.
+static void MockBroadcast(MockServer* s) {
+    for (int i = 0; i < MOCK_MAX_CLIENTS; ++i) {
+        MockTransferLedger(s, &s->clients[i]);
+    }
+}
+
+// --- Server-side client stream parsing --------------------------------------
+
+static void MockServerConsume(MockClient* c, uint32_t n) {
+    if (n >= c->rxLen) {
+        c->rxLen = 0;
+        return;
+    }
+    memmove(c->rx, c->rx + n, c->rxLen - n);
+    c->rxLen -= n;
+}
+
+static void MockServerPump(MockServer* s, int clientIdx) {
+    MockClient* c = &s->clients[clientIdx];
+    if (!c->active) {
+        return;
+    }
+
+    // Drain the client's outbound pipe into the server's parse buffer.
+    c->rxLen += MockPipeRead(&c->toServer, c->rx + c->rxLen, (uint32_t)sizeof(c->rx) - c->rxLen);
+
+    for (;;) {
+        if (!c->sawHello) {
+            if (c->rxLen < RSBS_RELAY_HELLO_LEN) {
+                return;
+            }
+            // Validate the magic the way the real server does.
+            if (memcmp(c->rx, RSBS_RELAY_MAGIC, RSBS_RELAY_MAGIC_LEN) != 0) {
+                c->active = false;
+                return;
+            }
+            MockServerConsume(c, RSBS_RELAY_HELLO_LEN);
+            c->sawHello = true;
+
+            // Server hello: magic + version + assigned client id.
+            uint8_t hello[RSBS_RELAY_SVHELLO_LEN];
+            memcpy(hello, RSBS_RELAY_MAGIC, RSBS_RELAY_MAGIC_LEN);
+            const uint32_t v = RSBS_RELAY_PROTOCOL_VERSION;
+            hello[5] = (uint8_t)(v & 0xFFu);
+            hello[6] = (uint8_t)((v >> 8) & 0xFFu);
+            hello[7] = (uint8_t)((v >> 16) & 0xFFu);
+            hello[8] = (uint8_t)((v >> 24) & 0xFFu);
+            hello[9] = (uint8_t)(clientIdx & 0xFFu);
+            hello[10] = 0u;
+            MockPipeWrite(&c->toClient, hello, RSBS_RELAY_SVHELLO_LEN);
+            continue;
+        }
+
+        if (!c->sawJoin) {
+            if (c->rxLen < RSBS_RELAY_JOIN_LEN) {
+                return;
+            }
+            uint32_t base = (uint32_t)c->rx[16] | ((uint32_t)c->rx[17] << 8) | ((uint32_t)c->rx[18] << 16) |
+                            ((uint32_t)c->rx[19] << 24);
+            MockServerConsume(c, RSBS_RELAY_JOIN_LEN);
+            c->sawJoin = true;
+            c->ready = true;
+            c->base = base;
+            // Catch-up: everything from base onward, before any live traffic.
+            MockTransferLedger(s, c);
+            continue;
+        }
+
+        // Command stream from the client.
+        if (c->rxLen < 1) {
+            return;
+        }
+        if (c->rx[0] == RSBS_RELAY_OP_NONE) {
+            MockServerConsume(c, 1);
+            continue;
+        }
+        if (c->rx[0] == RSBS_RELAY_OP_TRANSFER) {
+            if (c->rxLen < 1u + RSBS_RELAY_ENTRY_HEADER_LEN) {
+                return;
+            }
+            const uint32_t payloadLen = c->rx[9];
+            const uint32_t total = 1u + RSBS_RELAY_ENTRY_HEADER_LEN + payloadLen;
+            if (c->rxLen < total) {
+                return;
+            }
+            uint64_t key = 0;
+            for (int i = 7; i >= 0; --i) {
+                key = (key << 8) | (uint64_t)c->rx[1 + i];
+            }
+            MockLedgerWrite(s, key, c->rx + 10, payloadLen);
+            MockServerConsume(c, total);
+            MockBroadcast(s);
+            continue;
+        }
+        // Unknown opcode: the real server disconnects.
+        c->active = false;
+        return;
+    }
+}
+
+static void MockServerPumpAll(MockServer* s) {
+    for (int i = 0; i < MOCK_MAX_CLIENTS; ++i) {
+        MockServerPump(s, i);
+    }
+}
+
+// --- RelayChannel bindings --------------------------------------------------
+
+static int MockChanSend(void* userData, const uint8_t* data, uint32_t len) {
+    MockClient* c = (MockClient*)userData;
+    if (!c->active) {
+        return -1;
+    }
+    MockPipeWrite(&c->toServer, data, len);
+    return (int)len;
+}
+
+static int MockChanRecv(void* userData, uint8_t* data, uint32_t len) {
+    MockClient* c = (MockClient*)userData;
+    if (!c->active) {
+        return -1;
+    }
+    return (int)MockPipeRead(&c->toClient, data, len);
+}
+
+static void MockReset(MockServer* s) {
+    memset(s, 0, sizeof(*s));
+}
+
+static MockClient* MockAttach(MockServer* s, int idx) {
+    MockClient* c = &s->clients[idx];
+    memset(c, 0, sizeof(*c));
+    c->active = true;
+    return c;
+}
+
+static RelayChannel MockChannelFor(MockClient* c) {
+    RelayChannel ch;
+    ch.send = MockChanSend;
+    ch.recv = MockChanRecv;
+    ch.userData = c;
+    return ch;
+}
+
+// Run the whole loopback to quiescence: client ticks and server pumps
+// interleaved, so multi-round-trip flows (hello -> join -> catch-up) settle.
+static int PumpAll(MockServer* s, RelayClient** clients, int n, int rounds) {
+    int accepted = 0;
+    for (int r = 0; r < rounds; ++r) {
+        MockServerPumpAll(s);
+        for (int i = 0; i < n; ++i) {
+            accepted += Relay_Tick(clients[i]);
+        }
+    }
+    return accepted;
+}
+
+// ============================================================================
+// Shared fixtures
+// ============================================================================
+
+static const uint8_t kRoomA[RSBS_RELAY_UUID_LEN] = { 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88,
+                                                     0x99, 0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF, 0x01 };
+static const uint8_t kRoomB[RSBS_RELAY_UUID_LEN] = { 0xFE, 0xED, 0xFA, 0xCE, 0x00, 0x11, 0x22, 0x33,
+                                                     0x44, 0x55, 0x66, 0x77, 0x88, 0x99, 0xAA, 0xBB };
+
+typedef struct {
+    int count;
+    uint16_t ids[RSBS_SHARED_ITEM_CAP];
+    uint8_t origins[RSBS_SHARED_ITEM_CAP];
+} RelayAwardLog;
+
+static void RelayAward(const SharedItem* item, void* ctx) {
+    RelayAwardLog* log = (RelayAwardLog*)ctx;
+    if (log->count < RSBS_SHARED_ITEM_CAP) {
+        log->ids[log->count] = item->id;
+        log->origins[log->count] = (uint8_t)item->originGame;
+        log->count++;
+    }
+}
+
+static int RelayOccupied(void) {
+    int n = 0;
+    for (uint32_t i = 0; i < RSBS_SHARED_ITEM_CAP; ++i) {
+        if (gComboCtx.sharedItemsTagged[i].originGame != GAME_NONE) {
+            n++;
+        }
+    }
+    return n;
+}
+
+// ============================================================================
+// Test 1: the wire format itself
+// ============================================================================
+
+TestResult Test_RelayWireFormat(void) {
+    printf("[TEST] Relay wire format (golden vectors, ADR 0007 §2)\n");
+
+    // --- Client hello: "OOMM2" + LE u32 0x00000200 ---
+    uint8_t hello[RSBS_RELAY_HELLO_LEN];
+    RelayProto_EncodeHello(hello);
+    const uint8_t kHelloGold[RSBS_RELAY_HELLO_LEN] = { 'O', 'O', 'M', 'M', '2', 0x00, 0x02, 0x00, 0x00 };
+    NR_ASSERT(memcmp(hello, kHelloGold, sizeof(kHelloGold)) == 0);
+
+    // --- Join: uuid + LE u32 base. Always base 0 (ADR 0007 §3.3). ---
+    uint8_t join[RSBS_RELAY_JOIN_LEN];
+    RelayProto_EncodeJoin(kRoomA, 0u, join);
+    NR_ASSERT(memcmp(join, kRoomA, RSBS_RELAY_UUID_LEN) == 0);
+    NR_ASSERT(join[16] == 0 && join[17] == 0 && join[18] == 0 && join[19] == 0);
+
+    // --- Grant payload: exactly 16 bytes, magic-prefixed, little-endian. ---
+    RsbsGrantPayload g;
+    g.version = RSBS_GRANT_PAYLOAD_VERSION;
+    g.senderSlot = 2;
+    g.targetSlot = 1;
+    g.originGame = (uint8_t)GAME_OOT;
+    g.itemId = 0x1234;
+    g.senderSeq = 0x0007;
+    g.settingsHash = 0xDEADBEEFu;
+
+    uint8_t payload[RSBS_GRANT_PAYLOAD_LEN];
+    NR_ASSERT(RelayProto_EncodeGrant(&g, payload));
+    const uint8_t kGrantGold[RSBS_GRANT_PAYLOAD_LEN] = {
+        'R', 'S', 'B', 'S',      // magic
+        0x01,                    // version
+        0x02,                    // senderSlot
+        0x01,                    // targetSlot
+        0x01,                    // originGame == GAME_OOT
+        0x34, 0x12,              // itemId LE
+        0x07, 0x00,              // senderSeq LE
+        0xEF, 0xBE, 0xAD, 0xDE,  // settingsHash LE
+    };
+    NR_ASSERT(memcmp(payload, kGrantGold, sizeof(kGrantGold)) == 0);
+
+    // Round trip.
+    RsbsGrantPayload back;
+    NR_ASSERT(RelayProto_DecodeGrant(payload, RSBS_GRANT_PAYLOAD_LEN, &back));
+    NR_ASSERT(back.senderSlot == 2 && back.targetSlot == 1);
+    NR_ASSERT(back.originGame == (uint8_t)GAME_OOT && back.itemId == 0x1234);
+    NR_ASSERT(back.senderSeq == 7 && back.settingsHash == 0xDEADBEEFu);
+
+    // Ledger key: (slot << 48) | (seq << 16) | itemId.
+    NR_ASSERT(RelayProto_GrantKey(&g) == (((uint64_t)2 << 48) | ((uint64_t)7 << 16) | 0x1234u));
+
+    // Two DIFFERENT senders of the same item must produce DIFFERENT keys, or
+    // the server's own dedup would collapse two legitimate gifts — the ADR
+    // 0005 §1 bug, one layer lower.
+    RsbsGrantPayload g2 = g;
+    g2.senderSlot = 3;
+    NR_ASSERT(RelayProto_GrantKey(&g2) != RelayProto_GrantKey(&g));
+
+    // --- Malformed / foreign payloads are rejected, never accepted. ---
+    uint8_t bad[RSBS_GRANT_PAYLOAD_LEN];
+    memcpy(bad, payload, sizeof(bad));
+    bad[0] = 'X'; // foreign magic (e.g. an OoTMM client in the same room)
+    NR_ASSERT(!RelayProto_DecodeGrant(bad, RSBS_GRANT_PAYLOAD_LEN, &back));
+    memcpy(bad, payload, sizeof(bad));
+    bad[4] = 0x7F; // unknown version
+    NR_ASSERT(!RelayProto_DecodeGrant(bad, RSBS_GRANT_PAYLOAD_LEN, &back));
+    memcpy(bad, payload, sizeof(bad));
+    bad[7] = 0x00; // GAME_NONE
+    NR_ASSERT(!RelayProto_DecodeGrant(bad, RSBS_GRANT_PAYLOAD_LEN, &back));
+    NR_ASSERT(!RelayProto_DecodeGrant(payload, RSBS_GRANT_PAYLOAD_LEN - 1u, &back)); // short
+
+    // Encoder refuses malformed grants too, so a local bug never looks like a
+    // peer's bad data.
+    RsbsGrantPayload zero = g;
+    zero.targetSlot = 0;
+    NR_ASSERT(!RelayProto_EncodeGrant(&zero, payload));
+
+    // --- Incremental frame decode, including the keepalive NOP. ---
+    uint8_t frame[64];
+    uint32_t consumed = 0;
+    RelayLedgerEntry entry;
+
+    // The server emits OP_NONE keepalives; treating one as a bad opcode would
+    // drop a healthy connection after a few idle seconds.
+    frame[0] = RSBS_RELAY_OP_NONE;
+    NR_ASSERT(RelayProto_DecodeFrame(frame, 1, &consumed, &entry) == RSBS_RELAY_DECODE_NOP);
+    NR_ASSERT(consumed == 1);
+
+    const uint32_t n = RelayProto_EncodeTransfer(0xAABBCCDDu, payload, RSBS_GRANT_PAYLOAD_LEN, frame);
+    NR_ASSERT(n == 10u + RSBS_GRANT_PAYLOAD_LEN);
+    // A partial frame must ask for more rather than misparse.
+    NR_ASSERT(RelayProto_DecodeFrame(frame, n - 1u, &consumed, &entry) == RSBS_RELAY_DECODE_NEED_MORE);
+    NR_ASSERT(RelayProto_DecodeFrame(frame, n, &consumed, &entry) == RSBS_RELAY_DECODE_ENTRY);
+    NR_ASSERT(consumed == n && entry.key == 0xAABBCCDDu && entry.payloadLen == RSBS_GRANT_PAYLOAD_LEN);
+    NR_ASSERT(memcmp(entry.payload, payload, RSBS_GRANT_PAYLOAD_LEN) == 0);
+
+    // Room binding: a different room is a different ADR 0005 source, so a
+    // cursor can never be applied against a room that did not produce it.
+    NR_ASSERT(Relay_SourceKeyForRoom(kRoomA) != Relay_SourceKeyForRoom(kRoomB));
+    NR_ASSERT(Relay_SourceKeyForRoom(kRoomA) != 0u);
+
+    printf("[TEST] PASS: wire format\n");
+    return TEST_PASS;
+}
+
+// ============================================================================
+// Test 2: loopback delivery, self-echo, retransmit, distinct gifts, ordering
+// ============================================================================
+
+TestResult Test_RelayLoopback(void) {
+    printf("[TEST] Relay loopback delivery (ADR 0007 §8)\n");
+
+    ComboContext_Init();
+    MockReset(&gMockServer);
+
+    // Slot 1 = us, slot 2 and 3 = peers.
+    MockClient* mcA = MockAttach(&gMockServer, 0);
+    MockClient* mcB = MockAttach(&gMockServer, 1);
+    MockClient* mcC = MockAttach(&gMockServer, 2);
+
+    RelayClient a, b, cc;
+    Relay_Init(&a, kRoomA, 1, 0xABCDu); // receiver
+    Relay_Init(&b, kRoomA, 2, 0xABCDu); // peer
+    Relay_Init(&cc, kRoomA, 3, 0xABCDu); // second peer
+
+    RelayChannel chA = MockChannelFor(mcA);
+    RelayChannel chB = MockChannelFor(mcB);
+    RelayChannel chC = MockChannelFor(mcC);
+    NR_ASSERT(Relay_Connect(&a, &chA));
+    NR_ASSERT(Relay_Connect(&b, &chB));
+    NR_ASSERT(Relay_Connect(&cc, &chC));
+
+    RelayClient* all[3] = { &a, &b, &cc };
+    PumpAll(&gMockServer, all, 3, 4);
+    NR_ASSERT(a.state == RSBS_RELAY_STATE_READY);
+    NR_ASSERT(b.state == RSBS_RELAY_STATE_READY);
+
+    // --- Peer B gifts us two items, in order. ---
+    NR_ASSERT(Relay_SendGrant(&b, 1, GAME_OOT, 100));
+    NR_ASSERT(Relay_SendGrant(&b, 1, GAME_OOT, 200));
+    PumpAll(&gMockServer, all, 3, 4);
+
+    NR_ASSERT(a.statAccepted == 2);
+    NR_ASSERT(Combo_GetGrantCursor(a.sourceKey) == 2);
+    NR_ASSERT(RelayOccupied() == 2);
+
+    // --- SELF-ECHO: B receives its own two entries back (the real server does
+    // not skip the sender) and must award itself NOTHING. ---
+    NR_ASSERT(b.statEntriesSeen == 2);
+    NR_ASSERT(b.statNotForUs == 2);
+    NR_ASSERT(b.statAccepted == 0);
+    NR_ASSERT(Combo_GetGrantCursor(b.sourceKey) == 2); // same room == same source key
+    // C is in the room but addressed by nothing.
+    NR_ASSERT(cc.statNotForUs == 2 && cc.statAccepted == 0);
+
+    // --- RETRANSMIT yields exactly one item. Re-offering the identical
+    // (senderSlot, senderSeq) produces the same ledger key, which the server
+    // dedups before it ever fans out. ---
+    RsbsGrantPayload dupGrant;
+    dupGrant.version = RSBS_GRANT_PAYLOAD_VERSION;
+    dupGrant.senderSlot = 2;
+    dupGrant.targetSlot = 1;
+    dupGrant.originGame = (uint8_t)GAME_OOT;
+    dupGrant.itemId = 100;
+    dupGrant.senderSeq = 1; // the seq B already used for item 100
+    dupGrant.settingsHash = 0xABCDu;
+    uint8_t dupPayload[RSBS_GRANT_PAYLOAD_LEN];
+    NR_ASSERT(RelayProto_EncodeGrant(&dupGrant, dupPayload));
+    uint8_t dupFrame[64];
+    const uint32_t dn = RelayProto_EncodeTransfer(RelayProto_GrantKey(&dupGrant), dupPayload, RSBS_GRANT_PAYLOAD_LEN, dupFrame);
+    MockPipeWrite(&mcB->toServer, dupFrame, dn);
+    PumpAll(&gMockServer, all, 3, 4);
+
+    NR_ASSERT(gMockServer.count == 2);   // server-side dedup absorbed it
+    NR_ASSERT(a.statAccepted == 2);      // still exactly two
+    NR_ASSERT(RelayOccupied() == 2);
+
+    // --- TWO PEERS, SAME ITEM = TWO ITEMS (the ADR 0005 §1 regression). C
+    // gifts item 100 as well; distinct sender => distinct key => it survives
+    // the server's dedup, and the client-side content de-dup never sees it
+    // because sourced entries are flagged. ---
+    NR_ASSERT(Relay_SendGrant(&cc, 1, GAME_OOT, 100));
+    PumpAll(&gMockServer, all, 3, 4);
+    NR_ASSERT(gMockServer.count == 3);
+    NR_ASSERT(a.statAccepted == 3);
+    NR_ASSERT(RelayOccupied() == 3);
+
+    // --- RECEIVED-ORDER redemption. The give paths resolve progressives
+    // against the live save, so order changes WHAT the player gets. ---
+    RelayAwardLog log;
+    memset(&log, 0, sizeof(log));
+    const int redeemed = Combo_RedeemSharedItemsForGame(GAME_OOT, RelayAward, &log);
+    NR_ASSERT(redeemed == 3 && log.count == 3);
+    NR_ASSERT(log.ids[0] == 100 && log.ids[1] == 200 && log.ids[2] == 100);
+
+    // Single-use: a second safe point awards nothing more.
+    RelayAwardLog again;
+    memset(&again, 0, sizeof(again));
+    NR_ASSERT(Combo_RedeemSharedItemsForGame(GAME_OOT, RelayAward, &again) == 0);
+    NR_ASSERT(again.count == 0);
+
+    printf("[TEST] PASS: loopback delivery\n");
+    return TEST_PASS;
+}
+
+// ============================================================================
+// Test 3: late-join catch-up, cross-game switch, foreign entries
+// ============================================================================
+
+TestResult Test_RelayCatchup(void) {
+    printf("[TEST] Relay late-join catch-up + cross-game survival (ADR 0007 §3.3, §5.1)\n");
+
+    ComboContext_Init();
+    MockReset(&gMockServer);
+
+    MockClient* mcB = MockAttach(&gMockServer, 1);
+    RelayClient b;
+    Relay_Init(&b, kRoomA, 2, 0);
+    RelayChannel chB = MockChannelFor(mcB);
+    NR_ASSERT(Relay_Connect(&b, &chB));
+    RelayClient* justB[1] = { &b };
+    PumpAll(&gMockServer, justB, 1, 3);
+
+    // Peer B sends three grants for slot 1 BEFORE slot 1 ever joins — one of
+    // them for the OTHER game, so we also prove a grant crosses the switch.
+    NR_ASSERT(Relay_SendGrant(&b, 1, GAME_OOT, 11));
+    NR_ASSERT(Relay_SendGrant(&b, 1, GAME_MM, 22));
+    NR_ASSERT(Relay_SendGrant(&b, 1, GAME_OOT, 33));
+    PumpAll(&gMockServer, justB, 1, 4);
+    NR_ASSERT(gMockServer.count == 3);
+
+    // A foreign entry lands in the room too — an OoTMM client sharing the
+    // ledger. It must be skipped without desyncing the stream (ADR 0007 §4.3).
+    const uint8_t kForeign[8] = { 'O', 'o', 'T', 'M', 'M', 0, 0, 0 };
+    uint8_t fFrame[64];
+    const uint32_t fn = RelayProto_EncodeTransfer(0x1234567890ABCDEFull, kForeign, sizeof(kForeign), fFrame);
+    MockPipeWrite(&mcB->toServer, fFrame, fn);
+    PumpAll(&gMockServer, justB, 1, 3);
+    NR_ASSERT(gMockServer.count == 4);
+
+    // --- NOW slot 1 joins, at ledgerBase 0, and must receive the whole
+    // backlog. This is the late-joiner case. ---
+    MockClient* mcA = MockAttach(&gMockServer, 0);
+    RelayClient a;
+    Relay_Init(&a, kRoomA, 1, 0);
+    RelayChannel chA = MockChannelFor(mcA);
+    NR_ASSERT(Relay_Connect(&a, &chA));
+
+    RelayClient* both[2] = { &a, &b };
+    PumpAll(&gMockServer, both, 2, 6);
+
+    NR_ASSERT(a.state == RSBS_RELAY_STATE_READY);
+    NR_ASSERT(a.statEntriesSeen == 4);
+    NR_ASSERT(a.statForeignSkipped == 1); // skipped, and it did not desync
+    NR_ASSERT(a.statAccepted == 3);       // all three real grants caught up
+    NR_ASSERT(Combo_GetGrantCursor(a.sourceKey) == 3);
+
+    // --- Grants are split across the two games and BOTH survive: the OoT ones
+    // redeem on an OoT safe point, the MM one waits, un-redeemed, for MM. The
+    // relay needs no switch awareness at all — the array is process-global.
+    RelayAwardLog ootLog;
+    memset(&ootLog, 0, sizeof(ootLog));
+    NR_ASSERT(Combo_RedeemSharedItemsForGame(GAME_OOT, RelayAward, &ootLog) == 2);
+    NR_ASSERT(ootLog.ids[0] == 11 && ootLog.ids[1] == 33);
+
+    // The MM grant is still pending — exactly what "crosses the switch" means.
+    NR_ASSERT(Combo_CountSharedItems(GAME_MM, false) == 1);
+    RelayAwardLog mmLog;
+    memset(&mmLog, 0, sizeof(mmLog));
+    NR_ASSERT(Combo_RedeemSharedItemsForGame(GAME_MM, RelayAward, &mmLog) == 1);
+    NR_ASSERT(mmLog.count == 1 && mmLog.ids[0] == 22);
+    NR_ASSERT(mmLog.origins[0] == (uint8_t)GAME_MM);
+
+    // --- REJOIN: a reconnect replays from base 0 again. Every already-
+    // delivered grant must come back DUPLICATE (cursor), not re-award. This is
+    // the designed path of ADR 0005 §1, not an error case. ---
+    MockClient* mcA2 = MockAttach(&gMockServer, 3);
+    RelayClient a2;
+    Relay_Init(&a2, kRoomA, 1, 0);
+    RelayChannel chA2 = MockChannelFor(mcA2);
+    NR_ASSERT(Relay_Connect(&a2, &chA2));
+    RelayClient* rejoin[1] = { &a2 };
+    PumpAll(&gMockServer, rejoin, 1, 6);
+
+    NR_ASSERT(a2.statEntriesSeen == 4);
+    NR_ASSERT(a2.statDuplicate == 3); // the whole prefix was already delivered
+    NR_ASSERT(a2.statAccepted == 0);
+    NR_ASSERT(Combo_GetGrantCursor(a2.sourceKey) == 3); // unmoved
+    NR_ASSERT(RelayOccupied() == 3);                    // no re-award, no new entries
+
+    printf("[TEST] PASS: catch-up + cross-game\n");
+    return TEST_PASS;
+}
+
+// ============================================================================
+// Test 4: backpressure and loud overflow
+// ============================================================================
+
+TestResult Test_RelayBackpressure(void) {
+    printf("[TEST] Relay backpressure is loud and lossless (ADR 0005 §3, ADR 0007 §4.2)\n");
+
+    ComboContext_Init();
+    MockReset(&gMockServer);
+
+    // Fill the durable array with UN-REDEEMED in-process entries so the seam
+    // has nothing to reclaim and must refuse.
+    for (uint32_t i = 0; i < RSBS_SHARED_ITEM_CAP; ++i) {
+        NR_ASSERT(Combo_RecordSharedItem(GAME_OOT, (uint16_t)(1000 + i)) >= 0);
+    }
+    NR_ASSERT(RelayOccupied() == (int)RSBS_SHARED_ITEM_CAP);
+    NR_ASSERT(Combo_GetSharedItemOverflowCount() == 0);
+
+    MockClient* mcA = MockAttach(&gMockServer, 0);
+    MockClient* mcB = MockAttach(&gMockServer, 1);
+    RelayClient a, b;
+    Relay_Init(&a, kRoomA, 1, 0);
+    Relay_Init(&b, kRoomA, 2, 0);
+    RelayChannel chA = MockChannelFor(mcA);
+    RelayChannel chB = MockChannelFor(mcB);
+    NR_ASSERT(Relay_Connect(&a, &chA));
+    NR_ASSERT(Relay_Connect(&b, &chB));
+    RelayClient* all[2] = { &a, &b };
+    PumpAll(&gMockServer, all, 2, 4);
+
+    // A peer gift now cannot be recorded: the array is full of undelivered
+    // items, so the seam answers RETRY_FULL.
+    NR_ASSERT(Relay_SendGrant(&b, 1, GAME_OOT, 4242));
+    PumpAll(&gMockServer, all, 2, 4);
+
+    NR_ASSERT(a.statRetryFull > 0);
+    NR_ASSERT(a.statAccepted == 0);
+    // Backpressure, NOT loss: the cursor did not advance, so the grant is
+    // still owed and the client knows it needs a replay.
+    NR_ASSERT(Combo_GetGrantCursor(a.sourceKey) == 0);
+    NR_ASSERT(Relay_ReplayNeeded(&a));
+    // LOUD: the durable, .redsave-serialized counter moved.
+    NR_ASSERT(Combo_GetSharedItemOverflowCount() > 0);
+    // The grant is still queued client-side — it was not dropped on the floor.
+    NR_ASSERT(a.inboxCount == 1);
+
+    // --- Drain the array. The SAME grant, re-offered at the SAME seq, is now
+    // ACCEPTED rather than deduped. That is the property that makes
+    // RETRY_FULL backpressure instead of loss. ---
+    RelayAwardLog drain;
+    memset(&drain, 0, sizeof(drain));
+    NR_ASSERT(Combo_RedeemSharedItemsForGame(GAME_OOT, RelayAward, &drain) == (int)RSBS_SHARED_ITEM_CAP);
+
+    const int accepted = Relay_Tick(&a);
+    NR_ASSERT(accepted == 1);
+    NR_ASSERT(a.statAccepted == 1);
+    NR_ASSERT(Combo_GetGrantCursor(a.sourceKey) == 1);
+    NR_ASSERT(a.inboxCount == 0);
+
+    // --- Session invalidation retires the client's RAM alongside gComboCtx,
+    // so a dead session's undelivered grants cannot drain into the next one
+    // (#440 guidance on #460). ---
+    Relay_ClearSessionState(&a);
+    NR_ASSERT(a.inboxCount == 0 && a.outboxCount == 0);
+    // The counter restarts at 1 because the cursor died with gComboCtx —
+    // submitting seq N+1 against a fresh cursor of 0 would wedge on GAP.
+    NR_ASSERT(a.nextSeq == 1u);
+
+    printf("[TEST] PASS: backpressure\n");
+    return TEST_PASS;
+}
+
+// ============================================================================
+// Test 5: the suspend latch
+// ============================================================================
+
+TestResult Test_RelaySuspendLatch(void) {
+    printf("[TEST] Relay suspend latch stops applying, not polling (ADR 0006 §5)\n");
+
+    ComboContext_Init();
+    MockReset(&gMockServer);
+
+    MockClient* mcA = MockAttach(&gMockServer, 0);
+    MockClient* mcB = MockAttach(&gMockServer, 1);
+    RelayClient a, b;
+    Relay_Init(&a, kRoomA, 1, 0);
+    Relay_Init(&b, kRoomA, 2, 0);
+    RelayChannel chA = MockChannelFor(mcA);
+    RelayChannel chB = MockChannelFor(mcB);
+    NR_ASSERT(Relay_Connect(&a, &chA));
+    NR_ASSERT(Relay_Connect(&b, &chB));
+    RelayClient* all[2] = { &a, &b };
+    PumpAll(&gMockServer, all, 2, 4);
+
+    // Suspend the receiver, then have the peer send. Polling and decoding must
+    // continue — otherwise a suspended game stalls the peer and loses its
+    // ledger position — but nothing may be APPLIED.
+    Relay_OnSuspend(&a);
+    NR_ASSERT(Relay_SendGrant(&b, 1, GAME_OOT, 77));
+    NR_ASSERT(Relay_SendGrant(&b, 1, GAME_OOT, 88));
+    PumpAll(&gMockServer, all, 2, 4);
+
+    NR_ASSERT(a.statEntriesSeen == 2); // received and decoded
+    NR_ASSERT(a.inboxCount == 2);      // filed
+    NR_ASSERT(a.statAccepted == 0);    // but NOT applied
+    NR_ASSERT(RelayOccupied() == 0);
+    NR_ASSERT(Combo_GetGrantCursor(a.sourceKey) == 0);
+
+    // Resume drains in received order — the lifecycle has no implicit inverse,
+    // so this release is a separate, named action.
+    Relay_OnResume(&a);
+    const int accepted = Relay_Tick(&a);
+    NR_ASSERT(accepted == 2);
+    NR_ASSERT(a.inboxCount == 0);
+    NR_ASSERT(Combo_GetGrantCursor(a.sourceKey) == 2);
+
+    RelayAwardLog log;
+    memset(&log, 0, sizeof(log));
+    NR_ASSERT(Combo_RedeemSharedItemsForGame(GAME_OOT, RelayAward, &log) == 2);
+    NR_ASSERT(log.ids[0] == 77 && log.ids[1] == 88); // order preserved
+
+    printf("[TEST] PASS: suspend latch\n");
+    return TEST_PASS;
+}


### PR DESCRIPTION
Implements ADR 0007 (merged, `fd2d5802`). **Stacked on #473** — based on `claude/netplay-grant-foundation-2` because `Combo_SubmitSourcedGrant` is the seam and it is not on main yet. Retarget to main and rebase once #473 lands. Draft until then.

## Shape

Three layers, all under `src/common/netplay/` plus one test:

- **`relay_protocol.{h,c}`** — pure codec, no sockets. Byte-at-a-time LE so a big-endian host emits identical bytes with no packing pragma. Decodes the `OP_NONE` keepalive as a NOP: the real server emits one every few idle ticks, so treating a stray `0x00` as a bad opcode would drop a healthy connection.
- **`relay_client.{h,c}`** — state machine feeding `Combo_SubmitSourcedGrant`, the only netplay path into the grant model. No second route into `Combo_RecordSharedItem`.
- **`tests/test_netplay_relay.c`** — five loopback locks.

## ADR 0006 §5's salvage list, carried structurally

Each closes a *verified* Anchor hazard:

- **No receive thread** — the socket is serviced only inside `Relay_Tick()` on the game thread, so hazards #1/#2 cannot exist by construction and ADR 0005's "game thread only" contract needs no marshalling layer.
- **Bounded inbox, recoverable drop** — overflow drops *without* advancing the cursor and flags a replay. Composes with `RSBS_GRANT_RETRY_FULL`: both mean "the source still owes this".
- **Explicit suspend latch** — stops applying, keeps polling. Release is a separate named action.
- **Room binding** — free, because `sourceKey = fnv1a32(roomUuid)` *is* the fingerprint. A different room is a different ADR 0005 source, so a cursor can never be applied against a room that did not produce it.

**Carves nothing from `reserved[]`** — no coordination needed with #473's carve.

## Two bugs a convenient mock would have hidden

Worth calling out because they are exactly the failure class ADR 0006 warned about:

1. The 20-byte join was sent inline right after consuming the server hello. If that send blocked, the join was **dropped on the floor** — the hello was already consumed, so nothing would ever re-send it. Now there is a `JOINING` state meaning "hello done, join still owed".
2. `ChannelSendAll` restarted from zero after a partial send, which would put a prefix **on the wire twice** and desync the server's length-prefixed parser. Now both the join and the outbox track a caller-owned offset.

A never-blocking loopback surfaces neither. They were found by reading, not by the harness — which is itself a data point about §8's honesty.

## What the harness proves, and what it does not

The mock ledger implements multi-server's semantics: append-only, `u64` key dedup, `ledgerBase` replay, and **broadcast to every client including the sender**. That last clause is load-bearing — the real server does *not* skip the sender on `OP_TRANSFER` (only the chat path does), so self-echo is a live condition the client must filter by `targetSlot`. A mock that skipped the sender would hide a real bug, which is the shortcut ADR 0006 §2(b) caught in the AP mock.

**Proves:** retransmit → exactly one item; two peers' same item → two items (the ADR 0005 §1 regression); received-order redemption; grants survive a cross-game switch; late-join catch-up from base 0; rejoin replays as `DUPLICATE` not re-award; foreign payloads skip without desyncing; `RETRY_FULL` leaves the cursor unmoved and the same seq is later *accepted*; overflow is loud; suspend latch; golden byte vectors.

**Does not prove:** that our framing matches the real binary (the mock is a re-derivation from reading `client.c`/`ledger.c`); real socket behaviour (partial reads, `EAGAIN`, mid-frame disconnect, TCP segmentation); that upstream still behaves as read.

Unlike ADR 0006's gap this is a **defect class, not a wall** — multi-server's ledger never inspects the payload, so there is no admissibility check we can fail, and a framing bug is ours to fix unilaterally.

## Default-off, verified in both directions

`RSBS_NETPLAY` defaults OFF, and OFF means *absent*: no netplay source is appended to any target, so the default build gains no TU and links no symbol.

The relay gets **its own CI job** rather than a flag on `build-linux` — deliberately, because `build-linux` packages and uploads the released appimage, and default-off has to mean **shipped-off**. The job asserts both directions: the default configure references no netplay source, and the ON build actually links `Relay_Tick` (so the flag silently ceasing to add sources cannot go green vacuously).

No submodule, no transport library, no `.redsave` change, no auto-connect, no outbound connection in any default path.

## Not in this PR

The **redemption tick** ADR 0005 §4 defined-but-deferred needs a per-frame hook in each game — `games/oot/**` and `games/mm/**`, which is both outside this lane's agreed surface and live under PR #472. Filed as follow-up. Until it lands, relayed grants redeem at the two wired arrival safe points, which is correct but means a grant for the game you are *already in* waits for a switch.

The **real socket layer** is likewise deferred: it is untestable in CI (no network), so landing it alongside a harness that cannot exercise it would be the same category error ADR 0006 called out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!--- section:artifacts:start -->
### Build Artifacts
  - [rsbs-windows.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/8509429712.zip)
  - [rsbs-linux.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/8508652673.zip)
<!--- section:artifacts:end -->