### PR TITLE
Netplay relay client behind RSBS_NETPLAY (default OFF), with loopback locks (ADR 0007, #460)

### DIFF
--- a/.github/workflows/generate-builds.yml
+++ b/.github/workflows/generate-builds.yml
@@ -350,6 +350,107 @@ jobs:
           rsbs.appimage
           readme.txt
 
+  # ==========================================================================
+  # Netplay grant relay (ADR 0007, #460)
+  #
+  # A SEPARATE job rather than a flag on build-linux, deliberately: build-linux
+  # packages and uploads the released appimage, so enabling the relay there
+  # would SHIP a feature that is supposed to be off by default. Default-off has
+  # to mean shipped-off, which means the relay never enters a release artifact.
+  #
+  # This job does two things build-linux cannot:
+  #   1. builds with RSBS_NETPLAY=ON and runs the Relay* locks, which do not
+  #      exist in a default configure;
+  #   2. asserts the DEFAULT configure pulls in no netplay translation unit —
+  #      the verifiable form of "the default build is unaffected".
+  # It uploads nothing.
+  # ==========================================================================
+  netplay-relay:
+    needs: generate-rsbs-otr
+    runs-on: ubuntu-22.04
+    container:
+      image: ghcr.io/spencerduncan/redshipblueship-build:latest
+    steps:
+    - name: Git Checkout
+      uses: actions/checkout@v4
+      with:
+        submodules: true
+        fetch-depth: 1
+        fetch-tags: true
+    - name: Configure git safe directory
+      run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
+    - name: Install packaging tools
+      run: |
+        apt-get update
+        apt-get install -y imagemagick file desktop-file-utils
+    - name: Configure ccache
+      uses: hendrikmuhs/ccache-action@v1.2
+      with:
+        save: true
+        max-size: "1.5G"
+        key: ${{ runner.os }}-ccache-netplay-${{ github.ref }}
+        restore-keys: |
+          ${{ runner.os }}-ccache-netplay-${{ github.ref }}
+          ${{ runner.os }}-ccache-${{ github.ref }}
+          ${{ runner.os }}-ccache-refs/heads/main
+          ${{ runner.os }}-ccache
+    - name: Download soh.o2r
+      uses: actions/download-artifact@v4
+      with:
+        name: soh.o2r
+        path: build-cmake/soh
+    - name: Download 2ship.o2r
+      uses: actions/download-artifact@v4
+      with:
+        name: 2ship.o2r
+        path: build-cmake/mm
+    - name: Assert the DEFAULT build pulls in no netplay TU
+      # Configure-only (seconds, no compile) in the default configuration and
+      # grep the generated build system. With RSBS_NETPLAY=OFF the netplay
+      # sources are never appended to REDSHIP_COMMON_SOURCES, so no rule
+      # referencing them can exist. This is the negative control for the
+      # positive one below; without it "default OFF" is a claim about CMake
+      # that nothing checks.
+      run: |
+        cmake --no-warn-unused-cli -H. -Bbuild-default -GNinja -DCMAKE_BUILD_TYPE:STRING=Release >/dev/null
+        if grep -rq "netplay/relay_" build-default/build.ninja; then
+          echo "FAIL: default configure references a netplay source; RSBS_NETPLAY=OFF must mean absent."
+          grep -rn "netplay/relay_" build-default/build.ninja | head
+          exit 1
+        fi
+        echo "OK: default configure pulls in no netplay translation unit."
+      env:
+        CC: gcc-11
+        CXX: g++-11
+    - name: Build with RSBS_NETPLAY=ON
+      run: |
+        export PATH="/usr/lib/ccache:/usr/local/opt/ccache/libexec:$PATH"
+        cmake --no-warn-unused-cli -H. -Bbuild-cmake -GNinja -DCMAKE_BUILD_TYPE:STRING=Release -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DBUILD_REMOTE_CONTROL=1 -DRSBS_NETPLAY=1
+        cmake --build build-cmake --config Release -j10
+      env:
+        CC: gcc-11
+        CXX: g++-11
+        CCACHE_COMPILERCHECK: content
+    - name: Assert the relay actually linked
+      # Positive control. If the flag silently stopped adding the sources, the
+      # Relay* rows below would vanish and ctest's --no-tests=error would be
+      # the only thing standing between us and a vacuous green.
+      run: |
+        if ! nm -C build-cmake/redship | grep -q "Relay_Tick"; then
+          echo "FAIL: RSBS_NETPLAY=ON but Relay_Tick is not in the binary."
+          exit 1
+        fi
+        echo "OK: relay symbols linked."
+    - name: Run netplay relay locks
+      # ROM-free and display-free: the loopback ledger is in-process. See the
+      # header of src/common/tests/test_netplay_relay.c for what these prove
+      # and — equally load-bearing — what they do not.
+      run: ctest --test-dir build-cmake --output-on-failure --tests-regex "^Relay" --no-tests=error
+    - name: Run the full ROM-free tier with the relay built
+      # The relay must not perturb anything else. Same label the default
+      # build-linux job runs, so a regression here is attributable to the flag.
+      run: ctest --test-dir build-cmake --output-on-failure --label-regex "^redship$" --no-tests=error
+
   build-windows:
     # Issue #177 — investigation results (2026-06-01, runs 26731031162 / 26731511201 / 26731832242):
     #   * sccache hit rate: 99.82% (2848 hits / 2853 executed / 5 misses) — the cache works.

--- a/CMake/SingleExecutable.cmake
+++ b/CMake/SingleExecutable.cmake
@@ -59,6 +59,27 @@ if(WIN32)
     )
 endif()
 
+# ============================================================================
+# Netplay grant relay (ADR 0007, #460) — OFF by default, and OFF means ABSENT
+#
+# These sources are appended ONLY when RSBS_NETPLAY is ON. The default build
+# therefore gains no translation unit and links no new symbol, which is the
+# strongest verifiable form of "byte-unaffected" (byte-identical binaries are
+# not reproducible across toolchain nondeterminism; "no new linked symbols" is
+# checkable, and the netplay-default-off CI job checks it).
+#
+# No submodule and no transport library: the wire format is length-prefixed
+# binary over plain TCP, so a small socket shim beats putting a dependency in
+# every CI checkout for code that is inert by default (ADR 0006 §7).
+# ============================================================================
+if(RSBS_NETPLAY)
+    message(STATUS "Netplay grant relay: ENABLED (experimental, ADR 0007)")
+    list(APPEND REDSHIP_COMMON_SOURCES
+        ${CMAKE_SOURCE_DIR}/src/common/netplay/relay_protocol.c
+        ${CMAKE_SOURCE_DIR}/src/common/netplay/relay_client.c
+    )
+endif()
+
 set(REDSHIP_COMMON_HEADERS
     ${CMAKE_SOURCE_DIR}/src/common/game.h
     ${CMAKE_SOURCE_DIR}/src/common/archive_check.h
@@ -117,6 +138,14 @@ target_compile_definitions(redship_common PRIVATE COMBO_BUILDING_DLL)
 # pass) when the path is absent, which is what happens if the binary is run
 # from a relocated artifact rather than its build tree.
 target_compile_definitions(redship_common PRIVATE RSBS_SOURCE_DIR="${CMAKE_SOURCE_DIR}")
+
+# Netplay relay (ADR 0007). PUBLIC so test_runner.cpp's guarded #include of
+# tests/test_netplay_relay.c compiles in the same configuration the relay
+# sources do — a PRIVATE define here would silently drop the tests while the
+# relay itself built, which is the worst of both.
+if(RSBS_NETPLAY)
+    target_compile_definitions(redship_common PUBLIC RSBS_NETPLAY)
+endif()
 
 set_target_properties(redship_common PROPERTIES
     CXX_STANDARD 20
@@ -320,6 +349,25 @@ if(BUILD_TESTING)
     redship_add_test(NAME GrantRedeemNoSwitch COMMAND redship --test grant-redeem-no-switch)
     redship_add_test(NAME GrantOverflow COMMAND redship --test grant-overflow)
     redship_add_test(NAME GrantPersistence COMMAND redship --test grant-persistence)
+
+    # Netplay grant relay (ADR 0007, #460). Registered only when the relay is
+    # built, because with RSBS_NETPLAY=OFF the code under test does not exist —
+    # a row here would fail rather than skip. The netplay-default-off CI job
+    # builds with the flag ON and runs these; every other job stays default.
+    #
+    # What these lock, and the honest limit, is stated at the top of
+    # src/common/tests/test_netplay_relay.c: they drive the real codec and the
+    # real state machine over a mock ledger with multi-server's semantics, so
+    # they prove our SEMANTICS but not our admissibility to the real wire.
+    # Unlike the Archipelago case (ADR 0006 §2b) there is no external
+    # gatekeeper, so a framing mismatch is a defect we can fix, not a wall.
+    if(RSBS_NETPLAY)
+        redship_add_test(NAME RelayWireFormat COMMAND redship --test relay-wire-format)
+        redship_add_test(NAME RelayLoopback COMMAND redship --test relay-loopback)
+        redship_add_test(NAME RelayCatchup COMMAND redship --test relay-catchup)
+        redship_add_test(NAME RelayBackpressure COMMAND redship --test relay-backpressure)
+        redship_add_test(NAME RelaySuspendLatch COMMAND redship --test relay-suspend-latch)
+    endif()
     redship_add_test(NAME ArchiveHotswapLogic COMMAND redship --test archive-hotswap-logic)
     # Unified save (.redsave) headless tests — Phase 2 T6 (#35)
     redship_add_test(NAME SaveRoundtripTiers COMMAND redship --test save-roundtrip-tiers)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,6 +17,13 @@ option(SUPPRESS_WARNINGS "Suppress warnings in LUS and src (decomp)" ON)
 option(SINGLE_EXECUTABLE_BUILD "Build single redship executable (replaces dynamic library loading)" ON)
 option(USE_LLD_LINKER "Use LLVM's lld-link instead of MSVC linker (faster linking)" OFF)
 
+# Netplay grant relay (ADR 0007, #460). Default OFF, and OFF means ABSENT: no
+# netplay source is added to any target, so the default build links no new
+# symbols — the property the `netplay-default-off` CI job asserts against main.
+# There is no auto-connect and no outbound connection in any default path even
+# when this is ON; an operator must supply a room id and connect explicitly.
+option(RSBS_NETPLAY "Build the netplay grant relay client (experimental, ADR 0007)" OFF)
+
 # Always enable position-independent code - required for shared library builds
 # This repo is specifically for the unified combo project (shared libraries only)
 # For standalone executables, use upstream SoH/2Ship repos instead

--- a/src/common/netplay/relay_client.c
+++ b/src/common/netplay/relay_client.c
@@ -1,0 +1,450 @@
+/**
+ * @file relay_client.c
+ * @brief Grant-relay client implementation (ADR 0007).
+ *
+ * The whole file runs on the game thread. There is no thread here to get
+ * wrong — that is salvage item 1 (ADR 0006 §5) discharged by construction.
+ */
+
+#include "relay_client.h"
+
+#include <stdio.h>
+#include <string.h>
+
+#include "../shared_items.h" // Combo_SubmitSourcedGrant, ComboGrantResult
+
+// ============================================================================
+// Room fingerprint
+// ============================================================================
+
+uint32_t Relay_SourceKeyForRoom(const uint8_t roomUuid[RSBS_RELAY_UUID_LEN]) {
+    // FNV-1a 32. Forced nonzero because ADR 0005 reserves 0 for "empty slot".
+    uint32_t h = 2166136261u;
+    for (uint32_t i = 0; i < RSBS_RELAY_UUID_LEN; ++i) {
+        h ^= (uint32_t)roomUuid[i];
+        h *= 16777619u;
+    }
+    return h == 0u ? 1u : h;
+}
+
+// ============================================================================
+// Lifecycle
+// ============================================================================
+
+void Relay_Init(RelayClient* c, const uint8_t roomUuid[RSBS_RELAY_UUID_LEN], uint8_t localSlot, uint32_t settingsHash) {
+    if (c == NULL) {
+        return;
+    }
+    memset(c, 0, sizeof(*c));
+    if (roomUuid != NULL) {
+        memcpy(c->roomUuid, roomUuid, RSBS_RELAY_UUID_LEN);
+    }
+    c->sourceKey = Relay_SourceKeyForRoom(c->roomUuid);
+    c->localSlot = localSlot;
+    c->settingsHash = settingsHash;
+    c->state = RSBS_RELAY_STATE_IDLE;
+    c->nextSeq = 1u; // ADR 0005: a new source must start at seq 1
+    c->sendSeq = 0u;
+}
+
+/**
+ * Send from `data + *offset` onward, advancing *offset by whatever the channel
+ * accepted. Returns true only when the whole buffer is out.
+ *
+ * The caller-owned offset is the point: a real socket can accept a PREFIX and
+ * then block. Restarting from zero on the next attempt would put those bytes
+ * on the wire twice and desynchronise the server's length-prefixed parser —
+ * a corruption bug that a never-blocking loopback mock would never surface.
+ */
+static bool ChannelSendFrom(RelayClient* c, const uint8_t* data, uint32_t len, uint32_t* offset) {
+    while (*offset < len) {
+        const int n = c->channel.send(c->channel.userData, data + *offset, len - *offset);
+        if (n < 0) {
+            c->state = RSBS_RELAY_STATE_FAILED;
+            return false;
+        }
+        if (n == 0) {
+            return false; // would block; resume from *offset next tick
+        }
+        *offset += (uint32_t)n;
+    }
+    return true;
+}
+
+bool Relay_Connect(RelayClient* c, const RelayChannel* channel) {
+    if (c == NULL || channel == NULL || channel->send == NULL || channel->recv == NULL) {
+        return false;
+    }
+    c->channel = *channel;
+    c->channelSet = true;
+
+    uint8_t hello[RSBS_RELAY_HELLO_LEN];
+    RelayProto_EncodeHello(hello);
+    uint32_t off = 0;
+    if (!ChannelSendFrom(c, hello, RSBS_RELAY_HELLO_LEN, &off)) {
+        return false;
+    }
+    c->state = RSBS_RELAY_STATE_HELLO;
+    return true;
+}
+
+// ============================================================================
+// Inbox (bounded, recoverable drop — salvage item 2)
+// ============================================================================
+
+static void InboxPush(RelayClient* c, const RsbsGrantPayload* g) {
+    if (c->inboxCount >= RSBS_RELAY_INBOX_CAP) {
+        // Drop WITHOUT advancing the grant cursor and flag a replay. Bounded
+        // memory costs latency, never items: the dropped grant is re-derived
+        // by the next replay-from-zero (ADR 0007 §3.3).
+        c->statInboxDropped++;
+        c->replayNeeded = true;
+        return;
+    }
+    const uint32_t slot = (c->inboxHead + c->inboxCount) % RSBS_RELAY_INBOX_CAP;
+    c->inbox[slot] = *g;
+    c->inboxCount++;
+}
+
+static bool InboxPeek(const RelayClient* c, RsbsGrantPayload* out) {
+    if (c->inboxCount == 0) {
+        return false;
+    }
+    *out = c->inbox[c->inboxHead];
+    return true;
+}
+
+static void InboxPop(RelayClient* c) {
+    if (c->inboxCount == 0) {
+        return;
+    }
+    c->inboxHead = (c->inboxHead + 1u) % RSBS_RELAY_INBOX_CAP;
+    c->inboxCount--;
+}
+
+// ============================================================================
+// Frame handling
+// ============================================================================
+
+static void HandleEntry(RelayClient* c, const RelayLedgerEntry* entry) {
+    c->statEntriesSeen++;
+
+    RsbsGrantPayload g;
+    if (!RelayProto_DecodeGrant(entry->payload, entry->payloadLen, &g)) {
+        // Foreign or malformed: skip and count, never fatal (ADR 0007 §4.3).
+        // The server's own length prefix already kept us framed.
+        c->statForeignSkipped++;
+        return;
+    }
+
+    // Self-echo and other players' grants. The real server fans OP_TRANSFER out
+    // to EVERY client on the ledger INCLUDING the sender (client.c
+    // multiClientCmdTransfer does not skip client->id — unlike the chat path,
+    // which does), so our own gifts come straight back to us and MUST be
+    // filtered here.
+    if (g.targetSlot != c->localSlot) {
+        c->statNotForUs++;
+        return;
+    }
+
+    // Advisory only — the server does not read settingsHash and a peer that
+    // wants to lie about it can (ADR 0007 §5.3). Warn once; never enforce.
+    if (!c->settingsMismatchSeen && c->settingsHash != 0u && g.settingsHash != 0u &&
+        g.settingsHash != c->settingsHash) {
+        c->settingsMismatchSeen = true;
+        fprintf(stderr, "[relay] warning: peer slot %u reports a different settings hash "
+                        "(%08x vs %08x) — you may be on different seeds\n",
+                (unsigned)g.senderSlot, (unsigned)g.settingsHash, (unsigned)c->settingsHash);
+    }
+
+    InboxPush(c, &g);
+}
+
+static bool PumpReceive(RelayClient* c) {
+    // Drain whatever the channel has, into the accumulation buffer.
+    for (;;) {
+        if (c->rxLen >= RSBS_RELAY_RX_CAP) {
+            break; // full; decode below will drain it
+        }
+        const int n = c->channel.recv(c->channel.userData, c->rx + c->rxLen, RSBS_RELAY_RX_CAP - c->rxLen);
+        if (n < 0) {
+            c->state = RSBS_RELAY_STATE_FAILED;
+            return false;
+        }
+        if (n == 0) {
+            break;
+        }
+        c->rxLen += (uint32_t)n;
+    }
+    return true;
+}
+
+static void ConsumeRx(RelayClient* c, uint32_t n) {
+    if (n == 0) {
+        return;
+    }
+    if (n >= c->rxLen) {
+        c->rxLen = 0;
+        return;
+    }
+    memmove(c->rx, c->rx + n, c->rxLen - n);
+    c->rxLen -= n;
+}
+
+static void ProcessHandshake(RelayClient* c) {
+    if (c->state == RSBS_RELAY_STATE_HELLO) {
+        if (c->rxLen < RSBS_RELAY_SVHELLO_LEN) {
+            return;
+        }
+        if (memcmp(c->rx, RSBS_RELAY_MAGIC, RSBS_RELAY_MAGIC_LEN) != 0) {
+            fprintf(stderr, "[relay] server hello has bad magic; refusing\n");
+            c->state = RSBS_RELAY_STATE_FAILED;
+            return;
+        }
+        uint32_t serverVersion = 0;
+        for (int i = 3; i >= 0; --i) {
+            serverVersion = (serverVersion << 8) | (uint32_t)c->rx[RSBS_RELAY_MAGIC_LEN + i];
+        }
+        // Refuse rather than proceed hopefully into a misparse (ADR 0007 §3.4).
+        if (RSBS_RELAY_VERSION_MAJOR(serverVersion) != RSBS_RELAY_VERSION_MAJOR(RSBS_RELAY_PROTOCOL_VERSION)) {
+            fprintf(stderr, "[relay] server protocol %08x is incompatible with ours %08x; refusing\n",
+                    (unsigned)serverVersion, (unsigned)RSBS_RELAY_PROTOCOL_VERSION);
+            c->state = RSBS_RELAY_STATE_FAILED;
+            return;
+        }
+        c->serverClientId = (uint16_t)((uint16_t)c->rx[9] | ((uint16_t)c->rx[10] << 8));
+        ConsumeRx(c, RSBS_RELAY_SVHELLO_LEN);
+        // Move to JOINING rather than sending the join inline. If the send
+        // blocks we must be able to resume it on a later tick — and by then the
+        // server hello is already consumed, so a state that means "hello done,
+        // join still owed" is the only thing that keeps the join from being
+        // dropped on the floor.
+        c->state = RSBS_RELAY_STATE_JOINING;
+        c->joinSent = 0;
+    }
+
+    if (c->state == RSBS_RELAY_STATE_JOINING) {
+        // Join at base 0, always (ADR 0007 §3.3): the grant cursor de-dups the
+        // already-delivered prefix, so we never persist a second cursor.
+        uint8_t join[RSBS_RELAY_JOIN_LEN];
+        RelayProto_EncodeJoin(c->roomUuid, 0u, join);
+        if (!ChannelSendFrom(c, join, RSBS_RELAY_JOIN_LEN, &c->joinSent)) {
+            return; // partial or blocked; resumes from c->joinSent next tick
+        }
+        // The server sends no join acknowledgement — it simply begins streaming
+        // ledger entries — so there is nothing further to await.
+        c->state = RSBS_RELAY_STATE_READY;
+    }
+}
+
+static void ProcessFrames(RelayClient* c) {
+    for (;;) {
+        uint32_t consumed = 0;
+        RelayLedgerEntry entry;
+        const RelayDecodeStatus st = RelayProto_DecodeFrame(c->rx, c->rxLen, &consumed, &entry);
+        if (st == RSBS_RELAY_DECODE_NEED_MORE) {
+            return;
+        }
+        if (st == RSBS_RELAY_DECODE_ERROR) {
+            fprintf(stderr, "[relay] undecodable frame; closing\n");
+            c->state = RSBS_RELAY_STATE_FAILED;
+            return;
+        }
+        if (st == RSBS_RELAY_DECODE_ENTRY) {
+            HandleEntry(c, &entry);
+        }
+        // NOP and MSG are consumed and ignored.
+        ConsumeRx(c, consumed);
+    }
+}
+
+static void PumpSend(RelayClient* c) {
+    while (c->outboxCount > 0) {
+        const uint32_t slot = c->outboxHead;
+        if (!ChannelSendFrom(c, c->outbox[slot], c->outboxLen[slot], &c->outboxSent)) {
+            return; // partial or blocked; resumes from c->outboxSent next tick
+        }
+        c->outboxHead = (c->outboxHead + 1u) % RSBS_RELAY_OUTBOX_CAP;
+        c->outboxCount--;
+        c->outboxSent = 0; // next frame starts from its own beginning
+    }
+}
+
+// ============================================================================
+// Applying to the ADR 0005 seam
+// ============================================================================
+
+static int ApplyInbox(RelayClient* c) {
+    int accepted = 0;
+
+    while (c->inboxCount > 0) {
+        RsbsGrantPayload g;
+        if (!InboxPeek(c, &g)) {
+            break;
+        }
+
+        const ComboGrantResult r =
+            Combo_SubmitSourcedGrant(c->sourceKey, c->nextSeq, (GameId)g.originGame, g.itemId);
+
+        switch (r) {
+            case RSBS_GRANT_ACCEPTED:
+                c->statAccepted++;
+                c->nextSeq++;
+                accepted++;
+                InboxPop(c);
+                break;
+
+            case RSBS_GRANT_DUPLICATE:
+                // Already delivered in an earlier session/run — this is the
+                // designed outcome of the replay-from-zero catch-up, not an
+                // error. Advance past it.
+                c->statDuplicate++;
+                c->nextSeq++;
+                InboxPop(c);
+                break;
+
+            case RSBS_GRANT_RETRY_FULL:
+                // Backpressure, NOT loss (ADR 0005 §3): the cursor did not
+                // advance, so the grant is still owed. Leave it at the head of
+                // the inbox and stop — re-offering the same seq later is
+                // accepted rather than deduped. Advancing past this is the one
+                // way to actually lose an item.
+                c->statRetryFull++;
+                c->replayNeeded = true;
+                return accepted;
+
+            case RSBS_GRANT_GAP:
+                // Should be unreachable: we assign nextSeq densely ourselves.
+                // If it happens, the local model and our counter disagree, and
+                // guessing would corrupt ordering. Stop and force a replay.
+                c->statGap++;
+                c->replayNeeded = true;
+                return accepted;
+
+            case RSBS_GRANT_NO_SOURCE_SLOT:
+                fprintf(stderr, "[relay] all %u grant-source slots are taken; cannot bind room\n",
+                        (unsigned)RSBS_GRANT_SOURCE_CAP);
+                c->state = RSBS_RELAY_STATE_FAILED;
+                return accepted;
+
+            case RSBS_GRANT_REJECTED:
+            default:
+                // Malformed at the seam though it passed our decode. Drop it
+                // rather than wedging the stream; it is one peer's bad grant.
+                fprintf(stderr, "[relay] seam rejected grant (game %u item %u); dropping\n",
+                        (unsigned)g.originGame, (unsigned)g.itemId);
+                InboxPop(c);
+                break;
+        }
+    }
+
+    return accepted;
+}
+
+// ============================================================================
+// Public pump
+// ============================================================================
+
+int Relay_Tick(RelayClient* c) {
+    if (c == NULL || !c->channelSet) {
+        return 0;
+    }
+    if (c->state == RSBS_RELAY_STATE_IDLE || c->state == RSBS_RELAY_STATE_FAILED) {
+        return 0;
+    }
+
+    if (!PumpReceive(c)) {
+        return 0;
+    }
+
+    ProcessHandshake(c);
+
+    if (c->state == RSBS_RELAY_STATE_READY) {
+        ProcessFrames(c);
+        PumpSend(c);
+    }
+
+    // The latch stops APPLYING only. Receiving, decoding and filing continue,
+    // so a suspended game does not stall the peer or lose ledger position
+    // (salvage item 3).
+    if (c->suspended) {
+        return 0;
+    }
+
+    return ApplyInbox(c);
+}
+
+bool Relay_SendGrant(RelayClient* c, uint8_t targetSlot, GameId originGame, uint16_t itemId) {
+    if (c == NULL || c->outboxCount >= RSBS_RELAY_OUTBOX_CAP) {
+        return false;
+    }
+    if (targetSlot == 0 || c->localSlot == 0) {
+        return false;
+    }
+
+    if (c->sendSeq == 0xFFFFu) {
+        fprintf(stderr, "[relay] outbound sequence exhausted; refusing to wrap\n");
+        return false;
+    }
+
+    RsbsGrantPayload g;
+    g.version = RSBS_GRANT_PAYLOAD_VERSION;
+    g.senderSlot = c->localSlot;
+    g.targetSlot = targetSlot;
+    g.originGame = (uint8_t)originGame;
+    g.itemId = itemId;
+    g.senderSeq = (uint16_t)(c->sendSeq + 1u);
+    g.settingsHash = c->settingsHash;
+
+    uint8_t payload[RSBS_GRANT_PAYLOAD_LEN];
+    if (!RelayProto_EncodeGrant(&g, payload)) {
+        return false;
+    }
+
+    const uint32_t slot = (c->outboxHead + c->outboxCount) % RSBS_RELAY_OUTBOX_CAP;
+    const uint32_t n =
+        RelayProto_EncodeTransfer(RelayProto_GrantKey(&g), payload, RSBS_GRANT_PAYLOAD_LEN, c->outbox[slot]);
+    if (n == 0) {
+        return false;
+    }
+    c->outboxLen[slot] = n;
+    c->outboxCount++;
+    c->sendSeq = g.senderSeq;
+    return true;
+}
+
+void Relay_OnSuspend(RelayClient* c) {
+    if (c != NULL) {
+        c->suspended = true;
+    }
+}
+
+void Relay_OnResume(RelayClient* c) {
+    if (c != NULL) {
+        c->suspended = false;
+    }
+}
+
+void Relay_ClearSessionState(RelayClient* c) {
+    if (c == NULL) {
+        return;
+    }
+    // Undelivered grants belong to the session that received them. Retiring
+    // them here — called FROM Context_InvalidateSessionState — keeps one list
+    // of "things a dead session owns" (#440 guidance on #460).
+    c->inboxHead = 0;
+    c->inboxCount = 0;
+    c->outboxHead = 0;
+    c->outboxCount = 0;
+    c->outboxSent = 0;
+    c->rxLen = 0;
+    // The cursor died with gComboCtx, so our dense counter restarts too;
+    // otherwise we would submit seq N+1 against a cursor of 0 and wedge on GAP.
+    c->nextSeq = 1u;
+    c->sendSeq = 0u;
+    c->replayNeeded = true;
+}
+
+bool Relay_ReplayNeeded(const RelayClient* c) {
+    return c != NULL && c->replayNeeded;
+}

--- a/src/common/netplay/relay_client.h
+++ b/src/common/netplay/relay_client.h
@@ -1,0 +1,201 @@
+/**
+ * @file relay_client.h
+ * @brief Grant-relay client: state machine, bounded inbox, suspend latch.
+ *        ADR 0007. No transport here — see RelayChannel.
+ *
+ * This object turns a byte stream into calls on ADR 0005's producer seam
+ * (`Combo_SubmitSourcedGrant`). It is the ONLY netplay path into the grant
+ * model; it opens no second route into `Combo_RecordSharedItem` (#460).
+ *
+ * ADR 0006 §5's salvage list is carried STRUCTURALLY, not as guidance — each
+ * item closes a verified hazard in the vendored Anchor client:
+ *
+ *   1. NO RECEIVE THREAD (Anchor hazards #1, #2). The socket is serviced only
+ *      inside Relay_Tick(), which the caller invokes on the game thread. There
+ *      is no background thread to marshal from, so ADR 0005's "game thread
+ *      only" seam contract holds by construction rather than by discipline.
+ *   2. BOUNDED INBOX WITH RECOVERABLE DROP (Anchor hazard #3). Fixed ring; on
+ *      overflow we drop WITHOUT advancing the grant cursor and set a replay
+ *      flag. Bounded memory, zero item loss — the dropped grant is re-derived
+ *      by the next §3.3 replay-from-zero.
+ *   3. EXPLICIT SUSPEND LATCH. Relay_OnSuspend() stops APPLYING; polling and
+ *      decoding continue into the inbox. Relay_OnResume() drains in received
+ *      order. The lifecycle has no implicit inverse, so the release is a
+ *      separate named action.
+ *   4. ROOM BINDING, refuse-on-mismatch — and it costs no new state, because
+ *      `sourceKey` IS the room fingerprint (ADR 0007 §4.5). A different room
+ *      derives a different key, hence a different ADR 0005 source slot, hence
+ *      a fresh seq 1. A cursor can never be applied against a room that did
+ *      not produce it.
+ *
+ * THREADING: game thread only, like the seam it feeds.
+ *
+ * SESSION SCOPE: the inbox is session-scoped RAM. Per the #440 guidance on
+ * #460, it is cleared FROM Context_InvalidateSessionState (via
+ * Relay_ClearSessionState) rather than at our own call sites, so there stays
+ * one list of "things a dead session owns".
+ */
+
+#ifndef RSBS_COMMON_NETPLAY_RELAY_CLIENT_H
+#define RSBS_COMMON_NETPLAY_RELAY_CLIENT_H
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#include "relay_protocol.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// Bounded inbox depth (salvage item 2). Sized well above a realistic burst:
+// the whole point is that exceeding it costs latency, never items.
+#define RSBS_RELAY_INBOX_CAP 64u
+
+// Receive accumulation buffer. Must exceed the largest single frame
+// (1 + 9 + 128 = 138) with room to hold a partial next frame.
+#define RSBS_RELAY_RX_CAP 1024u
+
+// Outbound staging depth for locally-produced grants awaiting a writable
+// channel.
+#define RSBS_RELAY_OUTBOX_CAP 32u
+
+/**
+ * Transport abstraction. The loopback harness and a real TCP socket implement
+ * the SAME interface, so the harness drives the identical codec and state
+ * machine a real peer would — only the syscall layer differs. That is the
+ * honest form of the loopback claim (ADR 0007 §8).
+ *
+ * Both callbacks are non-blocking:
+ *   > 0  bytes transferred
+ *   == 0 would block / nothing available
+ *   < 0  fatal channel error
+ */
+typedef struct {
+    int (*send)(void* userData, const uint8_t* data, uint32_t len);
+    int (*recv)(void* userData, uint8_t* data, uint32_t len);
+    void* userData;
+} RelayChannel;
+
+typedef enum {
+    RSBS_RELAY_STATE_IDLE = 0,   // never connected; no outbound anything
+    RSBS_RELAY_STATE_HELLO,      // hello sent, awaiting the 11-byte server hello
+    RSBS_RELAY_STATE_JOINING,    // join sent, awaiting ledger stream
+    RSBS_RELAY_STATE_READY,      // streaming
+    RSBS_RELAY_STATE_FAILED,     // terminal: version mismatch or channel error
+} RelayState;
+
+typedef struct {
+    RelayState state;
+
+    RelayChannel channel;
+    bool channelSet;
+
+    uint8_t roomUuid[RSBS_RELAY_UUID_LEN];
+    uint32_t sourceKey; // fnv1a32(roomUuid), forced nonzero — ADR 0007 §3.1
+    uint8_t localSlot;  // our slot; entries with targetSlot != this are skipped
+    uint32_t settingsHash;
+    uint16_t serverClientId;
+
+    // Receive accumulation.
+    uint8_t rx[RSBS_RELAY_RX_CAP];
+    uint32_t rxLen;
+
+    // Bounded inbox of grants addressed to us, in ledger order.
+    RsbsGrantPayload inbox[RSBS_RELAY_INBOX_CAP];
+    uint32_t inboxHead;
+    uint32_t inboxCount;
+
+    // Outbound staging.
+    uint8_t outbox[RSBS_RELAY_OUTBOX_CAP][RSBS_RELAY_MAX_PAYLOAD + 10u];
+    uint32_t outboxLen[RSBS_RELAY_OUTBOX_CAP];
+    uint32_t outboxHead;
+    uint32_t outboxCount;
+    // How much of the HEAD outbox frame has already reached the channel. A
+    // real socket can accept a prefix and then block; restarting from zero
+    // would put those bytes on the wire twice and desync the server's parser.
+    uint32_t outboxSent;
+    // Same idea for the 20-byte join, which is owed once the server hello has
+    // been consumed and so cannot simply be re-derived from the state alone.
+    uint32_t joinSent;
+
+    // The dense per-room seq we assign to entries addressed to us (§3.2). This
+    // is NOT the ledger index: we skip other players' entries, and a hole would
+    // be a permanent RSBS_GRANT_GAP.
+    uint32_t nextSeq;
+
+    // Our own outbound counter, dense and 1-based per ADR 0007 §2.
+    uint16_t sendSeq;
+
+    bool suspended;    // latch (salvage item 3)
+    bool replayNeeded; // inbox overflow or a RETRY_FULL: re-derive by rejoining
+
+    // Diagnostics — all operator-visible, none of it load-bearing.
+    uint32_t statEntriesSeen;
+    uint32_t statForeignSkipped;
+    uint32_t statNotForUs;
+    uint32_t statAccepted;
+    uint32_t statDuplicate;
+    uint32_t statGap;
+    uint32_t statRetryFull;
+    uint32_t statInboxDropped;
+    bool settingsMismatchSeen;
+} RelayClient;
+
+/**
+ * Derive the ADR 0005 sourceKey from a room UUID (FNV-1a 32, forced nonzero).
+ * Exposed because it IS the room-fingerprint binding (§4.5) and tests assert
+ * that different rooms cannot share a cursor.
+ */
+uint32_t Relay_SourceKeyForRoom(const uint8_t roomUuid[RSBS_RELAY_UUID_LEN]);
+
+/**
+ * Initialise. Does NOT connect and does NOT touch the channel: an operator
+ * action is always required (ADR 0007 §7 — no auto-connect, ever).
+ */
+void Relay_Init(RelayClient* c, const uint8_t roomUuid[RSBS_RELAY_UUID_LEN], uint8_t localSlot, uint32_t settingsHash);
+
+/**
+ * Attach a transport and begin the handshake. Sends the client hello and joins
+ * at ledgerBase 0 — always zero, per ADR 0007 §3.3: the grant cursor de-dups
+ * the already-delivered prefix, so we never persist a second cursor.
+ */
+bool Relay_Connect(RelayClient* c, const RelayChannel* channel);
+
+/**
+ * Pump the transport. Call once per frame on the GAME THREAD. Drains the
+ * socket, decodes frames, files grants addressed to us into the inbox, and —
+ * unless suspended — applies them to the ADR 0005 seam in received order.
+ *
+ * @return the number of grants ACCEPTED by the seam this call.
+ */
+int Relay_Tick(RelayClient* c);
+
+/**
+ * Queue a grant TO a peer. Local-side production: this does not touch our own
+ * grant model at all (we are giving, not receiving).
+ * @return true if staged for send.
+ */
+bool Relay_SendGrant(RelayClient* c, uint8_t targetSlot, GameId originGame, uint16_t itemId);
+
+/** Suspend latch (salvage item 3): stop applying; keep polling. */
+void Relay_OnSuspend(RelayClient* c);
+
+/** Release the latch and resume applying, in received order. */
+void Relay_OnResume(RelayClient* c);
+
+/**
+ * Retire session-scoped RAM. Called FROM Context_InvalidateSessionState so a
+ * dead session's undelivered grants cannot drain into the next session — the
+ * same treatment Combo_ClearSharedItemOutbox() gets (#440 guidance on #460).
+ */
+void Relay_ClearSessionState(RelayClient* c);
+
+/** True if the inbox overflowed or a grant was refused for capacity. */
+bool Relay_ReplayNeeded(const RelayClient* c);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // RSBS_COMMON_NETPLAY_RELAY_CLIENT_H

--- a/src/common/netplay/relay_protocol.c
+++ b/src/common/netplay/relay_protocol.c
@@ -1,0 +1,230 @@
+/**
+ * @file relay_protocol.c
+ * @brief Wire codec for the grant relay (ADR 0007 §2, §3.4). Pure bytes.
+ *
+ * Every integer is read and written a byte at a time, little-endian, rather
+ * than memcpy'd from a packed struct. The server memcpy's native structs on
+ * x86-64, so LE is the wire truth; doing it by hand means this file produces
+ * identical bytes on a big-endian host and needs no packing pragma.
+ *
+ * Nothing here allocates, blocks, or touches a socket or gComboCtx. That is
+ * what makes the golden-vector tests in test_netplay_relay.c able to pin the
+ * exact wire bytes without a transport.
+ */
+
+#include "relay_protocol.h"
+
+#include <string.h>
+
+// ============================================================================
+// Little-endian scalar helpers
+// ============================================================================
+
+static void PutU16(uint8_t* p, uint16_t v) {
+    p[0] = (uint8_t)(v & 0xFFu);
+    p[1] = (uint8_t)((v >> 8) & 0xFFu);
+}
+
+static void PutU32(uint8_t* p, uint32_t v) {
+    p[0] = (uint8_t)(v & 0xFFu);
+    p[1] = (uint8_t)((v >> 8) & 0xFFu);
+    p[2] = (uint8_t)((v >> 16) & 0xFFu);
+    p[3] = (uint8_t)((v >> 24) & 0xFFu);
+}
+
+static void PutU64(uint8_t* p, uint64_t v) {
+    for (int i = 0; i < 8; ++i) {
+        p[i] = (uint8_t)((v >> (8 * i)) & 0xFFu);
+    }
+}
+
+static uint16_t GetU16(const uint8_t* p) {
+    return (uint16_t)((uint16_t)p[0] | ((uint16_t)p[1] << 8));
+}
+
+static uint32_t GetU32(const uint8_t* p) {
+    return (uint32_t)p[0] | ((uint32_t)p[1] << 8) | ((uint32_t)p[2] << 16) | ((uint32_t)p[3] << 24);
+}
+
+static uint64_t GetU64(const uint8_t* p) {
+    uint64_t v = 0;
+    for (int i = 7; i >= 0; --i) {
+        v = (v << 8) | (uint64_t)p[i];
+    }
+    return v;
+}
+
+static bool IsRealGame(uint8_t g) {
+    return g == (uint8_t)GAME_OOT || g == (uint8_t)GAME_MM;
+}
+
+// ============================================================================
+// Grant payload
+// ============================================================================
+
+bool RelayProto_EncodeGrant(const RsbsGrantPayload* grant, uint8_t* out) {
+    if (grant == NULL || out == NULL) {
+        return false;
+    }
+    // Refuse to put a malformed grant on the wire. These are exactly the
+    // conditions the receiving seam would reject with RSBS_GRANT_REJECTED, so
+    // catching them here keeps a local bug from looking like a peer's.
+    if (grant->senderSlot == 0 || grant->targetSlot == 0 || grant->senderSeq == 0) {
+        return false;
+    }
+    if (!IsRealGame(grant->originGame)) {
+        return false;
+    }
+    if (grant->version != RSBS_GRANT_PAYLOAD_VERSION) {
+        return false;
+    }
+
+    memcpy(out, RSBS_GRANT_PAYLOAD_MAGIC, RSBS_GRANT_PAYLOAD_MAGIC_LEN);
+    out[4] = grant->version;
+    out[5] = grant->senderSlot;
+    out[6] = grant->targetSlot;
+    out[7] = grant->originGame;
+    PutU16(out + 8, grant->itemId);
+    PutU16(out + 10, grant->senderSeq);
+    PutU32(out + 12, grant->settingsHash);
+    return true;
+}
+
+bool RelayProto_DecodeGrant(const uint8_t* in, uint32_t len, RsbsGrantPayload* out) {
+    if (in == NULL || out == NULL) {
+        return false;
+    }
+    // A foreign payload is NOT an error (ADR 0007 §4.3) — the ledger is
+    // shared-format by design, so an OoTMM client's entries land in the same
+    // room. Every rejection below is "skip and count", never "disconnect".
+    if (len != RSBS_GRANT_PAYLOAD_LEN) {
+        return false;
+    }
+    if (memcmp(in, RSBS_GRANT_PAYLOAD_MAGIC, RSBS_GRANT_PAYLOAD_MAGIC_LEN) != 0) {
+        return false;
+    }
+    if (in[4] != RSBS_GRANT_PAYLOAD_VERSION) {
+        return false;
+    }
+
+    RsbsGrantPayload g;
+    g.version = in[4];
+    g.senderSlot = in[5];
+    g.targetSlot = in[6];
+    g.originGame = in[7];
+    g.itemId = GetU16(in + 8);
+    g.senderSeq = GetU16(in + 10);
+    g.settingsHash = GetU32(in + 12);
+
+    if (g.senderSlot == 0 || g.targetSlot == 0 || g.senderSeq == 0) {
+        return false;
+    }
+    if (!IsRealGame(g.originGame)) {
+        return false;
+    }
+
+    *out = g;
+    return true;
+}
+
+uint64_t RelayProto_GrantKey(const RsbsGrantPayload* grant) {
+    if (grant == NULL) {
+        return 0;
+    }
+    return ((uint64_t)grant->senderSlot << 48) | ((uint64_t)grant->senderSeq << 16) | (uint64_t)grant->itemId;
+}
+
+// ============================================================================
+// Frame encoders (client -> server)
+// ============================================================================
+
+void RelayProto_EncodeHello(uint8_t* out) {
+    memcpy(out, RSBS_RELAY_MAGIC, RSBS_RELAY_MAGIC_LEN);
+    PutU32(out + RSBS_RELAY_MAGIC_LEN, RSBS_RELAY_PROTOCOL_VERSION);
+}
+
+void RelayProto_EncodeJoin(const uint8_t roomUuid[RSBS_RELAY_UUID_LEN], uint32_t ledgerBase, uint8_t* out) {
+    memcpy(out, roomUuid, RSBS_RELAY_UUID_LEN);
+    PutU32(out + RSBS_RELAY_UUID_LEN, ledgerBase);
+}
+
+uint32_t RelayProto_EncodeTransfer(uint64_t key, const uint8_t* payload, uint32_t payloadLen, uint8_t* out) {
+    if (out == NULL || payload == NULL || payloadLen > RSBS_RELAY_MAX_PAYLOAD) {
+        return 0;
+    }
+    out[0] = RSBS_RELAY_OP_TRANSFER;
+    PutU64(out + 1, key);
+    out[9] = (uint8_t)payloadLen;
+    memcpy(out + 10, payload, payloadLen);
+    return 10u + payloadLen;
+}
+
+// ============================================================================
+// Incremental decoder (server -> client)
+// ============================================================================
+
+RelayDecodeStatus RelayProto_DecodeFrame(const uint8_t* buf, uint32_t len, uint32_t* consumed, RelayLedgerEntry* entry) {
+    if (consumed != NULL) {
+        *consumed = 0;
+    }
+    if (buf == NULL || consumed == NULL || len == 0) {
+        return RSBS_RELAY_DECODE_NEED_MORE;
+    }
+
+    switch (buf[0]) {
+        case RSBS_RELAY_OP_NONE:
+            // Keepalive. The server emits these from multiClientEventTimer
+            // whenever it has been quiet for a few ticks, so a decoder that
+            // treated a stray 0x00 as a bad opcode would drop a perfectly
+            // healthy connection after a few idle seconds.
+            *consumed = 1;
+            return RSBS_RELAY_DECODE_NOP;
+
+        case RSBS_RELAY_OP_TRANSFER: {
+            if (len < 1u + RSBS_RELAY_ENTRY_HEADER_LEN) {
+                return RSBS_RELAY_DECODE_NEED_MORE;
+            }
+            // op(1) + key(8) => the size byte is at offset 9, payload at 10.
+            const uint32_t payloadLen = buf[9];
+            if (payloadLen > RSBS_RELAY_MAX_PAYLOAD) {
+                // The server refuses to STORE an oversized entry, so it should
+                // never emit one. Treat it as a broken stream rather than
+                // guessing a resync point: the length prefix is the only thing
+                // keeping us framed, so a bad one means we are already lost.
+                return RSBS_RELAY_DECODE_ERROR;
+            }
+            const uint32_t total = 1u + RSBS_RELAY_ENTRY_HEADER_LEN + payloadLen;
+            if (len < total) {
+                return RSBS_RELAY_DECODE_NEED_MORE;
+            }
+            if (entry != NULL) {
+                entry->key = GetU64(buf + 1);
+                entry->payloadLen = payloadLen;
+                if (payloadLen > 0) {
+                    memcpy(entry->payload, buf + 10, payloadLen);
+                }
+            }
+            *consumed = total;
+            return RSBS_RELAY_DECODE_ENTRY;
+        }
+
+        case RSBS_RELAY_OP_MSG: {
+            // op + u8 size + u16 senderId + text[size]. We decode it purely to
+            // stay framed, then discard: the relay carries grants, and routing
+            // peer chat into the game is not in ADR 0007's scope.
+            if (len < 4u) {
+                return RSBS_RELAY_DECODE_NEED_MORE;
+            }
+            const uint32_t textLen = buf[1];
+            const uint32_t total = 4u + textLen;
+            if (len < total) {
+                return RSBS_RELAY_DECODE_NEED_MORE;
+            }
+            *consumed = total;
+            return RSBS_RELAY_DECODE_MSG;
+        }
+
+        default:
+            return RSBS_RELAY_DECODE_ERROR;
+    }
+}

--- a/src/common/netplay/relay_protocol.h
+++ b/src/common/netplay/relay_protocol.h
@@ -1,0 +1,221 @@
+/**
+ * @file relay_protocol.h
+ * @brief Wire codec for the grant relay (ADR 0007). Pure bytes — no sockets.
+ *
+ * This layer implements the OoTMM `multi-server` wire format
+ * (https://github.com/OoTMM/multi-server, MIT, `master` @ 2025-03-27,
+ * VERSION 0x00000200). We speak its protocol; we vendor none of its code and
+ * we ship no server. See docs/adr/0007-grant-relay-netplay.md §1.
+ *
+ * WHY WE CAN REUSE IT (ADR 0007 §1.2): the server's ledger entry is
+ * `{u64 key; u8 size; opaque payload}` and `multiLedgerWrite` never inspects
+ * the payload. There is no game identity, no slot registry, no generated
+ * world — so unlike Archipelago (ADR 0006 §1.1) there is NO admissibility
+ * check a client can fail. An unmodified multi-server relays RSBS grants
+ * today because it cannot tell them from OoTMM's.
+ *
+ * WIRE FORMAT, transcribed from the server source and pinned by golden byte
+ * vectors in test_netplay_relay.c. All multi-byte integers are LITTLE-ENDIAN
+ * (the server memcpy's native structs on x86-64 Linux), and the codec below
+ * reads/writes them byte-by-byte so a big-endian host produces the same bytes.
+ *
+ *   Handshake, client -> server (9 bytes):
+ *       "OOMM2" + u32 clientVersion
+ *   Handshake, server -> client (11 bytes):
+ *       "OOMM2" + u32 serverVersion + u16 assignedClientId
+ *   Join, client -> server (20 bytes):
+ *       u8 roomUuid[16] + u32 ledgerBase
+ *   Then a command stream in both directions:
+ *       OP_NONE     (0x00)  1 byte. Keepalive NOP — the server emits one every
+ *                           few seconds from multiClientEventTimer. MUST be
+ *                           tolerated mid-stream or the client desyncs.
+ *       OP_TRANSFER (0x01)  server->client: u64 key + u8 size + payload[size]
+ *                           client->server: u64 key + u8 size + payload[size]
+ *       OP_MSG      (0x02)  server->client: u8 size + u16 senderId + text[size]
+ *                           (chat; we decode and discard — see relay_client.c)
+ *
+ * ECHO ASYMMETRY, and it is load-bearing for the harness: `multiClientCmdTransfer`
+ * fans a new entry out to EVERY client on the ledger **including the sender**
+ * (it does not skip `client->id`), whereas `multiClientCmdMsg` explicitly does
+ * skip the sender. So a client receives its own grants back and MUST filter by
+ * targetSlot. A mock that conveniently skipped the sender would hide that —
+ * exactly the shortcut ADR 0006 §2(b) caught in the AP mock.
+ *
+ * The RSBS payload (ADR 0007 §2) is ours and opaque to the server. Foreign or
+ * malformed payloads (an OoTMM client sharing the room) are skipped, never
+ * fatal: the server's own length prefix keeps the stream framed regardless.
+ */
+
+#ifndef RSBS_COMMON_NETPLAY_RELAY_PROTOCOL_H
+#define RSBS_COMMON_NETPLAY_RELAY_PROTOCOL_H
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#include "../game.h" // GameId
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// ============================================================================
+// Server protocol constants (pinned to multi-server master @ 2025-03-27)
+// ============================================================================
+
+#define RSBS_RELAY_MAGIC "OOMM2"
+#define RSBS_RELAY_MAGIC_LEN 5u
+
+// The server's VERSION. We refuse a connection whose high 16 bits differ
+// rather than proceeding hopefully into a misparse (ADR 0007 §3.4).
+#define RSBS_RELAY_PROTOCOL_VERSION 0x00000200u
+#define RSBS_RELAY_VERSION_MAJOR(v) ((v) >> 16)
+
+#define RSBS_RELAY_HELLO_LEN 9u  // "OOMM2" + u32 version
+#define RSBS_RELAY_SVHELLO_LEN 11u // "OOMM2" + u32 version + u16 clientId
+#define RSBS_RELAY_JOIN_LEN 20u  // uuid[16] + u32 ledgerBase
+#define RSBS_RELAY_UUID_LEN 16u
+
+// Command opcodes.
+#define RSBS_RELAY_OP_NONE 0x00u
+#define RSBS_RELAY_OP_TRANSFER 0x01u
+#define RSBS_RELAY_OP_MSG 0x02u
+
+// The server disconnects a client whose OP_TRANSFER header.size exceeds this
+// (client.c: `if (header.size > 128)`). Our payload is far smaller; this is
+// here so we can never emit a frame that gets us dropped.
+#define RSBS_RELAY_MAX_PAYLOAD 128u
+
+// OP_TRANSFER wire header: u64 key + u8 size.
+#define RSBS_RELAY_ENTRY_HEADER_LEN 9u
+
+// ============================================================================
+// The RSBS grant payload (ADR 0007 §2) — ours, opaque to the server
+// ============================================================================
+
+#define RSBS_GRANT_PAYLOAD_LEN 16u
+#define RSBS_GRANT_PAYLOAD_VERSION 1u
+#define RSBS_GRANT_PAYLOAD_MAGIC "RSBS"
+#define RSBS_GRANT_PAYLOAD_MAGIC_LEN 4u
+
+/**
+ * The encoded 16-byte layout, which is the authority (the struct below holds
+ * only the 12 bytes that are DATA — the magic is a constant, not a field):
+ *
+ *   off  size  field
+ *    0    4    magic  "RSBS"
+ *    4    1    version
+ *    5    1    senderSlot
+ *    6    1    targetSlot
+ *    7    1    originGame
+ *    8    2    itemId        (LE)
+ *   10    2    senderSeq     (LE)
+ *   12    4    settingsHash  (LE)
+ *   ----------------------------
+ *              16 bytes total
+ *
+ * ADR 0007 §2's table listed a trailing `reserved[2]`, which would have made
+ * the payload 18 bytes rather than the 16 it claimed. The layout above is the
+ * correct one and the ADR is corrected to match in this change. Growth room is
+ * not lost: the server's cap is 128 bytes, so a v2 payload simply gets a new
+ * `version` byte and a longer encoding — the decoder already rejects unknown
+ * versions by returning false (skip, not fatal), so old clients degrade to
+ * "skipped a grant they could not read" rather than misparsing one.
+ */
+
+/**
+ * One grant on the wire. Decoded/encoded field-by-field (never memcpy'd over
+ * the wire bytes) so there is no packing or endianness assumption.
+ */
+typedef struct {
+    uint8_t version;       // RSBS_GRANT_PAYLOAD_VERSION
+    uint8_t senderSlot;    // 1..255, self-asserted (trust model: ADR 0007 §6)
+    uint8_t targetSlot;    // 1..255, intended recipient
+    uint8_t originGame;    // GameId — the id-space owner (ADR 0002)
+    uint16_t itemId;       // RG_* if originGame == GAME_OOT, RI_* if GAME_MM
+    uint16_t senderSeq;    // sender's own dense 1-based counter
+    uint32_t settingsHash; // ADVISORY mismatch warning only (ADR 0007 §5.3)
+} RsbsGrantPayload;
+
+/**
+ * Encode a grant payload into exactly RSBS_GRANT_PAYLOAD_LEN bytes.
+ * @return true on success; false if `out` is NULL or the grant is malformed
+ *         (slot 0, seq 0, or originGame not a real game).
+ */
+bool RelayProto_EncodeGrant(const RsbsGrantPayload* grant, uint8_t* out);
+
+/**
+ * Decode a grant payload from exactly `len` bytes.
+ *
+ * @return true if the bytes are a well-formed RSBS grant payload. Returns
+ *         FALSE — not an error, per ADR 0007 §4.3 — for a foreign payload (bad
+ *         magic, e.g. an OoTMM client in the same room), an unknown version, a
+ *         wrong length, or a malformed field. The caller skips and counts it;
+ *         it must never disconnect or desync on this.
+ */
+bool RelayProto_DecodeGrant(const uint8_t* in, uint32_t len, RsbsGrantPayload* out);
+
+/**
+ * The ledger key for a grant (ADR 0007 §2):
+ *   (senderSlot << 48) | (senderSeq << 16) | itemId
+ *
+ * Unique per (sender, sequence), so the server's keySet absorbs a sender's own
+ * retransmit — while two DIFFERENT senders gifting the same item produce
+ * different keys and both survive. That second half matters: server-side dedup
+ * collapsing two legitimate gifts would reintroduce, one layer lower, the exact
+ * bug ADR 0005 §1 exists to fix.
+ */
+uint64_t RelayProto_GrantKey(const RsbsGrantPayload* grant);
+
+// ============================================================================
+// Frame encoders (client -> server)
+// ============================================================================
+
+/** Write the 9-byte client hello. `out` must hold RSBS_RELAY_HELLO_LEN. */
+void RelayProto_EncodeHello(uint8_t* out);
+
+/** Write the 20-byte join. `out` must hold RSBS_RELAY_JOIN_LEN. */
+void RelayProto_EncodeJoin(const uint8_t roomUuid[RSBS_RELAY_UUID_LEN], uint32_t ledgerBase, uint8_t* out);
+
+/**
+ * Write an OP_TRANSFER frame: op + u64 key + u8 size + payload.
+ * `out` must hold 1 + RSBS_RELAY_ENTRY_HEADER_LEN + payloadLen.
+ * @return the number of bytes written, or 0 if payloadLen > RSBS_RELAY_MAX_PAYLOAD.
+ */
+uint32_t RelayProto_EncodeTransfer(uint64_t key, const uint8_t* payload, uint32_t payloadLen, uint8_t* out);
+
+// ============================================================================
+// Incremental decoder (server -> client)
+// ============================================================================
+
+typedef enum {
+    RSBS_RELAY_DECODE_NEED_MORE = 0, // incomplete frame; keep buffering
+    RSBS_RELAY_DECODE_NOP,           // OP_NONE keepalive consumed
+    RSBS_RELAY_DECODE_ENTRY,         // a ledger entry was decoded
+    RSBS_RELAY_DECODE_MSG,           // a chat message was consumed (discarded)
+    RSBS_RELAY_DECODE_ERROR,         // unknown opcode — the stream is unusable
+} RelayDecodeStatus;
+
+typedef struct {
+    uint64_t key;
+    uint8_t payload[RSBS_RELAY_MAX_PAYLOAD];
+    uint32_t payloadLen;
+} RelayLedgerEntry;
+
+/**
+ * Try to decode one frame from the front of `buf`.
+ *
+ * @param consumed set to the number of bytes consumed (0 when NEED_MORE).
+ * @param entry    populated only when the result is RSBS_RELAY_DECODE_ENTRY.
+ *
+ * Tolerating OP_NONE is not optional: the server emits keepalive NOPs from
+ * multiClientEventTimer whenever it has been quiet, and a decoder that treated
+ * a stray 0x00 as a bad opcode would drop a healthy connection after a few
+ * idle seconds.
+ */
+RelayDecodeStatus RelayProto_DecodeFrame(const uint8_t* buf, uint32_t len, uint32_t* consumed, RelayLedgerEntry* entry);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // RSBS_COMMON_NETPLAY_RELAY_PROTOCOL_H

--- a/src/common/test_runner.cpp
+++ b/src/common/test_runner.cpp
@@ -146,6 +146,21 @@ extern "C" {
 // via shared_items.h.
 #include "tests/test_grant_sources.c"
 
+// Netplay grant-relay loopback locks (ADR 0007, #460). Guarded: with
+// RSBS_NETPLAY=OFF (the default) the relay sources are not in the build at all,
+// so the code under test does not exist. The `#include "tests/..."` text is
+// still present for redship_check_test_sources(), which globs the directory and
+// greps this file — the guard hides the code from the compiler, not the file
+// from the completeness check.
+//
+// Inside its own extern "C" block: every symbol it drives (Relay_*,
+// RelayProto_*, Combo_*) is C-linkage.
+#ifdef RSBS_NETPLAY
+extern "C" {
+#include "tests/test_netplay_relay.c"
+}
+#endif
+
 // MM scene-command parse regression (issue #344). Included at FILE SCOPE
 // (compiled as C++): it drives MM's S2H::ResourceFactoryBinarySceneV0 directly
 // over a synthetic scene buffer — no ROM archives or display needed.
@@ -1167,6 +1182,21 @@ const TestDescriptor gTests[] = {
     {"grant-persistence", "Cursors + overflow ride the .redsave; legacy loads unset; reset retires atomically "
      "(ADR 0005)",
      Test_GrantPersistence},
+#ifdef RSBS_NETPLAY
+    // Netplay 1b (ADR 0007, #460): the grant relay, over a loopback ledger with
+    // multi-server's semantics. Registered only when the relay is built.
+    {"relay-wire-format", "Relay wire format matches golden vectors; foreign payloads skip (ADR 0007)",
+     Test_RelayWireFormat},
+    {"relay-loopback", "Loopback peers: retransmit delivers once, two peers' same item delivers twice, "
+     "self-echo filtered (ADR 0007)",
+     Test_RelayLoopback},
+    {"relay-catchup", "Late joiner catches up from ledger base 0; grants survive a cross-game switch (ADR 0007)",
+     Test_RelayCatchup},
+    {"relay-backpressure", "A full array backpressures the relay without losing the grant (ADR 0007)",
+     Test_RelayBackpressure},
+    {"relay-suspend-latch", "Suspend stops applying but not polling; resume drains in order (ADR 0007)",
+     Test_RelaySuspendLatch},
+#endif
     {"context", "Test context/state management", Test_Context},
     // Clears all frozen states on entry and exit, so it must not run between a
     // test that freezes and one that expects that freeze to still be there.

--- a/src/common/tests/test_netplay_relay.c
+++ b/src/common/tests/test_netplay_relay.c
@@ -1,0 +1,772 @@
+/**
+ * @file test_netplay_relay.c
+ * @brief Loopback locks for the grant relay (ADR 0007). ROM-free, no sockets.
+ *
+ * WHAT THIS PROVES, and equally what it does NOT — stated here because ADR
+ * 0006 §2(b) caught the previous attempt's harness going green while real
+ * integration stayed impossible, and the honest statement is the deliverable:
+ *
+ * PROVES. Two client objects drive the REAL codec and the REAL state machine
+ * over a mock ledger implementing the same semantics as OoTMM's multi-server:
+ * append-only, u64-key dedup, `ledgerBase` replay, and — load-bearing —
+ * broadcast to EVERY client on the ledger INCLUDING the sender. Real bytes go
+ * through RelayProto_* in both directions; only the syscall layer is swapped.
+ *   - a retransmitted grant yields exactly ONE item
+ *   - two peers gifting the same item yield TWO items (the ADR 0005 §1 regression)
+ *   - received-order redemption
+ *   - grants survive a cross-game switch
+ *   - late-join catch-up delivers the whole backlog
+ *   - self-echo is filtered (the sender does not award itself its own gift)
+ *   - inbox overflow drops WITHOUT advancing the cursor, and is loud
+ *   - a foreign/malformed ledger entry is skipped without desyncing
+ *   - golden byte vectors pin the wire format
+ *
+ * DOES NOT PROVE. The mock is a re-derivation from reading multi-server's
+ * client.c/ledger.c, not the real binary — so it cannot prove our framing
+ * matches the wire. Nor does it prove real socket behaviour (partial reads,
+ * EAGAIN, mid-frame disconnect, TCP segmentation), nor that upstream still
+ * behaves as read (pinned: master @ 2025-03-27, VERSION 0x00000200).
+ *
+ * The distinction from ADR 0006's gap is real and is why this is worth
+ * locking: Archipelago's was a WALL — no client of ours could ever be
+ * admitted, because a real server validates the announced game against a
+ * generated world. multi-server's ledger never inspects the payload, so there
+ * is no admissibility check to fail and a framing mismatch is a DEFECT CLASS
+ * we can fix unilaterally. Different in kind, not merely in degree.
+ *
+ * Linkage note: #included into test_runner.cpp inside its own extern "C"
+ * block — every symbol it drives is C-linkage (relay_*, Combo_*).
+ */
+
+#include "../context.h"
+#include "../netplay/relay_client.h"
+#include "../netplay/relay_protocol.h"
+#include "../shared_items.h"
+#include "../test_runner.h"
+
+#include <stdio.h>
+#include <string.h>
+
+#define NR_ASSERT(cond)                                                                                                \
+    do {                                                                                                               \
+        if (!(cond)) {                                                                                                 \
+            printf("[TEST] FAIL: %s:%d: %s\n", __FILE__, __LINE__, #cond);                                             \
+            return TEST_FAIL;                                                                                          \
+        }                                                                                                              \
+    } while (0)
+
+// ============================================================================
+// Mock ledger server — the semantics of multi-server, in process
+// ============================================================================
+
+#define MOCK_MAX_ENTRIES 128
+#define MOCK_MAX_CLIENTS 4
+#define MOCK_PIPE_CAP 8192
+
+typedef struct {
+    uint64_t key;
+    uint8_t payload[RSBS_RELAY_MAX_PAYLOAD];
+    uint32_t payloadLen;
+} MockEntry;
+
+// A one-directional byte pipe. Deliberately a plain FIFO of bytes, not of
+// frames: the client must reassemble, which is what makes the codec's
+// incremental decoder actually exercised.
+typedef struct {
+    uint8_t buf[MOCK_PIPE_CAP];
+    uint32_t head;
+    uint32_t len;
+} MockPipe;
+
+typedef struct {
+    bool active;
+    bool ready;       // past the handshake
+    uint32_t base;    // ledgerBase: how many entries this client has been sent
+    MockPipe toClient;
+    MockPipe toServer;
+    // Server-side parse state for the client's own stream.
+    uint8_t rx[512];
+    uint32_t rxLen;
+    bool sawHello;
+    bool sawJoin;
+} MockClient;
+
+typedef struct {
+    MockEntry entries[MOCK_MAX_ENTRIES];
+    uint32_t count;
+    MockClient clients[MOCK_MAX_CLIENTS];
+    // Set to force the ledger to reject writes, to drive backpressure paths.
+    bool full;
+} MockServer;
+
+static void MockPipeWrite(MockPipe* p, const uint8_t* data, uint32_t len) {
+    for (uint32_t i = 0; i < len; ++i) {
+        if (p->len >= MOCK_PIPE_CAP) {
+            return; // drop; tests never intentionally overrun this
+        }
+        p->buf[(p->head + p->len) % MOCK_PIPE_CAP] = data[i];
+        p->len++;
+    }
+}
+
+static uint32_t MockPipeRead(MockPipe* p, uint8_t* out, uint32_t max) {
+    uint32_t n = 0;
+    while (n < max && p->len > 0) {
+        out[n++] = p->buf[p->head];
+        p->head = (p->head + 1u) % MOCK_PIPE_CAP;
+        p->len--;
+    }
+    return n;
+}
+
+static MockServer gMockServer;
+
+// --- Ledger ----------------------------------------------------------------
+
+// Append with dedup on `key`, exactly like multiLedgerWrite: an existing key
+// is silently ignored, which is the server-side half of idempotency.
+static void MockLedgerWrite(MockServer* s, uint64_t key, const uint8_t* payload, uint32_t len) {
+    if (s->full || s->count >= MOCK_MAX_ENTRIES) {
+        return;
+    }
+    for (uint32_t i = 0; i < s->count; ++i) {
+        if (s->entries[i].key == key) {
+            return; // dedup — the retransmit never fans out
+        }
+    }
+    MockEntry* e = &s->entries[s->count++];
+    e->key = key;
+    e->payloadLen = len;
+    memcpy(e->payload, payload, len);
+}
+
+// Stream every entry the client has not yet been sent. This is
+// multiClientTransferLedger: it is called both at join (catch-up from base)
+// and after every write (live tail), and it is the same code path for both.
+static void MockTransferLedger(MockServer* s, MockClient* c) {
+    if (!c->active || !c->ready) {
+        return;
+    }
+    while (c->base < s->count) {
+        const MockEntry* e = &s->entries[c->base];
+        uint8_t frame[1 + RSBS_RELAY_ENTRY_HEADER_LEN + RSBS_RELAY_MAX_PAYLOAD];
+        const uint32_t n = RelayProto_EncodeTransfer(e->key, e->payload, e->payloadLen, frame);
+        MockPipeWrite(&c->toClient, frame, n);
+        c->base++;
+    }
+}
+
+// The broadcast in multiClientCmdTransfer does NOT skip the sender (unlike the
+// chat path, which does). Reproducing that faithfully is the whole reason
+// self-echo filtering is testable here at all.
+static void MockBroadcast(MockServer* s) {
+    for (int i = 0; i < MOCK_MAX_CLIENTS; ++i) {
+        MockTransferLedger(s, &s->clients[i]);
+    }
+}
+
+// --- Server-side client stream parsing --------------------------------------
+
+static void MockServerConsume(MockClient* c, uint32_t n) {
+    if (n >= c->rxLen) {
+        c->rxLen = 0;
+        return;
+    }
+    memmove(c->rx, c->rx + n, c->rxLen - n);
+    c->rxLen -= n;
+}
+
+static void MockServerPump(MockServer* s, int clientIdx) {
+    MockClient* c = &s->clients[clientIdx];
+    if (!c->active) {
+        return;
+    }
+
+    // Drain the client's outbound pipe into the server's parse buffer.
+    c->rxLen += MockPipeRead(&c->toServer, c->rx + c->rxLen, (uint32_t)sizeof(c->rx) - c->rxLen);
+
+    for (;;) {
+        if (!c->sawHello) {
+            if (c->rxLen < RSBS_RELAY_HELLO_LEN) {
+                return;
+            }
+            // Validate the magic the way the real server does.
+            if (memcmp(c->rx, RSBS_RELAY_MAGIC, RSBS_RELAY_MAGIC_LEN) != 0) {
+                c->active = false;
+                return;
+            }
+            MockServerConsume(c, RSBS_RELAY_HELLO_LEN);
+            c->sawHello = true;
+
+            // Server hello: magic + version + assigned client id.
+            uint8_t hello[RSBS_RELAY_SVHELLO_LEN];
+            memcpy(hello, RSBS_RELAY_MAGIC, RSBS_RELAY_MAGIC_LEN);
+            const uint32_t v = RSBS_RELAY_PROTOCOL_VERSION;
+            hello[5] = (uint8_t)(v & 0xFFu);
+            hello[6] = (uint8_t)((v >> 8) & 0xFFu);
+            hello[7] = (uint8_t)((v >> 16) & 0xFFu);
+            hello[8] = (uint8_t)((v >> 24) & 0xFFu);
+            hello[9] = (uint8_t)(clientIdx & 0xFFu);
+            hello[10] = 0u;
+            MockPipeWrite(&c->toClient, hello, RSBS_RELAY_SVHELLO_LEN);
+            continue;
+        }
+
+        if (!c->sawJoin) {
+            if (c->rxLen < RSBS_RELAY_JOIN_LEN) {
+                return;
+            }
+            uint32_t base = (uint32_t)c->rx[16] | ((uint32_t)c->rx[17] << 8) | ((uint32_t)c->rx[18] << 16) |
+                            ((uint32_t)c->rx[19] << 24);
+            MockServerConsume(c, RSBS_RELAY_JOIN_LEN);
+            c->sawJoin = true;
+            c->ready = true;
+            c->base = base;
+            // Catch-up: everything from base onward, before any live traffic.
+            MockTransferLedger(s, c);
+            continue;
+        }
+
+        // Command stream from the client.
+        if (c->rxLen < 1) {
+            return;
+        }
+        if (c->rx[0] == RSBS_RELAY_OP_NONE) {
+            MockServerConsume(c, 1);
+            continue;
+        }
+        if (c->rx[0] == RSBS_RELAY_OP_TRANSFER) {
+            if (c->rxLen < 1u + RSBS_RELAY_ENTRY_HEADER_LEN) {
+                return;
+            }
+            const uint32_t payloadLen = c->rx[9];
+            const uint32_t total = 1u + RSBS_RELAY_ENTRY_HEADER_LEN + payloadLen;
+            if (c->rxLen < total) {
+                return;
+            }
+            uint64_t key = 0;
+            for (int i = 7; i >= 0; --i) {
+                key = (key << 8) | (uint64_t)c->rx[1 + i];
+            }
+            MockLedgerWrite(s, key, c->rx + 10, payloadLen);
+            MockServerConsume(c, total);
+            MockBroadcast(s);
+            continue;
+        }
+        // Unknown opcode: the real server disconnects.
+        c->active = false;
+        return;
+    }
+}
+
+static void MockServerPumpAll(MockServer* s) {
+    for (int i = 0; i < MOCK_MAX_CLIENTS; ++i) {
+        MockServerPump(s, i);
+    }
+}
+
+// --- RelayChannel bindings --------------------------------------------------
+
+static int MockChanSend(void* userData, const uint8_t* data, uint32_t len) {
+    MockClient* c = (MockClient*)userData;
+    if (!c->active) {
+        return -1;
+    }
+    MockPipeWrite(&c->toServer, data, len);
+    return (int)len;
+}
+
+static int MockChanRecv(void* userData, uint8_t* data, uint32_t len) {
+    MockClient* c = (MockClient*)userData;
+    if (!c->active) {
+        return -1;
+    }
+    return (int)MockPipeRead(&c->toClient, data, len);
+}
+
+static void MockReset(MockServer* s) {
+    memset(s, 0, sizeof(*s));
+}
+
+static MockClient* MockAttach(MockServer* s, int idx) {
+    MockClient* c = &s->clients[idx];
+    memset(c, 0, sizeof(*c));
+    c->active = true;
+    return c;
+}
+
+static RelayChannel MockChannelFor(MockClient* c) {
+    RelayChannel ch;
+    ch.send = MockChanSend;
+    ch.recv = MockChanRecv;
+    ch.userData = c;
+    return ch;
+}
+
+// Run the whole loopback to quiescence: client ticks and server pumps
+// interleaved, so multi-round-trip flows (hello -> join -> catch-up) settle.
+static int PumpAll(MockServer* s, RelayClient** clients, int n, int rounds) {
+    int accepted = 0;
+    for (int r = 0; r < rounds; ++r) {
+        MockServerPumpAll(s);
+        for (int i = 0; i < n; ++i) {
+            accepted += Relay_Tick(clients[i]);
+        }
+    }
+    return accepted;
+}
+
+// ============================================================================
+// Shared fixtures
+// ============================================================================
+
+static const uint8_t kRoomA[RSBS_RELAY_UUID_LEN] = { 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88,
+                                                     0x99, 0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF, 0x01 };
+static const uint8_t kRoomB[RSBS_RELAY_UUID_LEN] = { 0xFE, 0xED, 0xFA, 0xCE, 0x00, 0x11, 0x22, 0x33,
+                                                     0x44, 0x55, 0x66, 0x77, 0x88, 0x99, 0xAA, 0xBB };
+
+typedef struct {
+    int count;
+    uint16_t ids[RSBS_SHARED_ITEM_CAP];
+    uint8_t origins[RSBS_SHARED_ITEM_CAP];
+} RelayAwardLog;
+
+static void RelayAward(const SharedItem* item, void* ctx) {
+    RelayAwardLog* log = (RelayAwardLog*)ctx;
+    if (log->count < RSBS_SHARED_ITEM_CAP) {
+        log->ids[log->count] = item->id;
+        log->origins[log->count] = (uint8_t)item->originGame;
+        log->count++;
+    }
+}
+
+static int RelayOccupied(void) {
+    int n = 0;
+    for (uint32_t i = 0; i < RSBS_SHARED_ITEM_CAP; ++i) {
+        if (gComboCtx.sharedItemsTagged[i].originGame != GAME_NONE) {
+            n++;
+        }
+    }
+    return n;
+}
+
+// ============================================================================
+// Test 1: the wire format itself
+// ============================================================================
+
+TestResult Test_RelayWireFormat(void) {
+    printf("[TEST] Relay wire format (golden vectors, ADR 0007 §2)\n");
+
+    // --- Client hello: "OOMM2" + LE u32 0x00000200 ---
+    uint8_t hello[RSBS_RELAY_HELLO_LEN];
+    RelayProto_EncodeHello(hello);
+    const uint8_t kHelloGold[RSBS_RELAY_HELLO_LEN] = { 'O', 'O', 'M', 'M', '2', 0x00, 0x02, 0x00, 0x00 };
+    NR_ASSERT(memcmp(hello, kHelloGold, sizeof(kHelloGold)) == 0);
+
+    // --- Join: uuid + LE u32 base. Always base 0 (ADR 0007 §3.3). ---
+    uint8_t join[RSBS_RELAY_JOIN_LEN];
+    RelayProto_EncodeJoin(kRoomA, 0u, join);
+    NR_ASSERT(memcmp(join, kRoomA, RSBS_RELAY_UUID_LEN) == 0);
+    NR_ASSERT(join[16] == 0 && join[17] == 0 && join[18] == 0 && join[19] == 0);
+
+    // --- Grant payload: exactly 16 bytes, magic-prefixed, little-endian. ---
+    RsbsGrantPayload g;
+    g.version = RSBS_GRANT_PAYLOAD_VERSION;
+    g.senderSlot = 2;
+    g.targetSlot = 1;
+    g.originGame = (uint8_t)GAME_OOT;
+    g.itemId = 0x1234;
+    g.senderSeq = 0x0007;
+    g.settingsHash = 0xDEADBEEFu;
+
+    uint8_t payload[RSBS_GRANT_PAYLOAD_LEN];
+    NR_ASSERT(RelayProto_EncodeGrant(&g, payload));
+    const uint8_t kGrantGold[RSBS_GRANT_PAYLOAD_LEN] = {
+        'R', 'S', 'B', 'S',      // magic
+        0x01,                    // version
+        0x02,                    // senderSlot
+        0x01,                    // targetSlot
+        0x01,                    // originGame == GAME_OOT
+        0x34, 0x12,              // itemId LE
+        0x07, 0x00,              // senderSeq LE
+        0xEF, 0xBE, 0xAD, 0xDE,  // settingsHash LE
+    };
+    NR_ASSERT(memcmp(payload, kGrantGold, sizeof(kGrantGold)) == 0);
+
+    // Round trip.
+    RsbsGrantPayload back;
+    NR_ASSERT(RelayProto_DecodeGrant(payload, RSBS_GRANT_PAYLOAD_LEN, &back));
+    NR_ASSERT(back.senderSlot == 2 && back.targetSlot == 1);
+    NR_ASSERT(back.originGame == (uint8_t)GAME_OOT && back.itemId == 0x1234);
+    NR_ASSERT(back.senderSeq == 7 && back.settingsHash == 0xDEADBEEFu);
+
+    // Ledger key: (slot << 48) | (seq << 16) | itemId.
+    NR_ASSERT(RelayProto_GrantKey(&g) == (((uint64_t)2 << 48) | ((uint64_t)7 << 16) | 0x1234u));
+
+    // Two DIFFERENT senders of the same item must produce DIFFERENT keys, or
+    // the server's own dedup would collapse two legitimate gifts — the ADR
+    // 0005 §1 bug, one layer lower.
+    RsbsGrantPayload g2 = g;
+    g2.senderSlot = 3;
+    NR_ASSERT(RelayProto_GrantKey(&g2) != RelayProto_GrantKey(&g));
+
+    // --- Malformed / foreign payloads are rejected, never accepted. ---
+    uint8_t bad[RSBS_GRANT_PAYLOAD_LEN];
+    memcpy(bad, payload, sizeof(bad));
+    bad[0] = 'X'; // foreign magic (e.g. an OoTMM client in the same room)
+    NR_ASSERT(!RelayProto_DecodeGrant(bad, RSBS_GRANT_PAYLOAD_LEN, &back));
+    memcpy(bad, payload, sizeof(bad));
+    bad[4] = 0x7F; // unknown version
+    NR_ASSERT(!RelayProto_DecodeGrant(bad, RSBS_GRANT_PAYLOAD_LEN, &back));
+    memcpy(bad, payload, sizeof(bad));
+    bad[7] = 0x00; // GAME_NONE
+    NR_ASSERT(!RelayProto_DecodeGrant(bad, RSBS_GRANT_PAYLOAD_LEN, &back));
+    NR_ASSERT(!RelayProto_DecodeGrant(payload, RSBS_GRANT_PAYLOAD_LEN - 1u, &back)); // short
+
+    // Encoder refuses malformed grants too, so a local bug never looks like a
+    // peer's bad data.
+    RsbsGrantPayload zero = g;
+    zero.targetSlot = 0;
+    NR_ASSERT(!RelayProto_EncodeGrant(&zero, payload));
+
+    // --- Incremental frame decode, including the keepalive NOP. ---
+    uint8_t frame[64];
+    uint32_t consumed = 0;
+    RelayLedgerEntry entry;
+
+    // The server emits OP_NONE keepalives; treating one as a bad opcode would
+    // drop a healthy connection after a few idle seconds.
+    frame[0] = RSBS_RELAY_OP_NONE;
+    NR_ASSERT(RelayProto_DecodeFrame(frame, 1, &consumed, &entry) == RSBS_RELAY_DECODE_NOP);
+    NR_ASSERT(consumed == 1);
+
+    const uint32_t n = RelayProto_EncodeTransfer(0xAABBCCDDu, payload, RSBS_GRANT_PAYLOAD_LEN, frame);
+    NR_ASSERT(n == 10u + RSBS_GRANT_PAYLOAD_LEN);
+    // A partial frame must ask for more rather than misparse.
+    NR_ASSERT(RelayProto_DecodeFrame(frame, n - 1u, &consumed, &entry) == RSBS_RELAY_DECODE_NEED_MORE);
+    NR_ASSERT(RelayProto_DecodeFrame(frame, n, &consumed, &entry) == RSBS_RELAY_DECODE_ENTRY);
+    NR_ASSERT(consumed == n && entry.key == 0xAABBCCDDu && entry.payloadLen == RSBS_GRANT_PAYLOAD_LEN);
+    NR_ASSERT(memcmp(entry.payload, payload, RSBS_GRANT_PAYLOAD_LEN) == 0);
+
+    // Room binding: a different room is a different ADR 0005 source, so a
+    // cursor can never be applied against a room that did not produce it.
+    NR_ASSERT(Relay_SourceKeyForRoom(kRoomA) != Relay_SourceKeyForRoom(kRoomB));
+    NR_ASSERT(Relay_SourceKeyForRoom(kRoomA) != 0u);
+
+    printf("[TEST] PASS: wire format\n");
+    return TEST_PASS;
+}
+
+// ============================================================================
+// Test 2: loopback delivery, self-echo, retransmit, distinct gifts, ordering
+// ============================================================================
+
+TestResult Test_RelayLoopback(void) {
+    printf("[TEST] Relay loopback delivery (ADR 0007 §8)\n");
+
+    ComboContext_Init();
+    MockReset(&gMockServer);
+
+    // Slot 1 = us, slot 2 and 3 = peers.
+    MockClient* mcA = MockAttach(&gMockServer, 0);
+    MockClient* mcB = MockAttach(&gMockServer, 1);
+    MockClient* mcC = MockAttach(&gMockServer, 2);
+
+    RelayClient a, b, cc;
+    Relay_Init(&a, kRoomA, 1, 0xABCDu); // receiver
+    Relay_Init(&b, kRoomA, 2, 0xABCDu); // peer
+    Relay_Init(&cc, kRoomA, 3, 0xABCDu); // second peer
+
+    RelayChannel chA = MockChannelFor(mcA);
+    RelayChannel chB = MockChannelFor(mcB);
+    RelayChannel chC = MockChannelFor(mcC);
+    NR_ASSERT(Relay_Connect(&a, &chA));
+    NR_ASSERT(Relay_Connect(&b, &chB));
+    NR_ASSERT(Relay_Connect(&cc, &chC));
+
+    RelayClient* all[3] = { &a, &b, &cc };
+    PumpAll(&gMockServer, all, 3, 4);
+    NR_ASSERT(a.state == RSBS_RELAY_STATE_READY);
+    NR_ASSERT(b.state == RSBS_RELAY_STATE_READY);
+
+    // --- Peer B gifts us two items, in order. ---
+    NR_ASSERT(Relay_SendGrant(&b, 1, GAME_OOT, 100));
+    NR_ASSERT(Relay_SendGrant(&b, 1, GAME_OOT, 200));
+    PumpAll(&gMockServer, all, 3, 4);
+
+    NR_ASSERT(a.statAccepted == 2);
+    NR_ASSERT(Combo_GetGrantCursor(a.sourceKey) == 2);
+    NR_ASSERT(RelayOccupied() == 2);
+
+    // --- SELF-ECHO: B receives its own two entries back (the real server does
+    // not skip the sender) and must award itself NOTHING. ---
+    NR_ASSERT(b.statEntriesSeen == 2);
+    NR_ASSERT(b.statNotForUs == 2);
+    NR_ASSERT(b.statAccepted == 0);
+    NR_ASSERT(Combo_GetGrantCursor(b.sourceKey) == 2); // same room == same source key
+    // C is in the room but addressed by nothing.
+    NR_ASSERT(cc.statNotForUs == 2 && cc.statAccepted == 0);
+
+    // --- RETRANSMIT yields exactly one item. Re-offering the identical
+    // (senderSlot, senderSeq) produces the same ledger key, which the server
+    // dedups before it ever fans out. ---
+    RsbsGrantPayload dupGrant;
+    dupGrant.version = RSBS_GRANT_PAYLOAD_VERSION;
+    dupGrant.senderSlot = 2;
+    dupGrant.targetSlot = 1;
+    dupGrant.originGame = (uint8_t)GAME_OOT;
+    dupGrant.itemId = 100;
+    dupGrant.senderSeq = 1; // the seq B already used for item 100
+    dupGrant.settingsHash = 0xABCDu;
+    uint8_t dupPayload[RSBS_GRANT_PAYLOAD_LEN];
+    NR_ASSERT(RelayProto_EncodeGrant(&dupGrant, dupPayload));
+    uint8_t dupFrame[64];
+    const uint32_t dn = RelayProto_EncodeTransfer(RelayProto_GrantKey(&dupGrant), dupPayload, RSBS_GRANT_PAYLOAD_LEN, dupFrame);
+    MockPipeWrite(&mcB->toServer, dupFrame, dn);
+    PumpAll(&gMockServer, all, 3, 4);
+
+    NR_ASSERT(gMockServer.count == 2);   // server-side dedup absorbed it
+    NR_ASSERT(a.statAccepted == 2);      // still exactly two
+    NR_ASSERT(RelayOccupied() == 2);
+
+    // --- TWO PEERS, SAME ITEM = TWO ITEMS (the ADR 0005 §1 regression). C
+    // gifts item 100 as well; distinct sender => distinct key => it survives
+    // the server's dedup, and the client-side content de-dup never sees it
+    // because sourced entries are flagged. ---
+    NR_ASSERT(Relay_SendGrant(&cc, 1, GAME_OOT, 100));
+    PumpAll(&gMockServer, all, 3, 4);
+    NR_ASSERT(gMockServer.count == 3);
+    NR_ASSERT(a.statAccepted == 3);
+    NR_ASSERT(RelayOccupied() == 3);
+
+    // --- RECEIVED-ORDER redemption. The give paths resolve progressives
+    // against the live save, so order changes WHAT the player gets. ---
+    RelayAwardLog log;
+    memset(&log, 0, sizeof(log));
+    const int redeemed = Combo_RedeemSharedItemsForGame(GAME_OOT, RelayAward, &log);
+    NR_ASSERT(redeemed == 3 && log.count == 3);
+    NR_ASSERT(log.ids[0] == 100 && log.ids[1] == 200 && log.ids[2] == 100);
+
+    // Single-use: a second safe point awards nothing more.
+    RelayAwardLog again;
+    memset(&again, 0, sizeof(again));
+    NR_ASSERT(Combo_RedeemSharedItemsForGame(GAME_OOT, RelayAward, &again) == 0);
+    NR_ASSERT(again.count == 0);
+
+    printf("[TEST] PASS: loopback delivery\n");
+    return TEST_PASS;
+}
+
+// ============================================================================
+// Test 3: late-join catch-up, cross-game switch, foreign entries
+// ============================================================================
+
+TestResult Test_RelayCatchup(void) {
+    printf("[TEST] Relay late-join catch-up + cross-game survival (ADR 0007 §3.3, §5.1)\n");
+
+    ComboContext_Init();
+    MockReset(&gMockServer);
+
+    MockClient* mcB = MockAttach(&gMockServer, 1);
+    RelayClient b;
+    Relay_Init(&b, kRoomA, 2, 0);
+    RelayChannel chB = MockChannelFor(mcB);
+    NR_ASSERT(Relay_Connect(&b, &chB));
+    RelayClient* justB[1] = { &b };
+    PumpAll(&gMockServer, justB, 1, 3);
+
+    // Peer B sends three grants for slot 1 BEFORE slot 1 ever joins — one of
+    // them for the OTHER game, so we also prove a grant crosses the switch.
+    NR_ASSERT(Relay_SendGrant(&b, 1, GAME_OOT, 11));
+    NR_ASSERT(Relay_SendGrant(&b, 1, GAME_MM, 22));
+    NR_ASSERT(Relay_SendGrant(&b, 1, GAME_OOT, 33));
+    PumpAll(&gMockServer, justB, 1, 4);
+    NR_ASSERT(gMockServer.count == 3);
+
+    // A foreign entry lands in the room too — an OoTMM client sharing the
+    // ledger. It must be skipped without desyncing the stream (ADR 0007 §4.3).
+    const uint8_t kForeign[8] = { 'O', 'o', 'T', 'M', 'M', 0, 0, 0 };
+    uint8_t fFrame[64];
+    const uint32_t fn = RelayProto_EncodeTransfer(0x1234567890ABCDEFull, kForeign, sizeof(kForeign), fFrame);
+    MockPipeWrite(&mcB->toServer, fFrame, fn);
+    PumpAll(&gMockServer, justB, 1, 3);
+    NR_ASSERT(gMockServer.count == 4);
+
+    // --- NOW slot 1 joins, at ledgerBase 0, and must receive the whole
+    // backlog. This is the late-joiner case. ---
+    MockClient* mcA = MockAttach(&gMockServer, 0);
+    RelayClient a;
+    Relay_Init(&a, kRoomA, 1, 0);
+    RelayChannel chA = MockChannelFor(mcA);
+    NR_ASSERT(Relay_Connect(&a, &chA));
+
+    RelayClient* both[2] = { &a, &b };
+    PumpAll(&gMockServer, both, 2, 6);
+
+    NR_ASSERT(a.state == RSBS_RELAY_STATE_READY);
+    NR_ASSERT(a.statEntriesSeen == 4);
+    NR_ASSERT(a.statForeignSkipped == 1); // skipped, and it did not desync
+    NR_ASSERT(a.statAccepted == 3);       // all three real grants caught up
+    NR_ASSERT(Combo_GetGrantCursor(a.sourceKey) == 3);
+
+    // --- Grants are split across the two games and BOTH survive: the OoT ones
+    // redeem on an OoT safe point, the MM one waits, un-redeemed, for MM. The
+    // relay needs no switch awareness at all — the array is process-global.
+    RelayAwardLog ootLog;
+    memset(&ootLog, 0, sizeof(ootLog));
+    NR_ASSERT(Combo_RedeemSharedItemsForGame(GAME_OOT, RelayAward, &ootLog) == 2);
+    NR_ASSERT(ootLog.ids[0] == 11 && ootLog.ids[1] == 33);
+
+    // The MM grant is still pending — exactly what "crosses the switch" means.
+    NR_ASSERT(Combo_CountSharedItems(GAME_MM, false) == 1);
+    RelayAwardLog mmLog;
+    memset(&mmLog, 0, sizeof(mmLog));
+    NR_ASSERT(Combo_RedeemSharedItemsForGame(GAME_MM, RelayAward, &mmLog) == 1);
+    NR_ASSERT(mmLog.count == 1 && mmLog.ids[0] == 22);
+    NR_ASSERT(mmLog.origins[0] == (uint8_t)GAME_MM);
+
+    // --- REJOIN: a reconnect replays from base 0 again. Every already-
+    // delivered grant must come back DUPLICATE (cursor), not re-award. This is
+    // the designed path of ADR 0005 §1, not an error case. ---
+    MockClient* mcA2 = MockAttach(&gMockServer, 3);
+    RelayClient a2;
+    Relay_Init(&a2, kRoomA, 1, 0);
+    RelayChannel chA2 = MockChannelFor(mcA2);
+    NR_ASSERT(Relay_Connect(&a2, &chA2));
+    RelayClient* rejoin[1] = { &a2 };
+    PumpAll(&gMockServer, rejoin, 1, 6);
+
+    NR_ASSERT(a2.statEntriesSeen == 4);
+    NR_ASSERT(a2.statDuplicate == 3); // the whole prefix was already delivered
+    NR_ASSERT(a2.statAccepted == 0);
+    NR_ASSERT(Combo_GetGrantCursor(a2.sourceKey) == 3); // unmoved
+    NR_ASSERT(RelayOccupied() == 3);                    // no re-award, no new entries
+
+    printf("[TEST] PASS: catch-up + cross-game\n");
+    return TEST_PASS;
+}
+
+// ============================================================================
+// Test 4: backpressure and loud overflow
+// ============================================================================
+
+TestResult Test_RelayBackpressure(void) {
+    printf("[TEST] Relay backpressure is loud and lossless (ADR 0005 §3, ADR 0007 §4.2)\n");
+
+    ComboContext_Init();
+    MockReset(&gMockServer);
+
+    // Fill the durable array with UN-REDEEMED in-process entries so the seam
+    // has nothing to reclaim and must refuse.
+    for (uint32_t i = 0; i < RSBS_SHARED_ITEM_CAP; ++i) {
+        NR_ASSERT(Combo_RecordSharedItem(GAME_OOT, (uint16_t)(1000 + i)) >= 0);
+    }
+    NR_ASSERT(RelayOccupied() == (int)RSBS_SHARED_ITEM_CAP);
+    NR_ASSERT(Combo_GetSharedItemOverflowCount() == 0);
+
+    MockClient* mcA = MockAttach(&gMockServer, 0);
+    MockClient* mcB = MockAttach(&gMockServer, 1);
+    RelayClient a, b;
+    Relay_Init(&a, kRoomA, 1, 0);
+    Relay_Init(&b, kRoomA, 2, 0);
+    RelayChannel chA = MockChannelFor(mcA);
+    RelayChannel chB = MockChannelFor(mcB);
+    NR_ASSERT(Relay_Connect(&a, &chA));
+    NR_ASSERT(Relay_Connect(&b, &chB));
+    RelayClient* all[2] = { &a, &b };
+    PumpAll(&gMockServer, all, 2, 4);
+
+    // A peer gift now cannot be recorded: the array is full of undelivered
+    // items, so the seam answers RETRY_FULL.
+    NR_ASSERT(Relay_SendGrant(&b, 1, GAME_OOT, 4242));
+    PumpAll(&gMockServer, all, 2, 4);
+
+    NR_ASSERT(a.statRetryFull > 0);
+    NR_ASSERT(a.statAccepted == 0);
+    // Backpressure, NOT loss: the cursor did not advance, so the grant is
+    // still owed and the client knows it needs a replay.
+    NR_ASSERT(Combo_GetGrantCursor(a.sourceKey) == 0);
+    NR_ASSERT(Relay_ReplayNeeded(&a));
+    // LOUD: the durable, .redsave-serialized counter moved.
+    NR_ASSERT(Combo_GetSharedItemOverflowCount() > 0);
+    // The grant is still queued client-side — it was not dropped on the floor.
+    NR_ASSERT(a.inboxCount == 1);
+
+    // --- Drain the array. The SAME grant, re-offered at the SAME seq, is now
+    // ACCEPTED rather than deduped. That is the property that makes
+    // RETRY_FULL backpressure instead of loss. ---
+    RelayAwardLog drain;
+    memset(&drain, 0, sizeof(drain));
+    NR_ASSERT(Combo_RedeemSharedItemsForGame(GAME_OOT, RelayAward, &drain) == (int)RSBS_SHARED_ITEM_CAP);
+
+    const int accepted = Relay_Tick(&a);
+    NR_ASSERT(accepted == 1);
+    NR_ASSERT(a.statAccepted == 1);
+    NR_ASSERT(Combo_GetGrantCursor(a.sourceKey) == 1);
+    NR_ASSERT(a.inboxCount == 0);
+
+    // --- Session invalidation retires the client's RAM alongside gComboCtx,
+    // so a dead session's undelivered grants cannot drain into the next one
+    // (#440 guidance on #460). ---
+    Relay_ClearSessionState(&a);
+    NR_ASSERT(a.inboxCount == 0 && a.outboxCount == 0);
+    // The counter restarts at 1 because the cursor died with gComboCtx —
+    // submitting seq N+1 against a fresh cursor of 0 would wedge on GAP.
+    NR_ASSERT(a.nextSeq == 1u);
+
+    printf("[TEST] PASS: backpressure\n");
+    return TEST_PASS;
+}
+
+// ============================================================================
+// Test 5: the suspend latch
+// ============================================================================
+
+TestResult Test_RelaySuspendLatch(void) {
+    printf("[TEST] Relay suspend latch stops applying, not polling (ADR 0006 §5)\n");
+
+    ComboContext_Init();
+    MockReset(&gMockServer);
+
+    MockClient* mcA = MockAttach(&gMockServer, 0);
+    MockClient* mcB = MockAttach(&gMockServer, 1);
+    RelayClient a, b;
+    Relay_Init(&a, kRoomA, 1, 0);
+    Relay_Init(&b, kRoomA, 2, 0);
+    RelayChannel chA = MockChannelFor(mcA);
+    RelayChannel chB = MockChannelFor(mcB);
+    NR_ASSERT(Relay_Connect(&a, &chA));
+    NR_ASSERT(Relay_Connect(&b, &chB));
+    RelayClient* all[2] = { &a, &b };
+    PumpAll(&gMockServer, all, 2, 4);
+
+    // Suspend the receiver, then have the peer send. Polling and decoding must
+    // continue — otherwise a suspended game stalls the peer and loses its
+    // ledger position — but nothing may be APPLIED.
+    Relay_OnSuspend(&a);
+    NR_ASSERT(Relay_SendGrant(&b, 1, GAME_OOT, 77));
+    NR_ASSERT(Relay_SendGrant(&b, 1, GAME_OOT, 88));
+    PumpAll(&gMockServer, all, 2, 4);
+
+    NR_ASSERT(a.statEntriesSeen == 2); // received and decoded
+    NR_ASSERT(a.inboxCount == 2);      // filed
+    NR_ASSERT(a.statAccepted == 0);    // but NOT applied
+    NR_ASSERT(RelayOccupied() == 0);
+    NR_ASSERT(Combo_GetGrantCursor(a.sourceKey) == 0);
+
+    // Resume drains in received order — the lifecycle has no implicit inverse,
+    // so this release is a separate, named action.
+    Relay_OnResume(&a);
+    const int accepted = Relay_Tick(&a);
+    NR_ASSERT(accepted == 2);
+    NR_ASSERT(a.inboxCount == 0);
+    NR_ASSERT(Combo_GetGrantCursor(a.sourceKey) == 2);
+
+    RelayAwardLog log;
+    memset(&log, 0, sizeof(log));
+    NR_ASSERT(Combo_RedeemSharedItemsForGame(GAME_OOT, RelayAward, &log) == 2);
+    NR_ASSERT(log.ids[0] == 77 && log.ids[1] == 88); // order preserved
+
+    printf("[TEST] PASS: suspend latch\n");
+    return TEST_PASS;
+}


### PR DESCRIPTION
Supersedes #476 — same single commit, cherry-picked onto `main` now that its base (#473) squash-merged. Restacked as a cherry-pick rather than a rebase per the original author's note: replaying the foundation's individual commits against their own squashed form would conflict with itself.

Implements ADR 0007 (#474): a **grant-only relay** reusing OoTMM's `multi-server`, built on #473's per-source grant cursors.

**Why reuse works** — verified by reading the LICENSE bytes rather than trusting the classifier (ADR 0006 §6's lesson): OoTMM `multi-server` is **MIT**. But the load-bearing property is **content-agnosticism**: its ledger entry is `{u64 key; u8 size; opaque payload}` and it never inspects the payload — no game identity, no slot registry, **no admissibility check a client can fail**. That is the exact inverse of the Archipelago `InvalidGame` wall that made AP a non-starter. An unmodified `multi-server` relays RSBS grants today, and its `ledgerBase` + disk-persisted `keysSet` mean catch-up and server-side idempotency come free.

**Flag**: `RSBS_NETPLAY` defaults OFF, and OFF means *absent*. The relay gets its own CI job rather than a flag on `build-linux`, deliberately — `build-linux` packages the released AppImage, so default-off must mean shipped-off. Both directions are asserted: the default configure references no netplay TU, **and** the ON build actually links `Relay_Tick`, so the flag silently ceasing to add sources cannot pass vacuously. No submodule, no transport library.

**Harness** (5/5, plus the full tier with the relay built): retransmit → one item; two peers' same item → two items; ordering; cross-game survival; late-join catch-up; self-echo filtering; loud overflow. It does **not** prove framing against the real server binary, socket behaviour, or upstream drift. The mock fans out to every client *including the sender* because the real server does — skipping that would hide a real bug, which is ADR 0006 §2(b)'s exact shortcut.

Composes with #440's session invalidation by putting the RAM inbox in `Context_InvalidateSessionState` rather than clearing at its own call sites. **Carves nothing from `reserved[]`** — `sourceKey = fnv1a32(roomUuid)` is derived, and doubles as ADR 0006 §5's room-fingerprint binding.

Trust model is stated in full in the ADR: **trusted peers only, no validation**; the room UUID is a bearer capability.

🤖 Generated with [Claude Code](https://claude.com/claude-code)