### PR TITLE
Stop a moon crash from stripping the paired MM world's randomizer identity

### DIFF
--- a/CMake/SingleExecutable.cmake
+++ b/CMake/SingleExecutable.cmake
@@ -598,6 +598,21 @@ if(BUILD_TESTING)
         TIMEOUT 180
         ENVIRONMENT "SDL_AUDIODRIVER=dummy;RSBS_DISABLE_OTR_INIT=1")
 
+    # The operator-confirmed P0. A moon crash (three-day clock expiring, e.g.
+    # while AFK) runs Sram_ResetSaveFromMoonCrash, which re-reads the file from
+    # flash and memcpy's sizeof(Save) over gSaveContext.save. ShipSaveInfo --
+    # saveType AND the whole rando block -- is a MEMBER of Save, and a cross-game
+    # paired world lives only in memory until the player saves, so the reload
+    # stripped the randomizer identity: every IS_RANDO COND_HOOK unregistered and
+    # MM played vanilla, permanently, because the next switch-out froze that save.
+    # Probes arm state through a VB verdict, not a hook count (COND_HOOK's
+    # Unregister is deferred, so a count lags a disarm and would pass vacuously).
+    # Same display requirement, hence the same label/env.
+    redship_add_test(NAME MMMoonCrashArmState COMMAND redship --test mm-moon-crash-arm-state
+        LABEL rando
+        TIMEOUT 180
+        ENVIRONMENT "SDL_AUDIODRIVER=dummy;RSBS_DISABLE_OTR_INIT=1")
+
     # ========================================================================
     # Lane B — unified seed -> paired world (Phase 3.0)
     #

--- a/games/mm/2s2h/GameExports_SingleExe.cpp
+++ b/games/mm/2s2h/GameExports_SingleExe.cpp
@@ -1829,6 +1829,37 @@ void MM_Rando_PairOnCrossGameArrival(int hadFrozenState) {
     }
 
     if (hadFrozenState) {
+        // Self-heal a save that is INTERNALLY INCONSISTENT before accepting it.
+        //
+        // A legitimately vanilla MM file always has rando.finalSeed == 0:
+        // Sram_ResetSave memsets shipSaveInfo wholesale and MM_Sram_InitNewSave
+        // then stamps SAVETYPE_VANILLA, so nothing in MM's own code can author
+        // "a complete rando world sitting under a vanilla type byte". Seeing it
+        // is positive evidence that a RANDO file lost its type byte to a bulk
+        // Save overwrite (the moon-crash reload in z_sram_NES.c
+        // Sram_ResetSaveFromMoonCrash is the operator-confirmed instance, fixed
+        // at its source; this is the belt-and-braces catch for that whole class).
+        //
+        // Without this, the loss is PERMANENT and silent: once a vanilla-stamped
+        // save is frozen on the next switch-out, every later return leg restores
+        // it, re-reports "existing save", and MM plays vanilla forever with the
+        // player's entire placement table still sitting intact underneath.
+        if (!alreadyRando && gSaveContext.save.shipSaveInfo.rando.finalSeed != 0) {
+            gSaveContext.save.shipSaveInfo.saveType = SAVETYPE_RANDO;
+            fprintf(stderr,
+                    "[MM] pairing: REPAIRED — restored save carried a complete rando world "
+                    "(finalSeed=%08X) under saveType=vanilla; re-stamping SAVETYPE_RANDO\n",
+                    gSaveContext.save.shipSaveInfo.rando.finalSeed);
+            fflush(stderr);
+            // Fall through to the skip below: the world is the player's own and
+            // must NOT be regenerated. z_play.c's GameInteractor_ExecuteOnSaveLoad
+            // at the end of MM_Play_ConsumeStartupEntrance then arms the IS_RANDO
+            // COND_HOOKs against the repaired save.
+            fprintf(stderr, "[MM] pairing: skipped-because-existing-mm-save "
+                            "(frozen MM session restored, saveType=rando) — an existing file is never regenerated\n");
+            return;
+        }
+
         // A restored MM session — vanilla or rando — is the player's own save.
         // Re-running generation over it would wipe their progress (OnFileCreate
         // memsets shipSaveInfo.rando and re-authors the starting state), so the

--- a/games/mm/2s2h/mm_rando_gen_test.cpp
+++ b/games/mm/2s2h/mm_rando_gen_test.cpp
@@ -1159,4 +1159,191 @@ extern "C" int MM_Rando_HeadlessReloadArmState(void) {
     return 0;
 }
 
+// ============================================================================
+// Moon-crash arm-state lock — the operator-confirmed P0.
+//
+// A moon crash (the three-day clock expiring, e.g. while AFK) runs
+// Sram_ResetSaveFromMoonCrash (games/mm/src/code/z_sram_NES.c), which re-reads
+// the file from flash and memcpy's sizeof(Save) over gSaveContext.save.
+// ShipSaveInfo -- carrying saveType AND the whole rando block (finalSeed,
+// options, the RC_MAX placement table) -- is a MEMBER of Save, so that memcpy
+// overwrites the randomizer identity wholesale.
+//
+// A cross-game paired MM world is authored IN MEMORY at the arrival and is not
+// in MM flash until the player saves, so the reload pulls a vanilla on-disk
+// save: saveType reverts to SAVETYPE_VANILLA, every IS_RANDO COND_HOOK
+// unregisters, and MM plays vanilla for the rest of the session -- then the next
+// switch-out freezes THAT save, so the vanilla world survives every later return
+// leg. That is the "paired MM world plays vanilla" report.
+//
+// This row drives the REAL Sram_ResetSaveFromMoonCrash against a live paired
+// world. Arm state is probed through a VB verdict rather than a hook COUNT:
+// COND_HOOK's Unregister is DEFERRED (mm_game_hooks.h), so CountForTest lags a
+// disarm and would let this pass vacuously -- the same weakness that let the
+// original bug ship green.
+// ============================================================================
+extern "C" int MM_Rando_HeadlessMoonCrashArmState(void) {
+    auto ctx = Ship::Context::GetInstance();
+    if (ctx == nullptr || ctx->GetConsoleVariables() == nullptr) {
+        fprintf(stderr, "[MM-MOONCRASH] FAIL(1): Ship::Context not live\n");
+        return 1;
+    }
+
+    MM_Rando_Init();
+    if (Rando::Logic::Regions.empty()) {
+        fprintf(stderr, "[MM-MOONCRASH] FAIL(2): Logic/Regions graph empty — rando surface elided\n");
+        return 2;
+    }
+    if (gRegEditor == NULL) {
+        static RegEditor sMoonCrashRegEditor = {};
+        gRegEditor = &sMoonCrashRegEditor;
+    }
+
+    ComboContext_Init();
+    Combo_ClearForeignPlacements();
+    Combo_ClearFrozenState("mm");
+    Combo_ClearStartupEntrance();
+
+    // ----------------------------------------------------------------------
+    // Phase 1 — a live paired rando world, armed.
+    // fileNum 0 (not the cross-game session's 0xFF) keeps the flash page-table
+    // indexing inside gFlashSaveStartPages; this row is about saveType
+    // preservation, not the fileNum indexing question.
+    // ----------------------------------------------------------------------
+    memset(&gSaveContext, 0, sizeof(gSaveContext));
+    MM_Sram_InitNewSave();
+    gSaveContext.fileNum = 0;
+    gSaveContext.save.shipSaveInfo.saveType = SAVETYPE_RANDO;
+    gSaveContext.save.shipSaveInfo.rando.finalSeed = 0xC0FFEE01;
+    RANDO_SAVE_CHECKS[RC_CLOCK_TOWN_SOUTH_PLATFORM_PIECE_OF_HEART].shuffled = true;
+    GameInteractor_ExecuteOnSaveLoad(gSaveContext.fileNum);
+
+    if (GameInteractor_Should(VB_GIVE_ITEM_FROM_GREAT_FAIRY, true)) {
+        fprintf(stderr, "[MM-MOONCRASH] FAIL(3): the paired world did not arm the IS_RANDO give override — "
+                        "premise broken before the moon crash\n");
+        return 3;
+    }
+
+    // ----------------------------------------------------------------------
+    // Phase 2 — the REAL moon-crash reset. Flash holds no rando save for this
+    // in-memory paired world (nothing was ever written), which is exactly the
+    // production condition: the reload yields a zeroed/vanilla Save.
+    // ----------------------------------------------------------------------
+    static u8 sMoonCrashSaveBuf[SAVE_BUFFER_SIZE];
+    SramContext moonCrashSram = {};
+    moonCrashSram.saveBuf = sMoonCrashSaveBuf;
+
+    Sram_ResetSaveFromMoonCrash(&moonCrashSram);
+
+    // ----------------------------------------------------------------------
+    // Phase 3 — the world identity must survive, and the hooks must still be
+    // armed against it. A moon crash resets the CYCLE, never the rando identity.
+    // ----------------------------------------------------------------------
+    if (gSaveContext.save.shipSaveInfo.saveType != SAVETYPE_RANDO) {
+        fprintf(stderr, "[MM-MOONCRASH] FAIL(4): the moon-crash save reload reverted saveType to vanilla — every "
+                        "IS_RANDO hook disarms and MM plays vanilla for the rest of the session\n");
+        return 4;
+    }
+    if (gSaveContext.save.shipSaveInfo.rando.finalSeed != 0xC0FFEE01) {
+        fprintf(stderr,
+                "[MM-MOONCRASH] FAIL(5): the moon-crash reload lost the paired world identity "
+                "(finalSeed %08X, expected C0FFEE01)\n",
+                gSaveContext.save.shipSaveInfo.rando.finalSeed);
+        return 5;
+    }
+    if (!RANDO_SAVE_CHECKS[RC_CLOCK_TOWN_SOUTH_PLATFORM_PIECE_OF_HEART].shuffled) {
+        fprintf(stderr, "[MM-MOONCRASH] FAIL(6): the moon-crash reload wiped the placement table — the world would "
+                        "be armed but empty\n");
+        return 6;
+    }
+    if (GameInteractor_Should(VB_GIVE_ITEM_FROM_GREAT_FAIRY, true)) {
+        fprintf(stderr, "[MM-MOONCRASH] FAIL(7): saveType survived but the IS_RANDO hooks were left unregistered by "
+                        "the reload — MM would still play vanilla on a save that claims to be rando\n");
+        return 7;
+    }
+
+    // ----------------------------------------------------------------------
+    // Phase 4 — SELF-HEAL an already-corrupted save, through the REAL arrival.
+    //
+    // Saves damaged by this bug before the fix landed are still on disk: a
+    // complete rando world (finalSeed + placement table intact) sitting under
+    // saveType=VANILLA. MM's own code can never author that combination --
+    // Sram_ResetSave memsets shipSaveInfo wholesale and MM_Sram_InitNewSave then
+    // stamps SAVETYPE_VANILLA, so a vanilla file always has finalSeed == 0.
+    // Seeing it is positive evidence that a rando file lost its type byte, and
+    // MM_Rando_PairOnCrossGameArrival re-stamps SAVETYPE_RANDO rather than
+    // accepting a permanently-vanilla world.
+    //
+    // Driven through MM_Play_ConsumeStartupEntrance -- the real consumption
+    // point -- not by calling the pairing directly, so this covers the actual
+    // arrival path a player takes.
+    // ----------------------------------------------------------------------
+    const uint16_t kArrival = 0xD800; // ENTRANCE(SOUTH_CLOCK_TOWN, 0) — the OoT->MM arrival
+
+    ComboContext_Init();
+    Combo_ClearForeignPlacements();
+    Combo_ClearFrozenState("mm");
+    Combo_ClearStartupEntrance();
+
+    memset(&gSaveContext, 0, sizeof(gSaveContext));
+    MM_Sram_InitNewSave();
+    gSaveContext.fileNum = 0;
+
+    // DISARM first, against the vanilla bootstrap -- exactly what the arrival's
+    // cold gamestate-chain boot does before the consume. Without this the
+    // hooks would still be armed from Phase 1 and the re-arm assertion below
+    // would pass whether or not the repair actually re-dispatched anything,
+    // i.e. vacuously. (That is precisely the weakness this row exists to
+    // avoid: MMPairSwitchEntry's arming assertion is a bare count delta.)
+    GameInteractor_ExecuteOnSaveLoad(gSaveContext.fileNum);
+    if (!GameInteractor_Should(VB_GIVE_ITEM_FROM_GREAT_FAIRY, true)) {
+        fprintf(stderr, "[MM-MOONCRASH] FAIL(8): the vanilla bootstrap did not disarm the IS_RANDO give override — "
+                        "the Phase 4 re-arm assertion would be vacuous\n");
+        return 8;
+    }
+
+    // The corrupted shape: live rando world, vanilla type byte.
+    gSaveContext.save.shipSaveInfo.saveType = SAVETYPE_VANILLA;
+    gSaveContext.save.shipSaveInfo.rando.finalSeed = 0xC0FFEE02;
+    RANDO_SAVE_CHECKS[RC_CLOCK_TOWN_SOUTH_PLATFORM_PIECE_OF_HEART].shuffled = true;
+
+    // A paired OoT world exists (Lane B stamp), and this is a return leg: a
+    // frozen MM session restored by the consume below.
+    gComboCtx.sourceIsRando = 1;
+    gComboCtx.sharedRandoSeed = 4170548651u;
+    gComboCtx.sharedRandoSettingsHash = 0x5DAD32CEu;
+    Combo_FreezeState("mm", kArrival, &gSaveContext, sizeof(gSaveContext));
+    Combo_SetStartupEntrance(kArrival);
+
+    MM_Play_ConsumeStartupEntrance();
+
+    if (gSaveContext.save.shipSaveInfo.saveType != SAVETYPE_RANDO) {
+        fprintf(stderr, "[MM-MOONCRASH] FAIL(9): a restored save carrying a complete rando world under "
+                        "saveType=vanilla was accepted as vanilla — the world is unrecoverable and MM plays "
+                        "vanilla forever\n");
+        return 9;
+    }
+    if (gSaveContext.save.shipSaveInfo.rando.finalSeed != 0xC0FFEE02) {
+        fprintf(stderr, "[MM-MOONCRASH] FAIL(10): the repair regenerated or clobbered the player's world "
+                        "(finalSeed changed) — an existing file must never be regenerated\n");
+        return 10;
+    }
+    if (GameInteractor_Should(VB_GIVE_ITEM_FROM_GREAT_FAIRY, true)) {
+        fprintf(stderr, "[MM-MOONCRASH] FAIL(11): the repaired save did not leave the IS_RANDO hooks armed\n");
+        return 11;
+    }
+    fprintf(stderr, "[MM-MOONCRASH] self-heal repaired a vanilla-stamped rando world through the real arrival\n");
+
+    // Leave clean global state for later dispatches in the same process.
+    ComboContext_Init();
+    Combo_ClearForeignPlacements();
+    Combo_ClearFrozenState("mm");
+    Combo_ClearStartupEntrance();
+    memset(&gSaveContext, 0, sizeof(gSaveContext));
+
+    fprintf(stderr, "[MM-MOONCRASH] PASS: a moon crash preserves the paired world identity, leaves the IS_RANDO "
+                    "hooks armed, and an already-corrupted save self-heals on arrival\n");
+    return 0;
+}
+
 #endif // RSBS_SINGLE_EXECUTABLE

--- a/games/mm/src/code/z_sram_NES.c
+++ b/games/mm/src/code/z_sram_NES.c
@@ -1257,10 +1257,44 @@ void MM_Sram_InitDebugSave(void) {
     Sram_GenerateRandomSaveFields();
 }
 
+#ifdef RSBS_SINGLE_EXECUTABLE
+// Moon-crash reset must not destroy a cross-game paired world (#392 class).
+//
+// The reload below re-reads the file from flash and memcpy's sizeof(Save) over
+// gSaveContext.save. ShipSaveInfo -- which carries saveType AND the whole rando
+// block (finalSeed, options, the RC_MAX placement table) -- is a MEMBER of Save
+// (z64save.h), so that memcpy overwrites the randomizer identity wholesale.
+//
+// A cross-game paired MM world is authored IN MEMORY at the arrival
+// (MM_Rando_PairOnCrossGameArrival -> OnFileCreate) and is not represented in MM
+// flash until the player saves. So on a moon crash the reload pulls a vanilla
+// on-disk save, saveType reverts to SAVETYPE_VANILLA, every IS_RANDO COND_HOOK
+// unregisters, and MM silently plays vanilla for the rest of the session -- and
+// the next switch-out freezes THAT save into the blob, so the vanilla world then
+// survives every later return leg. Operator-confirmed: an AFK moon crash was the
+// trigger behind "the paired MM world plays vanilla".
+//
+// A moon crash resets the CYCLE, not the world's identity. Preserve the rando
+// half across the reload, exactly as cutsceneIndex is preserved just below --
+// but only when the reload actually lost it (flash held no rando save). If the
+// file on disk IS a rando save, upstream semantics win and this is a no-op.
+//
+// File-static rather than a stack local: ShipSaveInfo embeds randoSaveChecks
+// [RC_MAX] and is multiple KB. The save path is single-threaded.
+static ShipSaveInfo sMoonCrashShipSaveInfo;
+#endif
+
 void Sram_ResetSaveFromMoonCrash(SramContext* sramCtx) {
     GameInteractor_ExecuteBeforeMoonCrashSaveReset();
     s32 i;
     s32 cutsceneIndex = gSaveContext.save.cutsceneIndex;
+#ifdef RSBS_SINGLE_EXECUTABLE
+    s32 wasRando = (gSaveContext.save.shipSaveInfo.saveType == SAVETYPE_RANDO);
+
+    if (wasRando) {
+        sMoonCrashShipSaveInfo = gSaveContext.save.shipSaveInfo;
+    }
+#endif
 
     memset(sramCtx->saveBuf, 0, SAVE_BUFFER_SIZE);
 
@@ -1280,6 +1314,20 @@ void Sram_ResetSaveFromMoonCrash(SramContext* sramCtx) {
         memcpy(&gSaveContext, sramCtx->saveBuf, sizeof(Save));
     }
     gSaveContext.save.cutsceneIndex = cutsceneIndex;
+#ifdef RSBS_SINGLE_EXECUTABLE
+    if (wasRando && gSaveContext.save.shipSaveInfo.saveType != SAVETYPE_RANDO) {
+        gSaveContext.save.shipSaveInfo = sMoonCrashShipSaveInfo;
+        // Re-arm the save-shape-dependent hooks against the save that actually
+        // reaches gameplay -- the same contract MM_Play_ConsumeStartupEntrance
+        // honours at the cross-game arrival (games/mm/src/code/z_play.c). The
+        // rando behavior hooks are COND_HOOKs re-evaluated on OnSaveLoad against
+        // IS_RANDO; restoring saveType without re-dispatching would leave them
+        // unregistered from the reload above, i.e. still-vanilla behavior on a
+        // save that now correctly claims to be rando. Idempotent by
+        // construction: COND_HOOK unregisters before re-registering.
+        GameInteractor_ExecuteOnSaveLoad(gSaveContext.fileNum);
+    }
+#endif
 
     for (i = 0; i < ARRAY_COUNT(gSaveContext.eventInf); i++) {
         gSaveContext.eventInf[i] = 0;

--- a/src/common/test_runner.cpp
+++ b/src/common/test_runner.cpp
@@ -641,6 +641,34 @@ TestResult Test_MMReloadArmState(void) {
     return rc == 0 ? TEST_PASS : TEST_FAIL;
 }
 
+// Moon-crash arm-state lock (the operator-confirmed P0). A moon crash reloads
+// the file from flash over gSaveContext.save; ShipSaveInfo (saveType + the whole
+// rando block) is a MEMBER of Save, so an in-memory paired world loses its
+// randomizer identity and MM silently plays vanilla from then on -- permanently,
+// because the next switch-out freezes the vanilla save. Drives the REAL
+// Sram_ResetSaveFromMoonCrash and probes arm state through a VB verdict (not a
+// hook count, which lags a deferred unregister). Bridge body in
+// games/mm/2s2h/mm_rando_gen_test.cpp. Needs a display, same as mm-rando-gen.
+extern "C" int MM_Rando_HeadlessMoonCrashArmState(void);
+
+TestResult Test_MMMoonCrashArmState(void) {
+    printf("[TEST] mm-moon-crash-arm-state: a moon crash preserves the paired world and its IS_RANDO hooks\n");
+
+    auto ctx = CreateHarnessStyleContext();
+    if (!ctx) {
+        printf("[TEST] FAIL: could not create Ship::Context singleton\n");
+        return TEST_FAIL;
+    }
+
+    static char arg0[] = "redship";
+    static char* fakeArgv[] = { arg0, nullptr };
+    InitOTRForMMFirstBoot(1, fakeArgv);
+
+    int rc = MM_Rando_HeadlessMoonCrashArmState();
+    printf("[TEST] %s: moon-crash arm-state rc=%d\n", rc == 0 ? "PASS" : "FAIL", rc);
+    return rc == 0 ? TEST_PASS : TEST_FAIL;
+}
+
 TestResult Test_BootMM(void) {
     printf("[TEST] boot-mm: MM-first bring-up prerequisites (#330)\n");
     sTargetGame = GAME_MM;
@@ -1263,6 +1291,10 @@ const TestDescriptor gTests[] = {
     // mm-rando-gen, so `--test all` skips it.
     {"mm-reload-arm-state", "IS_RANDO hooks match the save on MM's non-arrival entry paths (#439)",
      Test_MMReloadArmState},
+    // The operator-confirmed P0: a moon crash must not strip a paired world's
+    // randomizer identity. Same display requirement, so `--test all` skips it.
+    {"mm-moon-crash-arm-state", "A moon crash preserves the paired MM world and its IS_RANDO hooks",
+     Test_MMMoonCrashArmState},
     {"boot-oot", "Shared-context bring-up leaves no null subsystems (#329)", Test_BootOoT},
     {"boot-mm", "MM-first bring-up prerequisites on the shared context (#330)", Test_BootMM},
     {"switch-oot-mm", "Test game switch OoT -> MM", Test_SwitchOoTMM},
@@ -1436,7 +1468,8 @@ int TestRunner_Run(const char* testName) {
                 strcmp(gTests[i].name, "rando-hint-crossgame") == 0 ||
                 strcmp(gTests[i].name, "mm-rando-gen") == 0 ||
                 strcmp(gTests[i].name, "mm-pair-switch-entry") == 0 ||
-                strcmp(gTests[i].name, "mm-reload-arm-state") == 0) {
+                strcmp(gTests[i].name, "mm-reload-arm-state") == 0 ||
+                strcmp(gTests[i].name, "mm-moon-crash-arm-state") == 0) {
                 printf("\n--- Skipping: %s (needs display; runs as a rando-label CTest) ---\n", gTests[i].name);
                 continue;
             }


### PR DESCRIPTION
Fixes the operator-confirmed **P0**: the paired MM world played fully vanilla after a cross-game round trip, and stayed vanilla forever afterwards.

## Root cause

A cross-game paired MM world is authored **in memory** at the OoT→MM arrival (`MM_Rando_PairOnCrossGameArrival` → `OnFileCreate`) and is not written to MM flash until the player saves.

When MM's three-day clock expires — a **moon crash**, e.g. while AFK — `z_demo.c` calls `Sram_ResetSaveFromMoonCrash`, which re-reads the file from flash and does:

```c
memcpy(&gSaveContext.save, sramCtx->saveBuf, sizeof(Save));
```

`ShipSaveInfo` carries `saveType` **and** the whole rando block (`finalSeed`, options, the `RC_MAX` placement table) and is a **member of `struct Save`** (`z64save.h`), so that memcpy overwrites the randomizer identity wholesale with the vanilla bytes on disk. `IS_RANDO` then reads false, every rando behavior `COND_HOOK` unregisters, and MM plays vanilla — and because the next switch-out **freezes that save into the cross-game blob**, the vanilla world survives every later return leg. Silent and permanent, with the player's placement table still sitting there intact.

Same class as #439 / #447 / #441 / #482 — live in-memory derived state destroyed by a re-authoring path that doesn't know about the cross-game session — reached from a new trigger.

## Operator evidence

Probe output across three round trips, first entry healthy:

```
[MM] pairing: paired world ACTIVE (mmFinalSeed=63175001 foreignPlacements=4)
[PROBE] OnSaveLoad #2: saveType=1 IS_RANDO=1 shuffledChecks=283
```

then after an AFK moon crash (operator returned to the opening Happy Mask Salesman cutscene — a cycle reset):

```
[MM] pairing: skipped-because-existing-mm-save (frozen MM session restored, saveType=vanilla)
```

A deliberate day-2 transition did **not** reproduce it, which is what isolated the trigger to the moon crash rather than an ordinary cycle/reload.

## Fix

1. **`z_sram_NES.c`** — snapshot `shipSaveInfo` before the flash reload; restore it when the reload lost the rando identity, then re-dispatch `GameInteractor_ExecuteOnSaveLoad` so the COND_HOOKs re-arm against the save that actually reaches gameplay (the same contract `MM_Play_ConsumeStartupEntrance` honours at the arrival). Mirrors the `cutsceneIndex` preservation already in that function; a no-op when flash legitimately holds a rando save. A moon crash resets the **cycle**, not the world's identity.

2. **`MM_Rando_PairOnCrossGameArrival`** — self-heal a restored save carrying a complete rando world (`rando.finalSeed != 0`) under `saveType=VANILLA`. MM's own code cannot author that combination (`Sram_ResetSave` memsets `shipSaveInfo` wholesale, `MM_Sram_InitNewSave` then stamps `SAVETYPE_VANILLA`, so a legitimate vanilla file always has `finalSeed == 0`), so it is positive evidence a rando file lost its type byte. Re-stamps `SAVETYPE_RANDO`, logs `pairing: REPAIRED`, and still returns **without regenerating**. Recovers saves already damaged before this landed.

## Lock

`mm-moon-crash-arm-state` (`rando` label) arms a paired world, drives the **real** `Sram_ResetSaveFromMoonCrash`, and asserts `saveType`, `finalSeed` and the placement table all survive with hooks still armed. Phase 4 first **disarms** against a vanilla bootstrap (asserting the disarm took, so the re-arm check cannot pass vacuously), then drives the **real** `MM_Play_ConsumeStartupEntrance` with a deliberately corrupted save to cover the self-heal — including that it does not regenerate.

Arm state is probed through a **VB verdict, not a hook count**: `COND_HOOK`'s `Unregister` is deferred, so `CountForTest` lags a disarm and would pass vacuously. That is precisely the weakness that let this ship green — `MMPairSwitchEntry`'s entire arming assertion is `OnFlagSet 0 -> 1`.

### Non-vacuousness (verified locally, both halves)

| Build | Result |
|---|---|
| Both fixes | **PASS** |
| Without fix 1 | **FAIL(4)** — `saveType` reverted to vanilla |
| Without fix 2 | **FAIL(9)** — corrupted world accepted as vanilla |

`mm-pair-switch-entry`, `mm-reload-arm-state`, `mm-rando-gen` all still pass. clang-format clean.

## Follow-ups (deliberately not in this PR)

- **`fileNum=255` OOB flash indexing.** A cross-game session runs with `fileNum == 0xFF`, and `Sram_ResetSaveFromMoonCrash` indexes `gFlashSaveStartPages[fileNum * FLASH_SAVE_MAIN_MULTIPLIER]` — a wild out-of-bounds read. Pre-existing and identical on `main`; adversarial review found it **inert today** (`SaveManager_GetFlashSaveFromPages` rejects the garbage page pair and both reads fail cleanly), so it is a latent defect rather than the cause of the operator's save corruption. Same shape in `z_message.c` and `SavingEnhancements.cpp` — range-check all three.
- **`MMPairSwitchEntry`'s vacuous arming assertion** should be strengthened to the VB-verdict probe used here.
- **`OnFileCreate`'s failure catch** leaves `rando.finalSeed` set while stamping `SAVETYPE_VANILLA`, making fix 2's invariant true-in-practice but not true-by-construction. `memset` the rando block there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!--- section:artifacts:start -->
### Build Artifacts
  - [rsbs-windows.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/8541369600.zip)
  - [rsbs-linux.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/8541139354.zip)
<!--- section:artifacts:end -->

