### PR TITLE
Guard OoT tracker init-funcs against the cross-game arrival wipe (#482)

### DIFF
--- a/CMake/SingleExecutable.cmake
+++ b/CMake/SingleExecutable.cmake
@@ -296,6 +296,16 @@ if(BUILD_TESTING)
     # linear gEntranceTable index — the OOB-read crash behind the Market
     # cutscene 0xC0000005.
     redship_add_test(NAME StartupEntrance COMMAND redship --test startup-entrance)
+    # Arrival-rehydration lock (#482): two more instances of the #441 class. A
+    # switch INTO OoT cold-boots the title chain, whose Save_InitFile(true)
+    # dispatches SaveManager initFuncs that blank the check tracker's areasSpoiled
+    # and the item tracker's typed notes -- both OUTSIDE gSaveContext. The frozen
+    # save is restored at Play_ConsumeStartupEntrance without re-running
+    # Save_LoadFile, so nothing rehydrates them; the next save then persists the
+    # blanked values. Guarded with Combo_HasStartupEntranceForGame("oot"). Drives
+    # the real init functions with and without the arrival flag (survive vs. still
+    # clear). Pure -- no display -- so it runs in this redship tier.
+    redship_add_test(NAME TrackerArrivalRehydration COMMAND redship --test tracker-arrival-rehydration)
     # Entrance-link dedup regression (#374): the default (mask shop) and test
     # (Mido's House) links both return through MM 0xC010, and both were
     # registered unconditionally. Entrance_CheckCrossGame resolves first-match,

--- a/games/oot/soh/Enhancements/randomizer/randomizer_check_tracker.cpp
+++ b/games/oot/soh/Enhancements/randomizer/randomizer_check_tracker.cpp
@@ -18,6 +18,7 @@
 #include "soh/ObjectExtension/ObjectExtension.h"
 #include "overlays/actors/ovl_En_GirlA/z_en_girla.h"
 
+#include <cstdio>
 #include <string>
 #include <sstream>
 #include <vector>
@@ -37,6 +38,10 @@ extern "C" {
 extern PlayState* OoT_gPlayState;
 }
 extern "C" GetItemEntry ItemTable_RetrieveEntry(s16 modIndex, s16 getItemID);
+// Cross-game arrival guard (#482, #441 shape). Defined in src/common/entrance.cpp.
+extern "C" bool Combo_HasStartupEntranceForGame(const char* gameId);
+extern "C" void Combo_SetStartupEntrance(uint16_t entrance);
+extern "C" void Combo_ClearStartupEntrance(void);
 
 extern std::vector<ItemTrackerItem> dungeonRewardStones;
 extern std::vector<ItemTrackerItem> dungeonRewardMedallions;
@@ -893,7 +898,63 @@ void CheckTrackerDialogMessage() {
 
 void InitTrackerData(bool isDebug) {
     TrySetAreas();
-    areasSpoiled = 0;
+    // Cross-game OoT arrival: do NOT reset the revealed-area state when a switch
+    // INTO OoT is restoring the live session (#482, same class/shape as #441).
+    // InitTrackerData is a SaveManager initFunc, so the arrival title-demo chain
+    // runs it (Opening_SetupTitleScreen -> OoT_Sram_InitDebugSave ->
+    // Save_InitFile(true) dispatches every initFunc). The frozen OoT save is
+    // restored afterwards at Play_ConsumeStartupEntrance WITHOUT going through
+    // Save_LoadFile, so nothing re-runs this tracker's LoadFile to rehydrate
+    // areasSpoiled. areasSpoiled lives OUTSIDE gSaveContext (a module global), so
+    // blanking it resets the check tracker's revealed areas on every OoT return
+    // leg -- and the next save persists 0 over the real value (SaveTrackerData).
+    // A genuine boot or return-to-title still clears, and the file load that
+    // follows rebuilds it.
+    if (!Combo_HasStartupEntranceForGame("oot")) {
+        areasSpoiled = 0;
+    }
+}
+
+// ---- Arrival-rehydration lock (#482), check-tracker half. -------------------
+// Drives the REAL InitTrackerData (the init function the arrival title-demo
+// Save_InitFile(true) dispatches) with the OoT arrival flag set -- areasSpoiled
+// MUST survive -- and without it -- the reset MUST still fire, so the pass is not
+// vacuous. Self-contained and pure (no OTR/display/SaveManager), because the CI
+// rando tier has no game archive and therefore never registers the tracker
+// initFuncs (SohGui::SetupGuiElements is gated on hasGameArchive). Returns the
+// failure count.
+extern "C" int RandoTest_CheckTrackerArrivalLock(void) {
+    int failures = 0;
+    const uint32_t kAreasSentinel = 0x00002A5Fu; // any nonzero revealed-area bitmask
+
+    areasSpoiled = kAreasSentinel;
+
+    // Arrival case: the init function must NOT reset areasSpoiled.
+    Combo_SetStartupEntrance(0x0100); // any pending entrance -> "a switch into OoT is in flight"
+    if (!Combo_HasStartupEntranceForGame("oot")) {
+        fprintf(stderr, "[tracker-crossgame] check: could not arm the OoT arrival flag; test setup is broken\n");
+        Combo_ClearStartupEntrance();
+        return 9;
+    }
+    InitTrackerData(true);
+    if (areasSpoiled != kAreasSentinel) {
+        fprintf(stderr, "[tracker-crossgame] check: FAIL - areasSpoiled reset by the arrival init (0x%X != 0x%X)\n",
+                areasSpoiled, kAreasSentinel);
+        failures++;
+    }
+
+    // Control: without the arrival flag the reset MUST fire (non-vacuous).
+    Combo_ClearStartupEntrance();
+    InitTrackerData(true);
+    if (areasSpoiled != 0) {
+        fprintf(stderr, "[tracker-crossgame] check: FAIL - init did NOT reset areasSpoiled off the arrival path "
+                        "(lock is vacuous, 0x%X)\n",
+                areasSpoiled);
+        failures++;
+    }
+
+    fprintf(stderr, "[tracker-crossgame] check: %d failures\n", failures);
+    return failures;
 }
 
 void SaveTrackerData(SaveContext* saveContext, int sectionID, bool fullSave) {

--- a/games/oot/soh/Enhancements/randomizer/randomizer_item_tracker.cpp
+++ b/games/oot/soh/Enhancements/randomizer/randomizer_item_tracker.cpp
@@ -1,4 +1,5 @@
 #include <algorithm>
+#include <cstdio>
 #include <map>
 #include <string>
 #include <vector>
@@ -1775,9 +1776,91 @@ void UpdateVectors() {
     shouldUpdateVectors = false;
 }
 
+// Cross-game OoT arrival: do NOT blank the player's typed tracker notes when a
+// switch INTO OoT is restoring the live session (#482, same class/shape as
+// #441's ClearItemLocations guard). ItemTrackerInitFile is a SaveManager
+// initFunc, so the arrival title-demo chain runs it: a switch into OoT cold-boots
+// the title screen, Opening_SetupTitleScreen -> OoT_Sram_InitDebugSave ->
+// Save_InitFile(true) dispatches every initFunc. The frozen OoT save is restored
+// afterwards at Play_ConsumeStartupEntrance WITHOUT going through Save_LoadFile,
+// so nothing re-runs ItemTrackerLoadFile to rehydrate the notes. itemTrackerNotes
+// lives OUTSIDE gSaveContext (a module static), so blanking it here strands the
+// player's notes for the rest of the OoT session -- and the very next save
+// persists the empty buffer over their real notes via ItemTrackerSaveFile. A
+// genuine boot or return-to-title (no arrival in flight) still clears, and the
+// file load that follows rehydrates the notes as before.
+extern "C" bool Combo_HasStartupEntranceForGame(const char* gameId);
+
 void ItemTrackerInitFile(bool isDebug) {
+    if (Combo_HasStartupEntranceForGame("oot")) {
+        return;
+    }
     itemTrackerNotes.clear();
     itemTrackerNotes.push_back(0);
+}
+
+// ---- Arrival-rehydration lock (#482), item-tracker half. -------------------
+// Drives the REAL ItemTrackerInitFile (the init function the arrival title-demo
+// Save_InitFile(true) dispatches) with the OoT arrival flag set -- the notes MUST
+// survive -- and without it -- the clear MUST still fire, so the pass is not
+// vacuous. Self-contained and pure (no OTR/display/SaveManager needed), because
+// the CI rando tier has no game archive and therefore never registers the tracker
+// initFuncs (SohGui::SetupGuiElements is gated on hasGameArchive). Returns the
+// failure count.
+extern "C" {
+void Combo_SetStartupEntrance(uint16_t entrance);
+void Combo_ClearStartupEntrance(void);
+}
+
+static bool ItemTrackerNotesEqual(const char* text) {
+    const char* data = itemTrackerNotes.Data;
+    if (data == nullptr) {
+        return text[0] == '\0';
+    }
+    for (size_t i = 0;; ++i) {
+        if (data[i] != text[i]) {
+            return false;
+        }
+        if (data[i] == '\0') {
+            return true;
+        }
+    }
+}
+
+extern "C" int RandoTest_ItemTrackerArrivalLock(void) {
+    int failures = 0;
+    const char* kNotes = "rsbs-crossgame-notes";
+
+    itemTrackerNotes.clear();
+    for (const char* p = kNotes; *p != '\0'; ++p) {
+        itemTrackerNotes.push_back(*p);
+    }
+    itemTrackerNotes.push_back('\0');
+
+    // Arrival case: the init function must NOT blank the notes.
+    Combo_SetStartupEntrance(0x0100); // any pending entrance -> "a switch into OoT is in flight"
+    if (!Combo_HasStartupEntranceForGame("oot")) {
+        fprintf(stderr, "[tracker-crossgame] item: could not arm the OoT arrival flag; test setup is broken\n");
+        Combo_ClearStartupEntrance();
+        return 9;
+    }
+    ItemTrackerInitFile(true);
+    if (!ItemTrackerNotesEqual(kNotes)) {
+        fprintf(stderr, "[tracker-crossgame] item: FAIL - itemTrackerNotes blanked by the arrival init\n");
+        failures++;
+    }
+
+    // Control: without the arrival flag the clear MUST fire (non-vacuous).
+    Combo_ClearStartupEntrance();
+    ItemTrackerInitFile(true);
+    if (!ItemTrackerNotesEqual("")) {
+        fprintf(stderr, "[tracker-crossgame] item: FAIL - init did NOT clear itemTrackerNotes off the arrival path "
+                        "(lock is vacuous)\n");
+        failures++;
+    }
+
+    fprintf(stderr, "[tracker-crossgame] item: %d failures\n", failures);
+    return failures;
 }
 
 void ItemTrackerSaveFile(SaveContext* saveContext, int sectionID, bool fullSave) {

--- a/src/common/test_runner.cpp
+++ b/src/common/test_runner.cpp
@@ -388,6 +388,15 @@ extern "C" int Rando_HeadlessHintReloadTest(const char* seedStr);
 // Drives the real Save_Init with and without the arrival flag.
 extern "C" int Rando_HeadlessHintCrossGameTest(const char* seedStr);
 extern "C" void InitOTRForMMFirstBoot(int argc, char* argv[]);
+// Arrival-rehydration lock (#482), bodies in the two OoT tracker TUs
+// (randomizer_item_tracker.cpp / randomizer_check_tracker.cpp). Each drives the
+// REAL SaveManager initFunc that the arrival title-demo Save_InitFile(true)
+// dispatches (ItemTrackerInitFile / InitTrackerData), with the OoT arrival flag
+// set (the out-of-save tracker global must survive) and without it (the clear
+// must still fire, so the pass is not vacuous). Both are pure -- no OTR/display
+// -- so they run in the display-free suite. Each returns a failure count.
+extern "C" int RandoTest_ItemTrackerArrivalLock(void);
+extern "C" int RandoTest_CheckTrackerArrivalLock(void);
 
 TestResult Test_RandoGen(void) {
     printf("[TEST] rando-gen: seed generation succeeds with default settings (#337)\n");
@@ -484,6 +493,26 @@ TestResult Test_RandoHintCrossGame(void) {
     int rc = Rando_HeadlessHintCrossGameTest("RSBSHINT1");
     printf("[TEST] %s: hint cross-game rc=%d\n", rc == 0 ? "PASS" : "FAIL", rc);
     return rc == 0 ? TEST_PASS : TEST_FAIL;
+}
+
+// Arrival-rehydration lock (#482). Two more instances of the #441 class on the
+// OoT side: the check tracker's `areasSpoiled` and the item tracker's typed
+// `itemTrackerNotes` are blanked by SaveManager initFuncs that the arrival
+// title-demo Save_InitFile(true) dispatches, but the frozen save is restored at
+// Play_ConsumeStartupEntrance without re-running Save_LoadFile, so nothing
+// rehydrates them -- they live OUTSIDE gSaveContext. Both are guarded with
+// Combo_HasStartupEntranceForGame("oot"). This lock drives the real init
+// functions with the arrival flag set (state must survive) and without it (the
+// clear must still fire, proving the pass is non-vacuous). Pure (no display, no
+// OTR, no game archive), so unlike the rando-hint locks it runs in the
+// display-free suite and is NOT skipped by `--test all`.
+TestResult Test_TrackerArrivalRehydration(void) {
+    printf("[TEST] tracker-arrival-rehydration: check/item tracker state survives a cross-game OoT arrival (#482)\n");
+    int failures = 0;
+    failures += RandoTest_CheckTrackerArrivalLock();
+    failures += RandoTest_ItemTrackerArrivalLock();
+    printf("[TEST] %s: tracker arrival rehydration failures=%d\n", failures == 0 ? "PASS" : "FAIL", failures);
+    return failures == 0 ? TEST_PASS : TEST_FAIL;
 }
 
 // Lane B unified-seed lock. Single run: bring up OoT, generate one pinned seed,
@@ -1209,6 +1238,12 @@ const TestDescriptor gTests[] = {
     // whose title-chain Save_Init used to wipe the placement table. Needs a
     // display like rando-gen, so `--test all` skips it (below).
     {"rando-hint-crossgame", "Item hints survive a cross-game OoT arrival (#441)", Test_RandoHintCrossGame},
+    // #482: two more instances of the #441 class -- the check tracker's
+    // areasSpoiled and the item tracker's typed notes are blanked by arrival
+    // init-funcs and never rehydrated. Pure (no display), so it runs in the
+    // display-free suite (NOT skipped by `--test all`).
+    {"tracker-arrival-rehydration", "Check/item tracker state survives a cross-game OoT arrival (#482)",
+     Test_TrackerArrivalRehydration},
     // Lane B unified seed: producer stamps gComboCtx at generation time; the
     // two-process same-seed determinism diff runs via the SeedDeterminism row.
     // Needs a display like rando-gen, so `--test all` skips it (below).


### PR DESCRIPTION
Fixes two instances found by the arrival-rehydration audit **#482**.

## The class (fourth and fifth instances)

A switch INTO a game cold-boots its title/init chain, which clears live in-memory derived state; the frozen `SaveContext` is restored afterward at `*_Play_ConsumeStartupEntrance` **without re-running `Save_LoadFile`/`LoadRandomizer`**, so any derived state the boot chain clears but the consume path doesn't rebuild decays silently. Prior: #439/#447, #469/#472, #441/#481.

On the OoT arrival, `Opening_SetupTitleScreen` → `OoT_Sram_InitDebugSave` → `Save_InitFile(true)` dispatches every SaveManager `initFunc`. Two of them blank state that lives **outside `gSaveContext`** and is never rehydrated by the consume path:

| initFunc | out-of-save state | symptom |
|---|---|---|
| `ItemTrackerInitFile` (`randomizer_item_tracker.cpp`) | `itemTrackerNotes` (typed notes) | notes blanked every OoT return leg; **permanently lost on next save** via `ItemTrackerSaveFile` |
| `InitTrackerData` (`randomizer_check_tracker.cpp`) | `areasSpoiled` (revealed-area bitmask) | revealed check-tracker areas reset every return leg; persisted as 0 on next save |

Both are invisible to save-file forensics (the on-disk save was correct until the blanked value is persisted), exactly the #441 shape.

## Fix

Guard both clears with `Combo_HasStartupEntranceForGame("oot")` — the established #441 pattern. A cross-game OoT arrival restoring the live session keeps the state; a genuine boot or return-to-title still clears, and the file load that follows rebuilds it.

## Lock

`tracker-arrival-rehydration` (`redship` label) drives the **real** init functions with the arrival flag set (state must survive) **and** without it (the clear must still fire, so the pass is non-vacuous — the #481 bar). Pure — no display, no OTR, no game archive — because the CI rando tier never registers the tracker `initFuncs` (`SohGui::SetupGuiElements` is gated on `hasGameArchive`), so it runs in the display-free suite and is not skipped by `--test all`. Red without the guards, green with them (counterfactual verification in the PR checks).

## Audit result

Full classified table of both games' arrival boot-init chains is in **#482**. The MM side is structurally covered by the #447 `OnSaveLoad` re-dispatch at `MM_Play_ConsumeStartupEntrance` (it rebuilds the entire `OnSaveLoad`-driven derived set); its one weak, self-healing candidate (`sSoundMode`) is filed separately as **#483**. These two OoT tracker clears are the only BROKEN instances warranting a fix.

Follow-up: #392.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!--- section:artifacts:start -->
### Build Artifacts
  - [rsbs-windows.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/8516565693.zip)
  - [rsbs-linux.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/8516414413.zip)
<!--- section:artifacts:end -->