### PR TITLE
Converge inventory §5.3 CVar remainder onto OoT keys (#462); close #453

### DIFF
--- a/games/mm/2s2h/BenGui/BenMenu.cpp
+++ b/games/mm/2s2h/BenGui/BenMenu.cpp
@@ -336,7 +336,7 @@ void BenMenu::AddSettings() {
         .Options(CheckboxOptions().Tooltip(
             "Search input box gets autofocus when visible. Does not affect using other widgets."));
     AddWidget(path, "Alt Assets Tab hotkey", WIDGET_CVAR_CHECKBOX)
-        .CVar("gEnhancements.Mods.AlternateAssetsHotkey")
+        .CVar("gSettings.Mods.AlternateAssetsHotkey")
         .Options(
             CheckboxOptions().Tooltip("Allows pressing the Tab key to toggle alternate assets.").DefaultValue(true));
     AddWidget(path, "Open App Files Folder", WIDGET_BUTTON)
@@ -792,7 +792,7 @@ void BenMenu::AddEnhancements() {
     path.column = SECTION_COLUMN_2;
     AddWidget(path, "Cameras", WIDGET_SEPARATOR_TEXT);
     AddWidget(path, "Free Look", WIDGET_CVAR_CHECKBOX)
-        .CVar("gEnhancements.Camera.FreeLook.Enable")
+        .CVar("gSettings.FreeLook.Enabled")
         .PreFunc([](WidgetInfo& info) {
             if (mBenMenu->disabledMap.at(DISABLE_FOR_DEBUG_CAM_ON).active)
                 info.activeDisables.push_back(DISABLE_FOR_DEBUG_CAM_ON);
@@ -801,12 +801,12 @@ void BenMenu::AddEnhancements() {
             "Enables free look camera control.\nNote: You must remap C buttons off of the right "
             "stick in the controller config menu, and map the camera stick to the right stick."));
     AddWidget(path, "Camera Distance: %d", WIDGET_CVAR_SLIDER_INT)
-        .CVar("gEnhancements.Camera.FreeLook.MaxCameraDistance")
+        .CVar("gSettings.FreeLook.MaxCameraDistance")
         .PreFunc([](WidgetInfo& info) { info.isHidden = mBenMenu->disabledMap.at(DISABLE_FOR_FREE_LOOK_OFF).active; })
         .Options(
             IntSliderOptions().Tooltip("Maximum Camera Distance for Free Look.").Min(100).Max(900).DefaultValue(185));
     AddWidget(path, "Camera Transition Speed: %d", WIDGET_CVAR_SLIDER_INT)
-        .CVar("gEnhancements.Camera.FreeLook.TransitionSpeed")
+        .CVar("gSettings.FreeLook.TransitionSpeed")
         .PreFunc([](WidgetInfo& info) { info.isHidden = mBenMenu->disabledMap.at(DISABLE_FOR_FREE_LOOK_OFF).active; })
         .Options(IntSliderOptions().Tooltip("Can someone help me?").Min(1).Max(900).DefaultValue(25));
     AddWidget(path, "Max Camera Height Angle: %.0f\xC2\xB0", WIDGET_CVAR_SLIDER_FLOAT)
@@ -907,7 +907,7 @@ void BenMenu::AddEnhancements() {
         .CVar("gCheats.InfiniteMagic")
         .Options(CheckboxOptions().Tooltip("Always have full Magic."));
     AddWidget(path, "Infinite Rupees", WIDGET_CVAR_CHECKBOX)
-        .CVar("gCheats.InfiniteRupees")
+        .CVar("gCheats.InfiniteMoney")
         .Options(CheckboxOptions().Tooltip("Always have a full Wallet."));
     AddWidget(path, "Infinite Consumables", WIDGET_CVAR_CHECKBOX)
         .CVar("gCheats.InfiniteConsumables")
@@ -931,7 +931,7 @@ void BenMenu::AddEnhancements() {
         .CVar("gCheats.UnrestrictedItems")
         .Options(CheckboxOptions().Tooltip("Allows all Forms to use all Items."));
     AddWidget(path, "Hookshot Anywhere", WIDGET_CVAR_CHECKBOX)
-        .CVar("gCheats.HookshotAnywhere")
+        .CVar("gCheats.HookshotEverything")
         .Options(CheckboxOptions().Tooltip("Allows most surfaces to be hookshot-able."));
     AddWidget(path, "Moon Jump on L", WIDGET_CVAR_CHECKBOX)
         .CVar("gCheats.MoonJumpOnL")
@@ -940,7 +940,7 @@ void BenMenu::AddEnhancements() {
         .CVar("gCheats.ElegyAnywhere")
         .Options(CheckboxOptions().Tooltip("Allows Elegy of Emptiness outside of Ikana."));
     AddWidget(path, "Climb Anywhere", WIDGET_CVAR_CHECKBOX)
-        .CVar("gCheats.ClimbAnywhere")
+        .CVar("gCheats.ClimbEverything")
         .Options(CheckboxOptions().Tooltip("Allows climbing on most walls regardless of vines."));
     AddWidget(path, "Stop Time in Dungeons", WIDGET_CVAR_COMBOBOX)
         .CVar("gCheats.TempleTimeStop")
@@ -966,7 +966,7 @@ void BenMenu::AddEnhancements() {
         .Options(CheckboxOptions().Tooltip("Allows Deku Link to hop indefinitely in water without drowning. This also "
                                            "prevents the velocity loss while in the air."));
     AddWidget(path, "Instant Putaway", WIDGET_CVAR_CHECKBOX)
-        .CVar("gEnhancements.Player.InstantPutaway")
+        .CVar("gEnhancements.InstantPutaway")
         .Options(CheckboxOptions().Tooltip("Allows Link to instantly puts away held item without waiting."));
     AddWidget(path, "Fierce Deity Putaway", WIDGET_CVAR_CHECKBOX)
         .CVar("gEnhancements.Player.FierceDeityPutaway")
@@ -991,10 +991,10 @@ void BenMenu::AddEnhancements() {
         .CVar("gEnhancements.Player.ManualJump")
         .Options(CheckboxOptions().Tooltip("Z + A to Jump and B while midair to Jump Attack."));
     AddWidget(path, "Dpad Equips", WIDGET_CVAR_CHECKBOX)
-        .CVar("gEnhancements.Dpad.DpadEquips")
+        .CVar("gEnhancements.DpadEquips")
         .Options(CheckboxOptions().Tooltip("Allows you to equip items to your D-pad."));
     AddWidget(path, "Unequip Items", WIDGET_CVAR_CHECKBOX)
-        .CVar("gEnhancements.Equipment.ItemUnequip")
+        .CVar("gEnhancements.ItemUnequip")
         .Options(CheckboxOptions().Tooltip("In the pause menu, press the same C-button or D-pad button an item is "
                                            "equipped to in order to unequip it."));
     AddWidget(path, "Fast Magic Arrow Equip Animation", WIDGET_CVAR_CHECKBOX)
@@ -1082,7 +1082,7 @@ void BenMenu::AddEnhancements() {
         .CVar("gEnhancements.A11y.NoScreenFlashForEnemyKill")
         .Options(CheckboxOptions().Tooltip("Disables the white screen flash on enemy kill."));
     AddWidget(path, "Bow Reticle", WIDGET_CVAR_CHECKBOX)
-        .CVar("gEnhancements.Graphics.BowReticle")
+        .CVar("gEnhancements.BowReticle")
         .Options(CheckboxOptions().Tooltip("Gives the bow a reticle when you draw an arrow."));
     AddWidget(path, "Mark Shooting Gallery Octoroks", WIDGET_CVAR_CHECKBOX)
         .CVar("gEnhancements.Minigames.MarkShootingGalleryOctoroks")
@@ -1106,10 +1106,10 @@ void BenMenu::AddEnhancements() {
             "into the game, you will be placed either at the entrance of the dungeon you saved in, or "
             "in South Clock Town, unless Remember Save Location is enabled."));
     AddWidget(path, "Remember Save Location", WIDGET_CVAR_CHECKBOX)
-        .CVar("gEnhancements.Saving.RememberSaveLocation")
+        .CVar("gEnhancements.RememberSaveLocation")
         .Options(CheckboxOptions().Tooltip("When loading a save, places Link at the last entrance he went through."));
     AddWidget(path, "Autosave", WIDGET_CVAR_CHECKBOX)
-        .CVar("gEnhancements.Saving.Autosave")
+        .CVar("gEnhancements.Autosave")
         .Callback([](WidgetInfo& info) { RegisterAutosave(); })
         .Options(CheckboxOptions().Tooltip(
             "Automatically create a persistent Owl Save on the chosen interval.\n\nWhen loading "
@@ -1225,13 +1225,13 @@ void BenMenu::AddEnhancements() {
         .Options(CheckboxOptions().Tooltip("Hide the game version and build details and display the authentic "
                                            "model and texture on the boot logo start screen."));
     AddWidget(path, "Disable Black Bar Letterboxes", WIDGET_CVAR_CHECKBOX)
-        .CVar("gEnhancements.Graphics.DisableBlackBars")
+        .CVar("gEnhancements.DisableBlackBars")
         .Options(CheckboxOptions().Tooltip(
             "Disables Black Bar Letterboxes during cutscenes and Z-targeting.\nNote: There may be "
             "minor visual glitches that were covered up by the black bars.\nPlease disable this "
             "setting before reporting a bug."));
     AddWidget(path, "Enemy Health Bars", WIDGET_CVAR_CHECKBOX)
-        .CVar("gEnhancements.Graphics.EnemyHealthBars")
+        .CVar("gEnhancements.EnemyHealthBar")
         .Options(CheckboxOptions().Tooltip("Renders a health bar for enemies and bosses when Z-targeted."));
     AddWidget(path, "Fix Scene Geometry Seams", WIDGET_CVAR_CHECKBOX)
         .CVar("gEnhancements.Graphics.FixSceneGeometrySeams")
@@ -1346,21 +1346,21 @@ void BenMenu::AddEnhancements() {
     // Cutscene Skips
     AddWidget(path, "Cutscenes", WIDGET_SEPARATOR_TEXT);
     AddWidget(path, "Hide Title Cards", WIDGET_CVAR_CHECKBOX)
-        .CVar("gEnhancements.Cutscenes.HideTitleCards")
+        .CVar("gEnhancements.TimeSavers.DisableTitleCard")
         .Options(CheckboxOptions().Tooltip("Hides Title Cards when entering areas."));
     AddWidget(path, "Skip One Point Cutscenes", WIDGET_CVAR_CHECKBOX)
-        .CVar("gEnhancements.Cutscenes.SkipOnePointCutscenes")
+        .CVar("gEnhancements.TimeSavers.SkipCutscene.OnePoint")
         .Options(CheckboxOptions().Tooltip(
             "Skips freezing Link to focus on various events like chest spawning, door unlocking, switch pressed, etc"));
     AddWidget(path, "Skip Entrance Cutscenes", WIDGET_CVAR_CHECKBOX)
-        .CVar("gEnhancements.Cutscenes.SkipEntranceCutscenes")
+        .CVar("gEnhancements.TimeSavers.SkipCutscene.Entrances")
         .Options(CheckboxOptions().Tooltip("Skip cutscenes that occur when first entering a new area."));
     AddWidget(path, "Skip to File Select", WIDGET_CVAR_CHECKBOX)
         .CVar("gEnhancements.Cutscenes.SkipToFileSelect")
         .Options(CheckboxOptions().Tooltip(
             "Skip the opening title sequence and go straight to the file select menu after boot."));
     AddWidget(path, "Skip Intro Sequence", WIDGET_CVAR_CHECKBOX)
-        .CVar("gEnhancements.Cutscenes.SkipIntroSequence")
+        .CVar("gEnhancements.TimeSavers.SkipCutscene.Intro")
         .Options(CheckboxOptions().Tooltip(
             "When starting a game you will be taken straight to South Clock Town as Deku Link."));
     AddWidget(path, "Skip First Cycle", WIDGET_CVAR_CHECKBOX)
@@ -1374,7 +1374,7 @@ void BenMenu::AddEnhancements() {
             "When starting a game you will be taken straight to South Clock Town as Human Link "
             "with Deku Mask, Ocarina, Song of Time, and Song of Healing."));
     AddWidget(path, "Skip Story Cutscenes", WIDGET_CVAR_CHECKBOX)
-        .CVar("gEnhancements.Cutscenes.SkipStoryCutscenes")
+        .CVar("gEnhancements.TimeSavers.SkipCutscene.Story")
         .Options(CheckboxOptions().Tooltip("This skips many of the cutscenes associated with the main story."));
     AddWidget(path, "Skip Misc Interactions", WIDGET_CVAR_CHECKBOX)
         .CVar("gEnhancements.Cutscenes.SkipMiscInteractions")
@@ -1421,7 +1421,7 @@ void BenMenu::AddEnhancements() {
         .CVar("gEnhancements.Timesavers.DampeDiggingSkip")
         .Options(CheckboxOptions().Tooltip("Only requires digging up one flame to spawn the big poe."));
     AddWidget(path, "Fast Chests", WIDGET_CVAR_CHECKBOX)
-        .CVar("gEnhancements.Timesavers.FastChests")
+        .CVar("gEnhancements.FastChests")
         .Options(CheckboxOptions().Tooltip("Uses the quick kick animation for all chests in vanilla gameplay."));
     AddWidget(path, "Faster Scene Transitions", WIDGET_CVAR_CHECKBOX)
         .CVar("gEnhancements.Timesavers.FasterSceneTransitions")
@@ -1536,7 +1536,7 @@ void BenMenu::AddEnhancements() {
                      .Max(6)
                      .DefaultValue(0));
     AddWidget(path, "Pause Buffer Input Window", WIDGET_CVAR_SLIDER_INT)
-        .CVar("gEnhancements.Restorations.PauseBufferWindow")
+        .CVar("gEnhancements.PauseBufferWindow")
         .Options(IntSliderOptions()
                      .Tooltip("Amount of time in frames you have to buffer an input while unpausing the game. Original "
                               "hardware is around 20.")
@@ -1549,7 +1549,7 @@ void BenMenu::AddEnhancements() {
     AddSidebarEntry("Enhancements", "Difficulty Options", 3);
     AddWidget(path, "Combat", WIDGET_SEPARATOR_TEXT);
     AddWidget(path, "Hyper Enemies", WIDGET_CVAR_CHECKBOX)
-        .CVar("gEnhancements.DifficultyOptions.HyperEnemies")
+        .CVar("gEnhancements.HyperEnemies")
         .Options(CheckboxOptions().Tooltip("Double the rate at which enemies are updated, making them more difficult"));
     AddWidget(path, "Damage Multiplier", WIDGET_CVAR_COMBOBOX)
         .CVar("gEnhancements.DifficultyOptions.DamageMultiplier")
@@ -1976,7 +1976,7 @@ void BenMenu::InitElement() {
         { DISABLE_FOR_CAMERAS_OFF,
           { [](disabledInfo& info) -> bool {
                return !CVarGetInteger("gEnhancements.Camera.DebugCam.Enable", 0) &&
-                      !CVarGetInteger("gEnhancements.Camera.FreeLook.Enable", 0);
+                      !CVarGetInteger("gSettings.FreeLook.Enabled", 0);
            },
             "Both Debug Camera and Free Look are Disabled" } },
         { DISABLE_FOR_DEBUG_CAM_ON,
@@ -1986,10 +1986,10 @@ void BenMenu::InitElement() {
           { [](disabledInfo& info) -> bool { return !CVarGetInteger("gEnhancements.Camera.DebugCam.Enable", 0); },
             "Debug Camera is Disabled" } },
         { DISABLE_FOR_FREE_LOOK_ON,
-          { [](disabledInfo& info) -> bool { return CVarGetInteger("gEnhancements.Camera.FreeLook.Enable", 0); },
+          { [](disabledInfo& info) -> bool { return CVarGetInteger("gSettings.FreeLook.Enabled", 0); },
             "Free Look is Enabled" } },
         { DISABLE_FOR_FREE_LOOK_OFF,
-          { [](disabledInfo& info) -> bool { return !CVarGetInteger("gEnhancements.Camera.FreeLook.Enable", 0); },
+          { [](disabledInfo& info) -> bool { return !CVarGetInteger("gSettings.FreeLook.Enabled", 0); },
             "Free Look is Disabled" } },
         { DISABLE_FOR_GYRO_OFF,
           { [](disabledInfo& info) -> bool {
@@ -2007,7 +2007,7 @@ void BenMenu::InitElement() {
            },
             "Right Stick Aiming is Disabled" } },
         { DISABLE_FOR_AUTO_SAVE_OFF,
-          { [](disabledInfo& info) -> bool { return !CVarGetInteger("gEnhancements.Saving.Autosave", 0); },
+          { [](disabledInfo& info) -> bool { return !CVarGetInteger("gEnhancements.Autosave", 0); },
             "AutoSave is Disabled" } },
         { DISABLE_FOR_NULL_PLAY_STATE,
           { [](disabledInfo& info) -> bool { return MM_gPlayState == NULL; }, "Not in game" } },
@@ -2058,7 +2058,9 @@ void BenMenu::InitElement() {
            },
             "Frame Advance is Disabled" } },
         { DISABLE_FOR_INTRO_SKIP_OFF,
-          { [](disabledInfo& info) -> bool { return !CVarGetInteger("gEnhancements.Cutscenes.SkipIntroSequence", 0); },
+          { [](disabledInfo& info) -> bool {
+               return !CVarGetInteger("gEnhancements.TimeSavers.SkipCutscene.Intro", 0);
+           },
             "Intro Skip Not Selected" } },
         { DISABLE_FOR_ADVANCED_RESOLUTION_ON,
           { [](disabledInfo& info) -> bool { return CVarGetInteger(CVAR_PREFIX_ADVANCED_RESOLUTION ".Enabled", 0); },

--- a/games/mm/2s2h/BenPort.cpp
+++ b/games/mm/2s2h/BenPort.cpp
@@ -1046,7 +1046,7 @@ extern "C" void Graph_StartFrame() {
 #endif
         case KbScancode::LUS_KB_TAB: {
             // Toggle HD Assets
-            if (CVarGetInteger("gEnhancements.Mods.AlternateAssetsHotkey", 1)) {
+            if (CVarGetInteger("gSettings.Mods.AlternateAssetsHotkey", 1)) {
                 CVarSetInteger("gEnhancements.Mods.AlternateAssets",
                                !CVarGetInteger("gEnhancements.Mods.AlternateAssets", 0));
             }

--- a/games/mm/2s2h/DeveloperTools/SaveEditor.cpp
+++ b/games/mm/2s2h/DeveloperTools/SaveEditor.cpp
@@ -755,7 +755,7 @@ void DrawSlot(InventorySlot slot) {
     ImGui::PushStyleColor(ImGuiCol_ButtonActive, ImVec4(1.0f, 1.0f, 1.0f, 0.1f));
     if (GET_CUR_FORM_BTN_SLOT(EQUIP_SLOT_C_LEFT) == slot || GET_CUR_FORM_BTN_SLOT(EQUIP_SLOT_C_DOWN) == slot ||
         GET_CUR_FORM_BTN_SLOT(EQUIP_SLOT_C_RIGHT) == slot ||
-        (CVarGetInteger("gEnhancements.Dpad.DpadEquips", 0) &&
+        (CVarGetInteger("gEnhancements.DpadEquips", 0) &&
          (DPAD_GET_CUR_FORM_BTN_SLOT(EQUIP_SLOT_D_RIGHT) == slot ||
           DPAD_GET_CUR_FORM_BTN_SLOT(EQUIP_SLOT_D_LEFT) == slot ||
           DPAD_GET_CUR_FORM_BTN_SLOT(EQUIP_SLOT_D_DOWN) == slot ||

--- a/games/mm/2s2h/Enhancements/Camera/FreeLook.cpp
+++ b/games/mm/2s2h/Enhancements/Camera/FreeLook.cpp
@@ -113,8 +113,8 @@ bool Camera_FreeLook(Camera* camera) {
         pitch = minPitch;
     }
 
-    f32 distTarget = CVarGetInteger("gEnhancements.Camera.FreeLook.MaxCameraDistance", roData->unk_04);
-    f32 transitionSpeed = CVarGetInteger("gEnhancements.Camera.FreeLook.TransitionSpeed", 25);
+    f32 distTarget = CVarGetInteger("gSettings.FreeLook.MaxCameraDistance", roData->unk_04);
+    f32 transitionSpeed = CVarGetInteger("gSettings.FreeLook.TransitionSpeed", 25);
     // Smooth step camera away to max camera distance. Camera collision is calculated later
     camera->dist = Camera_ScaledStepToCeilF(distTarget, camera->dist,
                                             transitionSpeed / (ABS(distTarget - camera->dist) + transitionSpeed), 0.0f);
@@ -163,7 +163,7 @@ bool Camera_CanFreeLook(Camera* camera) {
 }
 
 void RegisterCameraFreeLook() {
-    COND_VB_SHOULD(VB_USE_CUSTOM_CAMERA, CVarGetInteger("gEnhancements.Camera.FreeLook.Enable", 0), {
+    COND_VB_SHOULD(VB_USE_CUSTOM_CAMERA, CVarGetInteger("gSettings.FreeLook.Enabled", 0), {
         Camera* camera = va_arg(args, Camera*);
         switch (MM_sCameraSettings[camera->setting].cameraModes[camera->mode].funcId) {
             case CAM_FUNC_NORMAL0:
@@ -185,8 +185,8 @@ void RegisterCameraFreeLook() {
         }
     });
 
-    COND_HOOK(OnCameraChangeModeFlags, CVarGetInteger("gEnhancements.Camera.FreeLook.Enable", 0),
+    COND_HOOK(OnCameraChangeModeFlags, CVarGetInteger("gSettings.FreeLook.Enabled", 0),
               [](Camera* camera) { UpdateFreeLookState(camera); });
 }
 
-static RegisterShipInitFunc initFunc(RegisterCameraFreeLook, { "gEnhancements.Camera.FreeLook.Enable" });
+static RegisterShipInitFunc initFunc(RegisterCameraFreeLook, { "gSettings.FreeLook.Enabled" });

--- a/games/mm/2s2h/Enhancements/Cheats/ClimbAnywhere.cpp
+++ b/games/mm/2s2h/Enhancements/Cheats/ClimbAnywhere.cpp
@@ -2,7 +2,7 @@
 #include "2s2h/GameInteractor/GameInteractor.h"
 #include "2s2h/ShipInit.hpp"
 
-#define CVAR_NAME "gCheats.ClimbAnywhere"
+#define CVAR_NAME "gCheats.ClimbEverything"
 #define CVAR CVarGetInteger(CVAR_NAME, 0)
 
 void RegisterClimbAnywhere() {

--- a/games/mm/2s2h/Enhancements/Cheats/HookshotAnywhere.cpp
+++ b/games/mm/2s2h/Enhancements/Cheats/HookshotAnywhere.cpp
@@ -2,7 +2,7 @@
 #include "2s2h/GameInteractor/GameInteractor.h"
 #include "2s2h/ShipInit.hpp"
 
-#define CVAR_NAME "gCheats.HookshotAnywhere"
+#define CVAR_NAME "gCheats.HookshotEverything"
 #define CVAR CVarGetInteger(CVAR_NAME, 0)
 
 void RegisterHookshotAnywhere() {

--- a/games/mm/2s2h/Enhancements/Cheats/Infinite.cpp
+++ b/games/mm/2s2h/Enhancements/Cheats/Infinite.cpp
@@ -29,10 +29,10 @@ static RegisterShipInitFunc magicInitFunc(
 
 static RegisterShipInitFunc rupeesInitFunc(
     []() {
-        COND_HOOK(OnGameStateUpdate, CVarGetInteger("gCheats.InfiniteRupees", 0),
+        COND_HOOK(OnGameStateUpdate, CVarGetInteger("gCheats.InfiniteMoney", 0),
                   []() { gSaveContext.save.saveInfo.playerData.rupees = CUR_CAPACITY(UPG_WALLET); });
     },
-    { "gCheats.InfiniteRupees" });
+    { "gCheats.InfiniteMoney" });
 
 static RegisterShipInitFunc consumeablesInitFunc(
     []() {

--- a/games/mm/2s2h/Enhancements/Cutscenes/HideTitleCards.cpp
+++ b/games/mm/2s2h/Enhancements/Cutscenes/HideTitleCards.cpp
@@ -2,7 +2,7 @@
 #include "2s2h/GameInteractor/GameInteractor.h"
 #include "2s2h/ShipInit.hpp"
 
-#define CVAR_NAME "gEnhancements.Cutscenes.HideTitleCards"
+#define CVAR_NAME "gEnhancements.TimeSavers.DisableTitleCard"
 #define CVAR CVarGetInteger(CVAR_NAME, 0)
 
 void RegisterHideTitleCards() {

--- a/games/mm/2s2h/Enhancements/Cutscenes/SkipEntranceCutscenes.cpp
+++ b/games/mm/2s2h/Enhancements/Cutscenes/SkipEntranceCutscenes.cpp
@@ -6,7 +6,7 @@ extern "C" {
 #include "variables.h"
 }
 
-#define CVAR_NAME "gEnhancements.Cutscenes.SkipEntranceCutscenes"
+#define CVAR_NAME "gEnhancements.TimeSavers.SkipCutscene.Entrances"
 #define CVAR CVarGetInteger(CVAR_NAME, 0)
 
 void RegisterSkipEntranceCutscenes() {

--- a/games/mm/2s2h/Enhancements/Cutscenes/SkipIntroSequence.cpp
+++ b/games/mm/2s2h/Enhancements/Cutscenes/SkipIntroSequence.cpp
@@ -7,7 +7,7 @@ extern "C" {
 void Flags_SetWeekEventReg(s32 flag);
 }
 
-#define INTRO_CVAR_NAME "gEnhancements.Cutscenes.SkipIntroSequence"
+#define INTRO_CVAR_NAME "gEnhancements.TimeSavers.SkipCutscene.Intro"
 #define INTRO_CVAR CVarGetInteger(INTRO_CVAR_NAME, 0)
 #define FIRST_CYCLE_CVAR_NAME "gEnhancements.Cutscenes.SkipFirstCycle"
 #define FIRST_CYCLE_CVAR CVarGetInteger(FIRST_CYCLE_CVAR_NAME, 0)

--- a/games/mm/2s2h/Enhancements/Cutscenes/SkipOnePointCutscenes.cpp
+++ b/games/mm/2s2h/Enhancements/Cutscenes/SkipOnePointCutscenes.cpp
@@ -6,7 +6,7 @@ extern "C" {
 #include "overlays/actors/ovl_Obj_Syokudai/z_obj_syokudai.h"
 }
 
-#define CVAR_NAME "gEnhancements.Cutscenes.SkipOnePointCutscenes"
+#define CVAR_NAME "gEnhancements.TimeSavers.SkipCutscene.OnePoint"
 #define CVAR CVarGetInteger(CVAR_NAME, 0)
 
 void RegisterSkipOnePointCutscenes() {

--- a/games/mm/2s2h/Enhancements/Cutscenes/StoryCutscenes/SkipBiggoronSnowheadLullaby.cpp
+++ b/games/mm/2s2h/Enhancements/Cutscenes/StoryCutscenes/SkipBiggoronSnowheadLullaby.cpp
@@ -7,7 +7,7 @@ extern "C" {
 #include "functions.h"
 }
 
-#define CVAR_NAME "gEnhancements.Cutscenes.SkipStoryCutscenes"
+#define CVAR_NAME "gEnhancements.TimeSavers.SkipCutscene.Story"
 #define CVAR CVarGetInteger(CVAR_NAME, 0)
 
 #define BIGGORON_GORON_LULLABY_CSID 11

--- a/games/mm/2s2h/Enhancements/Cutscenes/StoryCutscenes/SkipBombBagTheftCutscene.cpp
+++ b/games/mm/2s2h/Enhancements/Cutscenes/StoryCutscenes/SkipBombBagTheftCutscene.cpp
@@ -7,7 +7,7 @@ extern "C" {
 void EnSuttari_TriggerTransition(PlayState* play, u16 entrance);
 }
 
-#define CVAR_NAME "gEnhancements.Cutscenes.SkipStoryCutscenes"
+#define CVAR_NAME "gEnhancements.TimeSavers.SkipCutscene.Story"
 #define CVAR CVarGetInteger(CVAR_NAME, 0)
 
 void RegisterSkipBombBagTheftCutscene() {

--- a/games/mm/2s2h/Enhancements/Cutscenes/StoryCutscenes/SkipClockTowerOpen.cpp
+++ b/games/mm/2s2h/Enhancements/Cutscenes/StoryCutscenes/SkipClockTowerOpen.cpp
@@ -7,13 +7,13 @@ extern "C" {
 #include "functions.h"
 }
 
-#define CVAR_NAME "gEnhancements.Cutscenes.SkipStoryCutscenes"
+#define CVAR_NAME "gEnhancements.TimeSavers.SkipCutscene.Story"
 #define CVAR CVarGetInteger(CVAR_NAME, 0)
 
 void RegisterSkipClockTowerOpen() {
     // This will handle skipping if you are around the Clock Town area, but not directly in south clock town
     COND_VB_SHOULD(VB_CLOCK_TOWER_OPENING_CONSIDER_THIS_FIRST_CYCLE, CVAR, {
-        if (CVarGetInteger("gEnhancements.Cutscenes.SkipStoryCutscenes", 0)) {
+        if (CVarGetInteger("gEnhancements.TimeSavers.SkipCutscene.Story", 0)) {
             *should = false;
         }
     });
@@ -23,7 +23,7 @@ void RegisterSkipClockTowerOpen() {
         if ((gSaveContext.save.entrance == ENTRANCE(SOUTH_CLOCK_TOWN, 0) ||
              gSaveContext.save.entrance == ENTRANCE(TERMINA_FIELD, 0)) &&
             gSaveContext.save.cutsceneIndex == 0xFFF1 &&
-            CVarGetInteger("gEnhancements.Cutscenes.SkipStoryCutscenes", 0)) {
+            CVarGetInteger("gEnhancements.TimeSavers.SkipCutscene.Story", 0)) {
             // Copied from ObjTokeidai_TowerOpening_EndCutscene
             SET_WEEKEVENTREG(WEEKEVENTREG_CLOCK_TOWER_OPENED);
             gSaveContext.save.cutsceneIndex = 0;

--- a/games/mm/2s2h/Enhancements/Cutscenes/StoryCutscenes/SkipClockTowerSkullKidEncounter.cpp
+++ b/games/mm/2s2h/Enhancements/Cutscenes/StoryCutscenes/SkipClockTowerSkullKidEncounter.cpp
@@ -19,7 +19,7 @@ void DmStk_ClockTower_Idle(DmStk* dmstk, PlayState* play);
 void DmStk_ChangeAnim(DmStk* dmstk, PlayState* play, SkelAnime* skelAnime, AnimationInfo* animInfo, u16 animIndex);
 }
 
-#define CVAR_NAME "gEnhancements.Cutscenes.SkipStoryCutscenes"
+#define CVAR_NAME "gEnhancements.TimeSavers.SkipCutscene.Story"
 #define CVAR CVarGetInteger(CVAR_NAME, 0)
 
 AnimationInfo moonLoop = { (AnimationHeader*)&gSkullKidCallDownMoonLoopAnim, 1.0f, 0.0f, -1.0f, ANIMMODE_LOOP, 0.0f };

--- a/games/mm/2s2h/Enhancements/Cutscenes/StoryCutscenes/SkipDefeatCaptainSequence.cpp
+++ b/games/mm/2s2h/Enhancements/Cutscenes/StoryCutscenes/SkipDefeatCaptainSequence.cpp
@@ -7,7 +7,7 @@ extern "C" {
 #include "functions.h"
 }
 
-#define CVAR_NAME "gEnhancements.Cutscenes.SkipStoryCutscenes"
+#define CVAR_NAME "gEnhancements.TimeSavers.SkipCutscene.Story"
 #define CVAR CVarGetInteger(CVAR_NAME, 0)
 
 void SkipDefeatCaptainTextbox() {

--- a/games/mm/2s2h/Enhancements/Cutscenes/StoryCutscenes/SkipFirstSongOfTimeFlashbacks.cpp
+++ b/games/mm/2s2h/Enhancements/Cutscenes/StoryCutscenes/SkipFirstSongOfTimeFlashbacks.cpp
@@ -6,7 +6,7 @@ extern "C" {
 #include "variables.h"
 }
 
-#define CVAR_NAME "gEnhancements.Cutscenes.SkipStoryCutscenes"
+#define CVAR_NAME "gEnhancements.TimeSavers.SkipCutscene.Story"
 #define CVAR CVarGetInteger(CVAR_NAME, 0)
 
 void RegisterSkipFirstSongOfTimeFlashbacks() {

--- a/games/mm/2s2h/Enhancements/Cutscenes/StoryCutscenes/SkipGiantsChamber.cpp
+++ b/games/mm/2s2h/Enhancements/Cutscenes/StoryCutscenes/SkipGiantsChamber.cpp
@@ -10,7 +10,7 @@ extern "C" {
 #include "functions.h"
 }
 
-#define CVAR_NAME "gEnhancements.Cutscenes.SkipStoryCutscenes"
+#define CVAR_NAME "gEnhancements.TimeSavers.SkipCutscene.Story"
 #define CVAR CVarGetInteger(CVAR_NAME, 0)
 
 /*

--- a/games/mm/2s2h/Enhancements/Cutscenes/StoryCutscenes/SkipHealingDarmani.cpp
+++ b/games/mm/2s2h/Enhancements/Cutscenes/StoryCutscenes/SkipHealingDarmani.cpp
@@ -8,7 +8,7 @@ extern "C" {
 #include "functions.h"
 }
 
-#define CVAR_NAME "gEnhancements.Cutscenes.SkipStoryCutscenes"
+#define CVAR_NAME "gEnhancements.TimeSavers.SkipCutscene.Story"
 #define CVAR CVarGetInteger(CVAR_NAME, 0)
 
 void RegisterSkipHealingDarmani() {

--- a/games/mm/2s2h/Enhancements/Cutscenes/StoryCutscenes/SkipHealingMikau.cpp
+++ b/games/mm/2s2h/Enhancements/Cutscenes/StoryCutscenes/SkipHealingMikau.cpp
@@ -8,7 +8,7 @@ extern "C" {
 #include "functions.h"
 }
 
-#define CVAR_NAME "gEnhancements.Cutscenes.SkipStoryCutscenes"
+#define CVAR_NAME "gEnhancements.TimeSavers.SkipCutscene.Story"
 #define CVAR CVarGetInteger(CVAR_NAME, 0)
 
 void RegisterSkipHealingMikau() {

--- a/games/mm/2s2h/Enhancements/Cutscenes/StoryCutscenes/SkipIkanaCurseCutscenes.cpp
+++ b/games/mm/2s2h/Enhancements/Cutscenes/StoryCutscenes/SkipIkanaCurseCutscenes.cpp
@@ -14,7 +14,7 @@ void func_80B6DE80(BgHakaCurtain* bgHakaCurtain);
 void EnPoComposer_SetupPlayCurse(EnPoComposer* enPoComposer);
 }
 
-#define CVAR_NAME "gEnhancements.Cutscenes.SkipStoryCutscenes"
+#define CVAR_NAME "gEnhancements.TimeSavers.SkipCutscene.Story"
 #define CVAR CVarGetInteger(CVAR_NAME, 0)
 
 void skipHealingPamelasFather() {

--- a/games/mm/2s2h/Enhancements/Cutscenes/StoryCutscenes/SkipLearningElegyOfEmptiness.cpp
+++ b/games/mm/2s2h/Enhancements/Cutscenes/StoryCutscenes/SkipLearningElegyOfEmptiness.cpp
@@ -5,7 +5,7 @@
 #include "2s2h/Rando/Rando.h"
 #include "2s2h/ShipInit.hpp"
 
-#define CVAR_NAME "gEnhancements.Cutscenes.SkipStoryCutscenes"
+#define CVAR_NAME "gEnhancements.TimeSavers.SkipCutscene.Story"
 #define CVAR CVarGetInteger(CVAR_NAME, 0)
 
 // Forced on in rando for now

--- a/games/mm/2s2h/Enhancements/Cutscenes/StoryCutscenes/SkipLearningEponasSong.cpp
+++ b/games/mm/2s2h/Enhancements/Cutscenes/StoryCutscenes/SkipLearningEponasSong.cpp
@@ -10,7 +10,7 @@ extern "C" {
 void EnMa4_SetupDialogueHandler(EnMa4* enMa4);
 }
 
-#define CVAR_NAME "gEnhancements.Cutscenes.SkipStoryCutscenes"
+#define CVAR_NAME "gEnhancements.TimeSavers.SkipCutscene.Story"
 #define CVAR CVarGetInteger(CVAR_NAME, 0)
 
 void RegisterSkipLearningEponasSong() {

--- a/games/mm/2s2h/Enhancements/Cutscenes/StoryCutscenes/SkipLearningGoronLullaby.cpp
+++ b/games/mm/2s2h/Enhancements/Cutscenes/StoryCutscenes/SkipLearningGoronLullaby.cpp
@@ -15,7 +15,7 @@ void func_80B5227C(EnGk* enGkActor, PlayState* play);
 void EnGo_Sleep(EnGo* enGoActor, PlayState* play);
 }
 
-#define CVAR_NAME "gEnhancements.Cutscenes.SkipStoryCutscenes"
+#define CVAR_NAME "gEnhancements.TimeSavers.SkipCutscene.Story"
 #define CVAR CVarGetInteger(CVAR_NAME, 0)
 
 static bool isGoronSleepQueued = false;

--- a/games/mm/2s2h/Enhancements/Cutscenes/StoryCutscenes/SkipLearningGoronLullabyIntro.cpp
+++ b/games/mm/2s2h/Enhancements/Cutscenes/StoryCutscenes/SkipLearningGoronLullabyIntro.cpp
@@ -11,7 +11,7 @@ extern "C" {
 #include "overlays/actors/ovl_En_Jg/z_en_jg.h"
 }
 
-#define CVAR_NAME "gEnhancements.Cutscenes.SkipStoryCutscenes"
+#define CVAR_NAME "gEnhancements.TimeSavers.SkipCutscene.Story"
 #define CVAR CVarGetInteger(CVAR_NAME, 0)
 
 void RegisterSkipLearningGoronLullabyIntro() {

--- a/games/mm/2s2h/Enhancements/Cutscenes/StoryCutscenes/SkipLearningNewWaveBossaNova.cpp
+++ b/games/mm/2s2h/Enhancements/Cutscenes/StoryCutscenes/SkipLearningNewWaveBossaNova.cpp
@@ -9,7 +9,7 @@ extern "C" {
 #include <functions.h>
 }
 
-#define CVAR_NAME "gEnhancements.Cutscenes.SkipStoryCutscenes"
+#define CVAR_NAME "gEnhancements.TimeSavers.SkipCutscene.Story"
 #define CVAR CVarGetInteger(CVAR_NAME, 0)
 
 // Forced on in rando for now

--- a/games/mm/2s2h/Enhancements/Cutscenes/StoryCutscenes/SkipLearningSonataOfAwakening.cpp
+++ b/games/mm/2s2h/Enhancements/Cutscenes/StoryCutscenes/SkipLearningSonataOfAwakening.cpp
@@ -10,7 +10,7 @@ extern "C" {
 #include "functions.h"
 }
 
-#define CVAR_NAME "gEnhancements.Cutscenes.SkipStoryCutscenes"
+#define CVAR_NAME "gEnhancements.TimeSavers.SkipCutscene.Story"
 #define CVAR CVarGetInteger(CVAR_NAME, 0)
 
 void RegisterSkipLearningSonataOfAwakening() {

--- a/games/mm/2s2h/Enhancements/Cutscenes/StoryCutscenes/SkipLearningSongOfHealing.cpp
+++ b/games/mm/2s2h/Enhancements/Cutscenes/StoryCutscenes/SkipLearningSongOfHealing.cpp
@@ -20,7 +20,7 @@ void MM_PlayerCall_Draw(Actor* thisx, PlayState* play);
 void Player_StopHorizontalMovement(Player* player);
 }
 
-#define CVAR_NAME "gEnhancements.Cutscenes.SkipStoryCutscenes"
+#define CVAR_NAME "gEnhancements.TimeSavers.SkipCutscene.Story"
 #define CVAR CVarGetInteger(CVAR_NAME, 0)
 
 #define OSN_STATE_END_CONVERSATION (1 << 5)

--- a/games/mm/2s2h/Enhancements/Cutscenes/StoryCutscenes/SkipLearningSongOfSoaring.cpp
+++ b/games/mm/2s2h/Enhancements/Cutscenes/StoryCutscenes/SkipLearningSongOfSoaring.cpp
@@ -11,7 +11,7 @@ extern "C" {
 #include "overlays/actors/ovl_En_Time_Tag/z_en_time_tag.h"
 }
 
-#define CVAR_NAME "gEnhancements.Cutscenes.SkipStoryCutscenes"
+#define CVAR_NAME "gEnhancements.TimeSavers.SkipCutscene.Story"
 #define CVAR CVarGetInteger(CVAR_NAME, 0)
 #define ENGRAVING_TEXT_ID 0xC02
 

--- a/games/mm/2s2h/Enhancements/Cutscenes/StoryCutscenes/SkipLearningSongOfStorms.cpp
+++ b/games/mm/2s2h/Enhancements/Cutscenes/StoryCutscenes/SkipLearningSongOfStorms.cpp
@@ -10,7 +10,7 @@ extern "C" {
 #include "functions.h"
 }
 
-#define CVAR_NAME "gEnhancements.Cutscenes.SkipStoryCutscenes"
+#define CVAR_NAME "gEnhancements.TimeSavers.SkipCutscene.Story"
 #define CVAR CVarGetInteger(CVAR_NAME, 0)
 
 // This is a song tutorial, so the skip is forced on in rando for now

--- a/games/mm/2s2h/Enhancements/Cutscenes/StoryCutscenes/SkipLearningSongOfTime.cpp
+++ b/games/mm/2s2h/Enhancements/Cutscenes/StoryCutscenes/SkipLearningSongOfTime.cpp
@@ -10,7 +10,7 @@ extern "C" {
 #include "variables.h"
 }
 
-#define CVAR_NAME "gEnhancements.Cutscenes.SkipStoryCutscenes"
+#define CVAR_NAME "gEnhancements.TimeSavers.SkipCutscene.Story"
 #define CVAR CVarGetInteger(CVAR_NAME, 0)
 
 void RegisterSkipLearningSongOfTime() {

--- a/games/mm/2s2h/Enhancements/Cutscenes/StoryCutscenes/SkipMilkRunCutscenes.cpp
+++ b/games/mm/2s2h/Enhancements/Cutscenes/StoryCutscenes/SkipMilkRunCutscenes.cpp
@@ -6,7 +6,7 @@ extern "C" {
 #include "variables.h"
 }
 
-#define CVAR_NAME "gEnhancements.Cutscenes.SkipStoryCutscenes"
+#define CVAR_NAME "gEnhancements.TimeSavers.SkipCutscene.Story"
 #define CVAR CVarGetInteger(CVAR_NAME, 0)
 
 void RegisterSkipMilkRunCutscenes() {

--- a/games/mm/2s2h/Enhancements/Cutscenes/StoryCutscenes/SkipMoonCrash.cpp
+++ b/games/mm/2s2h/Enhancements/Cutscenes/StoryCutscenes/SkipMoonCrash.cpp
@@ -6,7 +6,7 @@ extern "C" {
 #include "variables.h"
 }
 
-#define CVAR_NAME "gEnhancements.Cutscenes.SkipStoryCutscenes"
+#define CVAR_NAME "gEnhancements.TimeSavers.SkipCutscene.Story"
 #define CVAR CVarGetInteger(CVAR_NAME, 0)
 
 /**

--- a/games/mm/2s2h/Enhancements/Cutscenes/StoryCutscenes/SkipPrincessDelivery.cpp
+++ b/games/mm/2s2h/Enhancements/Cutscenes/StoryCutscenes/SkipPrincessDelivery.cpp
@@ -8,7 +8,7 @@ extern "C" {
 #include "overlays/actors/ovl_En_Dnp/z_en_dnp.h"
 }
 
-#define CVAR_NAME "gEnhancements.Cutscenes.SkipStoryCutscenes"
+#define CVAR_NAME "gEnhancements.TimeSavers.SkipCutscene.Story"
 #define CVAR CVarGetInteger(CVAR_NAME, 0)
 
 void RegisterSkipPrincessDelivery() {

--- a/games/mm/2s2h/Enhancements/Cutscenes/StoryCutscenes/SkipRaisingWoodfall.cpp
+++ b/games/mm/2s2h/Enhancements/Cutscenes/StoryCutscenes/SkipRaisingWoodfall.cpp
@@ -7,7 +7,7 @@ extern "C" {
 #include "functions.h"
 }
 
-#define CVAR_NAME "gEnhancements.Cutscenes.SkipStoryCutscenes"
+#define CVAR_NAME "gEnhancements.TimeSavers.SkipCutscene.Story"
 #define CVAR CVarGetInteger(CVAR_NAME, 0)
 
 void RegisterSkipRaisingWoodfall() {

--- a/games/mm/2s2h/Enhancements/Cutscenes/StoryCutscenes/SkipStoppingMoonCutscene.cpp
+++ b/games/mm/2s2h/Enhancements/Cutscenes/StoryCutscenes/SkipStoppingMoonCutscene.cpp
@@ -10,7 +10,7 @@ extern "C" {
 #include "functions.h"
 }
 
-#define CVAR_NAME "gEnhancements.Cutscenes.SkipStoryCutscenes"
+#define CVAR_NAME "gEnhancements.TimeSavers.SkipCutscene.Story"
 #define CVAR CVarGetInteger(CVAR_NAME, 0)
 
 void RegisterSkipStoppingMoon() {

--- a/games/mm/2s2h/Enhancements/Cutscenes/StoryCutscenes/SkipWakingAndRidingTurtle.cpp
+++ b/games/mm/2s2h/Enhancements/Cutscenes/StoryCutscenes/SkipWakingAndRidingTurtle.cpp
@@ -10,7 +10,7 @@ extern "C" {
 void DmChar08_Init(Actor* thisx, PlayState* play2);
 }
 
-#define CVAR_NAME "gEnhancements.Cutscenes.SkipStoryCutscenes"
+#define CVAR_NAME "gEnhancements.TimeSavers.SkipCutscene.Story"
 #define CVAR CVarGetInteger(CVAR_NAME, 0)
 
 void RegisterSkipWakingAndRidingTurtle() {

--- a/games/mm/2s2h/Enhancements/DifficultyOptions/HyperEnemies.cpp
+++ b/games/mm/2s2h/Enhancements/DifficultyOptions/HyperEnemies.cpp
@@ -7,7 +7,7 @@ extern "C" {
 #include "functions.h"
 }
 
-#define CVAR_NAME "gEnhancements.DifficultyOptions.HyperEnemies"
+#define CVAR_NAME "gEnhancements.HyperEnemies"
 #define CVAR CVarGetInteger(CVAR_NAME, 0)
 
 void RegisterHyperEnemies() {

--- a/games/mm/2s2h/Enhancements/Equipment/ItemUnequip.cpp
+++ b/games/mm/2s2h/Enhancements/Equipment/ItemUnequip.cpp
@@ -11,9 +11,9 @@ extern "C" {
 #include "overlays/kaleido_scope/ovl_kaleido_scope/z_kaleido_scope.h"
 }
 
-#define CVAR_DPAD_NAME "gEnhancements.Dpad.DpadEquips"
+#define CVAR_DPAD_NAME "gEnhancements.DpadEquips"
 #define CVAR_DPAD CVarGetInteger(CVAR_DPAD_NAME, 0)
-#define CVAR_NAME "gEnhancements.Equipment.ItemUnequip"
+#define CVAR_NAME "gEnhancements.ItemUnequip"
 #define CVAR CVarGetInteger(CVAR_NAME, 0)
 
 void RegisterDpadPageSwitchPrevention() {

--- a/games/mm/2s2h/Enhancements/Graphics/BowReticle.cpp
+++ b/games/mm/2s2h/Enhancements/Graphics/BowReticle.cpp
@@ -9,7 +9,7 @@ extern "C" {
 #include "objects/gameplay_keep/gameplay_keep.h"
 }
 
-#define CVAR_NAME "gEnhancements.Graphics.BowReticle"
+#define CVAR_NAME "gEnhancements.BowReticle"
 #define CVAR CVarGetInteger(CVAR_NAME, 0)
 
 void DrawBowReticle(PlayState* play, Player* player, f32 bowDistance) {

--- a/games/mm/2s2h/Enhancements/Graphics/DisableBlackBars.cpp
+++ b/games/mm/2s2h/Enhancements/Graphics/DisableBlackBars.cpp
@@ -2,7 +2,7 @@
 #include "2s2h/GameInteractor/GameInteractor.h"
 #include "2s2h/ShipInit.hpp"
 
-#define CVAR_NAME "gEnhancements.Graphics.DisableBlackBars"
+#define CVAR_NAME "gEnhancements.DisableBlackBars"
 #define CVAR CVarGetInteger(CVAR_NAME, 0)
 
 void RegisterDisableBlackBars() {

--- a/games/mm/2s2h/Enhancements/Graphics/EnemyHealthBars.cpp
+++ b/games/mm/2s2h/Enhancements/Graphics/EnemyHealthBars.cpp
@@ -16,7 +16,7 @@ extern "C" {
 #include "variables.h"
 }
 
-#define CVAR_NAME "gEnhancements.Graphics.EnemyHealthBars"
+#define CVAR_NAME "gEnhancements.EnemyHealthBar"
 #define CVAR CVarGetInteger(CVAR_NAME, 0)
 
 typedef enum {

--- a/games/mm/2s2h/Enhancements/Player/InstantPutaway.cpp
+++ b/games/mm/2s2h/Enhancements/Player/InstantPutaway.cpp
@@ -2,7 +2,7 @@
 #include "2s2h/GameInteractor/GameInteractor.h"
 #include "2s2h/ShipInit.hpp"
 
-#define CVAR_NAME "gEnhancements.Player.InstantPutaway"
+#define CVAR_NAME "gEnhancements.InstantPutaway"
 #define CVAR CVarGetInteger(CVAR_NAME, 0)
 
 void RegisterInstantPutaway() {

--- a/games/mm/2s2h/Enhancements/Restorations/PauseBufferInputs.cpp
+++ b/games/mm/2s2h/Enhancements/Restorations/PauseBufferInputs.cpp
@@ -7,7 +7,7 @@ extern "C" {
 #include "overlays/kaleido_scope/ovl_kaleido_scope/z_kaleido_scope.h"
 }
 
-#define CVAR_NAME "gEnhancements.Restorations.PauseBufferWindow"
+#define CVAR_NAME "gEnhancements.PauseBufferWindow"
 #define CVAR CVarGetInteger(CVAR_NAME, 0)
 
 static u16 inputBufferTimer = 0;

--- a/games/mm/2s2h/Enhancements/Saving/SavingEnhancements.cpp
+++ b/games/mm/2s2h/Enhancements/Saving/SavingEnhancements.cpp
@@ -8,7 +8,7 @@ extern "C" {
 #include <functions.h>
 }
 
-#define CVAR_REMEMBER_SAVE_LOCATION_NAME "gEnhancements.Saving.RememberSaveLocation"
+#define CVAR_REMEMBER_SAVE_LOCATION_NAME "gEnhancements.RememberSaveLocation"
 #define CVAR_REMEMBER_SAVE_LOCATION CVarGetInteger(CVAR_REMEMBER_SAVE_LOCATION_NAME, 0)
 
 static uint32_t autosaveInterval = 0;
@@ -285,7 +285,7 @@ void RegisterAutosave() {
         autosaveGameStateDrawFinishHookId = 0;
     }
 
-    if (CVarGetInteger("gEnhancements.Saving.Autosave", 0)) {
+    if (CVarGetInteger("gEnhancements.Autosave", 0)) {
         autosaveGameStateUpdateHookId = S2H::GameHooks::Register<GameInteractor::OnGameStateUpdate>([]() {
             if (MM_gPlayState == nullptr) {
                 return;

--- a/games/mm/2s2h/Enhancements/Timesavers/FastChests.cpp
+++ b/games/mm/2s2h/Enhancements/Timesavers/FastChests.cpp
@@ -3,7 +3,7 @@
 #include "2s2h/ShipInit.hpp"
 #include "2s2h/Rando/Rando.h"
 
-#define CVAR_NAME "gEnhancements.Timesavers.FastChests"
+#define CVAR_NAME "gEnhancements.FastChests"
 #define CVAR CVarGetInteger(CVAR_NAME, 0)
 
 void RegisterFastChests() {

--- a/games/mm/2s2h/GameExports_SingleExe.cpp
+++ b/games/mm/2s2h/GameExports_SingleExe.cpp
@@ -1157,7 +1157,7 @@ int GameInteractor_InvertControl(GIInvertType type) {
  * The old stub `int GameInteractor_Dpad(void* input, int dpad)` returned
  * the button combo unconditionally, force-enabling both CVar-gated D-pad
  * enhancements: BTN_DPAD_EQUIP (include/z64save.h) expanded to BTN_DPAD as
- * if gEnhancements.Dpad.DpadEquips were on, and the ocarina paths in
+ * if gEnhancements.DpadEquips were on, and the ocarina paths in
  * src/audio/code_8019AF00.c treated the D-pad as ocarina buttons as if
  * gEnhancements.Playback.DpadOcarina were on.
  *
@@ -1177,7 +1177,7 @@ uint32_t GameInteractor_Dpad(GIDpadType type, uint32_t buttonCombo) {
             }
             break;
         case GI_DPAD_EQUIP:
-            if (CVarGetInteger("gEnhancements.Dpad.DpadEquips", 0)) {
+            if (CVarGetInteger("gEnhancements.DpadEquips", 0)) {
                 result = buttonCombo;
             }
             break;

--- a/games/mm/2s2h/GameInteractor/GameInteractor.cpp
+++ b/games/mm/2s2h/GameInteractor/GameInteractor.cpp
@@ -395,7 +395,7 @@ uint32_t GameInteractor_Dpad(GIDpadType type, uint32_t buttonCombo) {
             }
             break;
         case GI_DPAD_EQUIP:
-            if (CVarGetInteger("gEnhancements.Dpad.DpadEquips", 0)) {
+            if (CVarGetInteger("gEnhancements.DpadEquips", 0)) {
                 result = buttonCombo;
             }
             break;

--- a/games/mm/include/z64save.h
+++ b/games/mm/include/z64save.h
@@ -648,7 +648,7 @@ typedef enum {
 #define BTN_DPAD_EQUIP (GameInteractor_Dpad(GI_DPAD_EQUIP, BTN_DPAD))
 
 #define CHECK_BTN_DPAD(input)                                                                                   \
-    (CVarGetInteger("gEnhancements.Dpad.DpadEquips", 0) &&                                                      \
+    (CVarGetInteger("gEnhancements.DpadEquips", 0) &&                                                      \
      (CHECK_BTN_ALL(input, BTN_DRIGHT) || CHECK_BTN_ALL(input, BTN_DLEFT) || CHECK_BTN_ALL(input, BTN_DDOWN) || \
       CHECK_BTN_ALL(input, BTN_DUP)))
 

--- a/games/mm/src/code/z_parameter.c
+++ b/games/mm/src/code/z_parameter.c
@@ -4939,7 +4939,7 @@ s32 MM_Inventory_ConsumeFairy(PlayState* play) {
                 }
             }
             // #region 2S2H [Dpad]
-            if (CVarGetInteger("gEnhancements.Dpad.DpadEquips", 0)) {
+            if (CVarGetInteger("gEnhancements.DpadEquips", 0)) {
                 for (u8 dpadBtn = EQUIP_SLOT_D_RIGHT; dpadBtn <= EQUIP_SLOT_D_UP; dpadBtn++) {
                     if (DPAD_GET_CUR_FORM_BTN_ITEM(dpadBtn) == ITEM_FAIRY) {
                         DPAD_SET_CUR_FORM_BTN_ITEM(dpadBtn, ITEM_BOTTLE);
@@ -5537,7 +5537,7 @@ void Magic_Update(PlayState* play) {
                      (BUTTON_ITEM_EQUIP(0, EQUIP_SLOT_C_DOWN) != ITEM_LENS_OF_TRUTH) &&
                      (BUTTON_ITEM_EQUIP(0, EQUIP_SLOT_C_RIGHT) != ITEM_LENS_OF_TRUTH) &&
                      //  #region 2S2H [Dpad]
-                     (!CVarGetInteger("gEnhancements.Dpad.DpadEquips", 0) ||
+                     (!CVarGetInteger("gEnhancements.DpadEquips", 0) ||
                       (DPAD_BUTTON_ITEM_EQUIP(0, EQUIP_SLOT_D_RIGHT) != ITEM_LENS_OF_TRUTH) &&
                           (DPAD_BUTTON_ITEM_EQUIP(0, EQUIP_SLOT_D_LEFT) != ITEM_LENS_OF_TRUTH) &&
                           (DPAD_BUTTON_ITEM_EQUIP(0, EQUIP_SLOT_D_DOWN) != ITEM_LENS_OF_TRUTH) &&
@@ -5898,7 +5898,7 @@ void MM_Interface_DrawItemButtons(PlayState* play) {
     gDPSetCombineMode(OVERLAY_DISP++, G_CC_MODULATEIA_PRIM, G_CC_MODULATEIA_PRIM);
 
     // #region 2S2H [Dpad]
-    if (CVarGetInteger("gEnhancements.Dpad.DpadEquips", 0)) {
+    if (CVarGetInteger("gEnhancements.DpadEquips", 0)) {
         s16 dpadAlpha =
             MAX(MAX(MAX(interfaceCtx->shipInterface.dpad.dRightAlpha, interfaceCtx->shipInterface.dpad.dLeftAlpha),
                     interfaceCtx->shipInterface.dpad.dDownAlpha),
@@ -9289,7 +9289,7 @@ void MM_Interface_Draw(PlayState* play) {
         Interface_DrawCButtonIcons(play);
 
         // #region 2S2H [Dpad]
-        if (CVarGetInteger("gEnhancements.Dpad.DpadEquips", 0)) {
+        if (CVarGetInteger("gEnhancements.DpadEquips", 0)) {
             Interface_DrawDButtonIcons(play);
         }
         // #endregion
@@ -10063,7 +10063,7 @@ void Interface_Init(PlayState* play) {
     }
 
     // #region 2S2H [Dpad]
-    if (CVarGetInteger("gEnhancements.Dpad.DpadEquips", 0)) {
+    if (CVarGetInteger("gEnhancements.DpadEquips", 0)) {
         if (DPAD_BUTTON_ITEM_EQUIP(0, EQUIP_SLOT_D_RIGHT) < ITEM_F0) {
             Interface_Dpad_LoadItemIconImpl(play, EQUIP_SLOT_D_RIGHT);
         }

--- a/games/mm/src/code/z_player_lib.c
+++ b/games/mm/src/code/z_player_lib.c
@@ -862,7 +862,7 @@ PlayerItemAction func_80123810(PlayState* play) {
         }
     }
     // #region 2S2H [Dpad]
-    if (CVarGetInteger("gEnhancements.Dpad.DpadEquips", 0)) {
+    if (CVarGetInteger("gEnhancements.DpadEquips", 0)) {
         for (i = 0; i < ARRAY_COUNT(sDItemButtons); i++) {
             if (CHECK_BTN_ALL(CONTROLLER1(&play->state)->press.button, sDItemButtons[i])) {
                 itemId = Player_Dpad_GetItemOnButton(play, player, i);

--- a/games/mm/src/overlays/actors/ovl_player_actor/z_player.c
+++ b/games/mm/src/overlays/actors/ovl_player_actor/z_player.c
@@ -3857,7 +3857,7 @@ void MM_Player_ProcessItemButtons(Player* this, PlayState* play) {
             // #region 2S2H [Dpad] - Changed from EquipSlot to s32 to allow for higher ranges
             s32 btn = func_8082FD0C(this, maskItemAction);
 
-            if (CVarGetInteger("gEnhancements.Dpad.DpadEquips", 0)) {
+            if (CVarGetInteger("gEnhancements.DpadEquips", 0)) {
                 if (btn <= EQUIP_SLOT_NONE) {
                     DpadEquipSlot dpadBtn = func_Dpad_8082FD0C(this, maskItemAction);
 
@@ -3899,7 +3899,7 @@ void MM_Player_ProcessItemButtons(Player* this, PlayState* play) {
         !(((Player_GetHeldBButtonSword(this) == PLAYER_B_SWORD_NONE) || (gSaveContext.jinxTimer == 0)) &&
           (MM_Player_ItemIsInUse(this, (IREG(1) != 0) ? ITEM_FISHING_ROD : Inventory_GetBtnBItem(play)) ||
            // #region 2S2H [Dpad]
-           (CVarGetInteger("gEnhancements.Dpad.DpadEquips", 0) &&
+           (CVarGetInteger("gEnhancements.DpadEquips", 0) &&
             (MM_Player_ItemIsInUse(this, DPAD_BTN_ITEM(EQUIP_SLOT_D_RIGHT)) ||
              MM_Player_ItemIsInUse(this, DPAD_BTN_ITEM(EQUIP_SLOT_D_LEFT)) ||
              MM_Player_ItemIsInUse(this, DPAD_BTN_ITEM(EQUIP_SLOT_D_DOWN)) ||
@@ -3923,7 +3923,7 @@ void MM_Player_ProcessItemButtons(Player* this, PlayState* play) {
         item = MM_Player_GetItemOnButton(play, this, i);
 
         // #region 2S2H [Dpad]
-        if (CVarGetInteger("gEnhancements.Dpad.DpadEquips", 0)) {
+        if (CVarGetInteger("gEnhancements.DpadEquips", 0)) {
             if (i >= EQUIP_SLOT_A) {
                 DpadEquipSlot j = func_Dpad_8082FDC4();
                 ItemId dpadItem = Player_Dpad_GetItemOnButton(play, this, j);
@@ -3947,7 +3947,7 @@ void MM_Player_ProcessItemButtons(Player* this, PlayState* play) {
                 sPlayerHeldItemButtonIsHeldDown = true;
             }
             // #region 2S2H [Dpad]
-            else if (CVarGetInteger("gEnhancements.Dpad.DpadEquips", 0)) {
+            else if (CVarGetInteger("gEnhancements.DpadEquips", 0)) {
                 for (i = 0; i < ARRAY_COUNT(sDpadItemButtons); i++) {
                     if (CHECK_BTN_ALL(sPlayerControlInput->cur.button, sDpadItemButtons[i])) {
                         break;
@@ -4614,7 +4614,7 @@ void func_80831944(PlayState* play, Player* this) {
         func_808318C0(play);
     }
     // #region 2S2H [Dpad]
-    else if (CVarGetInteger("gEnhancements.Dpad.DpadEquips", 0)) {
+    else if (CVarGetInteger("gEnhancements.DpadEquips", 0)) {
         if (Player_Dpad_GetItemOnButton(play, this, func_Dpad_8082FDC4()) == ITEM_LENS_OF_TRUTH) {
             func_808318C0(play);
         }
@@ -18279,7 +18279,7 @@ void Player_Action_68(Player* this, PlayState* play) {
                     }
                 }
                 // #region 2S2H [Dpad]
-                else if (CVarGetInteger("gEnhancements.Dpad.DpadEquips", 0)) {
+                else if (CVarGetInteger("gEnhancements.DpadEquips", 0)) {
                     if (Player_Dpad_GetItemOnButton(play, this, HELD_ITEM_TO_DPAD(this->heldItemButton)) ==
                         ITEM_BOTTLE) {
                         Actor* interactRangeActor = this->interactRangeActor;
@@ -18688,7 +18688,7 @@ void Player_Action_80(Player* this, PlayState* play) {
                     play->actorCtx.flags |= ACTORCTX_FLAG_PICTO_BOX_ON;
                 }
                 // #region 2S2H [Dpad]
-                else if (CVarGetInteger("gEnhancements.Dpad.DpadEquips", 0)) {
+                else if (CVarGetInteger("gEnhancements.DpadEquips", 0)) {
                     if ((play->sceneId == SCENE_20SICHITAI) &&
                         (Player_Dpad_GetItemOnButton(play, this, func_Dpad_8082FDC4()) == ITEM_PICTOGRAPH_BOX)) {
                         play->actorCtx.flags |= ACTORCTX_FLAG_PICTO_BOX_ON;

--- a/games/mm/src/overlays/kaleido_scope/ovl_kaleido_scope/z_kaleido_item.c
+++ b/games/mm/src/overlays/kaleido_scope/ovl_kaleido_scope/z_kaleido_item.c
@@ -272,7 +272,7 @@ void MM_KaleidoScope_DrawItemSelect(PlayState* play) {
         }
     }
     // #region 2S2H [Dpad]
-    if (CVarGetInteger("gEnhancements.Dpad.DpadEquips", 0)) {
+    if (CVarGetInteger("gEnhancements.DpadEquips", 0)) {
         for (i = EQUIP_SLOT_D_RIGHT; i <= EQUIP_SLOT_D_UP; i++, j += 4) {
             if (DPAD_GET_CUR_FORM_BTN_ITEM(i) != ITEM_NONE) {
                 if (DPAD_GET_CUR_FORM_BTN_SLOT(i) < ITEM_NUM_SLOTS) {
@@ -650,7 +650,7 @@ void KaleidoScope_UpdateItemCursor(PlayState* play) {
                             }
                         }
                         // #region 2S2H [Dpad]
-                        else if (CVarGetInteger("gEnhancements.Dpad.DpadEquips", 0)) {
+                        else if (CVarGetInteger("gEnhancements.DpadEquips", 0)) {
                             if (CHECK_BTN_ALL(CONTROLLER1(&play->state)->press.button, BTN_DRIGHT)) {
                                 if (sPlayerFormItems[GET_PLAYER_FORM] ==
                                     DPAD_BUTTON_ITEM_EQUIP(0, EQUIP_SLOT_D_RIGHT)) {
@@ -701,7 +701,7 @@ void KaleidoScope_UpdateItemCursor(PlayState* play) {
                         pauseCtx->equipTargetCBtn = PAUSE_EQUIP_C_RIGHT;
                     }
                     // #region 2S2H [Dpad]
-                    else if (CVarGetInteger("gEnhancements.Dpad.DpadEquips", 0)) {
+                    else if (CVarGetInteger("gEnhancements.DpadEquips", 0)) {
                         if (CHECK_BTN_ALL(CONTROLLER1(&play->state)->press.button, BTN_DRIGHT)) {
                             if ((Player_GetCurMaskItemId(play) != ITEM_NONE) &&
                                 (Player_GetCurMaskItemId(play) == DPAD_BUTTON_ITEM_EQUIP(0, EQUIP_SLOT_D_RIGHT))) {
@@ -1863,7 +1863,7 @@ void MM_KaleidoScope_UpdateItemEquip(PlayState* play) {
                 Interface_LoadItemIconImpl(play, EQUIP_SLOT_C_RIGHT);
             }
             // #region 2S2H [Dpad]
-            else if (CVarGetInteger("gEnhancements.Dpad.DpadEquips", 0)) {
+            else if (CVarGetInteger("gEnhancements.DpadEquips", 0)) {
                 KaleidoScope_UpdateDpadItemEquip(play);
             }
             // #endregion

--- a/games/mm/src/overlays/kaleido_scope/ovl_kaleido_scope/z_kaleido_mask.c
+++ b/games/mm/src/overlays/kaleido_scope/ovl_kaleido_scope/z_kaleido_mask.c
@@ -220,7 +220,7 @@ void KaleidoScope_DrawMaskSelect(PlayState* play) {
         }
     }
     // #region 2S2H [Dpad]
-    if (CVarGetInteger("gEnhancements.Dpad.DpadEquips", 0)) {
+    if (CVarGetInteger("gEnhancements.DpadEquips", 0)) {
         for (i = EQUIP_SLOT_D_RIGHT; i <= EQUIP_SLOT_D_UP; i++, j += 4) {
             if (DPAD_GET_CUR_FORM_BTN_ITEM(i) != ITEM_NONE) {
                 if (DPAD_GET_CUR_FORM_BTN_SLOT(i) >= ITEM_NUM_SLOTS) {
@@ -591,7 +591,7 @@ void KaleidoScope_UpdateMaskCursor(PlayState* play) {
                         }
                     }
                     // #region 2S2H [Dpad]
-                    else if (CVarGetInteger("gEnhancements.Dpad.DpadEquips", 0)) {
+                    else if (CVarGetInteger("gEnhancements.DpadEquips", 0)) {
                         if (CHECK_BTN_ALL(input->press.button, BTN_DRIGHT)) {
                             if (((Player_GetCurMaskItemId(play) != ITEM_NONE) &&
                                  (Player_GetCurMaskItemId(play) == DPAD_BUTTON_ITEM_EQUIP(0, EQUIP_SLOT_D_RIGHT))) ||
@@ -648,7 +648,7 @@ void KaleidoScope_UpdateMaskCursor(PlayState* play) {
                         pauseCtx->equipTargetCBtn = PAUSE_EQUIP_C_RIGHT;
                     }
                     // #region 2S2H [Dpad]
-                    else if (CVarGetInteger("gEnhancements.Dpad.DpadEquips", 0)) {
+                    else if (CVarGetInteger("gEnhancements.DpadEquips", 0)) {
                         if (CHECK_BTN_ALL(input->press.button, BTN_DRIGHT)) {
                             pauseCtx->equipTargetCBtn = PAUSE_EQUIP_D_RIGHT;
                         } else if (CHECK_BTN_ALL(input->press.button, BTN_DLEFT)) {
@@ -1236,7 +1236,7 @@ void KaleidoScope_UpdateMaskEquip(PlayState* play) {
                 Interface_LoadItemIconImpl(play, EQUIP_SLOT_C_RIGHT);
             }
             // #region 2S2H [Dpad]
-            else if (CVarGetInteger("gEnhancements.Dpad.DpadEquips", 0)) {
+            else if (CVarGetInteger("gEnhancements.DpadEquips", 0)) {
                 KaleidoScope_UpdateDpadMaskEquip(play);
             }
             // #endregion

--- a/games/oot/soh/OTRGlobals.cpp
+++ b/games/oot/soh/OTRGlobals.cpp
@@ -1731,14 +1731,16 @@ static void InitOTRImpl(int argc, char* argv[], bool runExtract) {
     conf->RegisterVersionUpdater(std::make_shared<SOH::ConfigVersion5Updater>());
     conf->RegisterVersionUpdater(std::make_shared<SOH::ConfigVersion6Updater>());
     // RSBS: cross-game key convergence — MM moves onto OoT's spelling for
-    // settings both games mean identically (ADR 0003 §5.1).
+    // settings both games mean identically (ADR 0003 §5.1). Version 7 is the
+    // audio + tunic tier (#34); version 8 is the inventory §5.3 remainder (#462).
     conf->RegisterVersionUpdater(std::make_shared<SOH::ConfigVersion7Updater>());
+    conf->RegisterVersionUpdater(std::make_shared<SOH::ConfigVersion8Updater>());
     conf->RunVersionUpdates();
 
     // RSBS: one-shot import of an existing 2Ship2Harkinian config, mapped
-    // through the same convergence table version 7 uses. Must run AFTER the
-    // version updates so the imported keys land in their converged spelling
-    // and cannot be re-migrated. No-op when there is nothing to import.
+    // through the same convergence table the version updaters use. Must run
+    // AFTER the version updates so the imported keys land in their converged
+    // spelling and cannot be re-migrated. No-op when there is nothing to import.
     SOH::ImportTwoShipConfig(conf.get());
 
     // The SoH GUI windows load OoT game assets while they initialize

--- a/games/oot/soh/config/ConfigMigrators.h
+++ b/games/oot/soh/config/ConfigMigrators.h
@@ -1589,4 +1589,65 @@ std::vector<Migration> version7Migrations = {
     { MigrationAction::RenameIfAbsent, "gCosmetics.Link_GoronTunic.Value", "gCosmetics.Link.GoronTunic.Value" },
     { MigrationAction::RenameIfAbsent, "gCosmetics.Link_ZoraTunic.Value", "gCosmetics.Link.ZoraTunic.Value" },
 };
+
+/**
+ * RSBS version 8 — the inventory §5.3 convergence remainder (#462).
+ *
+ * MM moves onto OoT's spelling for 23 more settings both games mean identically:
+ * inventory group A (identical leaf, MM adds a category prefix), group B
+ * (wording drift), group C (the cutscene-skip family), group D (free-look).
+ * Direction MM -> OoT per ADR 0003 decision (3).
+ *
+ * ALL of these are pure renames. Unlike version 7's audio family, every row here
+ * was verified to agree on TYPE, UNITS, RANGE and DEFAULT on both sides before it
+ * was treated as mechanical (see src/common/cvar_shared_keys.h), so RenameIfAbsent
+ * copies the stored value unchanged — no value transform is needed and none is
+ * safe to omit. The three §5.3 rows that FAILED that check (ClimbSpeed's
+ * additive-vs-multiplier units, and the two parked cheat pairs) are held out in
+ * RSBS::kMustStayDistinct and are not in this table.
+ *
+ * Same conflict rule as version 7 (ADR 0003 §6.3): OoT's value wins, and the
+ * legacy MM spelling is cleared either way so the migration cannot oscillate.
+ * This table mirrors the non-scaledPercent §5.3 rows of RSBS::kConvergedKeys;
+ * the 2Ship importer maps through that same manifest.
+ */
+std::vector<Migration> version8Migrations = {
+    // Group A — identical leaf, MM adds a category prefix.
+    { MigrationAction::RenameIfAbsent, "gEnhancements.Timesavers.FastChests", "gEnhancements.FastChests" },
+    { MigrationAction::RenameIfAbsent, "gEnhancements.Graphics.BowReticle", "gEnhancements.BowReticle" },
+    { MigrationAction::RenameIfAbsent, "gEnhancements.Graphics.DisableBlackBars", "gEnhancements.DisableBlackBars" },
+    { MigrationAction::RenameIfAbsent, "gEnhancements.Player.InstantPutaway", "gEnhancements.InstantPutaway" },
+    { MigrationAction::RenameIfAbsent, "gEnhancements.Equipment.ItemUnequip", "gEnhancements.ItemUnequip" },
+    { MigrationAction::RenameIfAbsent, "gEnhancements.Saving.Autosave", "gEnhancements.Autosave" },
+    { MigrationAction::RenameIfAbsent, "gEnhancements.Saving.RememberSaveLocation",
+      "gEnhancements.RememberSaveLocation" },
+    { MigrationAction::RenameIfAbsent, "gEnhancements.Dpad.DpadEquips", "gEnhancements.DpadEquips" },
+    { MigrationAction::RenameIfAbsent, "gEnhancements.Restorations.PauseBufferWindow",
+      "gEnhancements.PauseBufferWindow" },
+    { MigrationAction::RenameIfAbsent, "gEnhancements.DifficultyOptions.HyperEnemies", "gEnhancements.HyperEnemies" },
+    { MigrationAction::RenameIfAbsent, "gEnhancements.Mods.AlternateAssetsHotkey",
+      "gSettings.Mods.AlternateAssetsHotkey" },
+    // Group B — wording drift, same meaning.
+    { MigrationAction::RenameIfAbsent, "gCheats.ClimbAnywhere", "gCheats.ClimbEverything" },
+    { MigrationAction::RenameIfAbsent, "gCheats.HookshotAnywhere", "gCheats.HookshotEverything" },
+    { MigrationAction::RenameIfAbsent, "gCheats.InfiniteRupees", "gCheats.InfiniteMoney" },
+    { MigrationAction::RenameIfAbsent, "gEnhancements.Graphics.EnemyHealthBars", "gEnhancements.EnemyHealthBar" },
+    { MigrationAction::RenameIfAbsent, "gEnhancements.Cutscenes.HideTitleCards",
+      "gEnhancements.TimeSavers.DisableTitleCard" },
+    // Group C — cutscene-skip family.
+    { MigrationAction::RenameIfAbsent, "gEnhancements.Cutscenes.SkipEntranceCutscenes",
+      "gEnhancements.TimeSavers.SkipCutscene.Entrances" },
+    { MigrationAction::RenameIfAbsent, "gEnhancements.Cutscenes.SkipIntroSequence",
+      "gEnhancements.TimeSavers.SkipCutscene.Intro" },
+    { MigrationAction::RenameIfAbsent, "gEnhancements.Cutscenes.SkipOnePointCutscenes",
+      "gEnhancements.TimeSavers.SkipCutscene.OnePoint" },
+    { MigrationAction::RenameIfAbsent, "gEnhancements.Cutscenes.SkipStoryCutscenes",
+      "gEnhancements.TimeSavers.SkipCutscene.Story" },
+    // Group D — free-look.
+    { MigrationAction::RenameIfAbsent, "gEnhancements.Camera.FreeLook.Enable", "gSettings.FreeLook.Enabled" },
+    { MigrationAction::RenameIfAbsent, "gEnhancements.Camera.FreeLook.MaxCameraDistance",
+      "gSettings.FreeLook.MaxCameraDistance" },
+    { MigrationAction::RenameIfAbsent, "gEnhancements.Camera.FreeLook.TransitionSpeed",
+      "gSettings.FreeLook.TransitionSpeed" },
+};
 } // namespace SOH

--- a/games/oot/soh/config/ConfigUpdaters.cpp
+++ b/games/oot/soh/config/ConfigUpdaters.cpp
@@ -22,6 +22,8 @@ ConfigVersion6Updater::ConfigVersion6Updater() : ConfigVersionUpdater(6) {
 }
 ConfigVersion7Updater::ConfigVersion7Updater() : ConfigVersionUpdater(7) {
 }
+ConfigVersion8Updater::ConfigVersion8Updater() : ConfigVersionUpdater(8) {
+}
 
 void ConfigVersion1Updater::Update(Ship::Config* conf) {
     if (conf->GetInt("Window.Width", 640) == 640) {
@@ -214,6 +216,32 @@ void ConfigVersion7Updater::Update(Ship::Config* conf) {
             CVarSetInteger(key.canonical, VolumePercentFromFloatScale(CVarGetFloat(key.legacy, 1.0f)));
         }
         CVarClear(key.legacy);
+    }
+}
+
+// ============================================================================
+// Version 8 — the inventory §5.3 convergence remainder (#462)
+// ============================================================================
+
+/**
+ * 23 pure MM -> OoT renames (ADR 0004 inventory §5.3 groups A-D). Every row was
+ * verified to share type, units, range and default across both games before
+ * landing, so — unlike version 7's audio family — none needs a value transform;
+ * RenameIfAbsent copies the stored value across verbatim. Same conflict rule as
+ * version 7: OoT's value wins, the legacy spelling is cleared either way, so the
+ * migration is a no-op on re-run and cannot oscillate.
+ */
+void ConfigVersion8Updater::Update(Ship::Config* conf) {
+    for (Migration migration : version8Migrations) {
+        if (migration.action == MigrationAction::RenameIfAbsent) {
+            if (ShouldAdoptLegacyValue(CVarPresent(migration.from.c_str()),
+                                       CVarPresent(migration.to.value().c_str()))) {
+                CVarCopy(migration.from.c_str(), migration.to.value().c_str());
+            }
+        } else if (migration.action == MigrationAction::Rename) {
+            CVarCopy(migration.from.c_str(), migration.to.value().c_str());
+        }
+        CVarClear(migration.from.c_str());
     }
 }
 } // namespace SOH

--- a/games/oot/soh/config/ConfigUpdaters.h
+++ b/games/oot/soh/config/ConfigUpdaters.h
@@ -54,6 +54,23 @@ class ConfigVersion7Updater final : public Ship::ConfigVersionUpdater {
 };
 
 /**
+ * RSBS version 8 — the inventory §5.3 convergence remainder (#462).
+ *
+ * 23 more MM keys move onto OoT's spelling (groups A-D of the enhancement
+ * classification: category-prefix strips, wording drift, the cutscene-skip
+ * family, and free-look). All are PURE renames — each was verified to agree on
+ * type, units, range and default on both sides before landing here, so unlike
+ * version 7's audio family none needs a value transform. Same conflict rule
+ * (OoT's value wins) via version8Migrations' RenameIfAbsent rows; zero-loss and
+ * non-oscillating for the same reasons as version 7.
+ */
+class ConfigVersion8Updater final : public Ship::ConfigVersionUpdater {
+  public:
+    ConfigVersion8Updater();
+    void Update(Ship::Config* conf);
+};
+
+/**
  * @brief The ADR 0003 §6.3 conflict rule, as a pure predicate.
  *
  * A config can legitimately hold BOTH spellings of a converged setting: the

--- a/src/common/cvar_shared_keys.h
+++ b/src/common/cvar_shared_keys.h
@@ -131,18 +131,26 @@ struct ConvergedKey {
 };
 
 /**
- * The convergence set landed by this work. The single table the version-7
- * config updater and the 2Ship importer both consume, so the two cannot drift.
+ * The convergence set. The single table the config version updaters and the
+ * 2Ship importer all consume, so they cannot drift.
  *
- * SCOPE NOTE — this is not the whole convergence backlog. ADR 0003 §5.1 scoped
- * "tier 1" to these 9 keys; ADR 0004's inventory §5.3 independently found 26
- * more convergence rows. The two sets are very nearly DISJOINT, not nested:
- * the inventory classified MM's `gEnhancements.*`/`gCheats.*` categories and
- * the 35-key collision set, while the audio-volume family below is in neither
- * (MM and OoT spell it differently, so it is not a collision, and it is not an
- * enhancement). They intersect only on the three tunic keys. The inventory's
- * 26 rows are tracked separately and are NOT attempted here — four of them are
- * parked on unanswered taxonomy questions (see kMustStayDistinct).
+ * SCOPE — this table now carries BOTH waves of convergence:
+ *
+ *   - Tier 1 (#34 / PR #461): the 6 audio-volume keys and the 3 tunic-colour
+ *     keys. The volume rows carry scaledPercent=true because OoT stores integer
+ *     percent while MM stored a float scale; those need a value transform, not
+ *     just a rename (see the representation note above). Migrated by
+ *     ConfigVersion7Updater.
+ *   - The inventory §5.3 remainder (#462): 23 of its 26 rows. All pure renames —
+ *     each was re-verified against origin/main to agree on TYPE, UNITS, RANGE
+ *     and DEFAULT on both sides before it was treated as mechanical, because a
+ *     key-only swap across a representation gap is a silent no-op, not a fix
+ *     (the trap the volume rows hit). Migrated by ConfigVersion8Updater.
+ *
+ * The 3 unlanded §5.3 rows did NOT pass that verification and are held out:
+ * ClimbSpeed (OoT additive "+N" 0-12 vs MM multiplier 1-5×, incompatible units
+ * and neutral value) plus the two parked cheat pairs (scope/gate undecided) —
+ * all three now sit in kMustStayDistinct so a future plain rename fails CI.
  */
 inline constexpr ConvergedKey kConvergedKeys[] = {
     { RSBS_CVAR_LEGACY_VOLUME_MASTER, RSBS_CVAR_VOLUME_MASTER, true },
@@ -154,6 +162,57 @@ inline constexpr ConvergedKey kConvergedKeys[] = {
     { RSBS_CVAR_LEGACY_COLOR_KOKIRI_TUNIC, RSBS_CVAR_COLOR_KOKIRI_TUNIC, false },
     { RSBS_CVAR_LEGACY_COLOR_GORON_TUNIC, RSBS_CVAR_COLOR_GORON_TUNIC, false },
     { RSBS_CVAR_LEGACY_COLOR_ZORA_TUNIC, RSBS_CVAR_COLOR_ZORA_TUNIC, false },
+
+    // ---- Inventory §5.3 remainder (#462), ConfigVersion8Updater. ----
+    // All pure renames (scaledPercent=false): representation re-verified matching
+    // on both sides. MM's read sites and OoT's already agree on int/bool type and
+    // default, so version8Migrations copies the stored value unchanged.
+
+    // Group A — identical leaf, MM adds a category prefix. (ClimbSpeed is the
+    // 12th Group A row and is deliberately absent: it is in kMustStayDistinct
+    // because OoT reads it as an additive "+0..12" offset and MM as a "1..5x"
+    // multiplier — same name, incompatible units.)
+    { "gEnhancements.Timesavers.FastChests", "gEnhancements.FastChests", false },
+    { "gEnhancements.Graphics.BowReticle", "gEnhancements.BowReticle", false },
+    { "gEnhancements.Graphics.DisableBlackBars", "gEnhancements.DisableBlackBars", false },
+    { "gEnhancements.Player.InstantPutaway", "gEnhancements.InstantPutaway", false },
+    { "gEnhancements.Equipment.ItemUnequip", "gEnhancements.ItemUnequip", false },
+    // The Autosave ENABLE flag converges; the MM-only interval slider
+    // (gEnhancements.Saving.AutosaveInterval) does NOT ride along — it is in
+    // kMustStayDistinct because OoT hardcodes its interval with no CVar.
+    { "gEnhancements.Saving.Autosave", "gEnhancements.Autosave", false },
+    { "gEnhancements.Saving.RememberSaveLocation", "gEnhancements.RememberSaveLocation", false },
+    { "gEnhancements.Dpad.DpadEquips", "gEnhancements.DpadEquips", false },
+    { "gEnhancements.Restorations.PauseBufferWindow", "gEnhancements.PauseBufferWindow", false },
+    { "gEnhancements.DifficultyOptions.HyperEnemies", "gEnhancements.HyperEnemies", false },
+    // Top-level namespace change too: MM gEnhancements.Mods -> OoT gSettings.Mods.
+    { "gEnhancements.Mods.AlternateAssetsHotkey", "gSettings.Mods.AlternateAssetsHotkey", false },
+
+    // Group B — wording drift, same meaning. The two parked cheat pairs
+    // (InfiniteConsumables/InfiniteAmmo, UnrestrictedItems/NoRestrictItems) are
+    // NOT here — their scope/gate is undecided, so they stay in kMustStayDistinct.
+    { "gCheats.ClimbAnywhere", "gCheats.ClimbEverything", false },
+    { "gCheats.HookshotAnywhere", "gCheats.HookshotEverything", false },
+    { "gCheats.InfiniteRupees", "gCheats.InfiniteMoney", false },
+    { "gEnhancements.Graphics.EnemyHealthBars", "gEnhancements.EnemyHealthBar", false },
+    { "gEnhancements.Cutscenes.HideTitleCards", "gEnhancements.TimeSavers.DisableTitleCard", false },
+
+    // Group C — cutscene-skip family. OoT groups under TimeSavers.SkipCutscene.*,
+    // MM under Cutscenes.Skip*Cutscenes. Both bool. (OoT defaults these to
+    // IS_RANDO and MM to 0; that per-reader default difference is inherent to a
+    // shared key and pre-dates convergence — it is not a type mismatch.)
+    { "gEnhancements.Cutscenes.SkipEntranceCutscenes", "gEnhancements.TimeSavers.SkipCutscene.Entrances", false },
+    { "gEnhancements.Cutscenes.SkipIntroSequence", "gEnhancements.TimeSavers.SkipCutscene.Intro", false },
+    { "gEnhancements.Cutscenes.SkipOnePointCutscenes", "gEnhancements.TimeSavers.SkipCutscene.OnePoint", false },
+    { "gEnhancements.Cutscenes.SkipStoryCutscenes", "gEnhancements.TimeSavers.SkipCutscene.Story", false },
+
+    // Group D — free-look. OoT files it under gSettings.FreeLook, MM under
+    // gEnhancements.Camera.FreeLook. Enable is bool; MaxCameraDistance and
+    // TransitionSpeed are int sliders read with CVarGetInteger on BOTH sides
+    // (TransitionSpeed default 25 on both), so no representation gap.
+    { "gEnhancements.Camera.FreeLook.Enable", "gSettings.FreeLook.Enabled", false },
+    { "gEnhancements.Camera.FreeLook.MaxCameraDistance", "gSettings.FreeLook.MaxCameraDistance", false },
+    { "gEnhancements.Camera.FreeLook.TransitionSpeed", "gSettings.FreeLook.TransitionSpeed", false },
 };
 
 /**
@@ -209,6 +268,14 @@ inline constexpr DistinctPair kMustStayDistinct[] = {
       "gSettings.Controls.InvertShieldAimingYAxis",
       "Different namespace AND different axis coverage: OoT has X+Y, MM has Y only. Merging loses OoT's "
       "X axis." },
+    { "Climb speed (inventory §5.3 group A, reclassified P by #462)", "gEnhancements.Player.ClimbSpeed",
+      "gEnhancements.ClimbSpeed",
+      "Listed in §5.3 group A as 'both numeric', but representation verification found INCOMPATIBLE UNITS: "
+      "OoT reads it as an ADDITIVE offset (slider '+%d', 0-12, default 0; playSpeed += phi_f2 * value) while "
+      "MM reads it as a MULTIPLIER (slider 1-5, default 1; *speed *= value, gated value>1). The neutral value "
+      "(0 vs 1) and the range (0-12 vs 1-5) both disagree, so a shared slider cannot mean both. Same failure "
+      "shape as P1 text speed. Converge only after a maintainer decides which unit wins and MM's read/menu are "
+      "converted to it — a plain key swap is a regression, not a fix." },
     { "Autosave interval (inventory §5.3 group A caveat)", "gEnhancements.Saving.AutosaveInterval",
       "(none — OoT hardcodes THREE_MINUTES_IN_UNIX)",
       "The Autosave ENABLE flag is genuinely shared-intent, but OoT's interval is hardcoded with no CVar. "
@@ -337,12 +404,11 @@ inline constexpr std::size_t kDisputedClassificationKeyCount =
     sizeof(kDisputedClassificationKeys) / sizeof(kDisputedClassificationKeys[0]);
 inline constexpr std::size_t kMenuIndexKeyCount = sizeof(kMenuIndexKeys) / sizeof(kMenuIndexKeys[0]);
 
-// ADR 0003 §5.1 summarises tier 1 as "8 renames across 9 literal sites"; its
-// own sub-counts say 6 audio + 3 colour. Both describe this 9-entry table: 8 of
-// the 9 land on a key OoT already reads, and the 9th (Volume.Ambience) is an
-// adoption rather than a rename because OoT has no ambience channel to collide
-// with. Nine keys either way.
-static_assert(kConvergedKeyCount == 9, "tier 1 converges 9 keys (8 onto an existing OoT key + Ambience)");
+// Tier 1 (#34) landed 9 keys — 6 audio + 3 tunic. #462 adds 23 of the inventory
+// §5.3 remainder's 26 rows (the 3 held out are ClimbSpeed and the two parked
+// cheat pairs, all in kMustStayDistinct). 9 + 23 = 32. Pinning the count makes a
+// silently dropped or double-added row a compile error.
+static_assert(kConvergedKeyCount == 32, "tier 1 (9) + inventory §5.3 remainder (23 of 26; 3 held out) = 32");
 
 // ADR 0003 Appendix B measured 26 class-(S) collisions. This table carries 25:
 // DebugSaveFileMode was pulled out into kDisputedClassificationKeys because the

--- a/src/common/tests/test_cvar_classification.c
+++ b/src/common/tests/test_cvar_classification.c
@@ -106,9 +106,27 @@ std::vector<std::string> CvarClassSlurpTree(const std::filesystem::path& root, b
     return contents;
 }
 
-/// Does any scanned file contain this quoted key literal?
+/// Does any scanned file contain this quoted key literal? Substring form: the
+/// needle is the OPENING quote plus the key, so a prefix (e.g. a retired family
+/// namespace) matches every key under it.
 bool CvarClassTreeContainsLiteral(const std::vector<std::string>& tree, const char* key) {
     const std::string needle = std::string("\"") + key;
+    for (const std::string& text : tree) {
+        if (text.find(needle) != std::string::npos) {
+            return true;
+        }
+    }
+    return false;
+}
+
+/// Does any scanned file contain this key as a WHOLE quoted literal ("key")?
+/// Exact form, used where a retired key is a PREFIX of a surviving one — e.g.
+/// gEnhancements.Saving.Autosave retires while gEnhancements.Saving.AutosaveInterval
+/// stays (MM-only). The substring form above would false-match the survivor and
+/// report the retired key as still present. MM spells every CVar as a full
+/// literal, so the closing quote is always there to anchor against.
+bool CvarClassTreeContainsExactKey(const std::vector<std::string>& tree, const char* key) {
+    const std::string needle = std::string("\"") + key + "\"";
     for (const std::string& text : tree) {
         if (text.find(needle) != std::string::npos) {
             return true;
@@ -169,20 +187,29 @@ TestResult Test_CVarClassification(void) {
         }
     }
 
-    // Every retired spelling must fall under a retired PREFIX, so the
-    // prefix-level source scan below actually covers the whole convergence set
-    // rather than a subset someone forgot to extend.
-    for (std::size_t i = 0; i < RSBS::kConvergedKeyCount; i++) {
-        bool covered = false;
-        for (std::size_t p = 0; p < RSBS::kRetiredKeyPrefixCount; p++) {
-            const char* prefix = RSBS::kRetiredKeyPrefixes[p];
+    // Every retired FAMILY prefix must cover at least one converged legacy key.
+    // A prefix that matches nothing is stale: it would scan the tree for a family
+    // that no longer converges and quietly protect nothing.
+    //
+    // Note the direction. This does NOT require every legacy key to sit under a
+    // prefix. The two #461 prefixes (gSettings.Audio., gCosmetics.Link_) are
+    // ABANDONED NAMESPACES — every MM key in them retired — so a prefix scan is
+    // the right tool to catch a NEW sibling appearing there. The #462 §5.3 rows
+    // instead retire an individual leaf out of a namespace that STAYS LIVE
+    // (gEnhancements.Graphics. still hosts MM-only keys, gEnhancements.Saving.
+    // still hosts AutosaveInterval, gCheats. still hosts the shared cheats), so
+    // they have no family prefix. They are covered directly by the exact per-key
+    // scan (3a) below, which names each retired spelling in full.
+    for (std::size_t p = 0; p < RSBS::kRetiredKeyPrefixCount; p++) {
+        const char* prefix = RSBS::kRetiredKeyPrefixes[p];
+        bool covers = false;
+        for (std::size_t i = 0; i < RSBS::kConvergedKeyCount; i++) {
             if (strncmp(RSBS::kConvergedKeys[i].legacy, prefix, strlen(prefix)) == 0) {
-                covered = true;
+                covers = true;
                 break;
             }
         }
-        CVARCLASS_CHECK(covered, "a retired key is not covered by any retired prefix — the source scan would miss "
-                                 "new siblings in its family");
+        CVARCLASS_CHECK(covers, "a retired family prefix covers no converged legacy key — it is stale");
     }
 
     // ------------------------------------------------------------------
@@ -241,7 +268,7 @@ TestResult Test_CVarClassification(void) {
         // setting silently diverging again.
         for (std::size_t i = 0; i < RSBS::kConvergedKeyCount; i++) {
             const RSBS::ConvergedKey& key = RSBS::kConvergedKeys[i];
-            if (CvarClassTreeContainsLiteral(mmTree, key.legacy)) {
+            if (CvarClassTreeContainsExactKey(mmTree, key.legacy)) {
                 printf("[TEST] FAIL: MM still reads the retired key \"%s\".\n"
                        "[TEST]       It converged onto \"%s\"; reintroducing the old spelling means the setting\n"
                        "[TEST]       silently stops crossing the game boundary. Use the canonical key\n"
@@ -312,17 +339,26 @@ TestResult Test_CVarClassification(void) {
         // the manifest that would otherwise make every check above pass while
         // pointing at a key nothing uses. Skips Volume.Ambience, which is an
         // adoption rather than a rename — OoT has no ambience channel.
+        //
+        // OoT reaches gSettings.*, gEnhancements.* and gCheats.* through the
+        // CVAR_SETTING / CVAR_ENHANCEMENT / CVAR_CHEAT macros, so the full
+        // "gPrefix.Leaf" literal never appears in OoT source — only "Leaf" does.
+        // Strip those prefixes and probe the leaf. gCosmetics.* has no prefix
+        // macro on the OoT side (it is a raw literal), so it stays a full-literal
+        // probe by falling through with nothing stripped.
+        static const char* const kMacroBackedPrefixes[] = { "gSettings.", "gEnhancements.", "gCheats." };
         for (std::size_t i = 0; i < RSBS::kConvergedKeyCount; i++) {
             const char* canonical = RSBS::kConvergedKeys[i].canonical;
             if (strcmp(canonical, RSBS_CVAR_VOLUME_AMBIENCE) == 0) {
                 continue;
             }
-            // OoT reaches gSettings.* through the CVAR_SETTING macro, so match
-            // the leaf rather than the full literal for that family.
-            const char* settingPrefix = "gSettings.";
-            const char* probe = strncmp(canonical, settingPrefix, strlen(settingPrefix)) == 0
-                                    ? canonical + strlen(settingPrefix)
-                                    : canonical;
+            const char* probe = canonical;
+            for (const char* prefix : kMacroBackedPrefixes) {
+                if (strncmp(canonical, prefix, strlen(prefix)) == 0) {
+                    probe = canonical + strlen(prefix);
+                    break;
+                }
+            }
             if (!CvarClassTreeContainsLiteral(ootTree, probe)) {
                 printf("[TEST] FAIL: OoT does not appear to read the canonical key \"%s\" (probed \"%s\").\n"
                        "[TEST]       MM was converged onto a key OoT does not use — check the manifest for a\n"


### PR DESCRIPTION
Closes #462. Verifies and closes #453. Continues #34 / PR #461.

## What lands

MM moves onto OoT's spelling for **23** more settings both games mean identically — the enhancement-classification inventory §5.3 groups A/B/C/D. Adds `ConfigVersion8Updater` + `version8Migrations` (`RenameIfAbsent`, OoT's value wins, legacy cleared so it cannot oscillate), and extends the `--test cvar-classification` lock and the 2Ship importer to cover the new rows (the importer needs no code change — it iterates `RSBS::kConvergedKeys`).

## The #461 lesson, applied to every row

Every row was re-verified against `origin/main` to agree on **type, units, range AND default** — not just meaning — because a key-only swap across a representation gap is a silent no-op, not a fix. All 23 landed rows are pure renames: both games already read them with the same accessor and default, so `RenameIfAbsent` copies the stored value verbatim (no value transform, unlike v7's audio family).

Notable checks:
- **FreeLook** (group D): OoT and MM both read `MaxCameraDistance`/`TransitionSpeed` with `CVarGetInteger` (TransitionSpeed default **25** on both) — int/int, no float↔int trap. `Enable` is bool both sides.
- **PauseBufferWindow**: int, 0–40, default 0 on both.
- **Cutscene skips** (group C): both bool. OoT defaults these to `IS_RANDO`, MM to `0`; that per-reader default difference is inherent to a shared key and pre-dates convergence — it is not a type mismatch.
- **AlternateAssetsHotkey**: bool checkbox, default 1 both sides; also a top-level namespace move (`gEnhancements.Mods` → `gSettings.Mods`).

## Executed convergence set (MM legacy → OoT canonical)

**Group A (11)** — `Timesavers.FastChests`→`FastChests`, `Graphics.BowReticle`→`BowReticle`, `Graphics.DisableBlackBars`→`DisableBlackBars`, `Player.InstantPutaway`→`InstantPutaway`, `Equipment.ItemUnequip`→`ItemUnequip`, `Saving.Autosave`→`Autosave`, `Saving.RememberSaveLocation`→`RememberSaveLocation`, `Dpad.DpadEquips`→`DpadEquips`, `Restorations.PauseBufferWindow`→`PauseBufferWindow`, `DifficultyOptions.HyperEnemies`→`HyperEnemies`, `gEnhancements.Mods.AlternateAssetsHotkey`→`gSettings.Mods.AlternateAssetsHotkey`.

**Group B (5)** — `gCheats.ClimbAnywhere`→`ClimbEverything`, `gCheats.HookshotAnywhere`→`HookshotEverything`, `gCheats.InfiniteRupees`→`InfiniteMoney`, `Graphics.EnemyHealthBars`→`EnemyHealthBar`, `Cutscenes.HideTitleCards`→`TimeSavers.DisableTitleCard`.

**Group C (4)** — `Cutscenes.Skip{Entrance,IntroSequence,OnePoint,Story}Cutscenes` → `TimeSavers.SkipCutscene.{Entrances,Intro,OnePoint,Story}`.

**Group D (3)** — `Camera.FreeLook.Enable`→`gSettings.FreeLook.Enabled`, `Camera.FreeLook.MaxCameraDistance`→`gSettings.FreeLook.MaxCameraDistance`, `Camera.FreeLook.TransitionSpeed`→`gSettings.FreeLook.TransitionSpeed`.

106 MM literal sites renamed (concentrated in `DpadEquips` 27 and `SkipStoryCutscenes` 29).

## Deferred — held out of the convergence set (in `kMustStayDistinct`)

- **ClimbSpeed** (§5.3 group A, reclassified P): OoT reads it as an **additive** `+0..12` offset (`playSpeed += phi_f2 * value`, slider `+%d`), MM as a **multiplier** `1..5×` (`*speed *= value`, gated `>1`). The neutral value (0 vs 1) and range (0-12 vs 1-5) disagree — same failure shape as P1 text speed. A plain key swap would be a regression. Now a `kMustStayDistinct` row so a future rename fails CI.
- **`InfiniteConsumables`/`InfiniteAmmo`** and **`UnrestrictedItems`/`NoRestrictItems`** — scope/gate undecided (already parked).
- **Timesavers/TimeSavers casing**, **`Saving.AutosaveInterval`** (MM-only; OoT hardcodes the interval), **`DebugSaveFileMode`** (#454) — parked, untouched.

## Lock extension (both drift directions)

- Exact-key match for the retired-key scan: `gEnhancements.Saving.Autosave` is a **prefix** of the surviving MM-only `.AutosaveInterval`, which the old substring match would false-hit.
- Retired-prefix self-check inverted: family prefixes must cover ≥1 legacy key. #461's two prefixes are abandoned *namespaces*; the §5.3 rows retire an individual leaf from a namespace that stays live, so they carry no family prefix and are covered by the per-key scan.
- Canonical-probe now strips `gEnhancements.`/`gCheats.` (macro-backed, like `gSettings.`) since OoT never spells the full `gPrefix.Leaf` literal.
- `kConvergedKeyCount` static_assert bumped 9 → 32.

## #453 verdict — RESOLVED by #461 (verified against current main)

The only MM tunic reader is `BenPort.cpp:1850-1860`, **excluded from the single-exe link** (`games/mm/CMakeLists.txt:238`). It now reads the converged dot-form `gCosmetics.Link.{Kokiri,Goron,Zora}Tunic.Value`, and `version7Migrations` migrates an existing user's underscore value onto it (RenameIfAbsent). No other MM tunic reader exists. No gap remains, so #453 is closed with evidence rather than fixed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!--- section:artifacts:start -->
### Build Artifacts
  - [rsbs-windows.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/8514836502.zip)
  - [rsbs-linux.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/8513847545.zip)
<!--- section:artifacts:end -->