### PR TITLE
Stop MM's flash readbacks from erasing the paired world's randomizer identity (#487)

### DIFF
--- a/.github/clang-format-paths.txt
+++ b/.github/clang-format-paths.txt
@@ -42,6 +42,7 @@ games/mm/2s2h/mm_framebuffer_effects.c
 games/mm/2s2h/mm_gi_shim_test.cpp
 games/mm/2s2h/mm_notification_binding_test.cpp
 games/mm/2s2h/mm_resume_state_test.cpp
+games/mm/2s2h/mm_save_manager_stubs.c
 games/mm/2s2h/mm_trackers_gui_test.cpp
 games/mm/2s2h/z_scene_2SH.cpp
 games/mm/src/audio/lib/dcache.c

--- a/.github/clang-format-paths.txt
+++ b/.github/clang-format-paths.txt
@@ -37,6 +37,7 @@ games/mm/2s2h/TrackersGuiSingleExe.cpp
 games/mm/2s2h/TrackersGuiSingleExe.h
 games/mm/2s2h/mm_culling_test.cpp
 games/mm/2s2h/mm_fb_effects_test.cpp
+games/mm/2s2h/mm_flash_filenum_test.cpp
 games/mm/2s2h/mm_framebuffer_effects.c
 games/mm/2s2h/mm_gi_shim_test.cpp
 games/mm/2s2h/mm_notification_binding_test.cpp

--- a/CMake/CheckTestRegistration.cmake
+++ b/CMake/CheckTestRegistration.cmake
@@ -1,5 +1,12 @@
 # CMake/CheckTestRegistration.cmake
 #
+# NOTE: `cmake -P` script mode starts with NO policies set, so the if(IN_LIST)
+# operators below are parse errors ("Unknown arguments specified") unless
+# CMP0057 is requested explicitly. That is version-dependent enough to have hit
+# only a local CMake 4.4 run while CI stayed green, which is exactly the kind of
+# environment-shaped skew that makes a guard look broken when it is not.
+cmake_policy(SET CMP0057 NEW)
+#
 # Registration-completeness guard. Run as a CTest row in the tier it polices:
 #   cmake -DREDSHIP_EXE=<redship> -DMANIFEST=<manifest> -P CheckTestRegistration.cmake
 #

--- a/CMake/SingleExecutable.cmake
+++ b/CMake/SingleExecutable.cmake
@@ -466,6 +466,15 @@ if(BUILD_TESTING)
     # VisFbuf draw. This locks MM's call to its own MM_-dimension body (only one
     # definition survived, so no link error could catch the cross-bind).
     redship_add_test(NAME MMFbEffectsBinding COMMAND redship --test mm-fb-effects-binding)
+    # MM flash page-table OOB from the 0xFF fileNum sentinel
+    # (games/mm/2s2h/mm_flash_filenum_test.cpp). A cross-game MM session runs
+    # with gSaveContext.fileNum == 0xFF (no real file slot); the moon-crash reset
+    # and the owl-delete write it fires index gFlashSave*Pages /
+    # gFlashOwlSave*Pages by fileNum * FLASH_SAVE_MAIN_MULTIPLIER, so 0xFF runs
+    # hundreds of entries past the tables' end, and the reset copies the garbage
+    # over the live save (spawn-as-Fierce-Deity / all-Ocarina corruption).
+    # Display-free and ROM-free, so it runs in this redship tier.
+    redship_add_test(NAME MMFlashFileNumOob COMMAND redship --test mm-flash-filenum-oob)
     # MM tracker registration surface (#392): the four MM tracker windows must
     # register on the shared Gui under "MM "-prefixed names (SoH owns the
     # unprefixed ones; Gui::AddGuiWindow rejects duplicates) and their

--- a/CMake/SingleExecutable.cmake
+++ b/CMake/SingleExecutable.cmake
@@ -599,9 +599,8 @@ if(BUILD_TESTING)
     # OnSaveLoad (the disarm-then-rearm ordering #439 got wrong on the arrival
     # path, and the ordering the owl-save reload relies on), and an in-session
     # reload (Song of Time / cycle reset / DayTelop) must leave a live rando
-    # session's armed hooks untouched. Reads arm state through
-    # S2H::GameHooks::CountForTest<OnFlagSet>. Same display requirement, hence
-    # the same label/env.
+    # session's armed hooks untouched. Same display requirement, hence the same
+    # label/env.
     redship_add_test(NAME MMReloadArmState COMMAND redship --test mm-reload-arm-state
         LABEL rando
         TIMEOUT 180
@@ -618,6 +617,29 @@ if(BUILD_TESTING)
     # Unregister is deferred, so a count lags a disarm and would pass vacuously).
     # Same display requirement, hence the same label/env.
     redship_add_test(NAME MMMoonCrashArmState COMMAND redship --test mm-moon-crash-arm-state
+        LABEL rando
+        TIMEOUT 180
+        ENVIRONMENT "SDL_AUDIODRIVER=dummy;RSBS_DISABLE_OTR_INIT=1")
+
+    # #487, the same class on the save a player performs every cycle. An owl
+    # save ends in Sram_UpdateWriteToFlashOwlSave re-reading the file it just
+    # wrote and memcpy'ing it over gSaveContext for offsetof(SaveContext,
+    # fileNum) -- all of struct Save, ShipSaveInfo included. MM's flash read is
+    # a no-op stub in single-exe (games/mm/2s2h/mm_save_manager_stubs.c), so
+    # that commit writes ZEROS over the paired world's randomizer identity, in
+    # live gameplay. Also covers the file-copy leg (func_80147414).
+    #
+    # Tier: `rando`, not `redship`, and the choice was made on evidence rather
+    # than by copying the neighbours (#491 step 1). The display requirement
+    # comes from the DISPATCHER, not from the save code: every bridge in
+    # mm_rando_gen_test.cpp runs InitOTRForMMFirstBoot, whose OTRGlobals ctor
+    # constructs a Fast3dWindow when no window exists (games/oot/soh/
+    # OTRGlobals.cpp). The probe additionally needs MM_Rando_Init and a
+    # populated Rando::Logic::Regions. A display-free row IS possible for the
+    # flash code alone -- MMFlashFileNumOob drives Sram_ResetSaveFromMoonCrash
+    # with no window -- but it cannot carry the VB arm-state probe, which is
+    # this row's entire point.
+    redship_add_test(NAME MMOwlSaveArmState COMMAND redship --test mm-owl-save-arm-state
         LABEL rando
         TIMEOUT 180
         ENVIRONMENT "SDL_AUDIODRIVER=dummy;RSBS_DISABLE_OTR_INIT=1")

--- a/docs/unified-surface-findings.md
+++ b/docs/unified-surface-findings.md
@@ -257,3 +257,58 @@ Cheapest-first, each independently valuable:
 5. **`2ship_enh` migration + dispatch placement + guard flip** — the gateway to
    enhancements *and* the MM netplay client.
 6. **Netplay increment 1** on the `SharedItem` machinery.
+
+---
+
+## 7. MM's flash save path in single-exe (Lane 3 / #487, #491)
+
+> Investigated 2026-07-22 against `claude/lane3-owl-save-readback`, with a **local
+> build of the real binary** rather than static evidence alone.
+
+### The link check, run against the binary rather than inferred
+
+`games/mm/CMakeLists.txt` filters `2s2h/SaveManager/*.cpp` out of the single-exe
+link, and it is the only reference to that directory in any CMake file. The
+built `redship` binary confirms it: the real `SaveManager.cpp` contributes no
+object to the link, and MM's two flash entry points resolve to stubs. So MM's
+flash **read** returns whatever was in the caller's buffer already, and MM's
+flash **write** goes nowhere.
+
+### The bug class this creates
+
+Every "read the file back from flash, then `memcpy` it over `gSaveContext`" site
+commits an *untouched* buffer — in practice the zeros from the preceding
+`memset`. `ShipSaveInfo` (`saveType` **and** the whole rando block: `finalSeed`,
+options, the `RC_MAX` placement table) is a member of `struct Save`, so each such
+commit erases the paired world's randomizer identity. #485 caught the moon-crash
+instance. The complete inventory in `games/mm/src/code/z_sram_NES.c`:
+
+| Function | Reachable how | Status |
+|---|---|---|
+| `Sram_ResetSaveFromMoonCrash` | moon crash, live gameplay | fixed #485, now on the shared helper |
+| `Sram_UpdateWriteToFlashOwlSave` | **every owl save, live gameplay** | fixed here (#487) |
+| `func_80147414` (owl half of `Sram_CopySave`) | file-copy menu | fixed here |
+| `Sram_CopySave` | file-copy menu | fixed here |
+| `MM_Sram_OpenSave` | file-select LOAD | guarded here (inert in practice — the boot chain authors a vanilla bootstrap first) |
+| `func_801457CC` | file-select enumeration; uses the live `gSaveContext` as scratch for all seven slots | guarded here (same, inert in practice) |
+| `Sram_EraseSave` | erase menu | **not** guarded — it commits a `memset` buffer by design, and erasing a file is meant to clear it |
+| `func_80147314` | owl write | no read at all; not a member of this class |
+
+The guard is one shared pair (`Sram_Begin/EndRandoPreserve`) with a depth
+counter, because `Sram_CopySave` → `func_80147414` nests.
+
+### Two things deliberately left for the maintainer
+
+1. **Should `redship` have a real MM save path at all?** (#487 step 5.) With the
+   write stub also a no-op, MM's flash storage in single-exe persists nothing;
+   MM state survives a session only through the cross-game freeze/restore blobs.
+   Everything above assumes that stays true and makes the no-op *honest* (the
+   read stub now returns `-1` rather than claiming success). Wiring MM to a real
+   `.redsave`-backed store is a scoping decision, not a bug fix.
+2. **`MM_Sram_InitSave` computes its checksum before `OnSaveInit` runs.** The
+   hook is what stamps `SAVETYPE_RANDO` and the generated world, so the bytes
+   written to flash carry a checksum taken over the *pre-generation* image. On a
+   later enumeration that mismatch takes the backup path and can present the file
+   as empty. Harmless while the write is a no-op, which is why it is recorded
+   here rather than fixed inside a P0 correctness change: moving the checksum
+   changes on-disk bytes for standalone MM too, and belongs with (1).

--- a/games/mm/2s2h/mm_flash_filenum_test.cpp
+++ b/games/mm/2s2h/mm_flash_filenum_test.cpp
@@ -1,0 +1,159 @@
+/**
+ * @file mm_flash_filenum_test.cpp
+ * ROM-free, display-free lock for the MM flash page-table out-of-bounds read
+ * driven by gSaveContext.fileNum == 0xFF. CTest label "redship", row
+ * MMFlashFileNumOob in CMake/SingleExecutable.cmake, dispatch "mm-flash-filenum-oob"
+ * in src/common/test_runner.cpp.
+ *
+ * What was broken: a cross-game MM session runs with fileNum == 0xFF (the
+ * "no real file slot" sentinel the title/debug/mapselect boot leaves in
+ * gSaveContext, and which no cross-game arrival replaces). MM's flash paths
+ * index the fixed-size gFlashSave*Pages / gFlashOwlSave*Pages tables by
+ * `fileNum * FLASH_SAVE_MAIN_MULTIPLIER`, so 0xFF subscripts them at 510 --
+ * hundreds of entries past the end. On the moon-crash reset path
+ * (Sram_ResetSaveFromMoonCrash, plus DeleteOwlSave -> func_80147314 fired from
+ * the BeforeMoonCrashSaveReset hook) that wild index becomes a flash page
+ * number/count and the reset then copies the resulting garbage over the live
+ * save -- the operator's "spawn as Fierce Deity in the opening cutscene with
+ * every inventory slot reading as the Ocarina of Time" corruption.
+ *
+ * The invariant this locks: for every reachable fileNum -- including the 0xFF
+ * sentinel -- no flash page-table index is computed out of bounds, and the
+ * reported reset paths leave the live save intact when there is no real slot.
+ *
+ * Three checks, none needing a display or ROM:
+ *   1. Bounds invariant. Sram_FileNumHasFlashSlot accepts exactly the fileNums
+ *      whose every index form lands inside the real tables (length FLASH_SAVE_MAX
+ *      for the main tables, FILE_NUM_MAX*2 for the owl tables), and rejects
+ *      0xFF. This pins the guard's accept-set to the actual table extents.
+ *   2. Owl-delete write site. func_80147314(&sram, 0xFF) -- the second OOB site
+ *      on the moon-crash path -- must bail before touching gFlashOwlSave*Pages
+ *      and before mutating the save. A pre-stamped newf marker must survive.
+ *   3. Moon-crash reset (the reported path). Sram_ResetSaveFromMoonCrash under
+ *      the 0xFF sentinel must not reload from flash and must not overwrite the
+ *      live save with the zeroed buffer. A pre-stamped player name and day must
+ *      survive.
+ *
+ * Removing the fix (reverting the func_80147314 / Sram_ResetSaveFromMoonCrash
+ * guards) flips checks 2 and 3 to failure without any crash: the OOB reads land
+ * in adjacent .data, the funnel rejects the garbage pages as unavailable, and
+ * the save is corrupted exactly as observed.
+ */
+
+#include "global.h"
+
+#include <cstdio>
+#include <cstring>
+
+namespace {
+
+#define FLASH_ASSERT(cond, msg)                                           \
+    do {                                                                  \
+        if (!(cond)) {                                                    \
+            printf("[TEST] FAIL: %s (%s:%d)\n", msg, __FILE__, __LINE__); \
+            return 1;                                                     \
+        }                                                                 \
+    } while (0)
+
+// Backing store for the flash funnel's saveBuf. Static so the 128 KiB does not
+// land on the test's stack.
+u8 sSaveBuf[SAVE_BUFFER_SIZE];
+
+} // namespace
+
+extern "C" int MM_FlashFileNumOob_RunHeadless(void) {
+    printf("[TEST] mm-flash-filenum-oob: flash page-table indices stay in bounds for fileNum 0xFF\n");
+
+    // ------------------------------------------------------------------
+    // Check 1: the guard's accept-set matches the real table extents.
+    // The main page tables have FLASH_SAVE_MAX entries; the owl page tables
+    // have FILE_NUM_MAX * 2. Sram_FileNumHasFlashSlot must accept a fileNum iff
+    // every index the flash paths derive from it lands inside those tables.
+    // ------------------------------------------------------------------
+    for (s32 fileNum = 0; fileNum <= 0xFF; fileNum++) {
+        s32 accepted = Sram_FileNumHasFlashSlot(fileNum);
+
+        // Largest subscripts any flash path forms from fileNum:
+        //   main new-cycle + backup:   fileNum * 2 (+1)
+        //   main owl (MM_Sram_OpenSave): (fileNum + FILE_NUM_OWL_SAVE_OFFSET) * 2 (+1)
+        //   owl tables (func_80147314):  fileNum * 2 (+1)
+        s32 mainNewCycle = fileNum * FLASH_SAVE_MAIN_MULTIPLIER + FLASH_SAVE_BACKUP_OFFSET;
+        s32 mainOwl = (fileNum + FILE_NUM_OWL_SAVE_OFFSET) * FLASH_SAVE_MAIN_MULTIPLIER + FLASH_SAVE_BACKUP_OFFSET;
+        s32 owlTable = fileNum * FLASH_SAVE_MAIN_MULTIPLIER + FLASH_SAVE_BACKUP_OFFSET;
+
+        s32 inBounds = (fileNum >= 0) && (mainNewCycle < FLASH_SAVE_MAX) && (mainOwl < FLASH_SAVE_MAX) &&
+                       (owlTable < FILE_NUM_MAX * FLASH_SAVE_MAIN_MULTIPLIER);
+
+        FLASH_ASSERT(accepted == inBounds,
+                     "Sram_FileNumHasFlashSlot disagrees with the real flash-table bounds for some fileNum");
+    }
+
+    // The sentinel itself, and the legitimate slots, called out explicitly.
+    FLASH_ASSERT(!Sram_FileNumHasFlashSlot(0xFF), "0xFF sentinel must be rejected as a flash slot");
+    FLASH_ASSERT(Sram_FileNumHasFlashSlot(0) && Sram_FileNumHasFlashSlot(1) && Sram_FileNumHasFlashSlot(2),
+                 "real file slots 0..2 must be accepted");
+    FLASH_ASSERT(!Sram_FileNumHasFlashSlot(-1) && !Sram_FileNumHasFlashSlot(FILE_NUM_MAX),
+                 "out-of-range fileNums must be rejected");
+
+    // ------------------------------------------------------------------
+    // Check 2: func_80147314 (owl-save delete) honors the sentinel.
+    // This is the write site reached via DeleteOwlSave() from the
+    // BeforeMoonCrashSaveReset hook, and via MM_Sram_OpenSave's save-continue
+    // path -- both with gSaveContext.fileNum possibly 0xFF.
+    // ------------------------------------------------------------------
+    {
+        SramContext sramCtx;
+        memset(&sramCtx, 0, sizeof(sramCtx));
+        memset(sSaveBuf, 0, sizeof(sSaveBuf));
+        sramCtx.saveBuf = sSaveBuf;
+
+        memset(&gSaveContext, 0, sizeof(gSaveContext));
+        gSaveContext.fileNum = 0xFF;
+
+        // A marker that is NOT the 'ZELDA3' valid-file sentinel func_80147314
+        // writes on its way out; if the function runs it will overwrite this.
+        const char kNewfMarker[6] = { 'R', 'S', 'B', 'S', '!', '?' };
+        memcpy(gSaveContext.save.saveInfo.playerData.newf, kNewfMarker, sizeof(kNewfMarker));
+
+        func_80147314(&sramCtx, gSaveContext.fileNum);
+
+        FLASH_ASSERT(memcmp(gSaveContext.save.saveInfo.playerData.newf, kNewfMarker, sizeof(kNewfMarker)) == 0,
+                     "func_80147314 ran for the 0xFF sentinel -- OOB owl-save page index + save mutation");
+    }
+
+    // ------------------------------------------------------------------
+    // Check 3: Sram_ResetSaveFromMoonCrash (the reported crash path) preserves
+    // the live save under the 0xFF sentinel instead of reloading garbage from
+    // an out-of-bounds flash index and copying it over the save.
+    // ------------------------------------------------------------------
+    {
+        SramContext sramCtx;
+        memset(&sramCtx, 0, sizeof(sramCtx));
+        memset(sSaveBuf, 0, sizeof(sSaveBuf));
+        sramCtx.saveBuf = sSaveBuf;
+
+        memset(&gSaveContext, 0, sizeof(gSaveContext));
+        gSaveContext.fileNum = 0xFF;
+
+        const char kPlayerName[8] = { 'C', 'R', 'O', 'S', 'S', 'M', 'M', '\0' };
+        memcpy(gSaveContext.save.saveInfo.playerData.playerName, kPlayerName, sizeof(kPlayerName));
+        gSaveContext.save.day = 0x1234;
+        // A valid-file newf, so the CHECK_NEWF backup-reload branch is on the
+        // table too; with the fix the whole reload block is skipped.
+        const char kValidNewf[6] = { 'Z', 'E', 'L', 'D', 'A', '3' };
+        memcpy(gSaveContext.save.saveInfo.playerData.newf, kValidNewf, sizeof(kValidNewf));
+
+        Sram_ResetSaveFromMoonCrash(&sramCtx);
+
+        FLASH_ASSERT(memcmp(gSaveContext.save.saveInfo.playerData.playerName, kPlayerName, sizeof(kPlayerName)) == 0,
+                     "moon-crash reset clobbered the live player name under the 0xFF sentinel");
+        FLASH_ASSERT(gSaveContext.save.day == 0x1234,
+                     "moon-crash reset wiped save.day under the 0xFF sentinel (zeroed buffer copied over the save)");
+    }
+
+    // Leave gSaveContext clean for whatever runs next.
+    memset(&gSaveContext, 0, sizeof(gSaveContext));
+
+    printf("[TEST] mm-flash-filenum-oob: PASS\n");
+    return 0;
+}

--- a/games/mm/2s2h/mm_rando_gen_test.cpp
+++ b/games/mm/2s2h/mm_rando_gen_test.cpp
@@ -59,6 +59,11 @@ void Combo_FreezeState(const char* gameId, uint16_t returnEntrance, const void* 
 void Combo_ClearFrozenState(const char* gameId);
 void Combo_SetStartupEntrance(uint16_t entrance);
 void Combo_ClearStartupEntrance(void);
+
+// Owl-save / file-copy readback locks (#487). Sram_UpdateWriteToFlashOwlSave
+// and the owl page tables come from z64save.h above; func_80147414 is
+// file-scope in z_sram_NES.c with no header declaration of its own.
+void func_80147414(SramContext* sramCtx, s32 fileNum, s32 arg2);
 }
 
 extern "C" int MM_Rando_HeadlessGenTest(void) {
@@ -785,24 +790,39 @@ extern "C" int MM_Rando_HeadlessPairSwitchEntry(void) {
         MM_Sram_InitNewSave();
         GameInteractor_ExecuteOnSaveLoad(gSaveContext.fileNum);
 
-        const size_t hooksAfterBootChain = S2H::GameHooks::CountForTest<GameInteractor::OnFlagSet>();
+        // Arm state through a VB VERDICT, not a hook count (#491). COND_HOOK's
+        // Unregister is DEFERRED (mm_game_hooks.h: the id is queued and erased
+        // only by FlushPendingUnregistrations at the next Execute of that hook
+        // type), so CountForTest lags a disarm — as a disarm signal a count is
+        // simply wrong, and as an arm signal a "> baseline" comparison against
+        // a stale non-zero baseline is satisfiable without the hooks being
+        // live. GameInteractor_Should dispatches Execute<ShouldVanillaBehavior>,
+        // which applies the flush first, so the verdict is current. Same probe
+        // MMReloadArmState's Phase 4 and MMMoonCrashArmState use.
+        //
+        // The boot chain above dispatched OnSaveLoad against a VANILLA
+        // bootstrap, so the IS_RANDO give override must be DOWN here.
+        // Asserting that is what makes the re-arm assertion after the consume
+        // non-vacuous — previously the "arm" leg could pass on state left
+        // armed by an earlier row in the same process.
+        if (!GameInteractor_Should(VB_GIVE_ITEM_FROM_GREAT_FAIRY, true)) {
+            fprintf(stderr, "[MM-PAIR-SWITCH] FAIL(19): the boot chain did not disarm the IS_RANDO give override — "
+                            "the re-arm assertion below would be vacuous\n");
+            return 19;
+        }
 
         // The switch path's pending arrival, then the real consumption point.
         Combo_SetStartupEntrance(kArrival);
         MM_Play_ConsumeStartupEntrance();
 
         if (gSaveContext.save.shipSaveInfo.saveType == SAVETYPE_RANDO) {
-            const size_t hooksAfterConsume = S2H::GameHooks::CountForTest<GameInteractor::OnFlagSet>();
-            if (hooksAfterConsume == 0 || hooksAfterConsume <= hooksAfterBootChain) {
-                fprintf(stderr,
-                        "[MM-PAIR-SWITCH] FAIL(5): paired world generated but the IS_RANDO hooks were left "
-                        "DISARMED by the boot chain's OnSaveLoad (OnFlagSet %zu -> %zu) — MM would play with "
-                        "vanilla behavior in a rando world\n",
-                        hooksAfterBootChain, hooksAfterConsume);
+            if (GameInteractor_Should(VB_GIVE_ITEM_FROM_GREAT_FAIRY, true)) {
+                fprintf(stderr, "[MM-PAIR-SWITCH] FAIL(5): paired world generated but the IS_RANDO hooks were left "
+                                "DISARMED by the boot chain's OnSaveLoad — MM would play with vanilla behavior in a "
+                                "rando world\n");
                 return 5;
             }
-            fprintf(stderr, "[MM-PAIR-SWITCH] hooks re-armed at consumption (OnFlagSet %zu -> %zu)\n",
-                    hooksAfterBootChain, hooksAfterConsume);
+            fprintf(stderr, "[MM-PAIR-SWITCH] hooks re-armed at consumption (give VB suppressed)\n");
             usedMasterSeed = masterSeed;
             break;
         }
@@ -888,7 +908,14 @@ extern "C" int MM_Rando_HeadlessPairSwitchEntry(void) {
     memset(&gSaveContext, 0, sizeof(gSaveContext));
     MM_Sram_InitNewSave();
     GameInteractor_ExecuteOnSaveLoad(gSaveContext.fileNum);
-    const size_t returnHooksAfterBootChain = S2H::GameHooks::CountForTest<GameInteractor::OnFlagSet>();
+    // Same VB-verdict disarm assertion as the arrival leg (#491): the return
+    // leg's own boot chain must have taken the hooks DOWN, or the re-arm
+    // assertion below proves nothing.
+    if (!GameInteractor_Should(VB_GIVE_ITEM_FROM_GREAT_FAIRY, true)) {
+        fprintf(stderr, "[MM-PAIR-SWITCH] FAIL(20): the return leg's boot chain did not disarm the IS_RANDO give "
+                        "override — the re-arm assertion below would be vacuous\n");
+        return 20;
+    }
     Combo_SetStartupEntrance(kArrival);
     MM_Play_ConsumeStartupEntrance();
 
@@ -913,15 +940,10 @@ extern "C" int MM_Rando_HeadlessPairSwitchEntry(void) {
         fprintf(stderr, "[MM-PAIR-SWITCH] FAIL(14): return leg disturbed the foreign placement table\n");
         return 14;
     }
-    {
-        const size_t after = S2H::GameHooks::CountForTest<GameInteractor::OnFlagSet>();
-        if (after == 0 || after <= returnHooksAfterBootChain) {
-            fprintf(stderr,
-                    "[MM-PAIR-SWITCH] FAIL(15): return leg left the IS_RANDO hooks disarmed (OnFlagSet %zu -> "
-                    "%zu) — a restored rando save would play with vanilla behavior\n",
-                    returnHooksAfterBootChain, after);
-            return 15;
-        }
+    if (GameInteractor_Should(VB_GIVE_ITEM_FROM_GREAT_FAIRY, true)) {
+        fprintf(stderr, "[MM-PAIR-SWITCH] FAIL(15): return leg left the IS_RANDO hooks disarmed — a restored rando "
+                        "save would play with vanilla behavior\n");
+        return 15;
     }
     fprintf(stderr, "[MM-PAIR-SWITCH] return leg: restored, not regenerated, hooks re-armed\n");
 
@@ -961,6 +983,17 @@ extern "C" int MM_Rando_HeadlessPairSwitchEntry(void) {
     if (memcmp(beforeVanilla, gComboCtx.foreignPlacements, sizeof(beforeVanilla)) != 0) {
         fprintf(stderr, "[MM-PAIR-SWITCH] FAIL(18): skipping a vanilla save still disturbed the placement table\n");
         return 18;
+    }
+    // The skip path must also leave the OVERRIDES down, in both polarities: a
+    // save that stayed vanilla while the rando give override remained armed
+    // from the paired legs above would play a rando behavior set on a vanilla
+    // file. Both-polarity form because a one-sided check passes on a hook that
+    // answers unconditionally.
+    if (!GameInteractor_Should(VB_GIVE_ITEM_FROM_GREAT_FAIRY, true) ||
+        GameInteractor_Should(VB_GIVE_ITEM_FROM_GREAT_FAIRY, false)) {
+        fprintf(stderr, "[MM-PAIR-SWITCH] FAIL(21): the skipped vanilla save left the rando give override armed — "
+                        "rando behavior leaked onto a non-rando file\n");
+        return 21;
     }
     fprintf(stderr, "[MM-PAIR-SWITCH] existing vanilla save left untouched (skip path)\n");
 
@@ -1343,6 +1376,199 @@ extern "C" int MM_Rando_HeadlessMoonCrashArmState(void) {
 
     fprintf(stderr, "[MM-MOONCRASH] PASS: a moon crash preserves the paired world identity, leaves the IS_RANDO "
                     "hooks armed, and an already-corrupted save self-heals on arrival\n");
+    return 0;
+}
+
+// ============================================================================
+// Owl-save / file-copy readback lock (#487) — the second live leg of the class
+// #485 caught at the moon crash.
+//
+// Sram_UpdateWriteToFlashOwlSave (games/mm/src/code/z_sram_NES.c) finishes a
+// normal owl save by re-reading the file it just wrote and memcpy'ing that
+// buffer over gSaveContext for offsetof(SaveContext, fileNum) — all of struct
+// Save, ShipSaveInfo included. In single-exe MM's flash read is a stub that
+// fills nothing (games/mm/2s2h/mm_save_manager_stubs.c), so the commit is a
+// commit of ZEROS: saveType -> SAVETYPE_VANILLA, finalSeed -> 0, the RC_MAX
+// placement table -> empty. Unlike the moon crash this happens on the ordinary
+// save-and-quit a player performs every cycle. func_80147414 (the owl half of
+// Sram_CopySave) has the identical shape.
+//
+// Arm state is probed through a VB verdict, never a hook COUNT: COND_HOOK's
+// Unregister is DEFERRED (mm_game_hooks.h), so CountForTest lags a disarm. And
+// this particular corruption is invisible to a count in BOTH directions —
+// nothing re-dispatches OnSaveLoad after the readback, so the hooks stay
+// registered and keep firing against an emptied table. A count probe here would
+// not merely be weak, it would be blind.
+//
+// Non-vacuity is structural: each leg DISARMS against a vanilla bootstrap and
+// asserts the disarm took before re-arming, so a "just force rando on" fix
+// fails; and the assertions cover finalSeed and a placement-table entry, so a
+// fix that preserves only the type byte fails too.
+// ============================================================================
+extern "C" int MM_Rando_HeadlessOwlSaveArmState(void) {
+    auto ctx = Ship::Context::GetInstance();
+    if (ctx == nullptr || ctx->GetConsoleVariables() == nullptr) {
+        fprintf(stderr, "[MM-OWL-SAVE] FAIL(1): Ship::Context not live\n");
+        return 1;
+    }
+
+    MM_Rando_Init();
+    if (Rando::Logic::Regions.empty()) {
+        fprintf(stderr, "[MM-OWL-SAVE] FAIL(2): Logic/Regions graph empty — rando surface elided\n");
+        return 2;
+    }
+    if (gRegEditor == NULL) {
+        static RegEditor sOwlSaveRegEditor = {};
+        gRegEditor = &sOwlSaveRegEditor;
+    }
+
+    ComboContext_Init();
+    Combo_ClearForeignPlacements();
+    Combo_ClearFrozenState("mm");
+    Combo_ClearStartupEntrance();
+
+    static u8 sOwlSaveBuf[SAVE_BUFFER_SIZE];
+    SramContext owlSram = {};
+    owlSram.saveBuf = sOwlSaveBuf;
+
+    // ----------------------------------------------------------------------
+    // Phase 0 — DISARM against a vanilla bootstrap, and assert the disarm took.
+    // Without this every "armed" assertion below would pass on state left over
+    // from an earlier row in the same process, i.e. vacuously.
+    // fileNum 0 (not the cross-game 0xFF sentinel) keeps the owl page-table
+    // indexing in bounds; this row is about saveType preservation, not the
+    // fileNum indexing question that mm-flash-filenum-oob owns.
+    // ----------------------------------------------------------------------
+    memset(&gSaveContext, 0, sizeof(gSaveContext));
+    MM_Sram_InitNewSave();
+    gSaveContext.fileNum = 0;
+    GameInteractor_ExecuteOnSaveLoad(gSaveContext.fileNum);
+    if (!GameInteractor_Should(VB_GIVE_ITEM_FROM_GREAT_FAIRY, true)) {
+        fprintf(stderr, "[MM-OWL-SAVE] FAIL(3): the vanilla bootstrap did not disarm the IS_RANDO give override — "
+                        "every arm assertion in this row would be vacuous\n");
+        return 3;
+    }
+
+    // ----------------------------------------------------------------------
+    // Phase 1 — a live paired rando world, armed. Modeled the way a paired
+    // world reads in memory: saveType stamped, a world identity, a shuffled
+    // placement entry.
+    // ----------------------------------------------------------------------
+    gSaveContext.save.shipSaveInfo.saveType = SAVETYPE_RANDO;
+    gSaveContext.save.shipSaveInfo.rando.finalSeed = 0xC0FFEE03;
+    RANDO_SAVE_CHECKS[RC_CLOCK_TOWN_SOUTH_PLATFORM_PIECE_OF_HEART].shuffled = true;
+    GameInteractor_ExecuteOnSaveLoad(gSaveContext.fileNum);
+    if (GameInteractor_Should(VB_GIVE_ITEM_FROM_GREAT_FAIRY, true)) {
+        fprintf(stderr, "[MM-OWL-SAVE] FAIL(4): the paired world did not arm the IS_RANDO give override — premise "
+                        "broken before the owl save\n");
+        return 4;
+    }
+
+    // ----------------------------------------------------------------------
+    // Phase 2 — the REAL owl-save completion. status is neither 7 nor 8 and
+    // startWriteOsTime is 0, so the elapsed-time branch (the one carrying the
+    // readback) is the branch taken. Asserting status afterwards is mandatory:
+    // if the call fell into one of the write-progress branches instead, this
+    // row would silently test nothing.
+    // ----------------------------------------------------------------------
+    owlSram.status = 6;
+    owlSram.curPage = gFlashOwlSaveStartPages[0];
+    owlSram.numPages = gFlashOwlSaveNumPages[0];
+    owlSram.startWriteOsTime = 0;
+    gSaveContext.save.isOwlSave = true;
+
+    Sram_UpdateWriteToFlashOwlSave(&owlSram);
+
+    if (owlSram.status != 0) {
+        fprintf(stderr,
+                "[MM-OWL-SAVE] FAIL(5): the readback branch never ran (status %d) — the assertions below would be "
+                "vacuous\n",
+                owlSram.status);
+        return 5;
+    }
+
+    // ----------------------------------------------------------------------
+    // Phase 3 — the world identity must survive the readback, and the hooks
+    // must still be armed against it.
+    // ----------------------------------------------------------------------
+    if (gSaveContext.save.shipSaveInfo.saveType != SAVETYPE_RANDO) {
+        fprintf(stderr, "[MM-OWL-SAVE] FAIL(6): the owl-save readback reverted saveType to vanilla — every IS_RANDO "
+                        "hook disarms at the next load and MM plays vanilla for the rest of the session\n");
+        return 6;
+    }
+    if (gSaveContext.save.shipSaveInfo.rando.finalSeed != 0xC0FFEE03) {
+        fprintf(stderr,
+                "[MM-OWL-SAVE] FAIL(7): the owl-save readback lost the paired world identity (finalSeed %08X, "
+                "expected C0FFEE03)\n",
+                gSaveContext.save.shipSaveInfo.rando.finalSeed);
+        return 7;
+    }
+    if (!RANDO_SAVE_CHECKS[RC_CLOCK_TOWN_SOUTH_PLATFORM_PIECE_OF_HEART].shuffled) {
+        fprintf(stderr, "[MM-OWL-SAVE] FAIL(8): the owl-save readback wiped the placement table — the world would be "
+                        "armed but empty\n");
+        return 8;
+    }
+    if (GameInteractor_Should(VB_GIVE_ITEM_FROM_GREAT_FAIRY, true)) {
+        fprintf(stderr, "[MM-OWL-SAVE] FAIL(9): saveType survived the owl save but the IS_RANDO hooks were left "
+                        "unregistered — MM would still play vanilla on a save that claims to be rando\n");
+        return 9;
+    }
+    fprintf(stderr, "[MM-OWL-SAVE] owl-save completion preserved the paired world and its armed hooks\n");
+
+    // ----------------------------------------------------------------------
+    // Phase 4 — the same class on the file-copy path (func_80147414, the owl
+    // half of Sram_CopySave), which reads the SOURCE file over the live
+    // gSaveContext. Disarm and re-arm again rather than inheriting Phase 3's
+    // armed state, so this leg is non-vacuous on its own.
+    // ----------------------------------------------------------------------
+    // The memset also clears the placement table: RANDO_SAVE_CHECKS is
+    // gSaveContext.save.shipSaveInfo.rando.randoSaveChecks (Rando.h).
+    memset(&gSaveContext, 0, sizeof(gSaveContext));
+    MM_Sram_InitNewSave();
+    gSaveContext.fileNum = 0;
+    GameInteractor_ExecuteOnSaveLoad(gSaveContext.fileNum);
+    if (!GameInteractor_Should(VB_GIVE_ITEM_FROM_GREAT_FAIRY, true)) {
+        fprintf(stderr, "[MM-OWL-SAVE] FAIL(10): the vanilla bootstrap did not disarm before the copy leg — the "
+                        "assertions below would be vacuous\n");
+        return 10;
+    }
+
+    gSaveContext.save.shipSaveInfo.saveType = SAVETYPE_RANDO;
+    gSaveContext.save.shipSaveInfo.rando.finalSeed = 0xC0FFEE04;
+    RANDO_SAVE_CHECKS[RC_CLOCK_TOWN_SOUTH_PLATFORM_PIECE_OF_HEART].shuffled = true;
+    GameInteractor_ExecuteOnSaveLoad(gSaveContext.fileNum);
+    if (GameInteractor_Should(VB_GIVE_ITEM_FROM_GREAT_FAIRY, true)) {
+        fprintf(stderr, "[MM-OWL-SAVE] FAIL(11): the copy leg's paired world did not arm — premise broken\n");
+        return 11;
+    }
+
+    memset(sOwlSaveBuf, 0, SAVE_BUFFER_SIZE);
+    func_80147414(&owlSram, 0, 1);
+
+    if (gSaveContext.save.shipSaveInfo.saveType != SAVETYPE_RANDO ||
+        gSaveContext.save.shipSaveInfo.rando.finalSeed != 0xC0FFEE04 ||
+        !RANDO_SAVE_CHECKS[RC_CLOCK_TOWN_SOUTH_PLATFORM_PIECE_OF_HEART].shuffled) {
+        fprintf(stderr, "[MM-OWL-SAVE] FAIL(12): copying an owl file stripped the LIVE world's randomizer identity "
+                        "(saveType/finalSeed/placement table)\n");
+        return 12;
+    }
+    if (GameInteractor_Should(VB_GIVE_ITEM_FROM_GREAT_FAIRY, true)) {
+        fprintf(stderr, "[MM-OWL-SAVE] FAIL(13): the copy path left the IS_RANDO hooks unregistered\n");
+        return 13;
+    }
+    fprintf(stderr, "[MM-OWL-SAVE] file-copy readback left the live paired world intact and armed\n");
+
+    // Leave clean global state for later dispatches in the same process. The
+    // gSaveContext memset also clears the placement table and the save type,
+    // both of which live inside it.
+    ComboContext_Init();
+    Combo_ClearForeignPlacements();
+    Combo_ClearFrozenState("mm");
+    Combo_ClearStartupEntrance();
+    memset(&gSaveContext, 0, sizeof(gSaveContext));
+
+    fprintf(stderr, "[MM-OWL-SAVE] PASS: an owl save and a file copy both preserve the paired world identity and "
+                    "leave the IS_RANDO hooks armed\n");
     return 0;
 }
 

--- a/games/mm/2s2h/mm_save_manager_stubs.c
+++ b/games/mm/2s2h/mm_save_manager_stubs.c
@@ -1,0 +1,72 @@
+/**
+ * MM flash-storage stubs for the single-executable build (#487).
+ *
+ * games/mm/2s2h/SaveManager/SaveManager.cpp is filtered out of the single-exe
+ * link (games/mm/CMakeLists.txt, "Save Manager"), so MM's two flash-storage
+ * entry points -- the funnel every SysFlashrom_* call in
+ * games/mm/src/code/sys_flashrom.c goes through -- have no body. They were
+ * stubbed in src/common/mm_stubs.c as
+ *
+ *     int SaveManager_SysFlashrom_ReadData(void* dst, int page, int count)  { return 0; }
+ *     int SaveManager_SysFlashrom_WriteData(void* src, int page, int count) { return 0; }
+ *
+ * against real prototypes of `s32 (void*, u32, u32)` and `void (u8*, u32, u32)`
+ * (2s2h/SaveManager/SaveManager.h). Two separate faults in that:
+ *
+ *  1. THE READ LIED. Returning 0 means "read succeeded" while the caller's
+ *     buffer still holds whatever it held before -- in every MM caller, the
+ *     zeros from the preceding memset. Callers that check the return therefore
+ *     never take their backup-file fallback, and callers that ignore it
+ *     memcpy a zeroed buffer straight over gSaveContext. That is the mechanism
+ *     behind #487: an owl save in a paired rando world zeroed the live
+ *     ShipSaveInfo (saveType + the whole rando block) and MM played vanilla
+ *     for the rest of the session. The guard in z_sram_NES.c is what saves the
+ *     rando half; this return value is what stops the lie at its source, so
+ *     every "did the read work?" branch in MM gets the honest answer.
+ *     -1 is what the real SaveManager returns for a missing/unparsable file.
+ *
+ *  2. THE WRITE HAD THE WRONG SIGNATURE -- the mm_stubs.c drift class (#379,
+ *     the MotionBlur_Override and OTRConvertHUDXToScreenX faults). It is
+ *     benign only because its sole caller (sys_flashrom.c
+ *     SysFlashrom_WriteDataAsync) discards the value.
+ *
+ * Both are fixed here by being HEADER-CHECKED: this TU includes the real
+ * SaveManager.h, so the compiler rejects any future drift instead of leaving
+ * an ABI mismatch to be discovered at runtime. It lives in the MM target
+ * rather than in src/common/mm_stubs.c for two reasons: mm_stubs.c is built
+ * into redship_common, which is NOT compiled with RSBS_SINGLE_EXECUTABLE (so
+ * the guard below would compile to nothing there and collide with the real
+ * SaveManager in a standalone build), and it pulls in no MM headers at all --
+ * SaveManager.h's C branch needs MM's u8/u32/s32. Same shape and same reason
+ * as mm_framebuffer_effects.c and BenPortHudSingleExe.cpp.
+ *
+ * NOTE (#487 step 5, deliberately NOT settled here): with the write stub also
+ * a no-op, MM's flash storage in single-exe persists nothing at all. Whether
+ * `redship` should have a real MM save path is an operator-scoping question,
+ * not something this fix decides. Everything here assumes it stays a no-op and
+ * makes the no-op honest.
+ *
+ * Guarded to single-exe: a standalone 2ship build compiles the real
+ * SaveManager.cpp, which owns these symbols.
+ */
+#ifdef RSBS_SINGLE_EXECUTABLE
+
+#include "global.h"
+#include "2s2h/SaveManager/SaveManager.h"
+
+// Nothing is written, so report failure -- callers must not treat the
+// untouched buffer as a loaded save. See the header note above.
+s32 SaveManager_SysFlashrom_ReadData(void* addr, u32 pageNum, u32 pageCount) {
+    (void)addr;
+    (void)pageNum;
+    (void)pageCount;
+    return -1;
+}
+
+void SaveManager_SysFlashrom_WriteData(u8* addr, u32 pageNum, u32 pageCount) {
+    (void)addr;
+    (void)pageNum;
+    (void)pageCount;
+}
+
+#endif // RSBS_SINGLE_EXECUTABLE

--- a/games/mm/include/z64save.h
+++ b/games/mm/include/z64save.h
@@ -1846,6 +1846,14 @@ void Sram_IncrementDay(void);
 u16 Sram_CalcChecksum(void* data, size_t count);
 void MM_Sram_InitNewSave(void);
 void MM_Sram_InitDebugSave(void);
+// 2S2H [Port] Returns true only when `fileNum` is a real, in-bounds file slot
+// (0..FILE_NUM_MAX-1). fileNum is the 0xFF "no real slot" sentinel whenever no
+// file-select slot backs the session -- the title/debug/mapselect boot and, in
+// the RedShipBlueShip combo, every cross-game MM arrival. The flash save/load
+// paths index the fixed-size gFlashSave*Pages / gFlashOwlSave*Pages tables by
+// fileNum, so 0xFF (or anything past FILE_NUM_MAX) would subscript them far out
+// of bounds. Gate every such path on this.
+s32 Sram_FileNumHasFlashSlot(s32 fileNum);
 void Sram_ResetSaveFromMoonCrash(SramContext* sramCtx);
 void MM_Sram_OpenSave(struct FileSelectState* fileSelect, SramContext* sramCtx);
 void func_8014546C(SramContext* sramCtx);

--- a/games/mm/src/code/z_sram_NES.c
+++ b/games/mm/src/code/z_sram_NES.c
@@ -1269,6 +1269,83 @@ void MM_Sram_InitDebugSave(void) {
 }
 
 #ifdef RSBS_SINGLE_EXECUTABLE
+// ---------------------------------------------------------------------------
+// Flash-readback rando-identity guard (#485 / #487).
+//
+// Every "read the file back from flash, then memcpy it over gSaveContext" site
+// in this file destroys the live randomizer identity, because ShipSaveInfo --
+// saveType AND the whole rando block (finalSeed, options, the RC_MAX placement
+// table) -- is a MEMBER of Save (z64save.h), so a memcpy of sizeof(Save) or
+// offsetof(SaveContext, fileNum) overwrites it wholesale.
+//
+// A cross-game paired MM world is authored IN MEMORY at the arrival
+// (MM_Rando_PairOnCrossGameArrival -> OnFileCreate) and is not represented in
+// MM flash until the player saves. And in single-exe MM's flash read is a stub
+// (games/mm/2s2h/mm_save_manager_stubs.c) that never fills the buffer at all.
+// So a readback yields a vanilla/zeroed Save either way: saveType reverts to
+// SAVETYPE_VANILLA, every IS_RANDO COND_HOOK unregisters at the next
+// OnSaveLoad, and MM silently plays vanilla for the rest of the session -- then
+// the next switch-out freezes THAT save into the blob, so the vanilla world
+// survives every later return leg. Operator-confirmed for the moon-crash leg
+// (#485); #487 is the same class on the owl-save and file-copy legs.
+//
+// The guard preserves the rando half across ANY such readback, exactly as
+// cutsceneIndex is preserved across the moon-crash reload -- but only when the
+// reload actually lost it. If the data that came back IS a rando save, upstream
+// semantics win and this is a no-op. It is likewise a no-op whenever the live
+// save was not rando to begin with, which is every vanilla session and every
+// file-select enumeration reached from the vanilla boot bootstrap.
+//
+// File-static rather than a stack local: ShipSaveInfo embeds
+// randoSaveChecks[RC_MAX] and is multiple KB. The save path is single-threaded.
+//
+// The depth counter is not decoration: Sram_CopySave both wraps its own
+// readback and calls func_80147414, which wraps another. A flat latch would let
+// the inner End() clear the flag and turn the outer restore into a silent
+// no-op.
+static ShipSaveInfo sRandoPreserveInfo;
+static s32 sRandoPreserveWasRando;
+static s32 sRandoPreserveDepth;
+
+// Latch the live rando identity before a flash readback commits over it.
+static void Sram_BeginRandoPreserve(void) {
+    if (sRandoPreserveDepth++ != 0) {
+        return; // nested; the outer latch owns the restore
+    }
+    sRandoPreserveWasRando = (gSaveContext.save.shipSaveInfo.saveType == SAVETYPE_RANDO);
+    if (sRandoPreserveWasRando) {
+        sRandoPreserveInfo = gSaveContext.save.shipSaveInfo;
+    }
+}
+
+// Restore it if -- and only if -- the readback lost it.
+static void Sram_EndRandoPreserve(void) {
+    if (--sRandoPreserveDepth != 0) {
+        return;
+    }
+    if (sRandoPreserveWasRando && gSaveContext.save.shipSaveInfo.saveType != SAVETYPE_RANDO) {
+        gSaveContext.save.shipSaveInfo = sRandoPreserveInfo;
+        // Re-arm the save-shape-dependent hooks against the save that actually
+        // reaches gameplay -- the same contract MM_Play_ConsumeStartupEntrance
+        // honours at the cross-game arrival (games/mm/src/code/z_play.c). The
+        // rando behavior hooks are COND_HOOKs re-evaluated on OnSaveLoad against
+        // IS_RANDO; restoring saveType without re-dispatching would leave them
+        // in whatever state the readback's vanilla shape produced, i.e.
+        // still-vanilla behavior on a save that now correctly claims to be
+        // rando. Idempotent by construction: COND_HOOK unregisters before
+        // re-registering.
+        GameInteractor_ExecuteOnSaveLoad(gSaveContext.fileNum);
+    }
+    sRandoPreserveWasRando = 0;
+}
+#define RSBS_RANDO_PRESERVE_BEGIN() Sram_BeginRandoPreserve()
+#define RSBS_RANDO_PRESERVE_END() Sram_EndRandoPreserve()
+#else
+#define RSBS_RANDO_PRESERVE_BEGIN() ((void)0)
+#define RSBS_RANDO_PRESERVE_END() ((void)0)
+#endif
+
+#ifdef RSBS_SINGLE_EXECUTABLE
 // Moon-crash reset must not destroy a cross-game paired world (#392 class).
 //
 // The reload below re-reads the file from flash and memcpy's sizeof(Save) over
@@ -1290,22 +1367,18 @@ void MM_Sram_InitDebugSave(void) {
 // but only when the reload actually lost it (flash held no rando save). If the
 // file on disk IS a rando save, upstream semantics win and this is a no-op.
 //
-// File-static rather than a stack local: ShipSaveInfo embeds randoSaveChecks
-// [RC_MAX] and is multiple KB. The save path is single-threaded.
-static ShipSaveInfo sMoonCrashShipSaveInfo;
+// The preserve/restore itself is now the shared Sram_Begin/EndRandoPreserve
+// pair above (#487 found the same readback-then-commit shape on five other
+// paths); this comment stays because this site is where the class was first
+// diagnosed and operator-confirmed.
 #endif
 
 void Sram_ResetSaveFromMoonCrash(SramContext* sramCtx) {
     GameInteractor_ExecuteBeforeMoonCrashSaveReset();
     s32 i;
     s32 cutsceneIndex = gSaveContext.save.cutsceneIndex;
-#ifdef RSBS_SINGLE_EXECUTABLE
-    s32 wasRando = (gSaveContext.save.shipSaveInfo.saveType == SAVETYPE_RANDO);
 
-    if (wasRando) {
-        sMoonCrashShipSaveInfo = gSaveContext.save.shipSaveInfo;
-    }
-#endif
+    RSBS_RANDO_PRESERVE_BEGIN();
 
     memset(sramCtx->saveBuf, 0, SAVE_BUFFER_SIZE);
 
@@ -1332,20 +1405,8 @@ void Sram_ResetSaveFromMoonCrash(SramContext* sramCtx) {
         }
     }
     gSaveContext.save.cutsceneIndex = cutsceneIndex;
-#ifdef RSBS_SINGLE_EXECUTABLE
-    if (wasRando && gSaveContext.save.shipSaveInfo.saveType != SAVETYPE_RANDO) {
-        gSaveContext.save.shipSaveInfo = sMoonCrashShipSaveInfo;
-        // Re-arm the save-shape-dependent hooks against the save that actually
-        // reaches gameplay -- the same contract MM_Play_ConsumeStartupEntrance
-        // honours at the cross-game arrival (games/mm/src/code/z_play.c). The
-        // rando behavior hooks are COND_HOOKs re-evaluated on OnSaveLoad against
-        // IS_RANDO; restoring saveType without re-dispatching would leave them
-        // unregistered from the reload above, i.e. still-vanilla behavior on a
-        // save that now correctly claims to be rando. Idempotent by
-        // construction: COND_HOOK unregisters before re-registering.
-        GameInteractor_ExecuteOnSaveLoad(gSaveContext.fileNum);
-    }
-#endif
+
+    RSBS_RANDO_PRESERVE_END();
 
     for (i = 0; i < ARRAY_COUNT(gSaveContext.eventInf); i++) {
         gSaveContext.eventInf[i] = 0;
@@ -1395,6 +1456,16 @@ void MM_Sram_OpenSave(FileSelectState* fileSelect, SramContext* sramCtx) {
     s32 pad1;
     s32 fileNum;
 
+    // One BEGIN/END around the whole load rather than one per memcpy: this
+    // block commits up to twice (main file, then the backup on a bad newf) and
+    // only the final gSaveContext state matters, so a single END means at most
+    // one OnSaveLoad re-dispatch. Inert in the flow a player actually takes --
+    // the boot chain authors a VANILLA bootstrap before file select, so there
+    // is no rando identity live to lose here. It is here so that a LOAD can
+    // never be the thing that strips a live paired world, and because the
+    // single-exe read stub returns an untouched buffer for every slot.
+    RSBS_RANDO_PRESERVE_BEGIN();
+
     if (gSaveContext.flashSaveAvailable) {
         memset(sramCtx->saveBuf, 0, SAVE_BUFFER_SIZE);
 
@@ -1431,6 +1502,8 @@ void MM_Sram_OpenSave(FileSelectState* fileSelect, SramContext* sramCtx) {
             memcpy(&gSaveContext, sramCtx->saveBuf, gFlashSaveSizes[phi_t1]);
         }
     }
+
+    RSBS_RANDO_PRESERVE_END();
 
     gSaveContext.save.saveInfo.playerData.magicLevel = 0;
 
@@ -1575,6 +1648,14 @@ void func_801457CC(GameState* gameState, SramContext* sramCtx) {
     u16 sp6E;
     u16 newCheckSum;
     u16 maskCount;
+
+    // The file-select enumeration below reads EVERY slot through the live
+    // gSaveContext -- it is the scratch buffer for the whole scan, and the two
+    // fields it bothers to save and restore are time and flashSaveAvailable
+    // (D_801F6AF0/D_801F6AF2, below). One BEGIN/END spans the whole loop rather
+    // than each of its dozen commits: only the final state matters and a single
+    // END means at most one OnSaveLoad re-dispatch, never one per slot.
+    RSBS_RANDO_PRESERVE_BEGIN();
 
     if (gSaveContext.flashSaveAvailable) {
         D_801F6AF0 = CURRENT_TIME;
@@ -1868,6 +1949,10 @@ void func_801457CC(GameState* gameState, SramContext* sramCtx) {
         gSaveContext.flashSaveAvailable = D_801F6AF2;
     }
 
+    // After the D_801F6AF0/D_801F6AF2 restores, so the re-dispatch (if any) sees
+    // the same gSaveContext the caller will.
+    RSBS_RANDO_PRESERVE_END();
+
     gSaveContext.options.language = LANGUAGE_ENG;
 }
 
@@ -1892,6 +1977,13 @@ void Sram_CopySave(FileSelectState* fileSelect2, SramContext* sramCtx) {
     FileSelectState* fileSelect = fileSelect2;
     u16 i;
     s16 maskCount;
+
+    // Copying a file uses the live gSaveContext as scratch for the SOURCE
+    // file's bytes -- twice: once inside func_80147414 for the owl half, once
+    // at the readback below. This BEGIN must be taken before the func_80147414
+    // call so the OUTER latch owns the restore; the depth counter in
+    // Sram_Begin/EndRandoPreserve is what makes that nesting safe.
+    RSBS_RANDO_PRESERVE_BEGIN();
 
     if (gSaveContext.flashSaveAvailable) {
         if (fileSelect->isOwlSave[fileSelect->selectedFileIndex + FILE_NUM_OWL_SAVE_OFFSET]) {
@@ -1983,6 +2075,8 @@ void Sram_CopySave(FileSelectState* fileSelect2, SramContext* sramCtx) {
 
     gSaveContext.save.time = D_801F6AF0;
     gSaveContext.flashSaveAvailable = D_801F6AF2;
+
+    RSBS_RANDO_PRESERVE_END();
 }
 
 void MM_Sram_InitSave(FileSelectState* fileSelect2, SramContext* sramCtx) {
@@ -2015,6 +2109,26 @@ void MM_Sram_InitSave(FileSelectState* fileSelect2, SramContext* sramCtx) {
 
         memcpy(sramCtx->saveBuf, &gSaveContext.save, sizeof(Save));
         memcpy(&sramCtx->saveBuf[SAVE_BUFFER_SIZE_HALF], &gSaveContext.save, sizeof(Save));
+
+#ifdef RSBS_SINGLE_EXECUTABLE
+        // #487 step 6 / #467 recommendation 1: creating a file dispatched
+        // OnSaveInit and nothing else. OnSaveInit is the GENERATION hook -- it
+        // is what stamps SAVETYPE_RANDO (2s2h/Rando/MiscBehavior/
+        // OnFileCreate.cpp) -- but the IS_RANDO COND_HOOKs are re-evaluated
+        // ONLY by OnSaveLoad (2s2h/Rando/Rando.cpp OnSaveLoadHandler). So a
+        // freshly created rando file entered gameplay with whatever arm state
+        // the boot chain left behind, which for the title chain
+        // (TitleSetup_SetupTitleScreen -> a vanilla bootstrap) is DISARMED:
+        // a brand-new rando world that plays vanilla.
+        //
+        // Position: AFTER the two flash-buffer memcpys, not between the
+        // checksum and them. OnSaveInit must keep running before the memcpys or
+        // the generated world would never reach the buffer that gets written --
+        // the file on disk would be vanilla. Dispatching the load hook after
+        // the bytes are final means the hooks arm against exactly what was
+        // stored. Idempotent: COND_HOOK unregisters before re-registering.
+        GameInteractor_ExecuteOnSaveLoad(fileSelect->buttonIndex);
+#endif
 
         for (i = 0; i < ARRAY_COUNT(gSaveContext.save.saveInfo.playerData.newf); i++) {
             fileSelect->newf[fileSelect->buttonIndex][i] = gSaveContext.save.saveInfo.playerData.newf[i];
@@ -2203,12 +2317,20 @@ void Sram_UpdateWriteToFlashOwlSave(SramContext* sramCtx) {
         // 2S2H [Port] Some tricks require a save delay so we can't just force it to MM_zero
         // Finished status is hardcoded to 2 seconds instead of when the task finishes
         sramCtx->status = 0;
+        // #487, the P0 leg: this readback-then-commit runs at the END of a
+        // normal owl save, in live gameplay, over the save the player is
+        // playing. The read return is discarded and the memcpy covers
+        // offsetof(SaveContext, fileNum) -- all of struct Save, ShipSaveInfo
+        // included -- so with the single-exe read stub it commits zeros and the
+        // paired world's randomizer identity is gone from that moment on.
+        RSBS_RANDO_PRESERVE_BEGIN();
         memset(sramCtx->saveBuf, 0, SAVE_BUFFER_SIZE);
         gSaveContext.save.isOwlSave = false;
         gSaveContext.save.saveInfo.checksum = 0;
         // flash read to buffer then copy to save context
         SysFlashrom_ReadData(sramCtx->saveBuf, sramCtx->curPage, sramCtx->numPages);
         memcpy(&gSaveContext, sramCtx->saveBuf, offsetof(SaveContext, fileNum));
+        RSBS_RANDO_PRESERVE_END();
     }
 }
 
@@ -2257,6 +2379,17 @@ void func_80147314(SramContext* sramCtx, s32 fileNum) {
 void func_80147414(SramContext* sramCtx, s32 fileNum, s32 arg2) {
     s32 pad;
 
+    // 2S2H [Port] Same 0xFF sentinel guard as func_80147314 above: this indexes
+    // gFlashOwlSave*Pages[fileNum * FLASH_SAVE_MAIN_MULTIPLIER] with no bound of
+    // its own, and a cross-game MM session runs with fileNum == 0xFF.
+    if (!Sram_FileNumHasFlashSlot(fileNum)) {
+        return;
+    }
+
+    // The second #487 leg: reads the SOURCE file over the live gSaveContext.
+    // Nested inside Sram_CopySave's own BEGIN/END -- see the depth counter.
+    RSBS_RANDO_PRESERVE_BEGIN();
+
     // Clear save buffer
     memset(sramCtx->saveBuf, 0, SAVE_BUFFER_SIZE);
 
@@ -2271,6 +2404,8 @@ void func_80147414(SramContext* sramCtx, s32 fileNum, s32 arg2) {
 
     // Copy buffer to save context
     memcpy(&gSaveContext, sramCtx->saveBuf, offsetof(SaveContext, fileNum));
+
+    RSBS_RANDO_PRESERVE_END();
 
     Sram_SyncWriteToFlash(sramCtx, gFlashOwlSaveStartPages[arg2 * FLASH_SAVE_MAIN_MULTIPLIER],
                           gFlashOwlSaveNumPages[arg2 * FLASH_SAVE_MAIN_MULTIPLIER]);

--- a/games/mm/src/code/z_sram_NES.c
+++ b/games/mm/src/code/z_sram_NES.c
@@ -420,6 +420,17 @@ u8 sBitFlags8[] = {
     (1 << 0), (1 << 1), (1 << 2), (1 << 3), (1 << 4), (1 << 5), (1 << 6), (1 << 7),
 };
 
+// 2S2H [Port] Bounds guard for the flash page tables above. A real file slot is
+// 0..FILE_NUM_MAX-1; every other value -- most importantly the 0xFF "no real
+// slot" sentinel a cross-game / title / debug session leaves in
+// gSaveContext.fileNum -- must be rejected, because the flash paths index
+// gFlashSave*Pages[fileNum * FLASH_SAVE_MAIN_MULTIPLIER (+ FLASH_SAVE_BACKUP_OFFSET)]
+// and gFlashOwlSave*Pages[fileNum * FLASH_SAVE_MAIN_MULTIPLIER], which for 0xFF
+// runs hundreds of entries past the end of those fixed-size arrays.
+s32 Sram_FileNumHasFlashSlot(s32 fileNum) {
+    return (fileNum >= 0) && (fileNum < FILE_NUM_MAX);
+}
+
 u16 D_801F6AF0;
 u8 D_801F6AF2;
 
@@ -1298,20 +1309,27 @@ void Sram_ResetSaveFromMoonCrash(SramContext* sramCtx) {
 
     memset(sramCtx->saveBuf, 0, SAVE_BUFFER_SIZE);
 
-    if (SysFlashrom_ReadData(sramCtx->saveBuf, gFlashSaveStartPages[gSaveContext.fileNum * FLASH_SAVE_MAIN_MULTIPLIER],
-                             gFlashSaveNumPages[gSaveContext.fileNum * FLASH_SAVE_MAIN_MULTIPLIER]) != 0) {
-        SysFlashrom_ReadData(
-            sramCtx->saveBuf,
-            gFlashSaveStartPages[gSaveContext.fileNum * FLASH_SAVE_MAIN_MULTIPLIER + FLASH_SAVE_BACKUP_OFFSET],
-            gFlashSaveNumPages[gSaveContext.fileNum * FLASH_SAVE_MAIN_MULTIPLIER + FLASH_SAVE_BACKUP_OFFSET]);
-    }
-    memcpy(&gSaveContext.save, sramCtx->saveBuf, sizeof(Save));
-    if (CHECK_NEWF(gSaveContext.save.saveInfo.playerData.newf)) {
-        SysFlashrom_ReadData(
-            sramCtx->saveBuf,
-            gFlashSaveStartPages[gSaveContext.fileNum * FLASH_SAVE_MAIN_MULTIPLIER + FLASH_SAVE_BACKUP_OFFSET],
-            gFlashSaveNumPages[gSaveContext.fileNum * FLASH_SAVE_MAIN_MULTIPLIER + FLASH_SAVE_BACKUP_OFFSET]);
-        memcpy(&gSaveContext, sramCtx->saveBuf, sizeof(Save));
+    // 2S2H [Port] In a cross-game session (and the debug/mapselect boot) fileNum is the
+    // 0xFF "no real slot" sentinel, so there is no flash file to reload. Guarding here
+    // keeps us from indexing gFlashSaveStartPages/gFlashSaveNumPages far out of bounds AND
+    // from clobbering the live save with the still-zeroed buffer below.
+    if (Sram_FileNumHasFlashSlot(gSaveContext.fileNum)) {
+        if (SysFlashrom_ReadData(sramCtx->saveBuf,
+                                 gFlashSaveStartPages[gSaveContext.fileNum * FLASH_SAVE_MAIN_MULTIPLIER],
+                                 gFlashSaveNumPages[gSaveContext.fileNum * FLASH_SAVE_MAIN_MULTIPLIER]) != 0) {
+            SysFlashrom_ReadData(
+                sramCtx->saveBuf,
+                gFlashSaveStartPages[gSaveContext.fileNum * FLASH_SAVE_MAIN_MULTIPLIER + FLASH_SAVE_BACKUP_OFFSET],
+                gFlashSaveNumPages[gSaveContext.fileNum * FLASH_SAVE_MAIN_MULTIPLIER + FLASH_SAVE_BACKUP_OFFSET]);
+        }
+        memcpy(&gSaveContext.save, sramCtx->saveBuf, sizeof(Save));
+        if (CHECK_NEWF(gSaveContext.save.saveInfo.playerData.newf)) {
+            SysFlashrom_ReadData(
+                sramCtx->saveBuf,
+                gFlashSaveStartPages[gSaveContext.fileNum * FLASH_SAVE_MAIN_MULTIPLIER + FLASH_SAVE_BACKUP_OFFSET],
+                gFlashSaveNumPages[gSaveContext.fileNum * FLASH_SAVE_MAIN_MULTIPLIER + FLASH_SAVE_BACKUP_OFFSET]);
+            memcpy(&gSaveContext, sramCtx->saveBuf, sizeof(Save));
+        }
     }
     gSaveContext.save.cutsceneIndex = cutsceneIndex;
 #ifdef RSBS_SINGLE_EXECUTABLE
@@ -1381,6 +1399,10 @@ void MM_Sram_OpenSave(FileSelectState* fileSelect, SramContext* sramCtx) {
         memset(sramCtx->saveBuf, 0, SAVE_BUFFER_SIZE);
 
         if (gSaveContext.fileNum == 0xFF) {
+            // 2S2H [Port] The sentinel path reads file 1's new-cycle save; keep phi_t1 in
+            // step with that index so the gFlashSaveSizes[phi_t1] memcpy below is in bounds
+            // (it was otherwise left uninitialized and indexed the size table at random).
+            phi_t1 = FLASH_SAVE_FILE_1_NEW_CYCLE_SAVE;
             SysFlashrom_ReadData(sramCtx->saveBuf, gFlashSaveStartPages[FLASH_SAVE_FILE_1_NEW_CYCLE_SAVE],
                                  gFlashSaveNumPages[FLASH_SAVE_FILE_1_NEW_CYCLE_SAVE]);
         } else if (fileSelect->isOwlSave[gSaveContext.fileNum + FILE_NUM_OWL_SAVE_OFFSET]) {
@@ -2075,8 +2097,13 @@ void Sram_SaveSpecialEnterClockTown(PlayState* play) {
     // 2S2H [Enhancement] Store playtime before saving
     SavingEnhancements_AdvancePlaytime();
     func_80145698(sramCtx);
-    SysFlashrom_WriteDataSync(sramCtx->saveBuf, gFlashSaveStartPages[gSaveContext.fileNum * FLASH_SAVE_MAIN_MULTIPLIER],
-                              gFlashSpecialSaveNumPages[gSaveContext.fileNum * FLASH_SAVE_MAIN_MULTIPLIER]);
+    // 2S2H [Port] Skip the flash write for the 0xFF "no real slot" sentinel (cross-game /
+    // title / debug session); indexing gFlashSaveStartPages[fileNum * ...] would be OOB.
+    if (Sram_FileNumHasFlashSlot(gSaveContext.fileNum)) {
+        SysFlashrom_WriteDataSync(sramCtx->saveBuf,
+                                  gFlashSaveStartPages[gSaveContext.fileNum * FLASH_SAVE_MAIN_MULTIPLIER],
+                                  gFlashSpecialSaveNumPages[gSaveContext.fileNum * FLASH_SAVE_MAIN_MULTIPLIER]);
+    }
 }
 
 /**
@@ -2097,9 +2124,13 @@ void Sram_SaveSpecialNewDay(PlayState* play) {
     gSaveContext.save.day = day;
     gSaveContext.save.time = time;
     gSaveContext.save.cutsceneIndex = cutsceneIndex;
-    SysFlashrom_WriteDataSync(play->sramCtx.saveBuf,
-                              gFlashSaveStartPages[gSaveContext.fileNum * FLASH_SAVE_MAIN_MULTIPLIER],
-                              gFlashSaveNumPages[gSaveContext.fileNum * FLASH_SAVE_MAIN_MULTIPLIER]);
+    // 2S2H [Port] Skip the flash write for the 0xFF "no real slot" sentinel (cross-game /
+    // title / debug session); indexing gFlashSaveStartPages[fileNum * ...] would be OOB.
+    if (Sram_FileNumHasFlashSlot(gSaveContext.fileNum)) {
+        SysFlashrom_WriteDataSync(play->sramCtx.saveBuf,
+                                  gFlashSaveStartPages[gSaveContext.fileNum * FLASH_SAVE_MAIN_MULTIPLIER],
+                                  gFlashSaveNumPages[gSaveContext.fileNum * FLASH_SAVE_MAIN_MULTIPLIER]);
+    }
 }
 
 void Sram_SetFlashPagesDefault(SramContext* sramCtx, u32 curPage, u32 numPages) {
@@ -2183,6 +2214,14 @@ void Sram_UpdateWriteToFlashOwlSave(SramContext* sramCtx) {
 
 void func_80147314(SramContext* sramCtx, s32 fileNum) {
     s32 pad;
+
+    // 2S2H [Port] Reached with fileNum == 0xFF via DeleteOwlSave() (the
+    // BeforeMoonCrashSaveReset hook) and MM_Sram_OpenSave's save-continue path in a
+    // cross-game session. Bail before touching gFlashOwlSave*Pages[fileNum * ...], which
+    // for the 0xFF sentinel indexes hundreds of entries past those six-entry tables.
+    if (!Sram_FileNumHasFlashSlot(fileNum)) {
+        return;
+    }
 
     gSaveContext.save.isOwlSave = false;
 

--- a/src/common/mm_stubs.c
+++ b/src/common/mm_stubs.c
@@ -256,9 +256,17 @@ void Ship_HandleConsoleCrashAsReset(void) {}
 
 /* Resource manager functions are provided by BenPort.cpp */
 
-/* SaveManager stubs */
-int SaveManager_SysFlashrom_ReadData(void* dst, int page, int count) { (void)dst; (void)page; (void)count; return 0; }
-int SaveManager_SysFlashrom_WriteData(void* src, int page, int count) { (void)src; (void)page; (void)count; return 0; }
+/* The SaveManager_SysFlashrom_Read/WriteData stubs that used to live here are
+ * gone (#487). They were the same untyped-stub class as MotionBlur_Override
+ * above: `int(void*, int, int)` against real prototypes of
+ * `s32(void*, u32, u32)` and `void(u8*, u32, u32)`
+ * (games/mm/2s2h/SaveManager/SaveManager.h), and the read stub returned 0 --
+ * "success" -- while writing nothing into the caller's buffer, so MM committed
+ * zeroed buffers over gSaveContext. Header-checked implementations now live in
+ * games/mm/2s2h/mm_save_manager_stubs.c, which is compiled into the MM target
+ * and can therefore both see SaveManager.h's C branch and be guarded on
+ * RSBS_SINGLE_EXECUTABLE (redship_common, which builds this file, is not
+ * compiled with that define). */
 
 /* Combo_CheckEntranceSwitch and Combo_CheckHotSwap are now in
  * GameExports_SingleExe.cpp (they need real cross-game logic) */

--- a/src/common/test_runner.cpp
+++ b/src/common/test_runner.cpp
@@ -72,6 +72,14 @@ int MM_NotificationBinding_RunHeadless(void);
 // to HiRes 576 while the Bombers' Notebook is open. Returns 0 on pass, non-zero
 // on fail.
 int MM_FbEffectsBinding_RunHeadless(void);
+// MM flash page-table OOB lock (games/mm/2s2h/mm_flash_filenum_test.cpp): a
+// cross-game MM session runs with gSaveContext.fileNum == 0xFF, the "no real
+// slot" sentinel. The flash paths index the fixed-size gFlashSave*Pages /
+// gFlashOwlSave*Pages tables by fileNum * FLASH_SAVE_MAIN_MULTIPLIER, so 0xFF
+// runs hundreds of entries past their end -- a wild flash page number the
+// moon-crash reset then copies over the live save (the Fierce-Deity /
+// all-Ocarina corruption). Returns 0 on pass, non-zero on fail.
+int MM_FlashFileNumOob_RunHeadless(void);
 // MM tracker registration surface (games/mm/2s2h/mm_trackers_gui_test.cpp,
 // #392): the four MM tracker windows must register on a Gui under
 // "MM "-prefixed names (SoH owns the unprefixed ones and Gui::AddGuiWindow
@@ -245,6 +253,12 @@ static TestResult Test_MMNotificationBinding(void) {
 // wrapper over the C entry point in games/mm/2s2h/mm_fb_effects_test.cpp.
 static TestResult Test_MMFbEffectsBinding(void) {
     return MM_FbEffectsBinding_RunHeadless() == 0 ? TEST_PASS : TEST_FAIL;
+}
+
+// MM flash page-table OOB lock (see the extern decl above). Thin wrapper over
+// the C entry point in games/mm/2s2h/mm_flash_filenum_test.cpp.
+static TestResult Test_MMFlashFileNumOob(void) {
+    return MM_FlashFileNumOob_RunHeadless() == 0 ? TEST_PASS : TEST_FAIL;
 }
 
 // ============================================================================
@@ -1382,6 +1396,12 @@ const TestDescriptor gTests[] = {
      Test_MMNotificationBinding},
     {"mm-fb-effects-binding", "MM's scaled framebuffer draw binds its own body against MM's dimensions (#386)",
      Test_MMFbEffectsBinding},
+    // Flash page-table OOB from the 0xFF fileNum sentinel: the moon-crash reset
+    // (and the owl-delete write it fires) index the fixed-size flash tables far
+    // out of bounds in a cross-game MM session, then copy the garbage over the
+    // live save. Pure (no display), so it runs in the display-free suite.
+    {"mm-flash-filenum-oob", "Flash page indices stay in bounds for fileNum 0xFF; moon-crash reset keeps the save",
+     Test_MMFlashFileNumOob},
     {"mm-trackers-gui", "MM tracker windows register de-collided on the shared Gui + gate on the active game (#392)",
      Test_MMTrackersGui},
     // The two MM resume-contract tests below mutate process-global state

--- a/src/common/test_runner.cpp
+++ b/src/common/test_runner.cpp
@@ -683,6 +683,35 @@ TestResult Test_MMMoonCrashArmState(void) {
     return rc == 0 ? TEST_PASS : TEST_FAIL;
 }
 
+// Owl-save arm-state lock (#487). The same class as the moon crash, on the save
+// a player performs every cycle: Sram_UpdateWriteToFlashOwlSave re-reads the
+// file it just wrote and memcpy's it over gSaveContext, and MM's flash read is a
+// no-op stub in single-exe, so the paired world's ShipSaveInfo (saveType + the
+// whole rando block) is committed away as zeros. Also covers the file-copy leg
+// (func_80147414). Probes arm state through a VB verdict; a hook count is blind
+// here in both directions, since nothing re-dispatches OnSaveLoad after the
+// readback. Bridge body in games/mm/2s2h/mm_rando_gen_test.cpp. Needs a display,
+// same as mm-rando-gen.
+extern "C" int MM_Rando_HeadlessOwlSaveArmState(void);
+
+TestResult Test_MMOwlSaveArmState(void) {
+    printf("[TEST] mm-owl-save-arm-state: an owl save preserves the paired world and its IS_RANDO hooks\n");
+
+    auto ctx = CreateHarnessStyleContext();
+    if (!ctx) {
+        printf("[TEST] FAIL: could not create Ship::Context singleton\n");
+        return TEST_FAIL;
+    }
+
+    static char arg0[] = "redship";
+    static char* fakeArgv[] = { arg0, nullptr };
+    InitOTRForMMFirstBoot(1, fakeArgv);
+
+    int rc = MM_Rando_HeadlessOwlSaveArmState();
+    printf("[TEST] %s: owl-save arm-state rc=%d\n", rc == 0 ? "PASS" : "FAIL", rc);
+    return rc == 0 ? TEST_PASS : TEST_FAIL;
+}
+
 TestResult Test_BootMM(void) {
     printf("[TEST] boot-mm: MM-first bring-up prerequisites (#330)\n");
     sTargetGame = GAME_MM;
@@ -1309,6 +1338,11 @@ const TestDescriptor gTests[] = {
     // randomizer identity. Same display requirement, so `--test all` skips it.
     {"mm-moon-crash-arm-state", "A moon crash preserves the paired MM world and its IS_RANDO hooks",
      Test_MMMoonCrashArmState},
+    // #487: the owl save (and the file copy) do the same readback-then-commit
+    // over gSaveContext that the moon crash did. Same display requirement, so
+    // `--test all` skips it.
+    {"mm-owl-save-arm-state", "An owl save preserves the paired MM world and its IS_RANDO hooks (#487)",
+     Test_MMOwlSaveArmState},
     {"boot-oot", "Shared-context bring-up leaves no null subsystems (#329)", Test_BootOoT},
     {"boot-mm", "MM-first bring-up prerequisites on the shared context (#330)", Test_BootMM},
     {"switch-oot-mm", "Test game switch OoT -> MM", Test_SwitchOoTMM},
@@ -1489,7 +1523,8 @@ int TestRunner_Run(const char* testName) {
                 strcmp(gTests[i].name, "mm-rando-gen") == 0 ||
                 strcmp(gTests[i].name, "mm-pair-switch-entry") == 0 ||
                 strcmp(gTests[i].name, "mm-reload-arm-state") == 0 ||
-                strcmp(gTests[i].name, "mm-moon-crash-arm-state") == 0) {
+                strcmp(gTests[i].name, "mm-moon-crash-arm-state") == 0 ||
+                strcmp(gTests[i].name, "mm-owl-save-arm-state") == 0) {
                 printf("\n--- Skipping: %s (needs display; runs as a rando-label CTest) ---\n", gTests[i].name);
                 continue;
             }


### PR DESCRIPTION
In single-exe `redship`, MM's flash read is a stub that never fills the caller's buffer, and several MM save paths read a file back from flash and then `memcpy` the result over `gSaveContext`. Because `ShipSaveInfo` — `saveType` plus the whole rando block (`finalSeed`, options, the `RC_MAX` placement table) — is a member of `struct Save`, every one of those commits writes zeros over a cross-game paired world that lives only in memory. #485 fixed the moon-crash instance; this lane fixes the rest, including `Sram_UpdateWriteToFlashOwlSave`, which runs at the end of an ordinary owl save in live gameplay, so a player who saved and quit had MM silently play vanilla for the remainder of the session (and the next switch-out froze that vanilla save into the blob permanently).

This PR also subsumes and supersedes **PR #486** ("Guard MM flash page-table indexing against the 0xFF fileNum sentinel"): commit `0f2bde37` here is a cherry-pick of that fix. #486 cannot merge on its own because its head branch carries a deliberate counterfactual proof commit on top, so **#486 should be closed once this lands** — the fix ships here.

## What changed

- **Honest, header-checked flash stubs** — new `games/mm/2s2h/mm_save_manager_stubs.c` replaces the hand-written `SaveManager_SysFlashrom_ReadData/WriteData` stubs deleted from `src/common/mm_stubs.c`. The old read stub returned `0` ("success") while leaving the buffer untouched; it now returns `-1`, what the real SaveManager returns for a missing/unparsable file, so MM's "did the read work?" branches take their backup fallbacks. The write stub's `int` return is corrected to `void` (the `#379` signature-drift class). It lives in the MM target rather than `redship_common` because that is what lets it include `2s2h/SaveManager/SaveManager.h` and be guarded on `RSBS_SINGLE_EXECUTABLE`; `redship_common` is not compiled with that define. Added to `.github/clang-format-paths.txt`.
- **0xFF `fileNum` sentinel bounds guard** — `games/mm/include/z64save.h` and `games/mm/src/code/z_sram_NES.c` add `Sram_FileNumHasFlashSlot()`, applied to `Sram_ResetSaveFromMoonCrash`, `func_80147314`, `func_80147414`, `Sram_SaveSpecialEnterClockTown`, and `Sram_SaveSpecialNewDay`. A cross-game MM session runs with `fileNum == 0xFF`, which indexes `gFlashSave*Pages` / `gFlashOwlSave*Pages` hundreds of entries past their end. `MM_Sram_OpenSave`'s 0xFF branch also now initializes `phi_t1` so the `gFlashSaveSizes[phi_t1]` memcpy is in bounds.
- **Shared rando-identity preserve across every readback** — `games/mm/src/code/z_sram_NES.c` gains `Sram_Begin/EndRandoPreserve` (single-exe only, wrapped in `RSBS_RANDO_PRESERVE_BEGIN/END`), with the #485 moon-crash fix refactored onto it. Applied to `Sram_UpdateWriteToFlashOwlSave`, `func_80147414`, `Sram_CopySave`, `MM_Sram_OpenSave`, and `func_801457CC`. `Sram_EraseSave` is deliberately not guarded (it commits a `memset` buffer by design), and `func_80147314` has no read so is not in the class. The depth counter is load-bearing: `Sram_CopySave` wraps its own readback *and* calls `func_80147414`, which wraps another, so a flat latch would let the inner `End()` turn the outer restore into a no-op. On restore the pair re-dispatches `OnSaveLoad` so the `IS_RANDO` `COND_HOOK`s re-arm against the save that actually reaches gameplay.
- **`OnSaveLoad` dispatch on file creation** — `MM_Sram_InitSave` (`z_sram_NES.c`) now dispatches `GameInteractor_ExecuteOnSaveLoad` after the two flash-buffer memcpys. Creating a file only dispatched `OnSaveInit` (the generation hook that stamps `SAVETYPE_RANDO`), but the `IS_RANDO` `COND_HOOK`s are re-evaluated only by `OnSaveLoad`, so a brand-new rando file entered gameplay with the boot chain's arm state — disarmed, for the title chain.
- **Locks** — new `games/mm/2s2h/mm_flash_filenum_test.cpp` (`mm-flash-filenum-oob`, ROM-free and display-free) asserts the guard's accept-set matches the real table extents and that the sentinel paths leave the live save intact. New `mm-owl-save-arm-state` bridge in `games/mm/2s2h/mm_rando_gen_test.cpp` drives the real `Sram_UpdateWriteToFlashOwlSave` and `func_80147414` against a live paired world, probing arm state through a VB verdict rather than a hook count. Both rows registered in `src/common/test_runner.cpp` and `CMake/SingleExecutable.cmake` (the owl row is `rando`-labelled — the display requirement comes from `InitOTRForMMFirstBoot` building a Fast3dWindow, and the rationale is recorded in the CMake row).
- **#491: replace count-based arm-state probes with VB verdicts** — `MMPairSwitchEntry` in `games/mm/2s2h/mm_rando_gen_test.cpp` probed arm state with `CountForTest<OnFlagSet>` deltas at both the arrival and return legs. `COND_HOOK`'s unregister is deferred, so a count lags as a disarm signal and a `> baseline` check against a stale non-zero baseline is satisfiable without the hooks being live. Both legs move to VB verdicts and gain the missing "the boot chain disarmed first" assertion (FAIL 19, 20); the vanilla skip path gains a both-polarity pass-through assertion (FAIL 21). FAIL codes 5 and 15 are preserved so existing CI-log greps keep working, and `MMReloadArmState`'s stale comment is corrected in `CMake/SingleExecutable.cmake`.
- **CMake CMP0057 fix** — `CMake/CheckTestRegistration.cmake` now requests `CMP0057` explicitly. `cmake -P` script mode starts with no policies set, so `if(_entry IN_LIST _reg_unit)` parses as "Unknown arguments specified" on CMake 4.x; the registration guard hard-failed on a local CMake 4.4 run while CI, on an older cmake, stayed green.
- **Findings doc** — `docs/unified-surface-findings.md` gains section 7: the link check run against the built binary, the complete site-by-site inventory of the readback class with the fix/no-fix decision for each, and two items deliberately left for the maintainer (whether `redship` should have a real MM save path at all, and `MM_Sram_InitSave` computing its checksum before `OnSaveInit` runs).

## Why

The guard restores the rando half only when the readback actually lost it — if the data that came back *is* a rando save, upstream semantics win and it is a no-op, as is every vanilla session. The file-select paths (`MM_Sram_OpenSave`, `func_801457CC`) are inert in the flow a player takes, since the boot chain authors a vanilla bootstrap first; they are guarded so a LOAD or an enumeration can never become the thing that strips a live paired world.

Non-vacuity of the new locks is structural rather than asserted: each leg disarms against a vanilla bootstrap and asserts the disarm took before re-arming, so a "force rando on" fix fails, and the assertions cover `finalSeed` and a placement entry, so a fix preserving only the type byte fails. Verified red before green — with the guard macros neutered, `mm-owl-save-arm-state` fails FAIL(6) and `MMMoonCrashArmState` fails FAIL(4).

## Testing

The stacked tip passes `ctest -L "^redship$"` locally, including the new `MMFlashFileNumOob` row. The `rando`-tier rows (`MMOwlSaveArmState`, `MMPairSwitchEntry`, `MMMoonCrashArmState`) were run locally as well.

Hosted CI covers the compile and ROM-free tiers only. The gameplay tier (`int-*`) is **not** covered here — that tier needs a self-hosted ROM runner, which is not configured.

Closes #487
Closes #491
Refs #486 (superseded by this PR; close it once this lands)
Refs #485

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!--- section:artifacts:start -->
### Build Artifacts
  - [rsbs-windows.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/8572136277.zip)
  - [rsbs-linux.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/8571346494.zip)
<!--- section:artifacts:end -->