### PR TITLE
Guard MM flash page-table indexing against the 0xFF fileNum sentinel (fileNum=255 OOB)

### DIFF
--- a/.github/clang-format-paths.txt
+++ b/.github/clang-format-paths.txt
@@ -37,6 +37,7 @@ games/mm/2s2h/TrackersGuiSingleExe.cpp
 games/mm/2s2h/TrackersGuiSingleExe.h
 games/mm/2s2h/mm_culling_test.cpp
 games/mm/2s2h/mm_fb_effects_test.cpp
+games/mm/2s2h/mm_flash_filenum_test.cpp
 games/mm/2s2h/mm_framebuffer_effects.c
 games/mm/2s2h/mm_gi_shim_test.cpp
 games/mm/2s2h/mm_notification_binding_test.cpp

--- a/CMake/SingleExecutable.cmake
+++ b/CMake/SingleExecutable.cmake
@@ -466,6 +466,15 @@ if(BUILD_TESTING)
     # VisFbuf draw. This locks MM's call to its own MM_-dimension body (only one
     # definition survived, so no link error could catch the cross-bind).
     redship_add_test(NAME MMFbEffectsBinding COMMAND redship --test mm-fb-effects-binding)
+    # MM flash page-table OOB from the 0xFF fileNum sentinel
+    # (games/mm/2s2h/mm_flash_filenum_test.cpp). A cross-game MM session runs
+    # with gSaveContext.fileNum == 0xFF (no real file slot); the moon-crash reset
+    # and the owl-delete write it fires index gFlashSave*Pages /
+    # gFlashOwlSave*Pages by fileNum * FLASH_SAVE_MAIN_MULTIPLIER, so 0xFF runs
+    # hundreds of entries past the tables' end, and the reset copies the garbage
+    # over the live save (spawn-as-Fierce-Deity / all-Ocarina corruption).
+    # Display-free and ROM-free, so it runs in this redship tier.
+    redship_add_test(NAME MMFlashFileNumOob COMMAND redship --test mm-flash-filenum-oob)
     # MM tracker registration surface (#392): the four MM tracker windows must
     # register on the shared Gui under "MM "-prefixed names (SoH owns the
     # unprefixed ones; Gui::AddGuiWindow rejects duplicates) and their

--- a/games/mm/2s2h/mm_flash_filenum_test.cpp
+++ b/games/mm/2s2h/mm_flash_filenum_test.cpp
@@ -1,0 +1,159 @@
+/**
+ * @file mm_flash_filenum_test.cpp
+ * ROM-free, display-free lock for the MM flash page-table out-of-bounds read
+ * driven by gSaveContext.fileNum == 0xFF. CTest label "redship", row
+ * MMFlashFileNumOob in CMake/SingleExecutable.cmake, dispatch "mm-flash-filenum-oob"
+ * in src/common/test_runner.cpp.
+ *
+ * What was broken: a cross-game MM session runs with fileNum == 0xFF (the
+ * "no real file slot" sentinel the title/debug/mapselect boot leaves in
+ * gSaveContext, and which no cross-game arrival replaces). MM's flash paths
+ * index the fixed-size gFlashSave*Pages / gFlashOwlSave*Pages tables by
+ * `fileNum * FLASH_SAVE_MAIN_MULTIPLIER`, so 0xFF subscripts them at 510 --
+ * hundreds of entries past the end. On the moon-crash reset path
+ * (Sram_ResetSaveFromMoonCrash, plus DeleteOwlSave -> func_80147314 fired from
+ * the BeforeMoonCrashSaveReset hook) that wild index becomes a flash page
+ * number/count and the reset then copies the resulting garbage over the live
+ * save -- the operator's "spawn as Fierce Deity in the opening cutscene with
+ * every inventory slot reading as the Ocarina of Time" corruption.
+ *
+ * The invariant this locks: for every reachable fileNum -- including the 0xFF
+ * sentinel -- no flash page-table index is computed out of bounds, and the
+ * reported reset paths leave the live save intact when there is no real slot.
+ *
+ * Three checks, none needing a display or ROM:
+ *   1. Bounds invariant. Sram_FileNumHasFlashSlot accepts exactly the fileNums
+ *      whose every index form lands inside the real tables (length FLASH_SAVE_MAX
+ *      for the main tables, FILE_NUM_MAX*2 for the owl tables), and rejects
+ *      0xFF. This pins the guard's accept-set to the actual table extents.
+ *   2. Owl-delete write site. func_80147314(&sram, 0xFF) -- the second OOB site
+ *      on the moon-crash path -- must bail before touching gFlashOwlSave*Pages
+ *      and before mutating the save. A pre-stamped newf marker must survive.
+ *   3. Moon-crash reset (the reported path). Sram_ResetSaveFromMoonCrash under
+ *      the 0xFF sentinel must not reload from flash and must not overwrite the
+ *      live save with the zeroed buffer. A pre-stamped player name and day must
+ *      survive.
+ *
+ * Removing the fix (reverting the func_80147314 / Sram_ResetSaveFromMoonCrash
+ * guards) flips checks 2 and 3 to failure without any crash: the OOB reads land
+ * in adjacent .data, the funnel rejects the garbage pages as unavailable, and
+ * the save is corrupted exactly as observed.
+ */
+
+#include "global.h"
+
+#include <cstdio>
+#include <cstring>
+
+namespace {
+
+#define FLASH_ASSERT(cond, msg)                                           \
+    do {                                                                  \
+        if (!(cond)) {                                                    \
+            printf("[TEST] FAIL: %s (%s:%d)\n", msg, __FILE__, __LINE__); \
+            return 1;                                                     \
+        }                                                                 \
+    } while (0)
+
+// Backing store for the flash funnel's saveBuf. Static so the 128 KiB does not
+// land on the test's stack.
+u8 sSaveBuf[SAVE_BUFFER_SIZE];
+
+} // namespace
+
+extern "C" int MM_FlashFileNumOob_RunHeadless(void) {
+    printf("[TEST] mm-flash-filenum-oob: flash page-table indices stay in bounds for fileNum 0xFF\n");
+
+    // ------------------------------------------------------------------
+    // Check 1: the guard's accept-set matches the real table extents.
+    // The main page tables have FLASH_SAVE_MAX entries; the owl page tables
+    // have FILE_NUM_MAX * 2. Sram_FileNumHasFlashSlot must accept a fileNum iff
+    // every index the flash paths derive from it lands inside those tables.
+    // ------------------------------------------------------------------
+    for (s32 fileNum = 0; fileNum <= 0xFF; fileNum++) {
+        s32 accepted = Sram_FileNumHasFlashSlot(fileNum);
+
+        // Largest subscripts any flash path forms from fileNum:
+        //   main new-cycle + backup:   fileNum * 2 (+1)
+        //   main owl (MM_Sram_OpenSave): (fileNum + FILE_NUM_OWL_SAVE_OFFSET) * 2 (+1)
+        //   owl tables (func_80147314):  fileNum * 2 (+1)
+        s32 mainNewCycle = fileNum * FLASH_SAVE_MAIN_MULTIPLIER + FLASH_SAVE_BACKUP_OFFSET;
+        s32 mainOwl = (fileNum + FILE_NUM_OWL_SAVE_OFFSET) * FLASH_SAVE_MAIN_MULTIPLIER + FLASH_SAVE_BACKUP_OFFSET;
+        s32 owlTable = fileNum * FLASH_SAVE_MAIN_MULTIPLIER + FLASH_SAVE_BACKUP_OFFSET;
+
+        s32 inBounds = (fileNum >= 0) && (mainNewCycle < FLASH_SAVE_MAX) && (mainOwl < FLASH_SAVE_MAX) &&
+                       (owlTable < FILE_NUM_MAX * FLASH_SAVE_MAIN_MULTIPLIER);
+
+        FLASH_ASSERT(accepted == inBounds,
+                     "Sram_FileNumHasFlashSlot disagrees with the real flash-table bounds for some fileNum");
+    }
+
+    // The sentinel itself, and the legitimate slots, called out explicitly.
+    FLASH_ASSERT(!Sram_FileNumHasFlashSlot(0xFF), "0xFF sentinel must be rejected as a flash slot");
+    FLASH_ASSERT(Sram_FileNumHasFlashSlot(0) && Sram_FileNumHasFlashSlot(1) && Sram_FileNumHasFlashSlot(2),
+                 "real file slots 0..2 must be accepted");
+    FLASH_ASSERT(!Sram_FileNumHasFlashSlot(-1) && !Sram_FileNumHasFlashSlot(FILE_NUM_MAX),
+                 "out-of-range fileNums must be rejected");
+
+    // ------------------------------------------------------------------
+    // Check 2: func_80147314 (owl-save delete) honors the sentinel.
+    // This is the write site reached via DeleteOwlSave() from the
+    // BeforeMoonCrashSaveReset hook, and via MM_Sram_OpenSave's save-continue
+    // path -- both with gSaveContext.fileNum possibly 0xFF.
+    // ------------------------------------------------------------------
+    {
+        SramContext sramCtx;
+        memset(&sramCtx, 0, sizeof(sramCtx));
+        memset(sSaveBuf, 0, sizeof(sSaveBuf));
+        sramCtx.saveBuf = sSaveBuf;
+
+        memset(&gSaveContext, 0, sizeof(gSaveContext));
+        gSaveContext.fileNum = 0xFF;
+
+        // A marker that is NOT the 'ZELDA3' valid-file sentinel func_80147314
+        // writes on its way out; if the function runs it will overwrite this.
+        const char kNewfMarker[6] = { 'R', 'S', 'B', 'S', '!', '?' };
+        memcpy(gSaveContext.save.saveInfo.playerData.newf, kNewfMarker, sizeof(kNewfMarker));
+
+        func_80147314(&sramCtx, gSaveContext.fileNum);
+
+        FLASH_ASSERT(memcmp(gSaveContext.save.saveInfo.playerData.newf, kNewfMarker, sizeof(kNewfMarker)) == 0,
+                     "func_80147314 ran for the 0xFF sentinel -- OOB owl-save page index + save mutation");
+    }
+
+    // ------------------------------------------------------------------
+    // Check 3: Sram_ResetSaveFromMoonCrash (the reported crash path) preserves
+    // the live save under the 0xFF sentinel instead of reloading garbage from
+    // an out-of-bounds flash index and copying it over the save.
+    // ------------------------------------------------------------------
+    {
+        SramContext sramCtx;
+        memset(&sramCtx, 0, sizeof(sramCtx));
+        memset(sSaveBuf, 0, sizeof(sSaveBuf));
+        sramCtx.saveBuf = sSaveBuf;
+
+        memset(&gSaveContext, 0, sizeof(gSaveContext));
+        gSaveContext.fileNum = 0xFF;
+
+        const char kPlayerName[8] = { 'C', 'R', 'O', 'S', 'S', 'M', 'M', '\0' };
+        memcpy(gSaveContext.save.saveInfo.playerData.playerName, kPlayerName, sizeof(kPlayerName));
+        gSaveContext.save.day = 0x1234;
+        // A valid-file newf, so the CHECK_NEWF backup-reload branch is on the
+        // table too; with the fix the whole reload block is skipped.
+        const char kValidNewf[6] = { 'Z', 'E', 'L', 'D', 'A', '3' };
+        memcpy(gSaveContext.save.saveInfo.playerData.newf, kValidNewf, sizeof(kValidNewf));
+
+        Sram_ResetSaveFromMoonCrash(&sramCtx);
+
+        FLASH_ASSERT(memcmp(gSaveContext.save.saveInfo.playerData.playerName, kPlayerName, sizeof(kPlayerName)) == 0,
+                     "moon-crash reset clobbered the live player name under the 0xFF sentinel");
+        FLASH_ASSERT(gSaveContext.save.day == 0x1234,
+                     "moon-crash reset wiped save.day under the 0xFF sentinel (zeroed buffer copied over the save)");
+    }
+
+    // Leave gSaveContext clean for whatever runs next.
+    memset(&gSaveContext, 0, sizeof(gSaveContext));
+
+    printf("[TEST] mm-flash-filenum-oob: PASS\n");
+    return 0;
+}

--- a/games/mm/include/z64save.h
+++ b/games/mm/include/z64save.h
@@ -1846,6 +1846,14 @@ void Sram_IncrementDay(void);
 u16 Sram_CalcChecksum(void* data, size_t count);
 void MM_Sram_InitNewSave(void);
 void MM_Sram_InitDebugSave(void);
+// 2S2H [Port] Returns true only when `fileNum` is a real, in-bounds file slot
+// (0..FILE_NUM_MAX-1). fileNum is the 0xFF "no real slot" sentinel whenever no
+// file-select slot backs the session -- the title/debug/mapselect boot and, in
+// the RedShipBlueShip combo, every cross-game MM arrival. The flash save/load
+// paths index the fixed-size gFlashSave*Pages / gFlashOwlSave*Pages tables by
+// fileNum, so 0xFF (or anything past FILE_NUM_MAX) would subscript them far out
+// of bounds. Gate every such path on this.
+s32 Sram_FileNumHasFlashSlot(s32 fileNum);
 void Sram_ResetSaveFromMoonCrash(SramContext* sramCtx);
 void MM_Sram_OpenSave(struct FileSelectState* fileSelect, SramContext* sramCtx);
 void func_8014546C(SramContext* sramCtx);

--- a/games/mm/src/code/z_sram_NES.c
+++ b/games/mm/src/code/z_sram_NES.c
@@ -420,6 +420,17 @@ u8 sBitFlags8[] = {
     (1 << 0), (1 << 1), (1 << 2), (1 << 3), (1 << 4), (1 << 5), (1 << 6), (1 << 7),
 };
 
+// 2S2H [Port] Bounds guard for the flash page tables above. A real file slot is
+// 0..FILE_NUM_MAX-1; every other value -- most importantly the 0xFF "no real
+// slot" sentinel a cross-game / title / debug session leaves in
+// gSaveContext.fileNum -- must be rejected, because the flash paths index
+// gFlashSave*Pages[fileNum * FLASH_SAVE_MAIN_MULTIPLIER (+ FLASH_SAVE_BACKUP_OFFSET)]
+// and gFlashOwlSave*Pages[fileNum * FLASH_SAVE_MAIN_MULTIPLIER], which for 0xFF
+// runs hundreds of entries past the end of those fixed-size arrays.
+s32 Sram_FileNumHasFlashSlot(s32 fileNum) {
+    return (fileNum >= 0) && (fileNum < FILE_NUM_MAX);
+}
+
 u16 D_801F6AF0;
 u8 D_801F6AF2;
 
@@ -1264,20 +1275,27 @@ void Sram_ResetSaveFromMoonCrash(SramContext* sramCtx) {
 
     memset(sramCtx->saveBuf, 0, SAVE_BUFFER_SIZE);
 
-    if (SysFlashrom_ReadData(sramCtx->saveBuf, gFlashSaveStartPages[gSaveContext.fileNum * FLASH_SAVE_MAIN_MULTIPLIER],
-                             gFlashSaveNumPages[gSaveContext.fileNum * FLASH_SAVE_MAIN_MULTIPLIER]) != 0) {
-        SysFlashrom_ReadData(
-            sramCtx->saveBuf,
-            gFlashSaveStartPages[gSaveContext.fileNum * FLASH_SAVE_MAIN_MULTIPLIER + FLASH_SAVE_BACKUP_OFFSET],
-            gFlashSaveNumPages[gSaveContext.fileNum * FLASH_SAVE_MAIN_MULTIPLIER + FLASH_SAVE_BACKUP_OFFSET]);
-    }
-    memcpy(&gSaveContext.save, sramCtx->saveBuf, sizeof(Save));
-    if (CHECK_NEWF(gSaveContext.save.saveInfo.playerData.newf)) {
-        SysFlashrom_ReadData(
-            sramCtx->saveBuf,
-            gFlashSaveStartPages[gSaveContext.fileNum * FLASH_SAVE_MAIN_MULTIPLIER + FLASH_SAVE_BACKUP_OFFSET],
-            gFlashSaveNumPages[gSaveContext.fileNum * FLASH_SAVE_MAIN_MULTIPLIER + FLASH_SAVE_BACKUP_OFFSET]);
-        memcpy(&gSaveContext, sramCtx->saveBuf, sizeof(Save));
+    // 2S2H [Port] In a cross-game session (and the debug/mapselect boot) fileNum is the
+    // 0xFF "no real slot" sentinel, so there is no flash file to reload. Guarding here
+    // keeps us from indexing gFlashSaveStartPages/gFlashSaveNumPages far out of bounds AND
+    // from clobbering the live save with the still-zeroed buffer below.
+    if (Sram_FileNumHasFlashSlot(gSaveContext.fileNum)) {
+        if (SysFlashrom_ReadData(sramCtx->saveBuf,
+                                 gFlashSaveStartPages[gSaveContext.fileNum * FLASH_SAVE_MAIN_MULTIPLIER],
+                                 gFlashSaveNumPages[gSaveContext.fileNum * FLASH_SAVE_MAIN_MULTIPLIER]) != 0) {
+            SysFlashrom_ReadData(
+                sramCtx->saveBuf,
+                gFlashSaveStartPages[gSaveContext.fileNum * FLASH_SAVE_MAIN_MULTIPLIER + FLASH_SAVE_BACKUP_OFFSET],
+                gFlashSaveNumPages[gSaveContext.fileNum * FLASH_SAVE_MAIN_MULTIPLIER + FLASH_SAVE_BACKUP_OFFSET]);
+        }
+        memcpy(&gSaveContext.save, sramCtx->saveBuf, sizeof(Save));
+        if (CHECK_NEWF(gSaveContext.save.saveInfo.playerData.newf)) {
+            SysFlashrom_ReadData(
+                sramCtx->saveBuf,
+                gFlashSaveStartPages[gSaveContext.fileNum * FLASH_SAVE_MAIN_MULTIPLIER + FLASH_SAVE_BACKUP_OFFSET],
+                gFlashSaveNumPages[gSaveContext.fileNum * FLASH_SAVE_MAIN_MULTIPLIER + FLASH_SAVE_BACKUP_OFFSET]);
+            memcpy(&gSaveContext, sramCtx->saveBuf, sizeof(Save));
+        }
     }
     gSaveContext.save.cutsceneIndex = cutsceneIndex;
 
@@ -1333,6 +1351,10 @@ void MM_Sram_OpenSave(FileSelectState* fileSelect, SramContext* sramCtx) {
         memset(sramCtx->saveBuf, 0, SAVE_BUFFER_SIZE);
 
         if (gSaveContext.fileNum == 0xFF) {
+            // 2S2H [Port] The sentinel path reads file 1's new-cycle save; keep phi_t1 in
+            // step with that index so the gFlashSaveSizes[phi_t1] memcpy below is in bounds
+            // (it was otherwise left uninitialized and indexed the size table at random).
+            phi_t1 = FLASH_SAVE_FILE_1_NEW_CYCLE_SAVE;
             SysFlashrom_ReadData(sramCtx->saveBuf, gFlashSaveStartPages[FLASH_SAVE_FILE_1_NEW_CYCLE_SAVE],
                                  gFlashSaveNumPages[FLASH_SAVE_FILE_1_NEW_CYCLE_SAVE]);
         } else if (fileSelect->isOwlSave[gSaveContext.fileNum + FILE_NUM_OWL_SAVE_OFFSET]) {
@@ -2027,8 +2049,13 @@ void Sram_SaveSpecialEnterClockTown(PlayState* play) {
     // 2S2H [Enhancement] Store playtime before saving
     SavingEnhancements_AdvancePlaytime();
     func_80145698(sramCtx);
-    SysFlashrom_WriteDataSync(sramCtx->saveBuf, gFlashSaveStartPages[gSaveContext.fileNum * FLASH_SAVE_MAIN_MULTIPLIER],
-                              gFlashSpecialSaveNumPages[gSaveContext.fileNum * FLASH_SAVE_MAIN_MULTIPLIER]);
+    // 2S2H [Port] Skip the flash write for the 0xFF "no real slot" sentinel (cross-game /
+    // title / debug session); indexing gFlashSaveStartPages[fileNum * ...] would be OOB.
+    if (Sram_FileNumHasFlashSlot(gSaveContext.fileNum)) {
+        SysFlashrom_WriteDataSync(sramCtx->saveBuf,
+                                  gFlashSaveStartPages[gSaveContext.fileNum * FLASH_SAVE_MAIN_MULTIPLIER],
+                                  gFlashSpecialSaveNumPages[gSaveContext.fileNum * FLASH_SAVE_MAIN_MULTIPLIER]);
+    }
 }
 
 /**
@@ -2049,9 +2076,13 @@ void Sram_SaveSpecialNewDay(PlayState* play) {
     gSaveContext.save.day = day;
     gSaveContext.save.time = time;
     gSaveContext.save.cutsceneIndex = cutsceneIndex;
-    SysFlashrom_WriteDataSync(play->sramCtx.saveBuf,
-                              gFlashSaveStartPages[gSaveContext.fileNum * FLASH_SAVE_MAIN_MULTIPLIER],
-                              gFlashSaveNumPages[gSaveContext.fileNum * FLASH_SAVE_MAIN_MULTIPLIER]);
+    // 2S2H [Port] Skip the flash write for the 0xFF "no real slot" sentinel (cross-game /
+    // title / debug session); indexing gFlashSaveStartPages[fileNum * ...] would be OOB.
+    if (Sram_FileNumHasFlashSlot(gSaveContext.fileNum)) {
+        SysFlashrom_WriteDataSync(play->sramCtx.saveBuf,
+                                  gFlashSaveStartPages[gSaveContext.fileNum * FLASH_SAVE_MAIN_MULTIPLIER],
+                                  gFlashSaveNumPages[gSaveContext.fileNum * FLASH_SAVE_MAIN_MULTIPLIER]);
+    }
 }
 
 void Sram_SetFlashPagesDefault(SramContext* sramCtx, u32 curPage, u32 numPages) {
@@ -2135,6 +2166,14 @@ void Sram_UpdateWriteToFlashOwlSave(SramContext* sramCtx) {
 
 void func_80147314(SramContext* sramCtx, s32 fileNum) {
     s32 pad;
+
+    // 2S2H [Port] Reached with fileNum == 0xFF via DeleteOwlSave() (the
+    // BeforeMoonCrashSaveReset hook) and MM_Sram_OpenSave's save-continue path in a
+    // cross-game session. Bail before touching gFlashOwlSave*Pages[fileNum * ...], which
+    // for the 0xFF sentinel indexes hundreds of entries past those six-entry tables.
+    if (!Sram_FileNumHasFlashSlot(fileNum)) {
+        return;
+    }
 
     gSaveContext.save.isOwlSave = false;
 

--- a/games/mm/src/code/z_sram_NES.c
+++ b/games/mm/src/code/z_sram_NES.c
@@ -1279,7 +1279,7 @@ void Sram_ResetSaveFromMoonCrash(SramContext* sramCtx) {
     // 0xFF "no real slot" sentinel, so there is no flash file to reload. Guarding here
     // keeps us from indexing gFlashSaveStartPages/gFlashSaveNumPages far out of bounds AND
     // from clobbering the live save with the still-zeroed buffer below.
-    if (Sram_FileNumHasFlashSlot(gSaveContext.fileNum)) {
+    if (1 /* COUNTERFACTUAL: force reload to prove mm-flash-filenum-oob lock goes RED */) {
         if (SysFlashrom_ReadData(sramCtx->saveBuf,
                                  gFlashSaveStartPages[gSaveContext.fileNum * FLASH_SAVE_MAIN_MULTIPLIER],
                                  gFlashSaveNumPages[gSaveContext.fileNum * FLASH_SAVE_MAIN_MULTIPLIER]) != 0) {

--- a/src/common/test_runner.cpp
+++ b/src/common/test_runner.cpp
@@ -72,6 +72,14 @@ int MM_NotificationBinding_RunHeadless(void);
 // to HiRes 576 while the Bombers' Notebook is open. Returns 0 on pass, non-zero
 // on fail.
 int MM_FbEffectsBinding_RunHeadless(void);
+// MM flash page-table OOB lock (games/mm/2s2h/mm_flash_filenum_test.cpp): a
+// cross-game MM session runs with gSaveContext.fileNum == 0xFF, the "no real
+// slot" sentinel. The flash paths index the fixed-size gFlashSave*Pages /
+// gFlashOwlSave*Pages tables by fileNum * FLASH_SAVE_MAIN_MULTIPLIER, so 0xFF
+// runs hundreds of entries past their end -- a wild flash page number the
+// moon-crash reset then copies over the live save (the Fierce-Deity /
+// all-Ocarina corruption). Returns 0 on pass, non-zero on fail.
+int MM_FlashFileNumOob_RunHeadless(void);
 // MM tracker registration surface (games/mm/2s2h/mm_trackers_gui_test.cpp,
 // #392): the four MM tracker windows must register on a Gui under
 // "MM "-prefixed names (SoH owns the unprefixed ones and Gui::AddGuiWindow
@@ -245,6 +253,12 @@ static TestResult Test_MMNotificationBinding(void) {
 // wrapper over the C entry point in games/mm/2s2h/mm_fb_effects_test.cpp.
 static TestResult Test_MMFbEffectsBinding(void) {
     return MM_FbEffectsBinding_RunHeadless() == 0 ? TEST_PASS : TEST_FAIL;
+}
+
+// MM flash page-table OOB lock (see the extern decl above). Thin wrapper over
+// the C entry point in games/mm/2s2h/mm_flash_filenum_test.cpp.
+static TestResult Test_MMFlashFileNumOob(void) {
+    return MM_FlashFileNumOob_RunHeadless() == 0 ? TEST_PASS : TEST_FAIL;
 }
 
 // ============================================================================
@@ -1350,6 +1364,12 @@ const TestDescriptor gTests[] = {
      Test_MMNotificationBinding},
     {"mm-fb-effects-binding", "MM's scaled framebuffer draw binds its own body against MM's dimensions (#386)",
      Test_MMFbEffectsBinding},
+    // Flash page-table OOB from the 0xFF fileNum sentinel: the moon-crash reset
+    // (and the owl-delete write it fires) index the fixed-size flash tables far
+    // out of bounds in a cross-game MM session, then copy the garbage over the
+    // live save. Pure (no display), so it runs in the display-free suite.
+    {"mm-flash-filenum-oob", "Flash page indices stay in bounds for fileNum 0xFF; moon-crash reset keeps the save",
+     Test_MMFlashFileNumOob},
     {"mm-trackers-gui", "MM tracker windows register de-collided on the shared Gui + gate on the active game (#392)",
      Test_MMTrackersGui},
     // The two MM resume-contract tests below mutate process-global state


### PR DESCRIPTION
Fixes the `fileNum=255` OOB flash indexing flagged as a follow-up in #485.

## The bug

A cross-game MM session runs with `gSaveContext.fileNum == 0xFF`, the "no real
file slot" sentinel the title/debug/mapselect boot leaves in place and which no
cross-game arrival replaces (operator probe: `fileNum=255` across all six
`OnSaveLoad` dispatches, three round trips). MM's flash save/load paths index
the fixed-size `gFlashSave*Pages` / `gFlashOwlSave*Pages` tables by
`fileNum * FLASH_SAVE_MAIN_MULTIPLIER`, so `0xFF` subscripts them at **510** —
hundreds of entries past the end (the main tables have `FLASH_SAVE_MAX` = 14
entries; the owl tables have 6).

On the moon-crash reset path (idle → three-day clock expires → moon crash →
`z_demo.c` → `Sram_ResetSaveFromMoonCrash`) that wild index becomes a flash page
number/count; the desktop `SaveManager` funnel rejects the garbage pages as
`FLASH_SAVE_UNAVAILABLE` and returns without filling the buffer, so the reset's
`memcpy(&gSaveContext.save, saveBuf, sizeof(Save))` then copies the **zeroed**
buffer over the live save — the operator's spawn-as-Fierce-Deity, every-MM-slot-
reads-as-Ocarina corruption. On cartridge (or if the garbage happened to alias a
real slot) it is a genuine wild flash read.

## Decision: 0xFF is an intentional sentinel — guard and bail (candidate a)

`fileNum == 0xFF` is unambiguously the established "no real file slot" sentinel:

- `z_title.c` **sets** it (`gSaveContext.fileNum = 0xFF`) at the console-logo
  boot, before any file is picked; the file-select assigns a real `buttonIndex`
  (0..2) only when a slot is chosen.
- Every other flash path already gates on it and bails: `z_message.c`
  (`!= 0xFF`, 4 sites), `z_kaleido_scope_NES.c` (`|| fileNum == 255`),
  `MM_Sram_OpenSave` (`== 0xFF` branch), `SavingEnhancements::CanSave`
  (`fileNum == 255` → can't save).

Candidate (b) — "a cross-game MM session should carry a real slot index" — is
wrong for this port: MM's cross-game persistence goes through the unified
`.redsave` / freeze-state, not a file-select slot, and forcing a real `fileNum`
would make these paths clobber an actual on-disk `fileN.json`. The correct fix
is the existing convention: treat `0xFF` as "no flash slot" and bail, plus a
defensive bounds check so **any** unexpected `fileNum` can never index the tables
again.

## Audit — every fileNum-derived flash-table index

| # | Site | Index | Reachable with 0xFF? | Before | After |
|---|------|-------|----------------------|--------|-------|
| 1 | `Sram_ResetSaveFromMoonCrash` (read) | `gFlashSave{Start,Num}Pages[fileNum*2 (+1)]` | **Yes** — reported moon-crash path | unguarded | **guarded** (skip reload + the zero-copy) |
| 2 | `func_80147314` (owl-save delete, write) | `gFlashOwlSave{Start,Num}Pages[fileNum*2 (+1)]` | **Yes** — `DeleteOwlSave` (BeforeMoonCrashSaveReset hook) + `MM_Sram_OpenSave` save-continue | unguarded | **guarded** (bail at top) |
| 3 | `Sram_SaveSpecialEnterClockTown` (write) | `gFlashSaveStartPages / gFlashSpecialSaveNumPages[fileNum*2]` | Plausible (first South-Clock-Town entry) | unguarded | **guarded** |
| 4 | `Sram_SaveSpecialNewDay` (write) | `gFlashSave{Start,Num}Pages[fileNum*2]` | End-of-game | unguarded | **guarded** (defensive) |
| 5 | `MM_Sram_OpenSave` (read) | `gFlashSaveSizes[phi_t1]` | **Yes** | read guarded, but `phi_t1` **uninitialized** in the 0xFF branch → size table indexed at random | **fixed** (`phi_t1 = FLASH_SAVE_FILE_1_NEW_CYCLE_SAVE`) |
| 6 | `z_message.c` NEW_CYCLE_0 / OWL_SAVE_0 | `gFlashSaveStartPages / gFlashOwlSaveStartPages[fileNum*2]` | — | already `!= 0xFF` guarded | unchanged |
| 7 | `z_kaleido_scope_NES.c` pause-save | `gFlashOwlSaveStartPages / gFlashSaveStartPages[fileNum]` | — | already `\|\| fileNum == 255` guarded | unchanged |
| 8 | `z_file_nameset_NES.c:527` | `[buttonIndex*2]` | No — file-select cursor 0..2 | bounded | unchanged (safe) |
| 9 | `z_file_copy_erase.c:442,984` | `[copyDestFileIndex*2]`, `[selectedFileIndex*2]` | No — file-select 0..2 | bounded | unchanged (safe) |
| 10 | `func_801457CC` verify (z_sram_NES.c:1871) | `[fileSelect->selectedFileIndex*2]` | No — file-select 0..2 | bounded | unchanged (safe) |
| 11 | `func_80147414` (owl copy) | `gFlashOwlSaveStartPages[fileNum*2, arg2*2]` | No — `Sram_CopySave` passes bounded selected/copyDest indices | bounded | unchanged (safe) |
| 12 | `SaveManager.cpp:405` | `gFlashSaveStartPages[flashSave+1]` | No — `flashSave` is a validated `FlashSave` (new-cycle 0/2/4) | bounded | unchanged (safe) |

## The fix

A shared `Sram_FileNumHasFlashSlot(fileNum)` guard (real slot = `0..FILE_NUM_MAX-1`)
applied to sites 1–4, plus the `phi_t1` init for site 5. For the sentinel, the
moon-crash reset keeps the live in-memory save (it skips both the flash read and
the `memcpy` that would copy the zeroed buffer over it) and the write/owl-delete
paths simply do not touch flash — the same "no real slot → bail" contract sites
6/7 already follow.

## Lock — `mm-flash-filenum-oob` (redship tier, ROM-free, display-free)

Runs inside `--test all`. Three checks:

1. **Bounds invariant** — `Sram_FileNumHasFlashSlot` accepts a `fileNum` iff
   every index form it feeds (`fileNum*2(+1)` into the 14-entry main tables,
   `(fileNum+OWL_OFFSET)*2(+1)`, `fileNum*2(+1)` into the 6-entry owl tables)
   lands in bounds, and rejects `0xFF`. Pins the guard's accept-set to the real
   table extents.
2. **Owl-delete write site** — `func_80147314(&sram, 0xFF)` must bail before the
   OOB owl-table write; a pre-stamped `newf` marker must survive.
3. **Moon-crash reset (reported path)** — `Sram_ResetSaveFromMoonCrash` under the
   sentinel must not reload from flash and must not overwrite the live save; a
   pre-stamped player name and `save.day` must survive.

Not vacuous: checks 2 and 3 drive the **real** functions and assert the actual
save bytes, not a hook count. A counterfactual that removes the reset guard is
pushed to this PR's own check history to show the lock RED, then reverted before
merge.

## Coordination with #485

#485 (open, not merged) also edits `Sram_ResetSaveFromMoonCrash` to snapshot /
restore `shipSaveInfo` around the flash reload. The two changes compose — its
snapshot/restore brackets the reload; this guard wraps the reload — and for the
`0xFF` sentinel the reload is skipped so its restore is a trivial no-op. This PR
does **not** touch its `shipSaveInfo` preservation. If #485 lands first I will
rebase and nest this guard inside its bracketed block.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EmFBRmT3chuLacu3AGBu1F

---
_Generated by [Claude Code](https://claude.ai/code/session_01EmFBRmT3chuLacu3AGBu1F)_

<!--- section:artifacts:start -->
### Build Artifacts
  - [rsbs-windows.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/8543409820.zip)
<!--- section:artifacts:end -->