### PR TITLE
Fix #441: cross-game OoT arrival wiped the rando placement table (gossip stones read "No Item")

### DIFF
--- a/CMake/SingleExecutable.cmake
+++ b/CMake/SingleExecutable.cmake
@@ -510,6 +510,18 @@ if(BUILD_TESTING)
         TIMEOUT 180
         ENVIRONMENT "SDL_AUDIODRIVER=dummy;RSBS_DISABLE_OTR_INIT=1")
 
+    # Hint reload (#441), the RUNTIME complement to RandoHintValidity. That lock
+    # re-renders hints against the same live, fully-filled context, so it cannot
+    # see the operator-visible break: an item hint resolves its item at runtime
+    # from the placement table, and a fresh game AND a reload both rebuild that
+    # table from the save (FileChoose_LoadGame -> Save_LoadFile -> LoadRandomizer).
+    # This drives the real save -> Rando::Context reset -> reload cycle and locks
+    # that item hints still name their real item afterward. Same tier.
+    redship_add_test(NAME RandoHintReload COMMAND redship --test rando-hint-reload
+        LABEL rando
+        TIMEOUT 180
+        ENVIRONMENT "SDL_AUDIODRIVER=dummy;RSBS_DISABLE_OTR_INIT=1")
+
     # Song shuffle modes. Stock (RandoGen above) already covers mode 1 — "Song
     # Locations" is the default — which is the mode that regressed when the
     # linker dropped ShuffleSongs.cpp.o from the static soh_rando archive and

--- a/CMake/SingleExecutable.cmake
+++ b/CMake/SingleExecutable.cmake
@@ -522,6 +522,18 @@ if(BUILD_TESTING)
         TIMEOUT 180
         ENVIRONMENT "SDL_AUDIODRIVER=dummy;RSBS_DISABLE_OTR_INIT=1")
 
+    # Cross-game arrival lock (#441) — THE root-cause lock. A switch into OoT
+    # cold-boots the title chain, whose Title_Destroy -> OoT_Sram_InitSram ->
+    # Save_Init wiped the Rando::Context placement table while the frozen save was
+    # restored without re-running LoadRandomizer, so every item hint stranded on
+    # "No Item" though its location phrasing survived (ClearItemLocations never
+    # touches hintTable). Drives the real Save_Init with and without the arrival
+    # flag. Same display-but-no-archives tier.
+    redship_add_test(NAME RandoHintCrossGame COMMAND redship --test rando-hint-crossgame
+        LABEL rando
+        TIMEOUT 180
+        ENVIRONMENT "SDL_AUDIODRIVER=dummy;RSBS_DISABLE_OTR_INIT=1")
+
     # Song shuffle modes. Stock (RandoGen above) already covers mode 1 — "Song
     # Locations" is the default — which is the mode that regressed when the
     # linker dropped ShuffleSongs.cpp.o from the static soh_rando archive and

--- a/games/oot/soh/Enhancements/randomizer/3drando/menu.cpp
+++ b/games/oot/soh/Enhancements/randomizer/3drando/menu.cpp
@@ -206,6 +206,135 @@ extern "C" int Rando_HeadlessHintValidityTest(const char* seedStr) {
     return failures == 0 ? 0 : 1;
 }
 
+// Implemented in SaveManager.cpp (which owns the private SaveRandomizer /
+// LoadRandomizer and the section json cursor). Drives the REAL randomizer
+// section through save -> Rando::Context reset -> reload, in memory, exactly as
+// loading a saved file does.
+extern "C" void Rando_TestRoundTripRandomizerSection(int* outResetCleared, int* outPlacementRestored);
+
+// Hint-RELOAD lock (#441). PR #445 proved generation-time text is correct and
+// added a hint-validity lock, but that lock (and its toJSON()/Hint(json) round
+// trip) re-renders every hint against the SAME live, fully-filled context, so it
+// cannot see the operator-visible break: an ITEM hint resolves its item at
+// RUNTIME from ctx->GetItemLocation(loc)->GetPlacedItem(), and that placement
+// table is thrown away and rebuilt from the save on every load (a fresh new
+// game and a reload BOTH go FileChoose_LoadGame -> Save_LoadFile, which resets
+// the Rando::Context and rehydrates it via LoadRandomizer). A gossip stone read
+// "catching Big Poes leads to No Item" while the spoiler named a real item.
+// Gossip item hints carry NO hintKeys, so the location phrasing comes straight
+// from StaticData::GetLocation(loc)->GetHint() -- it survived, which proves the
+// hint's location was intact and only the location->placement resolution had
+// decayed to RG_NONE ("No Item" is itemTable[RG_NONE]).
+//
+// This drives the actual save -> context-reset -> reload cycle and asserts that
+// every enabled item hint still renders the SAME text it did live and never the
+// no-item sentinel. It is the reload-path complement to #445's generation-time
+// lock.
+extern "C" int Rando_HeadlessHintReloadTest(const char* seedStr) {
+    int rc = Rando_HeadlessSeedTest(seedStr);
+    if (rc != 0) {
+        fprintf(stderr, "[hint-reload] generation failed rc=%d\n", rc);
+        return rc;
+    }
+
+    auto ctx = Rando::Context::GetInstance();
+    if (!ctx) {
+        fprintf(stderr, "[hint-reload] no Rando::Context after generation\n");
+        return 4;
+    }
+
+    const std::string sentinel = Rando::StaticData::RetrieveItem(RG_NONE).GetName().GetEnglish();
+    if (sentinel.empty()) {
+        fprintf(stderr, "[hint-reload] itemTable[RG_NONE] has no name; item table not initialised\n");
+        return 5;
+    }
+
+    // Snapshot every enabled item hint's live rendered text BEFORE the reload.
+    struct HintSnapshot {
+        RandomizerHint key;
+        std::string name;
+        std::vector<std::string> messages;
+    };
+    std::vector<HintSnapshot> snapshots;
+    for (int h = RH_NONE + 1; h < RH_MAX; h++) {
+        const auto hintKey = static_cast<RandomizerHint>(h);
+        Rando::Hint* hint = ctx->GetHint(hintKey);
+        if (hint == nullptr || !hint->IsEnabled()) {
+            continue;
+        }
+        const HintType hintType = hint->GetHintType();
+        if (hintType != HINT_TYPE_ITEM && hintType != HINT_TYPE_ITEM_AREA) {
+            continue; // only item hints name an item that can decay to the sentinel
+        }
+        HintSnapshot snap;
+        snap.key = hintKey;
+        snap.name = Rando::StaticData::hintNames[hintKey].GetForCurrentLanguage(MF_CLEAN);
+        snap.messages = hint->GetAllMessageStrings(MF_CLEAN);
+        snapshots.push_back(std::move(snap));
+    }
+    fprintf(stderr, "[hint-reload] snapshotted %zu enabled item hints\n", snapshots.size());
+
+    // Do the real save -> reset -> reload. This rebuilds the Rando::Context.
+    int resetCleared = 0;
+    int placementRestored = 0;
+    Rando_TestRoundTripRandomizerSection(&resetCleared, &placementRestored);
+    fprintf(stderr, "[hint-reload] after reload: resetCleared=%d placementRestored=%d\n", resetCleared,
+            placementRestored);
+    if (resetCleared == 0) {
+        // The context reset did not empty the placement table, so the reload was
+        // never actually exercised; a pass here would be meaningless.
+        fprintf(stderr, "[hint-reload] the context reset did not clear placements; test cannot exercise the reload\n");
+        return 7;
+    }
+
+    // Re-render each hint against the REBUILT context and compare.
+    auto reloaded = Rando::Context::GetInstance();
+    if (!reloaded) {
+        fprintf(stderr, "[hint-reload] no Rando::Context after reload\n");
+        return 4;
+    }
+    size_t failures = 0;
+    for (const HintSnapshot& snap : snapshots) {
+        Rando::Hint* hint = reloaded->GetHint(snap.key);
+        const std::vector<std::string> after =
+            hint != nullptr ? hint->GetAllMessageStrings(MF_CLEAN) : std::vector<std::string>{};
+
+        for (const std::string& message : after) {
+            if (message.find(sentinel) != std::string::npos) {
+                fprintf(stderr, "[hint-reload] FAIL %s: after reload the hint resolves to the no-item sentinel: \"%s\"\n",
+                        snap.name.c_str(), message.c_str());
+                failures++;
+            }
+        }
+
+        if (after.size() != snap.messages.size()) {
+            fprintf(stderr, "[hint-reload] FAIL %s: reload changed message count %zu -> %zu\n", snap.name.c_str(),
+                    snap.messages.size(), after.size());
+            failures++;
+            continue;
+        }
+        for (size_t m = 0; m < after.size(); m++) {
+            if (after[m] == snap.messages[m]) {
+                continue;
+            }
+            const bool decayed = after[m].find(sentinel) != std::string::npos;
+            fprintf(stderr,
+                    "[hint-reload] FAIL %s: reload changed message%s\n  live:     \"%s\"\n  reloaded: \"%s\"\n",
+                    snap.name.c_str(), decayed ? " and it decayed to the no-item sentinel" : "",
+                    snap.messages[m].c_str(), after[m].c_str());
+            failures++;
+        }
+    }
+
+    if (snapshots.empty()) {
+        fprintf(stderr, "[hint-reload] no enabled item hints were generated; the lock would vacuously pass\n");
+        return 6;
+    }
+
+    fprintf(stderr, "[hint-reload] checked %zu item hints across a reload, %zu failures\n", snapshots.size(), failures);
+    return failures == 0 ? 0 : 1;
+}
+
 // Determinism harness bridge (Lane B, Phase 3.0): run ONE seed generation and
 // emit a canonical, side-effect-free digest of (a) the unified-seed producer's
 // output in gComboCtx and (b) the full item placement, so an external wrapper

--- a/games/oot/soh/Enhancements/randomizer/3drando/menu.cpp
+++ b/games/oot/soh/Enhancements/randomizer/3drando/menu.cpp
@@ -341,6 +341,151 @@ extern "C" int Rando_HeadlessHintReloadTest(const char* seedStr) {
     return failures == 0 ? 0 : 1;
 }
 
+// Implemented in SaveManager.cpp / src/common/entrance.cpp. Save_Init() is the
+// SRAM boot init the gamestate framework dispatches from Title_Destroy on every
+// pass through the title chain -- including the cold-boot chain a switch INTO
+// OoT walks. The Combo_* startup-entrance calls stand in for "a cross-game OoT
+// arrival is in flight".
+extern "C" void Save_Init(void);
+extern "C" void Combo_SetStartupEntrance(uint16_t entrance);
+extern "C" void Combo_ClearStartupEntrance(void);
+extern "C" bool Combo_HasStartupEntranceForGame(const char* gameId);
+
+// Cross-game arrival lock (#441). THE actual operator-visible defect: gossip
+// stones read "catching Big Poes leads to No Item" after switching OoT->MM->OoT.
+// The reload lock above proves a file LOAD rehydrates correctly; this proves the
+// OTHER entry into OoT does not. A switch into OoT cold-boots the gamestate chain
+// through the title screen, and Title_Destroy runs OoT_Sram_InitSram -> Save_Init
+// -> SaveManager::Init, whose tail wiped the Rando::Context placement table
+// (ClearItemLocations). The frozen OoT save is restored afterwards at
+// Play_ConsumeStartupEntrance WITHOUT going through Save_LoadFile, so nothing
+// re-runs LoadRandomizer to rehydrate it -- the #447 class. ClearItemLocations
+// only empties itemLocationTable, never hintTable, which is exactly why the hint
+// kept its location phrasing ("catching Big Poes") while the item resolved to
+// itemTable[RG_NONE] ("No Item").
+//
+// The fix guards that clear with Combo_HasStartupEntranceForGame("oot"). This
+// test drives the real Save_Init both WITH the arrival flag set (placements must
+// survive; item hints must still name their real item) and WITHOUT it (the clear
+// must still fire, proving the guard is the only thing that saved the world and
+// the assertion above is not vacuous).
+extern "C" int Rando_HeadlessHintCrossGameTest(const char* seedStr) {
+    int rc = Rando_HeadlessSeedTest(seedStr);
+    if (rc != 0) {
+        fprintf(stderr, "[hint-crossgame] generation failed rc=%d\n", rc);
+        return rc;
+    }
+    auto ctx = Rando::Context::GetInstance();
+    if (!ctx) {
+        fprintf(stderr, "[hint-crossgame] no Rando::Context after generation\n");
+        return 4;
+    }
+
+    const std::string sentinel = Rando::StaticData::RetrieveItem(RG_NONE).GetName().GetEnglish();
+    if (sentinel.empty()) {
+        fprintf(stderr, "[hint-crossgame] itemTable[RG_NONE] has no name; item table not initialised\n");
+        return 5;
+    }
+
+    // A sample location that holds a real item, to prove the placement table is
+    // (a) preserved on arrival and (b) genuinely cleared without the guard.
+    bool haveSample = false;
+    size_t sample = 0;
+    for (int i = 1; i < RC_MAX; i++) {
+        if (ctx->GetItemLocation(i)->GetPlacedRandomizerGet() != RG_NONE) {
+            haveSample = true;
+            sample = (size_t)i;
+            break;
+        }
+    }
+    if (!haveSample) {
+        fprintf(stderr, "[hint-crossgame] no placed items after generation; cannot exercise the lock\n");
+        return 8;
+    }
+
+    // Snapshot every enabled item hint's live text before the arrival.
+    struct HintSnapshot {
+        RandomizerHint key;
+        std::string name;
+        std::vector<std::string> messages;
+    };
+    std::vector<HintSnapshot> snapshots;
+    for (int h = RH_NONE + 1; h < RH_MAX; h++) {
+        const auto hintKey = static_cast<RandomizerHint>(h);
+        Rando::Hint* hint = ctx->GetHint(hintKey);
+        if (hint == nullptr || !hint->IsEnabled()) {
+            continue;
+        }
+        const HintType hintType = hint->GetHintType();
+        if (hintType != HINT_TYPE_ITEM && hintType != HINT_TYPE_ITEM_AREA) {
+            continue;
+        }
+        HintSnapshot snap;
+        snap.key = hintKey;
+        snap.name = Rando::StaticData::hintNames[hintKey].GetForCurrentLanguage(MF_CLEAN);
+        snap.messages = hint->GetAllMessageStrings(MF_CLEAN);
+        snapshots.push_back(std::move(snap));
+    }
+    if (snapshots.empty()) {
+        fprintf(stderr, "[hint-crossgame] no enabled item hints were generated; the lock would vacuously pass\n");
+        return 6;
+    }
+    fprintf(stderr, "[hint-crossgame] snapshotted %zu enabled item hints; sample check %zu\n", snapshots.size(), sample);
+
+    // ---- Arrival case: Save_Init must NOT wipe placements. ----
+    Combo_SetStartupEntrance(0x0100); // any pending entrance -> "a switch into OoT is in flight"
+    if (!Combo_HasStartupEntranceForGame("oot")) {
+        fprintf(stderr, "[hint-crossgame] could not arm the OoT arrival flag; test setup is broken\n");
+        Combo_ClearStartupEntrance();
+        return 9;
+    }
+    Save_Init();
+    const bool survivedArrival =
+        Rando::Context::GetInstance()->GetItemLocation(sample)->GetPlacedRandomizerGet() != RG_NONE;
+
+    size_t failures = 0;
+    auto afterArrival = Rando::Context::GetInstance();
+    for (const HintSnapshot& snap : snapshots) {
+        Rando::Hint* hint = afterArrival->GetHint(snap.key);
+        const std::vector<std::string> after =
+            hint != nullptr ? hint->GetAllMessageStrings(MF_CLEAN) : std::vector<std::string>{};
+        for (const std::string& message : after) {
+            if (message.find(sentinel) != std::string::npos) {
+                fprintf(stderr,
+                        "[hint-crossgame] FAIL %s: after a cross-game OoT arrival the hint resolves to the no-item "
+                        "sentinel: \"%s\"\n",
+                        snap.name.c_str(), message.c_str());
+                failures++;
+            }
+        }
+        if (after != snap.messages) {
+            fprintf(stderr, "[hint-crossgame] FAIL %s: the arrival changed the hint text\n", snap.name.c_str());
+            failures++;
+        }
+    }
+    if (!survivedArrival) {
+        fprintf(stderr, "[hint-crossgame] FAIL: sample check %zu was wiped to RG_NONE by the arrival Save_Init\n",
+                sample);
+        failures++;
+    }
+
+    // ---- Control: without the arrival flag, the clear MUST still fire, so the
+    // pass above cannot be a no-op that never reached ClearItemLocations. ----
+    Combo_ClearStartupEntrance();
+    Save_Init();
+    const bool clearedWhenNotArriving =
+        Rando::Context::GetInstance()->GetItemLocation(sample)->GetPlacedRandomizerGet() == RG_NONE;
+    if (!clearedWhenNotArriving) {
+        fprintf(stderr, "[hint-crossgame] FAIL: Save_Init did NOT clear placements off the arrival path -- the lock is "
+                        "vacuous (ClearItemLocations was never reached)\n");
+        failures++;
+    }
+
+    fprintf(stderr, "[hint-crossgame] checked %zu item hints across a cross-game arrival, %zu failures\n",
+            snapshots.size(), failures);
+    return failures == 0 ? 0 : 1;
+}
+
 // Determinism harness bridge (Lane B, Phase 3.0): run ONE seed generation and
 // emit a canonical, side-effect-free digest of (a) the unified-seed producer's
 // output in gComboCtx and (b) the full item placement, so an external wrapper

--- a/games/oot/soh/Enhancements/randomizer/3drando/menu.cpp
+++ b/games/oot/soh/Enhancements/randomizer/3drando/menu.cpp
@@ -274,6 +274,12 @@ extern "C" int Rando_HeadlessHintReloadTest(const char* seedStr) {
     }
     fprintf(stderr, "[hint-reload] snapshotted %zu enabled item hints\n", snapshots.size());
 
+    // Drop this local strong reference before the reset. Context::mContext is a
+    // weak_ptr, so the reset inside the round trip only builds a fresh context if
+    // every shared_ptr owner is released first; holding `ctx` here would pin the
+    // old, still-populated context and make the reload a no-op (a false pass).
+    ctx = nullptr;
+
     // Do the real save -> reset -> reload. This rebuilds the Rando::Context.
     int resetCleared = 0;
     int placementRestored = 0;

--- a/games/oot/soh/SaveManager.cpp
+++ b/games/oot/soh/SaveManager.cpp
@@ -2993,6 +2993,79 @@ void SaveManager::ConvertFromUnversioned() {
 #undef SLOT_OFFSET
 }
 
+// Test hook (#441). Runtime-resolution lock companion. See header for the bug.
+void SaveManager::TestRoundTripRandomizerSection(bool* outResetCleared, bool* outPlacementRestored) {
+    auto ctxBefore = Rando::Context::GetInstance();
+
+    // Sample a location that actually holds an item, so we can prove the reset
+    // really emptied the placement table and the reload really refilled it. A
+    // vacuous test (reset that never cleared) would otherwise pass silently.
+    bool haveSample = false;
+    size_t sample = 0;
+    RandomizerGet sampleBefore = RG_NONE;
+    for (size_t i = 1; i < RC_MAX; i++) {
+        RandomizerGet rg = ctxBefore->GetItemLocation(i)->GetPlacedRandomizerGet();
+        if (rg != RG_NONE) {
+            haveSample = true;
+            sample = i;
+            sampleBefore = rg;
+            break;
+        }
+    }
+
+    // Serialize the live randomizer section exactly as a real save does.
+    gSaveContext.ship.quest.id = QUEST_RANDOMIZER;
+    nlohmann::json section = nlohmann::json::object();
+    nlohmann::json* prev = currentJsonContext;
+    currentJsonContext = &section;
+    SaveRandomizer(&gSaveContext, 0, true);
+    currentJsonContext = prev;
+
+    // Reset the context exactly as Save_LoadFile does before a load: a real
+    // load never keeps the generation-time context, it rebuilds from the save.
+    OTRGlobals::Instance->gRandoContext->GetLogic()->SetContext(nullptr);
+    Rando::Settings::GetInstance()->ClearContext();
+    OTRGlobals::Instance->gRandoContext.reset();
+    OTRGlobals::Instance->gRandoContext = Rando::Context::CreateInstance();
+    OTRGlobals::Instance->gRandoContext->GetLogic()->SetSaveContext(&gSaveContext);
+    Rando::Settings::GetInstance()->AssignContext(OTRGlobals::Instance->gRandoContext);
+    OTRGlobals::Instance->gRandoContext->AddExcludedOptions();
+
+    RandomizerGet sampleAfterReset =
+        haveSample ? Rando::Context::GetInstance()->GetItemLocation(sample)->GetPlacedRandomizerGet() : RG_NONE;
+
+    // Reload the section exactly as LoadFile -> LoadRandomizer does.
+    prev = currentJsonContext;
+    currentJsonContext = &section;
+    LoadRandomizer();
+    currentJsonContext = prev;
+
+    RandomizerGet sampleAfterLoad =
+        haveSample ? Rando::Context::GetInstance()->GetItemLocation(sample)->GetPlacedRandomizerGet() : RG_NONE;
+
+    fprintf(stderr, "[hint-reload] sample check %zu: placedItem before=%d afterReset=%d afterLoad=%d\n", sample,
+            (int)sampleBefore, (int)sampleAfterReset, (int)sampleAfterLoad);
+
+    if (outResetCleared != nullptr) {
+        *outResetCleared = !haveSample || sampleAfterReset == RG_NONE;
+    }
+    if (outPlacementRestored != nullptr) {
+        *outPlacementRestored = !haveSample || sampleAfterLoad == sampleBefore;
+    }
+}
+
+extern "C" void Rando_TestRoundTripRandomizerSection(int* outResetCleared, int* outPlacementRestored) {
+    bool resetCleared = false;
+    bool placementRestored = false;
+    SaveManager::Instance->TestRoundTripRandomizerSection(&resetCleared, &placementRestored);
+    if (outResetCleared != nullptr) {
+        *outResetCleared = resetCleared ? 1 : 0;
+    }
+    if (outPlacementRestored != nullptr) {
+        *outPlacementRestored = placementRestored ? 1 : 0;
+    }
+}
+
 // C to C++ bridge
 
 extern "C" void Save_Init(void) {

--- a/games/oot/soh/SaveManager.cpp
+++ b/games/oot/soh/SaveManager.cpp
@@ -514,6 +514,12 @@ void SaveManager::SaveRandomizer(SaveContext* saveContext, int sectionID, bool f
 
 // Init() here is an extension of InitSram, and thus not truly an initializer for SaveManager itself. don't put any
 // class initialization stuff here
+// Cross-game arrival signal (src/common/entrance.h). True while a switch INTO
+// OoT is in flight, i.e. the boot chain is restoring the live OoT session rather
+// than performing a player-visible reset. Declared here (as z_title.c does)
+// to avoid pulling the src/common header into this OoT TU.
+extern "C" bool Combo_HasStartupEntranceForGame(const char* gameId);
+
 void SaveManager::Init() {
     // Wait on saves that snuck through the Wait in OnExitGame
     ThreadPoolWait();
@@ -574,7 +580,27 @@ void SaveManager::Init() {
         }
     }
     saveBlock = nlohmann::json::object();
-    OTRGlobals::Instance->gRandoContext->ClearItemLocations();
+
+    // #441: do NOT wipe the randomizer placement table when a cross-game arrival
+    // is restoring the live OoT session. This Init() runs from OoT_Sram_InitSram,
+    // which the gamestate framework dispatches via Title_Destroy on EVERY entry
+    // through the title chain -- including the cold-boot chain a switch INTO OoT
+    // walks (see z_title.c: the arrival sets running=false but Title_Destroy
+    // still fires). On that path the frozen OoT save is restored later at
+    // Play_ConsumeStartupEntrance WITHOUT going through Save_LoadFile, so nothing
+    // re-runs LoadRandomizer to rehydrate the Rando::Context. The context is an
+    // in-memory singleton that survives the switch (OoT is suspended, not shut
+    // down), so its placements are still valid here -- clearing them stranded
+    // every item hint on RG_NONE ("No Item"). ClearItemLocations only touches the
+    // itemLocationTable, not hintTable, which is why the hint's location phrasing
+    // survived while the item name decayed. On a genuine boot or a real
+    // return-to-title (no arrival in flight) the clear still runs, and the file
+    // load that follows rehydrates the table as before.
+    if (!Combo_HasStartupEntranceForGame("oot")) {
+        OTRGlobals::Instance->gRandoContext->ClearItemLocations();
+    } else {
+        SPDLOG_INFO("[#441] Skipping ClearItemLocations: cross-game OoT arrival is restoring the live rando session");
+    }
 }
 
 void SaveManager::StartupCheckAndInitMeta(int fileNum) {

--- a/games/oot/soh/SaveManager.cpp
+++ b/games/oot/soh/SaveManager.cpp
@@ -3012,6 +3012,13 @@ void SaveManager::TestRoundTripRandomizerSection(bool* outResetCleared, bool* ou
             break;
         }
     }
+    // Release this local strong reference BEFORE the reset below. The reset only
+    // produces a fresh context if gRandoContext.reset() drops the last owner so
+    // Context::mContext (a weak_ptr) expires; a lingering shared_ptr here would
+    // keep the old context alive, CreateInstance() would hand it straight back,
+    // and the "reload" would silently reuse the still-populated table. gRando
+    // Context still owns it, so SaveRandomizer below still sees the live world.
+    ctxBefore = nullptr;
 
     // Serialize the live randomizer section exactly as a real save does.
     gSaveContext.ship.quest.id = QUEST_RANDOMIZER;

--- a/games/oot/soh/SaveManager.h
+++ b/games/oot/soh/SaveManager.h
@@ -109,6 +109,18 @@ class SaveManager {
     void DeleteZeldaFile(int fileNum);
     bool IsRandoFile();
 
+    // Test hook (#441): drive the REAL randomizer section through a
+    // save -> context-reset -> reload cycle, in memory, exactly as loading a
+    // saved file does (Save_LoadFile resets the Rando::Context, then
+    // LoadFile -> LoadRandomizer rehydrates it). Gossip stones were reading
+    // "catching Big Poes leads to No Item" while that seed's spoiler named a
+    // real item; the hint's location survives the reload but the item name is
+    // resolved at RUNTIME from the placement table, which is rebuilt on every
+    // load. outResetCleared reports whether the reset actually emptied the
+    // sampled placement (guards against a vacuous test); outPlacementRestored
+    // reports whether the reload put it back.
+    void TestRoundTripRandomizerSection(bool* outResetCleared, bool* outPlacementRestored);
+
     // Use a name of "" to save to an array. You must be in a SaveArray callback.
     template <typename T> void SaveData(const std::string& name, const T& data) {
         if (name == "") {

--- a/src/common/test_runner.cpp
+++ b/src/common/test_runner.cpp
@@ -372,6 +372,14 @@ extern "C" int MM_Rando_HeadlessForeignDigest(const char* outPath);
 // must round-trip through locationNameToEnum (the transform the save file puts
 // hints through). Returns 0 only if every enabled hint passes all three.
 extern "C" int Rando_HeadlessHintValidityTest(const char* seedStr);
+// Hint-RELOAD lock (#441, body in menu.cpp): generates one seed, then drives the
+// REAL randomizer section through save -> Rando::Context reset -> reload (exactly
+// as loading a saved file does) and asserts every enabled item hint still renders
+// the same text and never the no-item sentinel. This is the runtime complement to
+// the generation-time RandoHintValidity lock: #445's checks re-render hints
+// against the live, fully-filled context, so they cannot see a placement table
+// that fails to rehydrate on load.
+extern "C" int Rando_HeadlessHintReloadTest(const char* seedStr);
 extern "C" void InitOTRForMMFirstBoot(int argc, char* argv[]);
 
 TestResult Test_RandoGen(void) {
@@ -417,6 +425,31 @@ TestResult Test_RandoHintValidity(void) {
 
     int rc = Rando_HeadlessHintValidityTest("RSBSHINT1");
     printf("[TEST] %s: hint validity rc=%d\n", rc == 0 ? "PASS" : "FAIL", rc);
+    return rc == 0 ? TEST_PASS : TEST_FAIL;
+}
+
+// Hint-RELOAD lock (#441). The operator saw gossip stones read "catching Big
+// Poes leads to No Item" while the spoiler named a real item. The hint's
+// location survives a load (it is stored by name), but the item name is resolved
+// at RUNTIME from the placement table, which is thrown away and rebuilt from the
+// save on every load. This drives the real save -> context-reset -> reload cycle
+// and proves item hints still name their real item afterward. Needs a display
+// (Fast3dWindow) like rando-gen, so `--test all` skips it.
+TestResult Test_RandoHintReload(void) {
+    printf("[TEST] rando-hint-reload: item hints survive a save/reload cycle (#441)\n");
+
+    auto ctx = CreateHarnessStyleContext();
+    if (!ctx) {
+        printf("[TEST] FAIL: could not create Ship::Context singleton\n");
+        return TEST_FAIL;
+    }
+
+    static char arg0[] = "redship";
+    static char* fakeArgv[] = { arg0, nullptr };
+    InitOTRForMMFirstBoot(1, fakeArgv);
+
+    int rc = Rando_HeadlessHintReloadTest("RSBSHINT1");
+    printf("[TEST] %s: hint reload rc=%d\n", rc == 0 ? "PASS" : "FAIL", rc);
     return rc == 0 ? TEST_PASS : TEST_FAIL;
 }
 
@@ -1135,6 +1168,10 @@ const TestDescriptor gTests[] = {
     // #441: no generated hint may resolve to the no-item sentinel. Needs a
     // display like rando-gen, so `--test all` skips it (below).
     {"rando-hint-validity", "Every generated hint names a real item (#441)", Test_RandoHintValidity},
+    // #441 runtime complement: item hints must still name their real item after a
+    // save/reload cycle rebuilds the placement table. Needs a display like
+    // rando-gen, so `--test all` skips it (below).
+    {"rando-hint-reload", "Item hints survive a save/reload cycle (#441)", Test_RandoHintReload},
     // Lane B unified seed: producer stamps gComboCtx at generation time; the
     // two-process same-seed determinism diff runs via the SeedDeterminism row.
     // Needs a display like rando-gen, so `--test all` skips it (below).
@@ -1323,6 +1360,7 @@ int TestRunner_Run(const char* testName) {
             // this display-free suite, where they would hang the 60s timeout.
             if (strcmp(gTests[i].name, "rando-gen") == 0 || strcmp(gTests[i].name, "rando-determinism") == 0 ||
                 strcmp(gTests[i].name, "rando-hint-validity") == 0 ||
+                strcmp(gTests[i].name, "rando-hint-reload") == 0 ||
                 strcmp(gTests[i].name, "mm-rando-gen") == 0 ||
                 strcmp(gTests[i].name, "mm-pair-switch-entry") == 0 ||
                 strcmp(gTests[i].name, "mm-reload-arm-state") == 0) {

--- a/src/common/test_runner.cpp
+++ b/src/common/test_runner.cpp
@@ -380,6 +380,13 @@ extern "C" int Rando_HeadlessHintValidityTest(const char* seedStr);
 // against the live, fully-filled context, so they cannot see a placement table
 // that fails to rehydrate on load.
 extern "C" int Rando_HeadlessHintReloadTest(const char* seedStr);
+// Cross-game arrival lock (#441, body in menu.cpp): THE operator-visible defect.
+// A switch into OoT cold-boots the title chain, whose Title_Destroy ->
+// OoT_Sram_InitSram -> Save_Init wiped the Rando::Context placement table while
+// the frozen save is restored without re-running LoadRandomizer, so every item
+// hint stranded on RG_NONE ("No Item") though its location phrasing survived.
+// Drives the real Save_Init with and without the arrival flag.
+extern "C" int Rando_HeadlessHintCrossGameTest(const char* seedStr);
 extern "C" void InitOTRForMMFirstBoot(int argc, char* argv[]);
 
 TestResult Test_RandoGen(void) {
@@ -450,6 +457,32 @@ TestResult Test_RandoHintReload(void) {
 
     int rc = Rando_HeadlessHintReloadTest("RSBSHINT1");
     printf("[TEST] %s: hint reload rc=%d\n", rc == 0 ? "PASS" : "FAIL", rc);
+    return rc == 0 ? TEST_PASS : TEST_FAIL;
+}
+
+// Cross-game arrival lock (#441). THE operator-visible defect: gossip stones read
+// "catching Big Poes leads to No Item" after an OoT->MM->OoT switch. The switch
+// into OoT cold-boots the title chain, whose Title_Destroy -> OoT_Sram_InitSram
+// -> Save_Init wiped the Rando::Context placement table (ClearItemLocations),
+// and the frozen save is restored afterwards without going through Save_LoadFile,
+// so nothing re-ran LoadRandomizer to rehydrate it. Drives the real Save_Init
+// with the arrival flag set (placements must survive) and without it (the clear
+// must still fire). Needs a display like rando-gen, so `--test all` skips it.
+TestResult Test_RandoHintCrossGame(void) {
+    printf("[TEST] rando-hint-crossgame: item hints survive a cross-game OoT arrival (#441)\n");
+
+    auto ctx = CreateHarnessStyleContext();
+    if (!ctx) {
+        printf("[TEST] FAIL: could not create Ship::Context singleton\n");
+        return TEST_FAIL;
+    }
+
+    static char arg0[] = "redship";
+    static char* fakeArgv[] = { arg0, nullptr };
+    InitOTRForMMFirstBoot(1, fakeArgv);
+
+    int rc = Rando_HeadlessHintCrossGameTest("RSBSHINT1");
+    printf("[TEST] %s: hint cross-game rc=%d\n", rc == 0 ? "PASS" : "FAIL", rc);
     return rc == 0 ? TEST_PASS : TEST_FAIL;
 }
 
@@ -1172,6 +1205,10 @@ const TestDescriptor gTests[] = {
     // save/reload cycle rebuilds the placement table. Needs a display like
     // rando-gen, so `--test all` skips it (below).
     {"rando-hint-reload", "Item hints survive a save/reload cycle (#441)", Test_RandoHintReload},
+    // #441 root-cause lock: item hints must survive a cross-game OoT arrival,
+    // whose title-chain Save_Init used to wipe the placement table. Needs a
+    // display like rando-gen, so `--test all` skips it (below).
+    {"rando-hint-crossgame", "Item hints survive a cross-game OoT arrival (#441)", Test_RandoHintCrossGame},
     // Lane B unified seed: producer stamps gComboCtx at generation time; the
     // two-process same-seed determinism diff runs via the SeedDeterminism row.
     // Needs a display like rando-gen, so `--test all` skips it (below).
@@ -1361,6 +1398,7 @@ int TestRunner_Run(const char* testName) {
             if (strcmp(gTests[i].name, "rando-gen") == 0 || strcmp(gTests[i].name, "rando-determinism") == 0 ||
                 strcmp(gTests[i].name, "rando-hint-validity") == 0 ||
                 strcmp(gTests[i].name, "rando-hint-reload") == 0 ||
+                strcmp(gTests[i].name, "rando-hint-crossgame") == 0 ||
                 strcmp(gTests[i].name, "mm-rando-gen") == 0 ||
                 strcmp(gTests[i].name, "mm-pair-switch-entry") == 0 ||
                 strcmp(gTests[i].name, "mm-reload-arm-state") == 0) {


### PR DESCRIPTION
Fixes #441.

## Root cause: runtime resolution, and it is a cross-game arrival, not the file load

Gossip stones read **"They say that catching Big Poes leads to No Item"** after an OoT->MM->OoT switch, while that seed's spoiler correctly named a real item (**Nayru's Love**). PR #445 (merged) proved the (a)/(b) triage — **(a) resolution, not fill** — and locked the generation-time invariant, but its hint-validity checks re-render every hint against the same live, fully-filled `Rando::Context`, so they could not see the operator-visible break.

An item hint resolves its item name at **runtime** from `ctx->GetItemLocation(loc)->GetPlacedItem()`. Gossip item hints carry **no `hintKeys`**, so the location phrasing ("catching Big Poes") comes straight from `StaticData::GetLocation(loc)->GetHint()` — it survived, which proves the hint's location was intact and only the **location->placement** lookup had gone to `RG_NONE` ("No Item" is `itemTable[RG_NONE]`).

A switch **into** OoT cold-boots the gamestate chain through the title screen. The framework dispatches `Title_Destroy -> OoT_Sram_InitSram -> Save_Init -> SaveManager::Init` on that path (see `z_title.c`: the arrival sets `running=false`, but `Title_Destroy` still fires). `SaveManager::Init`'s tail unconditionally ran `gRandoContext->ClearItemLocations()`, emptying the placement table. The frozen OoT save is restored **afterwards** at `Play_ConsumeStartupEntrance` **without** going through `Save_LoadFile`, so nothing re-runs `LoadRandomizer` to rehydrate the context — the **#447 class** ("state exists but the arrival path never rehydrates it"). `ClearItemLocations` only empties `itemLocationTable`, never `hintTable`, which is exactly why the phrasing survived while the item decayed. The `Rando::Context` is an in-memory singleton that survives the switch (OoT is suspended, not shut down), so its placements were still valid at `Init()` time — clearing them was the whole bug.

## Fix

Guard the clear with `Combo_HasStartupEntranceForGame("oot")`: a cross-game OoT arrival restoring the live session keeps its placement table. A genuine boot or return-to-title (no arrival in flight) still clears, and the file load that follows rehydrates as before.

## Locks (both ROM-free, `rando` label)

- **RandoHintReload** — drives the real `SaveRandomizer -> Rando::Context reset -> LoadRandomizer` cycle and asserts item hints survive a file **load**. This passes on `main` already — it proves the file-load path was never the bug and isolates the defect to the arrival path.
- **RandoHintCrossGame** — THE root-cause lock. Drives the real `Save_Init` with the arrival flag set (placements + item hints must survive) and without it (the clear must still fire, so the pass is not vacuous). Red without the guard, green with it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!--- section:artifacts:start -->
### Build Artifacts
  - [rsbs-windows.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/8514726956.zip)
  - [rsbs-linux.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/8514508044.zip)
<!--- section:artifacts:end -->