### PR TITLE
Phase 3.1 planning: roadmap §5 waves + per-lane worker prompts (#492)

### DIFF
--- a/.claude/lanes/SHARED.md
+++ b/.claude/lanes/SHARED.md
@@ -1,0 +1,15 @@
+## Shared files — no owner, append-only (applies to every lane)
+
+Three files are written by nearly every lane. **Nobody owns them.** Append at the end of the relevant block, never reorder existing entries, and expect trivial rebases:
+
+- `CMake/SingleExecutable.cmake`
+- `src/common/test_runner.cpp`
+- `.github/clang-format-paths.txt`
+
+`redship_add_test()` already reduced test registration to one appended line, which is why this is safe — but it takes **three coordinated edits**, and the build hard-fails if you do fewer:
+
+1. `redship_add_test(NAME Foo COMMAND redship --test foo)` in `CMake/SingleExecutable.cmake`. `LABEL` defaults to `redship` — the **display-free, ROM-free** tier that runs on every PR. Pass `LABEL rando` only if a window genuinely must come up; that tier needs xvfb and a longer timeout.
+2. A `gTests[]` entry in `src/common/test_runner.cpp`. `TestRegistrationComplete` FATAL_ERRORs on a CMake row with no `gTests` entry, or the reverse.
+3. If you add a new `src/common/tests/*.c`, `#include` it in `src/common/test_runner.cpp` — `redship_check_test_sources()` FATAL_ERRORs on a test source that is never included.
+
+`games/mm/2s2h/GameExports_SingleExe.cpp` is shared at **function** granularity, not file: Lane 1 has `MM_ConsumeSharedItems`, Lane 3 has `MM_Rando_PairOnCrossGameArrival`, Lane 5 has `MM_Rando_Init`, Lane 6 has `MM_AwardSharedItem`. A function-scoped claim does not prevent a textual conflict — rebase, don't reorder.

--- a/.claude/lanes/lane1.md
+++ b/.claude/lanes/lane1.md
@@ -1,0 +1,58 @@
+You are Lane 1 of six on RedShipBlueShip Phase 3.1 (#492): the **serialization spine**. Yours is the only lane that changes `.redsave` format, and the phase's longest pole.
+
+Read #492, then #490, then #498, then #493.
+
+## Step 1 — #490, merged before anything else
+
+Defuse the `foreignPlacements` cap trap in `src/common/context.h`. **This is not a cap bump.** `grantCursors` and `sharedItemOverflowCount` are carved after `foreignPlacements` and the offset static_asserts are expressed *in terms of the cap*, so they follow a bump instead of catching it.
+
+All four of #490's Work steps are in scope, including the two that are easy to skip: **step 3 is the actual lock** (extend `Test_SaveComboLegacyRecord` in `src/common/tests/test_save_roundtrip.c` with a v2 fixed-offset case using `SaveTestWriteCraftedSlot`, asserting bytes at literal offsets 672/676/736 land in `grantCursors[0]` and `sharedItemOverflowCount`), and step 4 is the explanatory comment at `src/common/tests/test_grant_sources.c:91-98`. Without step 3 this ships as a comment-and-assert change with no red-today lock.
+
+**Why this is first, stated precisely** — do not let anyone "optimize" it away on discovering the weaker version: the 672/736 asserts do **not** guard your step 3 carve (that block lands after `sharedItemOverflowCount`, leaving those offsets untouched). What #490 actually buys is (a) the rewritten DO-NOT-BUMP comment at `context.h:161-167`, which is what tells your own step 3 to carve a second block rather than widen the cap, and (b) plain textual conflict avoidance, since both issues edit `context.h:161-185` and the assert chain at `:401-427`.
+
+## Step 2 — the byte budget, before you carve anything
+
+`reserved[264]` has **five** claimants, not one: your `foreignPlacementsOoT` block (#493 step 2, which would shrink it to 216), Lane 4's MM-profile digest (#497 step 7 *and* #499 step 4 — #499's Tier-1 lock does not compile until it lands), #498's combo-settings term, and #460's netplay grant fields.
+
+You own `context.h`, so you own the budget. Publish the allocation on #490 or #493 and get Lane 4's digest size before you carve. One format version covering all known carves beats four sequential re-versions.
+
+## Step 3 — the prep commit, and it must be ADDITIVE
+
+Origin-dispatch the pool/name surface (`Combo_GetForeignItemName`, `Combo_GetForeignItemByName`) so each pool's definition stays in the single TU where its enum is in scope.
+
+**This cannot be a breaking signature change.** Four call sites live in other lanes' files: `games/mm/2s2h/Rando/Foreign.cpp:180` (Lane 2), `games/mm/2s2h/Rando/Spoiler/Apply.cpp:93` (Lane 2, via #488), `games/mm/2s2h/mm_rando_gen_test.cpp:291` (Lane 3), `src/common/tests/test_foreign_items.c:95` (Lane 2). Add the origin-aware entry points and keep the existing symbols as thin wrappers, so the commit lands standalone. Lane 6 branches from it for the icon accessor.
+
+Name collision is **not hypothetical**: `kForeignPoolV1` has the literal string `"Bomb Bag"` (`ForeignItemsSingleExe.cpp:61`) and MM's `RI_BOMB_BAG_20` row is also literally `"Bomb Bag"` (`StaticData/Items.cpp:37`). Origin-dispatch of the name→item inverse is mandatory, and the cross-pool collision assertion goes RED the moment an MM pool exists.
+
+## Step 4 — write the #498 ADR before #493's code
+
+Three decisions belong to #498 but get made inside #493 whether or not anyone writes them down: where combo settings live, **what gates generation** (move the `sourceIsRando`/`sharedRandoSettingsHash` stamp at `3drando/playthrough.cpp:116-118` above `Fill()` at `:81`, versus an explicit pre-generation opt-in), and one symmetric pool versus two. Record them as an ADR under #498. Making them implicitly inside an XL PR is how they become undiscoverable.
+
+## Step 5 — #493, the reverse direction
+
+Follow the issue's ordered Work section, **minus step 5's MM-side give** — Lane 6 owns `MM_AwardSharedItem` and creates `games/mm/2s2h/Rando/ForeignItemsSingleExe.cpp`. You add `kForeignPoolMMV1` to that TU after Lane 6 merges.
+
+**Rebase onto Lane 2's #488 before step 7, not before step 3.** Steps 1–6 and 8–9 need nothing from `Foreign.cpp`. The dependency is pattern-mirroring for the OoT host allowlist, and it is soft — MM anchors on `RCTYPE_CHEST` over `Rando::StaticData::Checks`, while yours anchors on `RCTYPE_STANDARD`/`ACTOR_EN_BOX` plus the `GetFinalGIEntry` + `GiveItemEntryWithoutActor` funnel against a different type enum. Shared shape, no shared code. Do not idle the phase's longest pole on its smallest lane.
+
+## Files you own
+
+`src/common/context.h`, `context.cpp`, `foreign_items.h`, `foreign_items.c`, `src/common/tests/test_save_roundtrip.c`, `src/common/tests/test_grant_sources.c`, `games/oot/soh/Enhancements/randomizer/ForeignItemsSingleExe.cpp`, `SeedContext.cpp`, `randomizer.cpp`, `randomizerTypes.h`, `3drando/playthrough.cpp`, `3drando/spoiler_log.cpp`, `3drando/menu.cpp`, and `MM_ConsumeSharedItems` in `games/mm/2s2h/GameExports_SingleExe.cpp`.
+
+Read-only, no claim needed: `z_en_box.c` (#493 step 8 explicitly says **do not** try to recover the RC on the actor path — it is diagnosis, not a work site).
+
+## Do not touch
+
+`Rando/Foreign.cpp` (Lane 2 — expires to Lane 4 after #488 merges, not to you), `Rando/Spoiler/*` (Lane 2 for `Apply.cpp`, else read-only), `z_sram_NES.c` / `mm_stubs.c` / `mm_rando_gen_test.cpp` (Lane 3), `SohGui/*` and `MiscBehavior/OnFileCreate.cpp` (Lane 4), `TrackersGuiSingleExe.cpp` (Lane 5), `MiscBehavior/CheckQueue.cpp` and `DrawItem.cpp` (Lane 6).
+
+## Non-negotiables
+
+- **Append** `RG_*` sentinel enumerators after the last existing one, before `RG_MAX`. Inserting invalidates every existing spoiler and every pinned determinism digest — spoilers store raw ints.
+- Mirror the forward-side seeding exactly (`Foreign.cpp:137-142`): `Ship_Hash` over `sharedRandoSeed`, `sharedRandoSettingsHash`, the per-file final seed, and a `":foreign-rev-v1"` tag, with a nonzero fallback when the hash is 0, feeding a **local** xorshift. Never `Random_Init`'s stream, or the fill's reproducibility moves.
+- Locks are **per row**, not per lane. `ForeignItemGiveReverse` is the default `redship` label. The determinism-digest extension must carry `LABEL rando` with the display-tier timeout and environment, copying the existing `RandoGen` row.
+- Non-vacuity differs per step. For #493: a test that pokes the placement table is vacuous — it must enter the production give path through a bridge, as `MM_Rando_Foreign_RecordPickup` does (`Foreign.cpp:204`). For #490 it is the opposite shape: literal byte offsets in a crafted 1024-byte Tier-1 record driven through the real `Load`, never `offsetof` compared against `offsetof`.
+- Two placement tables means every clear / invalidate / serialize / spoiler site updates in **both** or they desynchronize — the #440 class. Enumerate the sites before editing any.
+- #493 step 5 requires adding new TUs to `.github/clang-format-paths.txt`. It is an explicit allowlist that errors on stale entries, and `src/common/*` is deliberately absent from it.
+
+## Stop and report if
+
+The table shape needs an ADR 0002 amendment, the determinism digest changes shape, or `reserved[]` cannot fit the five claimants. Do not force it — getting a format carve wrong compiles clean and breaks saves the operator already holds.

--- a/.claude/lanes/lane2.md
+++ b/.claude/lanes/lane2.md
@@ -1,0 +1,40 @@
+You are Lane 2 of six on RedShipBlueShip Phase 3.1 (#492). Small, fast, and it unblocks part of Lane 1 and part of Lane 4.
+
+Read #492, then #488.
+
+## Your work
+
+Close #488: foreign-item host selection trusts the fill-time `.shuffled` bit alone, so a pinned OoT item can land on a check with no runtime give-path and strand — invisible, unwinnable, indistinguishable from a missing item.
+
+`Rando::Foreign::PlaceForeignItems` (`Foreign.cpp:117-161`) selects hosts by `RANDO_SAVE_CHECKS[id].shuffled` plus `RITYPE_JUNK`, excluding only `RCTYPE_SHOP` / `RCTYPE_TINGLE_SHOP`. Replace that inline predicate with an allowlist of check types that have a **game-guaranteed** setter, anchored on `RCTYPE_CHEST` — the chest flag is set by vanilla actor code independent of any rando hook.
+
+Extract it as `Rando::Foreign::IsEligibleHost(RandoCheckId)` with an `extern "C" int MM_Rando_Foreign_IsEligibleHost(uint16_t)` bridge, placed next to the existing `MM_Rando_Foreign_RecordPickup` bridge at `Foreign.cpp:204-206`. That bridge is what makes the lock non-vacuous, and it is the whole reason to extract rather than edit in place.
+
+Report how many checks survive the tightened predicate. That number sizes the foreign pool — it feeds **#495** (the rule-defined pool), not #493, which is capped at `RSBS_FOREIGN_PLACEMENT_CAP` regardless. Say it on #495 so the number has a consumer.
+
+## Files you own
+
+`games/mm/2s2h/Rando/Foreign.cpp` and `Foreign.h`, and you are **first writer** on `src/common/tests/test_foreign_items.c` — append your rows now; Lane 1 rebases onto you.
+
+You also own `games/mm/2s2h/Rando/Spoiler/Apply.cpp` for the duration of #488 step 6. Lane 5 has been told to treat `Rando/Spoiler/*` as read-only, so it is yours; hand it back when you merge.
+
+## Two cross-lane asks you must make before you start
+
+Both are mandatory steps of #488 in files another lane owns. Neither lane will offer — ask on the issue.
+
+- **`games/mm/2s2h/Rando/MiscBehavior/OnFileCreate.cpp:245`** (Lane 4). Step 5 throws a `runtime_error` inside `OnFileCreate`'s existing try on a host shortfall. Lane 4 rewrites `:112-120` and `:132-137` for #499 — different region, same file. Agree an order.
+- **`games/mm/2s2h/mm_rando_gen_test.cpp:296-303`** (Lane 3). Your secondary lock replaces the `FAIL(12)` post-condition with `MM_Rando_Foreign_IsEligibleHost(p.mmCheckId) != 0`. Note `FAIL(11)` at `:276-285` asserts `placedCount == poolCount`, so a supply shortfall breaks that row whether or not you touch it. Lane 3 lands first (#487 is P0) — rebase onto it.
+
+## Do not touch
+
+`src/common/context.h`, `foreign_items.h`, `foreign_items.c` (Lane 1 — if your predicate needs a new accessor, ask on #493 rather than adding one), `ForeignItemsSingleExe.cpp` (Lane 1), `Rando/StaticData/*` (read-only; if the host class needs a new field on `RandoStaticCheck` at `StaticData.h:20-28`, that is #488's embedded decision and the issue recommends deferring it to its own ADR — raise it, do not just do it), `MiscBehavior/CheckQueue.cpp` (Lane 6; read `:40-52` to understand the give path — the foreign branch is nested inside `if (randoSaveCheck.eligible)` at `:39-53`).
+
+## Non-negotiables
+
+- Lock at the default `redship` label. The bar: drive `MM_Rando_Foreign_IsEligibleHost` directly and assert it returns 0 for a disallowed host, so the check never enters `candidates`. RED today because the predicate reads no eligibility bit, accepts sentinel items, and accepts every non-shop check type.
+- Do **not** phrase the bar around `Combo_SetForeignPlacement`. That function already rejects `mmCheckId == 0`, untagged items, duplicate hosts and overflow — and it lives in `src/common/foreign_items.c`, which is Lane 1's. Making it the observable would force you into a forbidden file and push MM check-class semantics into a deliberately game-agnostic layer.
+- There is no relocation mechanism in the tree. `PlaceForeignItems` picks from a candidate vector and erases the pick; nothing re-homes a placement. Do not assert "rejected **or relocated**" — you would be inviting yourself to invent one.
+
+## Stop and report if
+
+The tightened predicate cannot host 4 items, or the current 4 pinned placements have been landing on unsafe hosts all along. Both change the operator's playtest expectations and #495's sizing, and both are worth more than a quiet fix that widens the predicate to hit a number.

--- a/.claude/lanes/lane3.md
+++ b/.claude/lanes/lane3.md
@@ -1,0 +1,48 @@
+You are Lane 3 of six on RedShipBlueShip Phase 3.1 (#492): **live P0-class correctness** in MM's save path. Lane 5's tracker work cannot be validated until you land, so land early.
+
+Read #492, then #487, then #491. Read merged PR #485 — the moon-crash leg of this exact class, whose fix shape you reuse. **Rebase onto open PR #486**, which touches `sys_flashrom.c` and `z_sram_NES.c` before you.
+
+## Step 1 — #487
+
+In the `redship` single-exe build MM's `SaveManager` TU is filtered out of the link (`games/mm/CMakeLists.txt:301`), so `SaveManager_SysFlashrom_ReadData` resolves to the stub at `src/common/mm_stubs.c:260` — which **returns 0 (success) without filling the caller's buffer**. `Sram_UpdateWriteToFlashOwlSave` (`z_sram_NES.c:2175-2180`) memsets the buffer, calls that read, ignores the return, and memcpy's the zeroed buffer over `gSaveContext` for `offsetof(SaveContext, fileNum)` — i.e. all of `struct Save`, including the 2S2H `shipSaveInfo` block. (Do not trust the `0x3CA0` annotation in the header; that is the vanilla N64 offset, and the port's struct is far larger.)
+
+**Do #487's step 1 before writing any fix**, but note the standing convention forbids local builds while other agents run and CI emits no link map. The static evidence is already conclusive — `games/mm/CMakeLists.txt:301` is the only reference to `2s2h/SaveManager` in any CMake file. Record that as the confirmation, or arrange who runs the build; do not block on it.
+
+**Enumerate the readback sites by grep — do not trust a count.** The two unguarded owl-save readback-then-commit sites are `Sram_UpdateWriteToFlashOwlSave` (`:2179-2180`) and `func_80147414` (`:2225-2234`). `Sram_ResetSaveFromMoonCrash` (`:1301-1314`) is #485's, already guarded. **`func_80147314` is not one of them** — it copies the live context *into* the flash buffer and contains no `SysFlashrom_ReadData` call at all. There are further readback-then-commit sites at `:1404`, `:1588`, `:1682`, `:1706`, `:1801`, `:1862`, `:1929`; a helper written for "three sites" will silently under-cover.
+
+#487 step 6 is in scope and lives in a file you own: `MM_Sram_InitSave` dispatches `OnSaveInit` at `z_sram_NES.c:1992` and never `OnSaveLoad` (#467 recommendation 1). Per #469 the dispatch goes *after* the flash-buffer memcpy, not between the checksum and it — pick a position and write down which.
+
+## Step 2 — #491
+
+Strengthen the arming probe. `MMPairSwitchEntry` probes arm state by `CountForTest<OnFlagSet>` at **two** sites — the arrival leg (`:788`, `:795-800`) and the return leg (`:891`, `:916-921`) — and the assertion is a relative comparison against a boot-chain baseline, not a literal `0 -> 1`. Both must move to the VB verdict. `MMReloadArmState` already carries a VB-verdict leg at `:1118-1143` to copy.
+
+## The sequencing fact that makes or breaks your lock
+
+Rando `COND_HOOK`s are re-evaluated **only** inside `OnSaveLoadHandler` (`Rando.cpp:13-21`, registered `:41`), and the owl readback dispatches no `OnSaveLoad`. So immediately after the readback the hooks are still registered and a VB probe reports **ARMED** even though `saveType` is already 0. The disarm happens at the next `OnSaveLoad`.
+
+Your lock must therefore dispatch `GameInteractor_ExecuteOnSaveLoad` (or drive a path that does) after the readback before asserting arm state. Without that, the arm-state leg is itself vacuous and only the `saveType` / `finalSeed` / check-entry assertions carry weight.
+
+## Files you own
+
+`games/mm/src/code/z_sram_NES.c`, `src/common/mm_stubs.c` (and `mm_stubs.cpp` if the header check lands there), `games/mm/2s2h/mm_rando_gen_test.cpp`, `docs/unified-surface-findings.md`, and you may **append** rows in the MM block of `CMake/SingleExecutable.cmake` as well as edit the existing `MMPairSwitchEntry` / `MMReloadArmState` / `MMMoonCrashArmState` rows.
+
+Lane 2 needs `mm_rando_gen_test.cpp:296-303` (the `FAIL(12)` post-condition) and Lane 4 wants assertions there for #499. You land first; both rebase onto you.
+
+## Do not touch
+
+`context.h` / `foreign_items.*` (Lane 1), `Rando/Foreign.cpp` (Lane 2), `MiscBehavior/OnFileCreate.cpp` and `Rando/Menu.cpp` (Lane 4), `TrackersGuiSingleExe.cpp` / `Rando/CheckTracker/*` (Lane 5), `CheckQueue.cpp` (Lane 6). In `games/mm/2s2h/GameExports_SingleExe.cpp` you have `MM_Rando_PairOnCrossGameArrival` only — Lanes 1, 5 and 6 hold other functions in that file.
+
+You probably do **not** need `sys_flashrom.c` (its redirect at `:83` already forwards the return faithfully; it has other callers at `:226`) or `mm_resume_state_test.cpp` (nothing in either issue lands there). Do not claim them by habit.
+
+## Non-negotiables
+
+- Prefer **one shared helper** over per-site guards, and cover the sites you enumerated — not just the one you were pointed at.
+- `return -1` applies to the **read** stub only. The write twin at `mm_stubs.c:261` is `int(void*, int, int)` against a real `void(u8*, u32, u32)` — once header-checked it cannot return anything. Its header-checked fix is becoming `void`.
+- Including `SaveManager.h` from `mm_stubs.c` takes the C branch, which needs `u8`/`u32`/`s32`; that TU currently pulls no MM ultra64 typedefs. Decide whether MM include paths belong in that C file or whether the header check moves to `mm_stubs.cpp`, and say which.
+- Tier: attempt a display-free `redship` row first, per #491 step 1. Fall back to `LABEL rando` only if `MM_Rando_Init` / `Ship::Context` proves necessary, and record which in the CMake comment. #487's lock is specified as `redship`; do not hardcode `rando` and foreclose the tier question that is #491's whole point.
+- Non-vacuity: first **disarm** against a vanilla bootstrap and assert the disarm took, *then* assert the re-arm — a blanket "always force rando" fix must fail that phase. A third phase asserts the rando block survives, so a fix preserving only the type byte also fails.
+- End your rows with the explicit cleanup block `MMReloadArmState` uses. MM and OoT share one `gSaveContext` storage; without it you flake the `AllTests` aggregate.
+
+## Stop and report if
+
+The link check shows the real `SaveManager.cpp` in the binary, or you conclude MM saves in single-exe persist nothing at all (the write stub is also a no-op). The latter is #487 step 5's scoping question for the operator — whether `redship` should have a real MM save path — not something to settle inside this fix.

--- a/.claude/lanes/lane4.md
+++ b/.claude/lanes/lane4.md
@@ -1,0 +1,58 @@
+You are Lane 4 of six on RedShipBlueShip Phase 3.1 (#492): the **settings and menu surface**. It is unblocked today, contrary to earlier planning — but two of your steps reach into other lanes' files, so read the asks below before starting.
+
+Read #492 (including the correction comment on #451), then #497, then #499, then `docs/adr/0004-menu-information-architecture.md` (Status: Proposed) and `docs/adr/0003-settings-namespace.md` (also Proposed).
+
+## Decide the scope before writing anything
+
+#497 offers two scopes "roughly an order of magnitude" apart and flags it as an open maintainer call:
+
+- **ADR 0004 §4.1 minimum** (`:186-189`) — a read-only "Paired" summary plus an MM logic-mode picker inside the existing OoT rando pane.
+- **The full 46-option MM pane.**
+
+Pick one and record it on #497 before step 1. Do not discover this mid-implementation.
+
+## The #451 premise, stated correctly
+
+The four `kMenuIndexKeys` (`src/common/cvar_shared_keys.h:390-394`) have **no compiled MM-side reader** — MM's readers are `BenGui/BenMenu.cpp:298,684,1792` (a TU in no CMake target) and `BenGui/Menu.cpp:599` (in the elided `2ship_rando_ui`). OoT's SohMenu *does* read all four from the live link (`SohMenuSettings.cpp:127`, `SohMenuEnhancements.cpp:148`, `SohMenuDevTools.cpp:35`, `Menu.cpp:568`).
+
+So #451 is a *two shells indexing one key* hazard whose arming condition is a **second, MM-side** shell entering the link — not any reader. The `2ship_enh` WHOLE_ARCHIVE flip does not cause that, and MM's option table (`Rando::StaticData::Options`) is already linked via WHOLE_ARCHIVE'd `2ship_rando`. Take ADR 0004's route — extend the live SohMenu — rather than reviving BenMenu.
+
+**This distinction constrains your own work:** `SohMenuEnhancements.cpp` is both a linked reader of one of these keys *and* a file you will edit. #497 step 2's invariant ("assert every reader of a `kMenuIndexKeys` entry is on a not-linked allowlist") is RED at head as literally worded. Scope it over MM-side readers.
+
+## Three hazards that will bite silently
+
+- **Hints are hard-blocked by #438.** All six MM hint families register on `OnOpenText` (`EnGs.cpp:73,84`; `EnSsh.cpp:52-57`; `EnZow.cpp:27-35`; `EnTalk.cpp:68`; `DmStk.cpp:116`), which has no MM dispatch point. `RO_SHUFFLE_SHOPS` and the `OnActorKill` leg of `RO_SHUFFLE_ENEMY_DROPS` are likewise blocked. You are not blocked on #438 for the **IA**; you very much are for the **hints** half of #499.
+- **Half-armed options are worse than off.** Enabling an option whose hook type is dormant widens the pool (checks become `shuffled` via `Logic/GeneratePools.cpp:60-130`) but the behaviour never arms — items sit on checks the game cannot award. Audit every row you enable against #438's dispatch table.
+- **A generation throw silently reverts the world to vanilla** with no retry (`Foreign.cpp:20-27`, `OnFileCreate.cpp:293-307`) and the player just sees vanilla MM. Measure dead-end rates before shipping a raised profile.
+
+Also unresolved and blocking anything that iterates the option id space: `RO_ACCESS_MAJORA_REMAINS` is declared at `Rando/Types.h:2875` with no row in `Options.cpp` — 47 ids, 46 rows. Both #497 step 4 and #499 step 5 need this settled first.
+
+**Timing constraint** from #499: on the real cross-game path the profile is snapshotted when `MM_Rando_PairOnCrossGameArrival` dispatches `OnSaveInit` at arrival (`GameExports_SingleExe.cpp:1819,1857`), and an existing MM save is never regenerated (`:1832-1848`). Any chooser must therefore be reachable **while OoT is active, before the switch**. That constrains where the pane can live.
+
+## Two cross-lane asks you must make before you start
+
+- **`src/common/context.h`** (Lane 1). #497 step 7 and #499 step 4 both carve an MM-profile digest from the front of `reserved[]`, and #499's Tier-1 lock assertion (b) does not compile until it lands. Lane 1 owns `context.h` and is budgeting `reserved[264]` across five claimants — **give Lane 1 your digest size early** so it lands in one format version rather than a second re-versioning.
+- **`games/mm/2s2h/Rando/Foreign.cpp` / `Foreign.h`** (Lane 2, until #488 merges). #499 step 2 extracts the `OnFileCreate.cpp:112-120` loop and the `:132-137` pins into a callable `Rando::ResolvePairedProfile()` there, and your Tier-1 lock drives that function directly. Lane 2's claim ends when #488 merges; agree the handoff explicitly.
+
+Lane 2 also needs `MiscBehavior/OnFileCreate.cpp:245` (#488 step 5, a throw inside the existing try) — a different region of a file you own. Agree an order with Lane 2.
+
+## Files you own
+
+`games/oot/soh/SohGui/*` (including `SohMenuRandomizer.cpp`, the likeliest edit target, and `MenuTypes.h`), `docs/adr/0004-menu-information-architecture.md`, `docs/adr/0003-settings-namespace.md`, `src/common/cvar_shared_keys.h`, `src/common/tests/test_cvar_classification.c`, `games/mm/2s2h/Rando/MiscBehavior/OnFileCreate.cpp`, `Rando/StaticData/Options.cpp`, `Rando/Types.h`, `games/mm/CMakeLists.txt`, `.github/scripts/check-registrar-elision.sh`, and `src/common/ComboMenuBar.cpp` **and `.h`** (#497 step 6's deletion also touches its two references in `CMake/SingleExecutable.cmake:48,94` — it cannot be completed without them).
+
+`games/mm/2s2h/Rando/Menu.cpp` is **read-only reference** for the 9-group taxonomy at `:988-1028`. Do not claim or link it: it is elided into `2ship_rando_ui`, #497's decision forecloses reviving it, and pulling it into the link drags `BenGui/Menu.cpp` — which is exactly the #451 arming condition.
+
+## Do not touch
+
+`foreign_items.*` (Lane 1), `mm_rando_gen_test.cpp` (Lane 3 — it lands first; rebase, or add a separate TU), `TrackersGuiSingleExe.cpp` (Lane 5), `CheckQueue.cpp` / `DrawItem.cpp` (Lane 6). Lane 5 registers its windows on the shared `Ship::Context` Gui, deliberately bypassing the menu shell — do not route it through your new IA without agreeing that with Lane 5.
+
+## Non-negotiables
+
+- **Do not move MM's rando hook registration to the raw GameInteractor surface** (#467). If you do, OoT's file-select load starts re-evaluating MM's `IS_RANDO` conditions against OoT's `gSaveContext`.
+- Do not "fix #451 along the way." If your work causes an **MM** TU that reads one of those four keys to enter the link, that arms it — say so on #451 rather than absorbing it.
+- #497 step 1 is more than flipping a status line: it folds #454's resolution into ADR 0003 §4.1 and ADR 0004 §2d, updates `kDisputedClassificationKeys` (`cvar_shared_keys.h:370-372`, which still lists `gDeveloperTools.DebugSaveFileMode`) and its count static_assert, and resolves the ADR's five open maintainer calls. ADR 0003 is itself still Proposed with no issue tracking acceptance.
+- Locks register via `redship_add_test(NAME ... COMMAND ... LABEL rando TIMEOUT 180 ENVIRONMENT ...)` — the argument is `LABEL`, singular. Default (omitted) is `redship`, the display-free tier. Menu *appearance* is operator-verified; do not claim a visual result CI did not prove.
+
+## Stop and report if
+
+The #451 premise above is wrong and MM's options genuinely cannot be hosted without the WHOLE_ARCHIVE flip — that reopens #451 as a real gate and changes the phase's sequencing. Also report if, once `context.h` and `Foreign.cpp` are excluded pending the asks above, #499's remaining deliverable is too thin to be worth a PR on its own; say so rather than working around the ownership.

--- a/.claude/lanes/lane5.md
+++ b/.claude/lanes/lane5.md
@@ -1,0 +1,52 @@
+You are Lane 5 of six on RedShipBlueShip Phase 3.1 (#492): **visibility** — making the cross-game world legible to the player at all.
+
+Read #492, then #489, then #496. Read merged PR #457, which registered MM's trackers on the shared Gui; you are fixing and extending what it landed.
+
+## Ownership decision already made for you
+
+#458 (the combo tracker) is **deferred for 3.1**, and **#496 owns the cross-game tracker slice outright**. Earlier drafting told you to negotiate that boundary with #458; there is no counterparty, so proceed unilaterally and note the decision on both issues.
+
+#458 is also not a prerequisite and not a substrate: it reads the *inactive* game's frozen shadow and is staleness-labelled. Your spoiler view reads `gComboCtx.foreignPlacements` through the live `foreign_items.h` surface, which already exists.
+
+## Step 1 — #489, and steps 1–3 land together
+
+Three faults, and the issue is emphatic that partial landing is worse than nothing: landing step 3 alone gives named rows in a window that cannot open; landing 1–2 alone gives an openable window of blank rows.
+
+On the `CheckNames` fault specifically — `PopulateCheckNames()` already exists and is complete (`Rando/StaticData/Checks.cpp:2326-2330`, array at `:11`). **Nothing in Checks.cpp needs to change.** The defect is that its only caller is `BenPort.cpp:874`, and `BenPort.cpp` is CMake-excluded (`games/mm/CMakeLists.txt:238`). The fix is a **new call site** — `MM_Rando_Init` in `games/mm/2s2h/GameExports_SingleExe.cpp:1372-1373`, or `TrackersGuiSingleExe.cpp`.
+
+For #489 step 2, take **route B**. The issue offers two routes and route A (SohMenu `WIDGET_WINDOW_BUTTON` rows in `SohGui/SohMenuEnhancements.cpp`) is Lane 4's file. Route B is a `Show()`-on-persisted-CVar helper called from `MM_TrackersGui_Init` in `TrackersGuiSingleExe.cpp`, inside your ownership. Same for #496 step 4: read the CVar live in `Draw()` rather than adding a `SohGui/Menu.cpp` row.
+
+## Step 2 — #496
+
+The paired world's cross-game spoiler exists only as a JSON file on disk (`randomizer-mm/RSBSPAIR<masterSeed>.json`) — the operator had to be told the absolute path. Build the in-game view.
+
+Note the generation path **cannot** be reused as a view: `GenerateFromSaveContext` reads `gSaveContext` / `RANDO_SAVE_CHECKS` through MM's layout, and the view must read `gComboCtx` instead. That is why no `Rando/Spoiler/*` file needs editing here.
+
+#496 step 5 is a registration-seam decision that may want an ADR. Your default is the shared `Ship::Context` Gui pattern #457 established — if that is the decision, record it; do not hit it as an open question mid-task.
+
+## Files you own
+
+`games/mm/2s2h/TrackersGuiSingleExe.cpp` and `.h`, `games/mm/2s2h/Enhancements/Trackers/*`, `games/mm/2s2h/mm_trackers_gui_test.cpp`, new `src/common/combo_spoiler_view.{h,c}`, and its harness at **`src/common/tests/test_combo_spoiler_view.c`** (the `tests/` path, matching `test_foreign_items.c` — not `src/common/`). In `games/mm/2s2h/GameExports_SingleExe.cpp` you have `MM_Rando_Init` only; Lanes 1, 3 and 6 hold other functions there.
+
+`Rando/CheckTracker/*` is read-mostly — `CheckTracker.cpp` already reads its CVar live at `:454-457` and needs no change under #489; only the ItemTracker does.
+
+## Do not touch
+
+`context.h` / `foreign_items.*` (Lane 1 — read the accessors; ask on #493 if you need a new one), `Rando/Spoiler/*` (Lane 2 holds `Apply.cpp` for #488 step 6; nothing there is yours), `Rando/Foreign.cpp` (Lane 2), `z_sram_NES.c` / `mm_rando_gen_test.cpp` (Lane 3), `SohGui/*` (Lane 4), `CheckQueue.cpp` / `DrawItem.cpp` (Lane 6).
+
+## Non-negotiables
+
+- **Locks stay in the default, display-free `redship` label.** `MMTrackersGui` (`CMake/SingleExecutable.cmake:475`) passes no `LABEL` and the test file's own header says `CTest label "redship"`. Do **not** add `LABEL rando` — that is the xvfb seed-generation tier, and moving there drops your rows out of the `redship` run entirely.
+- The #489 bar is what the issue designs, and it is reachable in that tier: an `MM_TrackersGui_ShouldShow(name)` visibility predicate that is RED today, plus `Rando::StaticData::CheckNames[<RC_* id>]` non-empty and equal to its `convertEnumToReadableName` form. Both are pure — no ImGui, no save. Do **not** assert "non-zero checks for the active MM game": that implies a populated `RANDO_SAVE_CHECKS`, i.e. a real rando save, which this harness deliberately does not build (`mm_trackers_gui_test.cpp:20-28`).
+- Guard your edit to the vendored `Enhancements/Trackers/ItemTracker/ItemTracker.cpp:383-386` with `RSBS_SINGLE_EXECUTABLE`. An unguarded divergence in a vendored 2S2H TU is an upstream-sync landmine.
+- Window names stay `MM `-prefixed. SoH owns the unprefixed four on the shared Gui and `Gui::AddGuiWindow` rejects duplicates with a **silent** no-register from the caller's side.
+- Keep the `MMActiveGated<Base>` wrapper on every MM window. `gSaveContext` storage is unified, so an MM tracker drawing while OoT is active reads OoT bytes through MM's layout, and the shared Gui calls `Update()`/`Draw()` every frame regardless of active game.
+- Keep tracker icon textures gated on `MM_Rando_AssetsReady()` — the string-path `LoadGuiTexture` crashes on a missing resource, and the harness reaches this path windowed but archive-free.
+
+## Validation depends on Lane 3
+
+`CheckTrackerWindow::Draw` prints "No Rando Save Loaded" and returns when `!MM_gPlayState || !IS_RANDO` (`CheckTracker.cpp:478-486`), and the `saveType` clobber Lane 3 is fixing (#487) flips that mid-session. **Do not judge a tracker fix against a playtest that hits it.** Your operator verification waits on #487.
+
+## Stop and report if
+
+The no-data cause turns out to be upstream of the trackers — `RANDO_SAVE_CHECKS` genuinely empty on the arrival path rather than merely unread. That is an arrival-rehydration finding in the #482/#487 class and belongs to Lane 3.

--- a/.claude/lanes/lane6.md
+++ b/.claude/lanes/lane6.md
@@ -1,0 +1,53 @@
+You are Lane 6 of six on RedShipBlueShip Phase 3.1 (#492): **arrival and presentation** — what happens at the moment a foreign item is awarded, and what the player sees.
+
+Read #492, then #502, then #494. #502 is carved out of #493 step 5; read that step for context but **not** the rest of #493.
+
+## Why this lane exists
+
+Two pieces of the cross-game item experience are unowned by every other lane, and both are cheap relative to their value. Neither depends on #493's `.redsave` carve, and both are **O(1) in pool size** — doing them does not get more expensive if the pool grows, and doing them first does not save the pool work any effort.
+
+## Step 1 — #502, wire the MM-side award
+
+`MM_AwardSharedItem` is still the Lane-A1 logging stub: it only `fprintf`s "Lane C wires the MM give" (`games/mm/2s2h/GameExports_SingleExe.cpp:1772-1776`). `MM_ConsumeSharedItems` already calls `Combo_RedeemSharedItemsForGame(GAME_MM, MM_AwardSharedItem, nullptr)` at `:1786-1788`, so the whole consumer walk is live and lands on a no-op.
+
+Create `games/mm/2s2h/Rando/ForeignItemsSingleExe.cpp` under `RSBS_SINGLE_EXECUTABLE` with `extern "C" int MM_ForeignItem_Give(uint16_t riId)`, and replace the stub with the real give. Do **not** clear the entry — `Combo_RedeemSharedItemsForGame` sets `RSBS_SHARED_ITEM_REDEEMED`. MM Rando TUs are glob-collected into `2ship_rando`, which links WHOLE_ARCHIVE, so a new TU survives with no CMake edit.
+
+**Lane 1 extends this same TU later** with `kForeignPoolMMV1` (the reverse-direction source pool). You create the file and the give; Lane 1 adds the pool after you merge. Keep the file small and the boundary obvious.
+
+**The NULL-play hazard is real and is the main risk in this step.** MM's redemption point runs *before* `MM_gPlayState` is assigned: `MM_ConsumeSharedItems()` is called at `z_play.c:2406`, while `MM_gPlayState = this` happens at `:2468`. `Rando::GiveItem`'s default branch calls `MM_Item_Give(MM_gPlayState, ...)`, and `Item_GiveImpl` (`z_parameter.c:4136`) has only partial 2S2H nullptr guards — `Inventory_IncrementSkullTokenCount(play->sceneId)`, `MM_Health_ChangeBy(play, ...)` and `Magic_Add(play, ...)` are unguarded derefs. `Rando::GrantStartingItems` (`StartingItems.cpp:66-68`) proves a NULL-play give works for *some* items, not for any item.
+
+So: either trace each candidate `RI_*` for NULL-play safety and restrict to the safe set, or move MM redemption to the gameplay-gated frame-tick safe point that `src/common/shared_items.h:52-64` already defines and nothing wires. Pick one deliberately and say which on the issue — a badly chosen item crashes the arrival path.
+
+## Step 2 — #494, foreign-item presentation
+
+Correct the framing first: **names already work.** The pickup textbox interpolates the item's real display name (`Rando/MiscBehavior/CheckQueue.cpp:70-72`) and both spoiler surfaces name items individually (`Rando/Spoiler/Generate.cpp:41-42`, `:63-74`). What is a shared `RI_RUPEE_HUGE` stand-in is only the **textbox icon** and the **get-item model**, and both are pool-size-invariant.
+
+**Slice 6 is a correctness item, not polish, and it is the one to prioritise:** no draw path consults `Rando::Foreign::IsForeignCheck`, so a foreign check currently sits in the MM world *disguised as the junk item the fill left there*. The player has no way to know a check holds a cross-game item until they collect it. That is true identically at 4 items and at 32.
+
+The other half of the issue is the OoT side: `OoT_AwardSharedItem` (`games/oot/soh/GameExports_SingleExe.cpp:1035-1039`) awards silently — a foreign item arrives in OoT with no notification at all.
+
+Work the tiers in order of blocking factor. The icon tier needs an answer to whether the receiving game can resolve the origin game's assets at all (`oot.o2r` vs `mm.o2r` mounting) — establish that before promising a real icon, and fall back to a distinct generic foreign marker if it turns out both archives are not simultaneously addressable. A real 3D model is the only tier that scales per-item, so it is explicitly out of scope.
+
+Closing slice 4 also unparks #427 item 1, which has been waiting on exactly this work ("When Lane C1 touches presentation, replace with an explicit bridge" — the `Notification::Emit` cross-bind).
+
+## Files you own
+
+`games/mm/2s2h/Rando/MiscBehavior/CheckQueue.cpp`, `games/mm/2s2h/Rando/DrawItem.cpp`, `games/mm/2s2h/Rando/ActorBehavior/*`, the new `games/mm/2s2h/Rando/ForeignItemsSingleExe.cpp`, `MM_AwardSharedItem` in `games/mm/2s2h/GameExports_SingleExe.cpp`, and `OoT_AwardSharedItem` in `games/oot/soh/GameExports_SingleExe.cpp`.
+
+## Do not touch
+
+`src/common/foreign_items.h` / `.c` and `context.h` (Lane 1), `Rando/Foreign.cpp` (Lane 2 — you may call `IsForeignCheck`, not edit it), `z_sram_NES.c` / `mm_rando_gen_test.cpp` (Lane 3), `SohGui/*` and `OnFileCreate.cpp` (Lane 4), `TrackersGuiSingleExe.cpp` / `Rando/Spoiler/*` (Lane 5 / Lane 2).
+
+## Your one upstream dependency
+
+Tier 2a of #494 — a `Combo_GetForeignItemIconName`-style accessor — lands in `src/common/foreign_items.h` and `ForeignItemsSingleExe.cpp` (OoT), both Lane 1's. **Wait for Lane 1's prep commit** (the additive origin-dispatch of the pool/name surface) and branch from it, then ask Lane 1 to add the icon accessor alongside. Everything else in this lane needs nothing from Lane 1.
+
+## Non-negotiables
+
+- Locks at the default `redship` label. Presentation is display-tier and the honest lock is on the **resolution surface**, not the pixels: assert a non-null icon/name descriptor for every pool entry, RED while the icon is hardcoded to `RI_RUPEE_HUGE`. Do not claim a visual result CI did not prove — the operator verifies appearance.
+- The step-1 give must be locked non-vacuously: plant the shared item through the real `Combo_RecordSharedItem` and drive the real `MM_AwardSharedItem`, then assert exactly one award and the entry marked `RSBS_SHARED_ITEM_REDEEMED`, and that a second redeem awards zero. Calling `Rando::GiveItem` directly from a test is vacuous.
+- Any edit to a vendored 2S2H TU under `Enhancements/` or `ActorBehavior/` needs an `RSBS_SINGLE_EXECUTABLE` guard, or it is an upstream-sync landmine.
+
+## Stop and report if
+
+The archive story rules out cross-game asset resolution entirely. That caps presentation at a generic-but-distinct marker permanently, which is a product decision the operator should make rather than something to work around — and it would also settle how far #495's pool can grow before the experience degrades.

--- a/.claude/worker-prompts.md
+++ b/.claude/worker-prompts.md
@@ -1,7 +1,31 @@
-# Worker loop goals — Wave 4 (updated 2026-07-19)
+# Worker loop goals — Phase 3.1 lanes (updated 2026-07-22)
 
-**Current phase: Phase 3.0 — Basic Combo Randomizer.** Phase 2 closed with PR #368
-(merged as c8c47fa6): the first full OoT↔MM gameplay round trip.
+**Current phase: Phase 3.1 — Two-Way Combo Randomizer (#492).** Phase 3.0 closed
+its contract (milestone 17/17): four hand-pinned OoT items crossing into MM
+checks, one direction, surviving a round trip, described by a spoiler log.
+
+## Lanes — one prompt per lane in `.claude/lanes/`
+
+Read `.claude/lanes/SHARED.md` first; it carries the append-only shared-file
+protocol and the three-edit CTest registration rule that hard-fails the build if
+you do fewer.
+
+| Lane | Issues | Owns, roughly |
+|---|---|---|
+| 1 | #490 → #498 ADR → #493 | `context.h`, `foreign_items.*`, OoT rando pool + spoiler |
+| 2 | #488 | `Rando/Foreign.cpp`, `Spoiler/Apply.cpp` (for #488 only) |
+| 3 | #487 → #491 | `z_sram_NES.c`, `mm_stubs.c`, `mm_rando_gen_test.cpp` |
+| 4 | #497 → #499 | `SohGui/*`, ADR 0003/0004, `cvar_shared_keys.h`, `OnFileCreate.cpp` |
+| 5 | #489 → #496 | `TrackersGuiSingleExe.*`, trackers, `combo_spoiler_view.*` |
+| 6 | #502 → #494 | `CheckQueue.cpp`, `DrawItem.cpp`, both `*_AwardSharedItem` |
+
+Lane 1 is the only lane that changes `.redsave` format and owns the
+`reserved[264]` byte budget across all five claimants — Lane 4 must hand it a
+digest size before carving, not after.
+
+Ordering that is load-bearing: **Lane 3 lands first** (#487 is P0 and Lane 5's
+verification depends on it). Lane 1 rebases onto Lane 2 **before #493 step 7**,
+not before step 3 — gating the longest pole on the smallest lane idles the phase.
 
 This file deliberately holds almost no state. Its failure mode is going stale — an
 earlier revision claimed "Wave 3" and "eleven commits awaiting push" for a day
@@ -12,15 +36,19 @@ that gets updated as work lands.
 
 | What | Where |
 |---|---|
-| Phase 3 tracker (lanes, waves, current state) | **#392** |
+| Phase 3.1 tracker (waves, corrections, current state) | **#492** |
+| Per-lane worker prompts | `.claude/lanes/lane<N>.md` |
+| Phase 3.1 waves and the four sequencing corrections | `docs/phase3-roadmap.md` §5 |
+| Phase 3.2 (cross-game logic, Lane D promoted) | #500 |
+| Phase 3.0 tracker (closed contract, prior art) | #392 |
 | Phase 3 execution plan and wave assignments | `docs/phase3-execution-prompt.md` |
-| Phase 3 roadmap (MVP definition, lanes A–D) | `docs/phase3-roadmap.md` |
 | Phase 2 follow-ups still open | #381 |
 | Pre-alpha v0.1.0 readiness gates | #321 |
 | Player-visible known issues | `docs/known-issues.md` |
 | Prior local-iteration postmortems | `docs/ci-gameplay-repro-postmortem.md` |
 
-Read #392 first. It is the live one; the docs are the reasoning behind it.
+Read #492 and your lane prompt first. They are the live ones; the docs are the
+reasoning behind them, and #392 is the closed phase they build on.
 
 ## Standing conventions
 

--- a/docs/phase3-roadmap.md
+++ b/docs/phase3-roadmap.md
@@ -204,14 +204,85 @@ invalidate A/B/C.
 A → B in parallel with A's back half → C. D is out of scope.
 Gate C on Lane A being merged and locked; C without A is unverifiable.
 
-## 5. LATER — Phase 3.1+
+## 5. NEXT — Phase 3.1 "Two-Way Combo Randomizer"
+
+Phase 3.0 met its contract and its milestone reads 17/17 closed. What it shipped
+is **four hand-pinned OoT items** (`kForeignPoolV1`,
+`games/oot/soh/Enhancements/randomizer/ForeignItemsSingleExe.cpp:58-63`) placed
+into MM checks, one direction, named correctly over a shared `RI_RUPEE_HUGE`
+icon and model, hosts drawn at random from junk-holding shuffled checks with
+shops excluded, no cross-game logic, no MM options surfaced, and every
+`RO_SHUFFLE_*` / `RO_HINTS_*` off in the paired profile.
+
+Tracker: **#492**. Contract:
+
+> **Items cross in both directions, chosen by rule rather than by a hand-written
+> array, presented with their own identity, and configurable from one menu.**
+
+Logic stays out — Lane D is promoted to its own 3.2 tracker (#500). 3.1 keeps
+the 3.0 bargain: free-form placement plus a spoiler log.
+
+### Four corrections to the sequencing this section used to imply
+
+Each was adversarially verified against the tree, and each refuted the
+intuitive ordering. Plans written without them are wrong in ways that compile.
+
+1. **The reverse direction is not a mirror of Lane C** (#493). Only the
+   origin-tagged `SharedItem` carrier is direction-neutral. The placement table
+   is hard-keyed `uint16_t mmCheckId` with static_asserted `.redsave` offsets;
+   OoT generates *first* and stamps the pairing key only at the end of
+   `Playthrough_Init`, after `Fill()` and after `SpoilerLog_Write()`; and OoT's
+   actor collection path drops the `RandomizerCheck` before the give, so the
+   foreign identity must ride inside the `GetItemEntry`. **XL, not L.**
+2. **The combo tracker is not a substrate** under presentation, placement rules
+   or hints. #458 is a read-only, staleness-labelled reader of the *inactive*
+   game's frozen shadow and structurally cannot serve a live write-time
+   placement pass. Those three run in the active game and already share
+   `src/common/foreign_items.h`. Sequence #458 in parallel, not first.
+3. **`RSBS_FOREIGN_PLACEMENT_CAP` is a trap, not a deadline** (#490). Raising it
+   in place is *already* a silent `.redsave` format break at head, because
+   `grantCursors` and `sharedItemOverflowCount` are carved after it and the
+   offset static_asserts are expressed in terms of the cap, so they follow a
+   bump instead of catching it. The comment at `src/common/context.h:161-167`
+   still promises this is cheap. Defusing the comment is the urgent part; the
+   capacity increase belongs with whatever grows the pool.
+4. **#451 does not gate the menu theme** (#497). Three of its four contended
+   keys have no compiled reader in any target (`BenGui/BenMenu.cpp` is a member
+   of no CMake target) and the fourth lives in a different archive than the
+   `2ship_enh` WHOLE_ARCHIVE flip touches. MM's option *table*
+   (`Rando::StaticData::Options`) is already in the link via WHOLE_ARCHIVE'd
+   `2ship_rando`, so a SohMenu-hosted MM pane can be built today. **The settings
+   theme is unblocked now.**
+
+### Waves
+
+- **Wave 0 — hardening**: #487 (owl-save readback zeroes the live MM
+  SaveContext — a still-live P0-class defect with the same symptom as the
+  moon-crash leg closed in PR #485), #488 (host predicate), #489 (MM trackers
+  show no data), #490 (cap comment), #491 (vacuous arrival lock). Wave 0 blocks
+  **operator playtest acceptance** of live-play-facing work; it does **not**
+  block the ROM-free `gComboCtx` / `src/common` increments, which never read
+  `saveType` and start immediately.
+- **Wave 1 — two directions**: #493. Separable cheaper increment: wiring
+  `MM_AwardSharedItem` (still the Lane-A1 logging stub) to a real give needs
+  none of the OoT-side work.
+- **Wave 2 — identity and breadth**, parallel with Wave 1: #494 (presentation),
+  #495 (rule-defined pool), #496 (in-game spoiler view), #458 (combo tracker).
+  Presentation and pool-scaling are **independent** — foreign pickups already
+  name each item individually, so presentation is O(1) in pool size.
+- **Wave 3 — configuration**, parallel throughout: #497 (menu IA + ADR 0004),
+  #498 (combo-level settings), #499 (MM shuffles and hints on).
+
+## 5a. LATER — beyond 3.1
 
 Directional, not committed:
 
-- **Cross-game logic + beatability check** (Lane D promoted)
-- **Cross-game item placement, both directions, full item pool**
+- **Cross-game logic + beatability check** — Lane D, promoted to #500
 - **Cross-game entrance shuffle** — `entrance.h` was designed for it; the
-  1:1 link table generalizes to any-entrance→any-entrance
+  1:1 link table generalizes to any-entrance→any-entrance. Needs 3.2's logic to
+  be more than a spoiler-log mode
+- **Netplay 1b / multiworld player slots** — ADR 0007 specifies the shape;
+  #460 is 1a
 - **`sharedFlags` semantics** — which world events are genuinely shared
   (this needs a design decision, not just plumbing)
 - **#34 settings migration** — deferred here by design since Phase 2

--- a/docs/phase3-roadmap.md
+++ b/docs/phase3-roadmap.md
@@ -246,10 +246,14 @@ intuitive ordering. Plans written without them are wrong in ways that compile.
    bump instead of catching it. The comment at `src/common/context.h:161-167`
    still promises this is cheap. Defusing the comment is the urgent part; the
    capacity increase belongs with whatever grows the pool.
-4. **#451 does not gate the menu theme** (#497). Three of its four contended
-   keys have no compiled reader in any target (`BenGui/BenMenu.cpp` is a member
-   of no CMake target) and the fourth lives in a different archive than the
-   `2ship_enh` WHOLE_ARCHIVE flip touches. MM's option *table*
+4. **#451 does not gate the menu theme** (#497). Its four contended keys have no
+   compiled **MM-side** reader: MM's readers are `BenGui/BenMenu.cpp` (a TU in
+   no CMake target) and `BenGui/Menu.cpp` (in the elided `2ship_rando_ui`),
+   neither of which the `2ship_enh` WHOLE_ARCHIVE flip touches. OoT's SohMenu
+   *does* read all four from the live link (`SohMenuSettings.cpp:127`,
+   `SohMenuEnhancements.cpp:148`, `SohMenuDevTools.cpp:35`, `Menu.cpp:568`) —
+   that is the shared half of the hazard, not its arming condition, which is a
+   *second*, MM-side shell indexing the same key. MM's option *table*
    (`Rando::StaticData::Options`) is already in the link via WHOLE_ARCHIVE'd
    `2ship_rando`, so a SohMenu-hosted MM pane can be built today. **The settings
    theme is unblocked now.**


### PR DESCRIPTION
`docs/phase3-roadmap.md` §5 was five directional bullets written before Phase 3.0 shipped. Phase 3.0 has since closed its contract (milestone 17/17), and four of the sequencing assumptions §5 implies are now refutable against the tree.

Replaces §5 with the planned **Phase 3.1 — Two-Way Combo Randomizer** (#492): the shipped 3.0 surface recorded plainly, the 3.1 contract, four corrections, and the four waves with issue numbers. Directional items beyond 3.1 move to a new §5a.

## The four corrections

1. **The reverse direction is not a mirror of Lane C** (#493). Only the origin-tagged `SharedItem` carrier is direction-neutral. The placement table is hard-keyed `uint16_t mmCheckId` with static_asserted `.redsave` offsets; OoT generates *first* and stamps the pairing key only at the end of `Playthrough_Init`, after `Fill()` and after `SpoilerLog_Write()`; and OoT's actor collection path drops the `RandomizerCheck` before the give. **XL, not L.**
2. **#458 is not a substrate** under presentation, placement rules or hints — it is a read-only reader of the *inactive* game's frozen shadow and cannot serve a live write-time placement pass. Those three run in the active game against `src/common/foreign_items.h`. Parallel, not first.
3. **`RSBS_FOREIGN_PLACEMENT_CAP` is a trap, not a deadline** (#490). Raising it in place is *already* a silent `.redsave` format break at head, because `grantCursors` and `sharedItemOverflowCount` are carved after it and the offset static_asserts are expressed in terms of the cap — so they follow a bump instead of catching it. `src/common/context.h:161-167` still promises the bump is cheap.
4. **#451 does not gate the menu theme** (#497). Three of its four contended keys have no compiled reader in any target (`BenGui/BenMenu.cpp` is in no CMake target); MM's option table is already in the link via WHOLE_ARCHIVE'd `2ship_rando`. Settings work is unblocked today.

## Note for reviewers

Wave 0 carries #487 — a **still-live P0-class defect with the same user-visible symptom as the moon-crash leg fixed in #485**. `SaveManager/*.cpp` is filtered out of the MM target (`games/mm/CMakeLists.txt:301`), so `SaveManager_SysFlashrom_ReadData` resolves to a stub that returns success without filling the buffer (`src/common/mm_stubs.c:260`), and the owl-save path memcpy's that zeroed buffer over `gSaveContext` (`z_sram_NES.c:2175-2180`). #485's self-heal cannot catch it because the zero-fill takes `finalSeed` with it. That issue carries a link-map confirmation as its first step.

Docs only — no build or test surface touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)