### PR TITLE
Make MM's trackers openable and named, and add the in-game cross-game spoiler panel

### DIFF
--- a/CMake/SingleExecutable.cmake
+++ b/CMake/SingleExecutable.cmake
@@ -33,6 +33,12 @@ set(REDSHIP_COMMON_SOURCES
     # and both spoiler surfaces; the pinned pool itself is OoT-side
     # (soh/Enhancements/randomizer/ForeignItemsSingleExe.cpp)
     ${CMAKE_SOURCE_DIR}/src/common/foreign_items.c
+    # Read-only view model over those placements (#496) — the in-game answer to
+    # "which MM check hosts which OoT item, and has it been collected", so the
+    # spoiler stops being a JSON path the operator has to be told
+    ${CMAKE_SOURCE_DIR}/src/common/combo_spoiler_view.c
+    # The window that renders it — the first common-owned Gui element (ADR 0008)
+    ${CMAKE_SOURCE_DIR}/src/common/ComboSpoilerWindow.cpp
     ${CMAKE_SOURCE_DIR}/src/common/entrance.cpp
     ${CMAKE_SOURCE_DIR}/src/common/test_runner.cpp
     ${CMAKE_SOURCE_DIR}/src/common/integration_test_hooks.cpp
@@ -88,6 +94,8 @@ set(REDSHIP_COMMON_HEADERS
     ${CMAKE_SOURCE_DIR}/src/common/context.h
     ${CMAKE_SOURCE_DIR}/src/common/shared_items.h
     ${CMAKE_SOURCE_DIR}/src/common/foreign_items.h
+    ${CMAKE_SOURCE_DIR}/src/common/combo_spoiler_view.h
+    ${CMAKE_SOURCE_DIR}/src/common/ComboSpoilerWindow.h
     ${CMAKE_SOURCE_DIR}/src/common/entrance.h
     ${CMAKE_SOURCE_DIR}/src/common/test_runner.h
     ${CMAKE_SOURCE_DIR}/src/common/integration_test_hooks.h
@@ -345,6 +353,8 @@ if(BUILD_TESTING)
     # shared structure, the crossing awards exactly once on the OoT side, and
     # gComboCtx.foreignPlacements round-trips through the .redsave record.
     redship_add_test(NAME ForeignItemGive COMMAND redship --test foreign-item-give)
+    redship_add_test(NAME ComboSpoilerView COMMAND redship --test combo-spoiler-view)
+    redship_add_test(NAME ComboSpoilerWindow COMMAND redship --test combo-spoiler-window)
     # Cross-game session invalidation (#440). A soft reset or a new game must
     # retire the previous session's frozen blobs, shadows and gComboCtx
     # crossings — while a cross-game arrival and a legitimate existing-slot

--- a/docs/adr/0008-common-owned-gui-registration.md
+++ b/docs/adr/0008-common-owned-gui-registration.md
@@ -1,0 +1,96 @@
+# ADR 0008: Cross-game Gui windows register from `src/common` on the shared `Ship::Context` Gui, from a lifecycle entry point
+
+- Status: **Accepted** (2026-07-22)
+- For: #492 (Phase 3.1 tracker), Lane 5 — #496 step 5
+- Depends on: the shared-Gui registration pattern PR #457 established for MM's
+  tracker windows (`games/mm/2s2h/TrackersGuiSingleExe.cpp`)
+
+This settles the seam for **every** future cross-game panel, not just #496's.
+#458 (the combo tracker) needs the same answer and should not re-litigate it.
+
+## Context
+
+Both games register their own windows on one shared `Ship::Gui`: OoT does it
+from `SohGui.cpp` during its boot, MM from `MM_TrackersGui_Init` via
+`MM_Rando_Init`. That worked while every window belonged to a game.
+
+#496 introduces the first window that belongs to **neither**. The cross-game
+spoiler view reads only `gComboCtx` — it deliberately touches no
+`gSaveContext`, which is what lets it render correctly under `GAME_OOT`,
+`GAME_MM` and `GAME_NONE` alike. Hanging it off a game's boot would make a
+game-neutral window's existence depend on which game booted:
+
+- Register from **MM's** boot and the window does not exist until the player
+  has crossed into MM at least once. The crossings it describes are placed
+  MM-side, so this is the tempting choice — and it is exactly wrong, because
+  the player who most needs the view is the one still in OoT wondering where
+  their hookshot went.
+- Register from **OoT's** boot and MM-only sessions never get it.
+- Register from **both** and `Gui::AddGuiWindow` silently rejects the second
+  attempt (SPDLOG_ERROR and return, `libultraship/src/ship/window/gui/Gui.cpp`),
+  so the duplicate is invisible until someone reads the log.
+
+`src/common` had no wired Gui element at all before this. `ComboMenuBar` is
+compiled but nothing outside its own TU references it, so there was no
+precedent to copy — only a gap.
+
+## Decision
+
+**1. Cross-game Gui windows are owned by `src/common` and registered from a
+`src/common` entry point, not from either game's boot.**
+
+A window whose data source is `gComboCtx` registers itself; a window whose data
+source is a game's `gSaveContext` stays with that game. That is the ownership
+test, and it is a test about the *data*, not about the pixels: MM's check
+tracker reads MM's save through MM's layout and therefore stays MM's, even
+though it is displayed in the same combo binary.
+
+**2. The registration point is the shared `Ship::Context` Gui, under a
+distinct, unprefixed-by-a-game name.** SoH owns the four unprefixed tracker
+names and MM owns the `MM `-prefixed four; common-owned windows take names in
+neither space. `AddGuiWindow`'s duplicate rejection is silent from the caller's
+side, so name collisions are a registration-time bug that surfaces only as a
+missing window — every registrar must keep its names disjoint.
+
+**3. Registration is idempotent and tolerates being called before, after, or
+instead of either game's boot.** The concrete guard is the #457 one: check
+`GetGuiWindow(name) != nullptr` and return.
+
+**4. Registration must no-op cleanly when the shared context has no window.**
+Every ROM-free harness runs in that state, and it is the reason
+`MM_TrackersGui_Init` already returns early on a null `GetWindow()`/`GetGui()`.
+
+**5. Common-owned windows do not read `gSaveContext` at all.** This is what
+makes them safe to draw under any active game, and it is why they need no
+equivalent of MM's `MMActiveGated` wrapper. A future common-owned window that
+*does* need per-game data must gate like MM's do rather than relax this.
+
+## Consequences
+
+- The cross-game spoiler view (#496) is reachable in an OoT-only session, which
+  is the session where it matters most.
+- #458's combo tracker inherits this seam rather than inventing a second one.
+  Its slice that reads the *inactive game's frozen shadow* is still
+  common-owned by rule 1; its per-game check adapters are not.
+- `Ship::GuiWindow` latches its visibility CVar in the constructor and nothing
+  re-syncs CVar → visibility per frame
+  (`libultraship/src/ship/window/gui/GuiWindow.cpp`). A common-owned window
+  therefore needs its own openability route, exactly as MM's trackers do —
+  either a live CVar read in `Draw()` or an explicit sync. Registration alone
+  does not make a window reachable, and #489 is the bug report proving it.
+- The three-edit CTest registration rule applies: a common-owned window's
+  headless lock (registration, idempotence, and `Draw()`/`Update()` under all
+  three `GameId`s with no ImGui context) belongs in the display-free `redship`
+  tier.
+
+## Alternatives rejected
+
+**A `SohMenu` `WIDGET_WINDOW_BUTTON` row as the registration seam.** That is
+OoT's menu machinery (`games/oot/soh/SohGui/Menu.cpp`); routing a game-neutral
+window through it re-creates the OoT-boot dependency this ADR exists to avoid,
+and puts a common-owned concern in a game-owned file. It remains a fine way to
+*open* such a window once registered — the two questions are separate.
+
+**A registry both games push into at boot.** More machinery than the problem
+has: with `AddGuiWindow` already keyed by name and already idempotent-checkable,
+a second registry would be a second source of truth about what is registered.

--- a/games/mm/2s2h/Enhancements/Trackers/ItemTracker/ItemTracker.cpp
+++ b/games/mm/2s2h/Enhancements/Trackers/ItemTracker/ItemTracker.cpp
@@ -9,6 +9,13 @@
 #include "2s2h/ShipUtils.h"
 #include <spdlog/fmt/fmt.h>
 
+#ifdef RSBS_SINGLE_EXECUTABLE
+// S2H::TrackersGui::kItemTrackerVisibilityCVar — the same string the ctor call
+// in RegisterWindows passes, so the live Draw-time read below cannot drift
+// away from the CVar the window was registered under.
+#include "2s2h/TrackersGuiSingleExe.h"
+#endif
+
 extern "C" {
 #include "z64save.h"
 #include "variables.h"
@@ -381,9 +388,31 @@ void DrawItemTrackerGroup(TrackerGroup& trackerGroup) {
 }
 
 void ItemTrackerWindow::Draw() {
+#ifdef RSBS_SINGLE_EXECUTABLE
+    // Read the visibility CVar LIVE, mirroring MM's own check tracker
+    // (2s2h/Rando/CheckTracker/CheckTracker.cpp:454-457), instead of trusting
+    // the ctor-latched IsVisible().
+    //
+    // Ship::GuiWindow reads its visibility CVar exactly once, in the ctor
+    // (libultraship GuiWindow.cpp:13-15), and only ever writes the reverse
+    // direction afterwards. Upstream 2S2H reopens this window through BenMenu,
+    // which is link-elided in the single exe (games/mm/CMakeLists.txt:245), so
+    // a console `set gWindows.ItemTracker 1` after MM has booted could never
+    // make the window appear (#489 cause 1). MMActiveGated::Draw
+    // (2s2h/TrackersGuiSingleExe.cpp) re-syncs IsVisible() from the same CVar
+    // before delegating here, so the two agree; this read is what keeps the
+    // window honest if that wrapper is ever bypassed.
+    //
+    // RSBS_SINGLE_EXECUTABLE-guarded on purpose: this is a vendored 2S2H TU
+    // and an unguarded divergence is an upstream-sync landmine.
+    if (!CVarGetInteger(S2H::TrackersGui::kItemTrackerVisibilityCVar, 0)) {
+        return;
+    }
+#else
     if (!IsVisible()) {
         return;
     }
+#endif
 
     if (!MM_gPlayState) {
         return;

--- a/games/mm/2s2h/TrackersGuiSingleExe.cpp
+++ b/games/mm/2s2h/TrackersGuiSingleExe.cpp
@@ -47,9 +47,16 @@
 #include <ship/window/Window.h>
 #include <ship/window/gui/Gui.h>
 
+#include <cstring>
+#include <string>
+#include <utility> // std::forward, for the MMActiveGated ctor pass-through
+
+#include <libultraship/bridge/consolevariablebridge.h>
+
 #include "2s2h/Rando/CheckTracker/CheckTracker.h"
 #include "2s2h/Enhancements/Trackers/ItemTracker/ItemTracker.h"
 #include "2s2h/Enhancements/Trackers/ItemTracker/ItemTrackerSettings.h"
+#include "2s2h/Rando/StaticData/StaticData.h" // Rando::StaticData::PopulateCheckNames
 #include "2s2h/DeveloperTools/SaveEditor.h"
 #include "2s2h/ShipUtils.h"
 
@@ -139,21 +146,58 @@ void InitSafeItemsForInventorySlot() {
 namespace {
 
 /**
+ * Drive `window`'s visibility to whatever its visibility CVar currently says
+ * (#489 cause 1). See the SyncVisibilityFromCVars doc comment in the header
+ * for why this is safe without a real Ship::Window: the assignment always
+ * moves visibility TO the stored CVar value, so GuiWindow::SetVisibility's
+ * `shouldSave` is always false and the Context::GetWindow()->GetGui() deref at
+ * GuiWindow.cpp:61 is never reached.
+ */
+void SyncVisibilityFromCVar(Ship::GuiWindow& window, const char* cvar) {
+    if (cvar == nullptr || cvar[0] == '\0') {
+        return;
+    }
+    const bool wanted = CVarGetInteger(cvar, 0) != 0;
+    if (window.IsVisible() == wanted) {
+        return;
+    }
+    if (wanted) {
+        window.Show();
+    } else {
+        window.Hide();
+    }
+}
+
+/**
  * Active-game gate. Draw() covers the per-frame ImGui path (both the base
  * GuiWindow::Draw used by the settings windows and the full Draw overrides in
  * CheckTracker.cpp / ItemTracker.cpp); UpdateElement() covers Gui's
  * unconditional per-frame Update(). The bases' bodies run only while MM is
  * the active game. The mm-trackers-gui lock calls Draw() with OoT active and
  * no ImGui context, so an ungated path aborts the test process.
+ *
+ * The gate is also where the per-frame CVar->visibility re-sync lives (#489
+ * cause 1). libultraship never re-reads a window's visibility CVar after the
+ * ctor, and the single exe has no BenMenu to call Show(), so without this the
+ * settings windows — which reach ImGui through the base GuiWindow::Draw and
+ * its `if (!IsVisible()) return;` — would be permanently stuck at whatever
+ * the config held on MM's first boot. Deliberately INSIDE the active-game
+ * gate: syncing while OoT is active would be wasted work every frame, and the
+ * ROM-free lock drives Draw() with OoT active specifically to prove nothing
+ * below the gate runs then.
  */
 template <typename BaseWindow> class MMActiveGated final : public BaseWindow {
   public:
-    using BaseWindow::BaseWindow;
+    template <typename... Args>
+    explicit MMActiveGated(const std::string& consoleVariable, Args&&... args)
+        : BaseWindow(consoleVariable, std::forward<Args>(args)...), mVisibilityCVar(consoleVariable) {
+    }
 
     void Draw() override {
         if (!MM_TrackersGui_ShouldDraw()) {
             return;
         }
+        SyncVisibilityFromCVar(*this, mVisibilityCVar.c_str());
         BaseWindow::Draw();
     }
 
@@ -164,7 +208,44 @@ template <typename BaseWindow> class MMActiveGated final : public BaseWindow {
         }
         BaseWindow::UpdateElement();
     }
+
+  private:
+    // GuiWindow keeps mVisibilityConsoleVariable private, so the wrapper holds
+    // its own copy of the same string it passed to the base ctor.
+    std::string mVisibilityCVar;
 };
+
+// The four registered windows, in kAllTrackerWindowNames order, held as the
+// plain GuiWindow base so one table covers all four MMActiveGated
+// instantiations. MM_TrackersGui_ShouldShow and SyncVisibilityFromCVars
+// resolve by name through this table rather than through the Gui registry, so
+// they work on whichever Gui RegisterWindows was last handed (the ROM-free
+// harness uses a standalone one, not the shared Ship::Context Gui).
+struct TrackerWindowSlot {
+    const char* name;
+    const char* cvar;
+    std::shared_ptr<Ship::GuiWindow> window;
+};
+
+TrackerWindowSlot gTrackerSlots[] = {
+    { S2H::TrackersGui::kCheckTrackerWindowName, S2H::TrackersGui::kCheckTrackerVisibilityCVar, nullptr },
+    { S2H::TrackersGui::kCheckTrackerSettingsWindowName, S2H::TrackersGui::kCheckTrackerSettingsVisibilityCVar,
+      nullptr },
+    { S2H::TrackersGui::kItemTrackerWindowName, S2H::TrackersGui::kItemTrackerVisibilityCVar, nullptr },
+    { S2H::TrackersGui::kItemTrackerSettingsWindowName, S2H::TrackersGui::kItemTrackerSettingsVisibilityCVar, nullptr },
+};
+
+TrackerWindowSlot* FindTrackerSlot(const char* windowName) {
+    if (windowName == nullptr) {
+        return nullptr;
+    }
+    for (TrackerWindowSlot& slot : gTrackerSlots) {
+        if (strcmp(slot.name, windowName) == 0) {
+            return &slot;
+        }
+    }
+    return nullptr;
+}
 
 } // namespace
 
@@ -175,6 +256,23 @@ void RegisterWindows(std::shared_ptr<Ship::Gui> gui) {
     if (gui == nullptr) {
         return;
     }
+
+    // #489 cause 2: Rando::StaticData::CheckNames is RC_MAX empty strings in
+    // every single-exe binary — PopulateCheckNames' only caller upstream is
+    // BenPort.cpp:874, and games/mm/CMakeLists.txt:238 excludes that TU. The
+    // check tracker labels and filters every row through this array
+    // (CheckTracker.cpp:334, :408), so without this call it renders scene
+    // headers over blank rows. Re-homing an excluded-TU initializer here is
+    // the #457 precedent InitSafeItemsForInventorySlot already set.
+    //
+    // Ahead of the idempotence return on purpose: population is what the
+    // trackers need, and a caller that re-registers must not be able to reach
+    // a state where the windows exist but the names do not. PopulateCheckNames
+    // is a pure overwrite over StaticData::Checks, so re-running is free.
+    // Display-only — GetCheckIdFromName compares RandoStaticCheck.name, so
+    // spoiler read/write does not depend on this.
+    Rando::StaticData::PopulateCheckNames();
+
     // Idempotence: MM_Rando_Init is once-only guarded, but the headless
     // harness may drive registration directly more than once.
     if (gui->GetGuiWindow(kCheckTrackerWindowName) != nullptr) {
@@ -192,20 +290,38 @@ void RegisterWindows(std::shared_ptr<Ship::Gui> gui) {
     // "gWindows.CheckTracker" itself, so the ctor CVar must stay in sync
     // with the vendored macro (CVAR_NAME_SHOW_CHECK_TRACKER).
     BenGui::mRandoCheckTrackerWindow = std::make_shared<MMActiveGated<Rando::CheckTracker::CheckTrackerWindow>>(
-        "gWindows.CheckTracker", kCheckTrackerWindowName, ImVec2(375, 460));
+        kCheckTrackerVisibilityCVar, kCheckTrackerWindowName, ImVec2(375, 460));
     gui->AddGuiWindow(BenGui::mRandoCheckTrackerWindow);
 
     BenGui::mRandoCheckTrackerSettingsWindow = std::make_shared<MMActiveGated<Rando::CheckTracker::SettingsWindow>>(
-        "gWindows.CheckTrackerSettings", kCheckTrackerSettingsWindowName);
+        kCheckTrackerSettingsVisibilityCVar, kCheckTrackerSettingsWindowName);
     gui->AddGuiWindow(BenGui::mRandoCheckTrackerSettingsWindow);
 
     BenGui::mItemTrackerWindow =
-        std::make_shared<MMActiveGated<ItemTrackerWindow>>("gWindows.ItemTracker", kItemTrackerWindowName);
+        std::make_shared<MMActiveGated<ItemTrackerWindow>>(kItemTrackerVisibilityCVar, kItemTrackerWindowName);
     gui->AddGuiWindow(BenGui::mItemTrackerWindow);
 
     BenGui::mItemTrackerSettingsWindow = std::make_shared<MMActiveGated<ItemTrackerSettingsWindow>>(
-        "gWindows.ItemTrackerSettings", kItemTrackerSettingsWindowName, ImVec2(800, 400));
+        kItemTrackerSettingsVisibilityCVar, kItemTrackerSettingsWindowName, ImVec2(800, 400));
     gui->AddGuiWindow(BenGui::mItemTrackerSettingsWindow);
+
+    gTrackerSlots[0].window = BenGui::mRandoCheckTrackerWindow;
+    gTrackerSlots[1].window = BenGui::mRandoCheckTrackerSettingsWindow;
+    gTrackerSlots[2].window = BenGui::mItemTrackerWindow;
+    gTrackerSlots[3].window = BenGui::mItemTrackerSettingsWindow;
+
+    // The windows were just constructed, so each one latched its CVar a moment
+    // ago and this is a no-op today. It is here so registration and the
+    // openability contract cannot drift apart if construction ever moves.
+    SyncVisibilityFromCVars();
+}
+
+void SyncVisibilityFromCVars(void) {
+    for (TrackerWindowSlot& slot : gTrackerSlots) {
+        if (slot.window != nullptr) {
+            SyncVisibilityFromCVar(*slot.window, slot.cvar);
+        }
+    }
 }
 
 } // namespace TrackersGui
@@ -213,6 +329,14 @@ void RegisterWindows(std::shared_ptr<Ship::Gui> gui) {
 
 extern "C" bool MM_TrackersGui_ShouldDraw(void) {
     return Context_GetCurrentGame() == GAME_MM;
+}
+
+extern "C" bool MM_TrackersGui_ShouldShow(const char* windowName) {
+    const TrackerWindowSlot* slot = FindTrackerSlot(windowName);
+    if (slot == nullptr || slot->window == nullptr) {
+        return false;
+    }
+    return slot->window->IsVisible();
 }
 
 extern "C" void MM_TrackersGui_Init(void) {
@@ -227,6 +351,14 @@ extern "C" void MM_TrackersGui_Init(void) {
     }
 
     S2H::TrackersGui::RegisterWindows(gui);
+
+    // #489 cause 1: honour the PERSISTED visibility CVars. Registration is
+    // once-only per process (MM_Rando_Init's sRandoInitDone), and libultraship
+    // never re-reads a window's visibility CVar after its ctor, so a config
+    // that already says "gWindows.ItemTracker=1" from a previous session must
+    // be applied here or the window silently stays shut. Runtime toggling is
+    // handled per-frame by the MMActiveGated Draw wrapper.
+    S2H::TrackersGui::SyncVisibilityFromCVars();
 
     // Tracker icons (check-type icons, item/quest icons). Upstream loads
     // these from BenPort.cpp's InitOTR; gated on the archive because the

--- a/games/mm/2s2h/TrackersGuiSingleExe.h
+++ b/games/mm/2s2h/TrackersGuiSingleExe.h
@@ -49,6 +49,18 @@ inline constexpr const char* kAllTrackerWindowNames[] = {
     kItemTrackerSettingsWindowName,
 };
 
+// Visibility CVars, kept as MM's upstream "gWindows.*" names (OoT's windows
+// use "gOpenWindows.*", so there is no store collision to rename around).
+// These are the SAME strings the ctor calls in RegisterWindows pass; naming
+// them here is what keeps the ctor CVar, the CVar->visibility sync, and
+// ItemTracker.cpp's live Draw-time read from drifting apart. CheckTracker.cpp
+// spells its own copy as CVAR_NAME_SHOW_CHECK_TRACKER (CheckTracker.cpp:54);
+// that one is vendored and stays where it is.
+inline constexpr const char* kCheckTrackerVisibilityCVar = "gWindows.CheckTracker";
+inline constexpr const char* kCheckTrackerSettingsVisibilityCVar = "gWindows.CheckTrackerSettings";
+inline constexpr const char* kItemTrackerVisibilityCVar = "gWindows.ItemTracker";
+inline constexpr const char* kItemTrackerSettingsVisibilityCVar = "gWindows.ItemTrackerSettings";
+
 /**
  * Instantiate the MM tracker windows (populating the BenGui::m*Window
  * globals) and register them on `gui`. Idempotent: if the check-tracker
@@ -57,6 +69,26 @@ inline constexpr const char* kAllTrackerWindowNames[] = {
  * which would drop SoH's windows off the shared Gui too.
  */
 void RegisterWindows(std::shared_ptr<Ship::Gui> gui);
+
+/**
+ * Reconcile each registered MM tracker window's visibility with the live value
+ * of its "gWindows.*" CVar (#489 cause 1).
+ *
+ * Ship::GuiWindow reads its visibility CVar exactly once, in the constructor
+ * (libultraship GuiWindow.cpp:13-15), and SyncVisibilityConsoleVariable only
+ * ever writes visibility -> CVar, never the reverse. Upstream 2S2H reopened
+ * windows through BenMenu's WIDGET_WINDOW_BUTTON rows, and BenMenu is
+ * link-elided here — so without this call three of the four MM tracker windows
+ * can never be opened after MM's first boot, whatever the CVar says.
+ *
+ * Safe with no real Ship::Window: it only ever drives a window's visibility TO
+ * the value its own CVar already holds, and GuiWindow::SetVisibility assigns
+ * mIsVisible BEFORE computing `shouldSave = storedCVar != IsVisible()`. That
+ * comparison is therefore always false here, so the
+ * Context::GetWindow()->GetGui() deref at GuiWindow.cpp:61 — a null deref in
+ * the ROM-free harness — is never reached.
+ */
+void SyncVisibilityFromCVars(void);
 
 } // namespace TrackersGui
 } // namespace S2H
@@ -70,6 +102,17 @@ extern "C" {
  * ROM-free lock can flip it without a Gui.
  */
 bool MM_TrackersGui_ShouldDraw(void);
+
+/**
+ * Per-window visibility predicate (#489 cause 1): true iff the MM tracker
+ * window registered under `windowName` exists AND currently considers itself
+ * visible. An unknown name is false.
+ *
+ * This reports the window's OWN latched visibility, deliberately not a CVar
+ * read — that is what makes it a real check on SyncVisibilityFromCVars rather
+ * than a tautology over the CVar store. Pure: no ImGui, no save, no gSaveContext.
+ */
+bool MM_TrackersGui_ShouldShow(const char* windowName);
 
 /**
  * Production entry point, called from MM_Rando_Init (once-only by its guard):

--- a/games/mm/2s2h/mm_trackers_gui_test.cpp
+++ b/games/mm/2s2h/mm_trackers_gui_test.cpp
@@ -45,6 +45,8 @@
 #include "2s2h/Rando/CheckTracker/CheckTracker.h"
 #include "2s2h/Enhancements/Trackers/ItemTracker/ItemTracker.h"
 #include "2s2h/Enhancements/Trackers/ItemTracker/ItemTrackerSettings.h"
+#include "2s2h/Rando/StaticData/StaticData.h" // CheckNames / Checks
+#include "2s2h/ShipUtils.h"                   // convertEnumToReadableName
 #include "context.h"
 
 namespace BenGui {
@@ -200,6 +202,91 @@ extern "C" int MM_TrackersGui_RunHeadless(void) {
     Context_SetCurrentGame(prevGame);
     TGT_ASSERT(mmActiveDraws, "MM_TrackersGui_ShouldDraw() false while MM is the active game");
 
+    // ---- 4. VISIBILITY: the ctor's CVar latch must not be the last word ----
+    // #489 cause 1. Ship::GuiWindow reads its visibility CVar exactly once, in
+    // the constructor (libultraship GuiWindow.cpp:13-15), and
+    // SyncVisibilityConsoleVariable only ever writes mIsVisible -> CVar, never
+    // the reverse. In the single exe nothing calls Show() on these windows —
+    // BenMenu, upstream's only route to it, is link-elided — so without a
+    // CVar -> visibility sync three of the four MM tracker windows can never be
+    // opened at all after MM's first boot.
+    //
+    // This drives the REAL production path: S2H::TrackersGui::RegisterWindows
+    // constructing the real window types through the real Ship::GuiWindow ctor
+    // on a fresh Gui, with the visibility CVars CLEARED — the inverse of leg 1
+    // above, which forces them on before construction.
+    for (const char* cvar : kMMWindowVisibilityCVars) {
+        CVarClear(cvar);
+    }
+    auto visGui = std::make_shared<Ship::Gui>();
+    S2H::TrackersGui::RegisterWindows(visGui);
+
+    for (const char* name : S2H::TrackersGui::kAllTrackerWindowNames) {
+        TGT_ASSERT(!MM_TrackersGui_ShouldShow(name), "window reports drawable with its visibility CVar cleared");
+    }
+    TGT_ASSERT(!MM_TrackersGui_ShouldShow("MM Nonexistent Window"), "unknown window name reported drawable");
+    TGT_ASSERT(!MM_TrackersGui_ShouldShow(nullptr), "null window name reported drawable");
+
+    // The latch is REAL: setting the CVar after construction changes nothing on
+    // its own. Asserting this first is what keeps the leg below from going
+    // vacuous — if libultraship ever starts re-syncing per frame, this fails
+    // loudly rather than silently making the sync untested.
+    CVarSetInteger(S2H::TrackersGui::kItemTrackerVisibilityCVar, 1);
+    TGT_ASSERT(!MM_TrackersGui_ShouldShow(S2H::TrackersGui::kItemTrackerWindowName),
+               "ctor visibility latch is gone — this leg no longer pins #489 cause 1");
+
+    // ...and the production sync is what makes the window openable. RED before
+    // SyncVisibilityFromCVars existed: IsVisible() stayed false forever.
+    S2H::TrackersGui::SyncVisibilityFromCVars();
+    TGT_ASSERT(MM_TrackersGui_ShouldShow(S2H::TrackersGui::kItemTrackerWindowName),
+               "item tracker still not drawable after the CVar->visibility sync (#489 cause 1)");
+    // Only the window whose CVar was set: the sync must not open all four.
+    TGT_ASSERT(!MM_TrackersGui_ShouldShow(S2H::TrackersGui::kCheckTrackerSettingsWindowName),
+               "sync opened a window whose visibility CVar was still cleared");
+    TGT_ASSERT(!MM_TrackersGui_ShouldShow(S2H::TrackersGui::kItemTrackerSettingsWindowName),
+               "sync opened a window whose visibility CVar was still cleared");
+
+    // Reversible: the settings windows are otherwise unreachable by any route,
+    // so closing has to work through the same seam as opening.
+    CVarSetInteger(S2H::TrackersGui::kItemTrackerSettingsVisibilityCVar, 1);
+    CVarClear(S2H::TrackersGui::kItemTrackerVisibilityCVar);
+    S2H::TrackersGui::SyncVisibilityFromCVars();
+    TGT_ASSERT(MM_TrackersGui_ShouldShow(S2H::TrackersGui::kItemTrackerSettingsWindowName),
+               "item tracker settings window did not open from its CVar");
+    TGT_ASSERT(!MM_TrackersGui_ShouldShow(S2H::TrackersGui::kItemTrackerWindowName),
+               "clearing the CVar did not close the item tracker");
+
+    // Surviving all of the above is itself an assertion: Show()/Hide() route
+    // through GuiWindow::SetVisibility -> SyncVisibilityConsoleVariable, which
+    // dereferences Context::GetWindow()->GetGui() when the stored CVar and the
+    // new visibility disagree. This harness has NO window, so a sync that ever
+    // drove visibility AWAY from the CVar's own value would null-deref here.
+
+    // ---- 5. CheckNames is populated in single-exe builds ------------------
+    // #489 cause 2. Rando::StaticData::CheckNames is RC_MAX empty strings
+    // (Checks.cpp:11) and PopulateCheckNames' only upstream caller is
+    // BenPort.cpp:874, which games/mm/CMakeLists.txt:238 excludes — so every
+    // check-tracker row rendered a blank label. RegisterWindows now calls it.
+    // This drives the REAL PopulateCheckNames over the REAL StaticData::Checks
+    // map; RED before that call site existed.
+    {
+        const RandoCheckId kProbe = RC_CLOCK_TOWER_ROOF_OCARINA;
+        const auto& probeCheck = Rando::StaticData::Checks.at(kProbe);
+        TGT_ASSERT(!Rando::StaticData::CheckNames[kProbe].empty(),
+                   "CheckNames entry is still empty — PopulateCheckNames never ran (#489 cause 2)");
+        TGT_ASSERT(Rando::StaticData::CheckNames[kProbe] == convertEnumToReadableName(probeCheck.name),
+                   "CheckNames entry is not its convertEnumToReadableName form");
+        // Not just one entry: the whole map was walked.
+        size_t namedCount = 0;
+        for (const auto& [checkId, staticCheck] : Rando::StaticData::Checks) {
+            if (!Rando::StaticData::CheckNames[checkId].empty()) {
+                namedCount++;
+            }
+        }
+        TGT_ASSERT(namedCount >= Rando::StaticData::Checks.size() - 1,
+                   "PopulateCheckNames left named checks behind (only RC_UNKNOWN may be empty)");
+    }
+
     // Cleanup: don't leak forced-visible tracker CVars into later tests or a
     // saved cvar file.
     for (const char* cvar : kMMWindowVisibilityCVars) {
@@ -207,7 +294,8 @@ extern "C" int MM_TrackersGui_RunHeadless(void) {
     }
 
     printf("[TEST] PASS: mm-trackers-gui — four MM tracker windows register under de-collided names beside "
-           "SoH's, and their draw path is inert unless MM is the active game\n");
+           "SoH's, their draw path is inert unless MM is the active game, their visibility tracks the live "
+           "CVar, and CheckNames is populated\n");
     return 0;
 }
 

--- a/rsbs/src/main.cpp
+++ b/rsbs/src/main.cpp
@@ -25,6 +25,7 @@
 #include "game.h"
 #include "game_lifecycle.h"
 #include "context.h"
+#include "ComboSpoilerWindow.h" // Combo_SpoilerWindow_Init (#496, ADR 0008)
 #include "entrance.h"
 #include "rsbs_version.h"
 #include "test_runner.h"
@@ -488,6 +489,14 @@ int main(int argc, char** argv) {
     // Keep context's view of the current game in sync with the runner so that
     // cross-game entrance hooks dispatch against the right game (issue #170).
     Context_SetCurrentGame(selectedGame);
+
+    // Cross-game spoiler panel (#496). Registered HERE, from the combo entry
+    // point, rather than from either game's boot: it reads only gComboCtx, so
+    // hanging it off MM's boot would hide it from the OoT-only session that
+    // most needs it, and off OoT's boot would hide it from MM-only sessions
+    // (ADR 0008). Whichever game started has created the Ship::Context and
+    // its Gui by now; the call is a safe no-op if it has not.
+    Combo_SpoilerWindow_Init();
 
     // Belt and braces: re-assert the unattended-safe handlers after game init.
     // The claim above already makes Ship::Context::InitCrashHandler a no-op

--- a/src/common/ComboSpoilerWindow.cpp
+++ b/src/common/ComboSpoilerWindow.cpp
@@ -1,0 +1,132 @@
+/**
+ * @file ComboSpoilerWindow.cpp
+ * @brief Renders the cross-game spoiler model in-game (#496; ADR 0008).
+ *
+ * See ComboSpoilerWindow.h for the contract. Every value drawn here comes from
+ * combo_spoiler_view.h; this file holds no state of its own and caches
+ * nothing, so a crossing collected mid-session updates on the next frame.
+ */
+
+#include "ComboSpoilerWindow.h"
+
+#include <imgui.h>
+#include <ship/Context.h>
+#include <ship/window/Window.h>
+#include <ship/window/gui/Gui.h>
+#include <libultraship/bridge/consolevariablebridge.h>
+
+#include "combo_spoiler_view.h"
+
+namespace ComboGui {
+
+void ComboSpoilerWindow::Draw() {
+    // Read the visibility CVar LIVE rather than trusting the ctor-latched
+    // IsVisible(). Ship::GuiWindow reads the CVar exactly once, in its ctor,
+    // and only ever writes visibility -> CVar afterwards, so a window with no
+    // menu row could otherwise never be opened after registration (#489 cause
+    // 1; MM's check tracker does the same at CheckTracker.cpp:454-457).
+    if (!CVarGetInteger(kComboSpoilerVisibilityCVar, 0)) {
+        return;
+    }
+
+    ImGui::SetNextWindowSize(ImVec2(460.0f, 320.0f), ImGuiCond_FirstUseEver);
+    if (!ImGui::Begin(kComboSpoilerWindowName, nullptr, ImGuiWindowFlags_NoFocusOnAppearing)) {
+        ImGui::End();
+        return;
+    }
+
+    DrawElement();
+
+    ImGui::End();
+}
+
+void ComboSpoilerWindow::DrawElement() {
+    ComboSpoilerSummary summary;
+    Combo_SpoilerPairingSummary(&summary);
+
+    // "Not paired" and "paired with zero crossings" are different facts and
+    // must never render the same way — an empty table under a seed header
+    // would tell the player this world has no crossings when the truth is that
+    // these two worlds were never paired at all (see combo_spoiler_view.h).
+    if (!summary.paired) {
+        ImGui::TextWrapped("No paired world.");
+        ImGui::Spacing();
+        ImGui::TextWrapped("This save was not generated as a cross-game pair, so no OoT items were placed into "
+                           "MM checks. Generate a randomized OoT world and start a new MM file from it to pair "
+                           "them.");
+        return;
+    }
+
+    ImGui::Text("Seed: %u", (unsigned)summary.sharedRandoSeed);
+    ImGui::Text("Settings digest: %08X", (unsigned)summary.sharedRandoSettingsHash);
+    ImGui::Separator();
+
+    const int rowCount = Combo_SpoilerRowCount();
+    if (rowCount == 0) {
+        ImGui::TextWrapped("Paired, but this world hosts no cross-game items.");
+        return;
+    }
+
+    ImGui::Text("Cross-game items: %d", rowCount);
+    ImGui::Spacing();
+
+    if (ImGui::BeginTable("##ComboSpoilerRows", 3,
+                          ImGuiTableFlags_Borders | ImGuiTableFlags_RowBg | ImGuiTableFlags_ScrollY)) {
+        // MM check IDS, not names: common code has no MM check-name table and
+        // must not acquire one by including an MM header. Resolving these to
+        // readable names needs the MM adapter (#458). Labelled as ids so the
+        // column is honest about what it is.
+        ImGui::TableSetupColumn("MM Check ID", ImGuiTableColumnFlags_WidthFixed, 110.0f);
+        ImGui::TableSetupColumn("Hosts", ImGuiTableColumnFlags_WidthStretch);
+        ImGui::TableSetupColumn("Collected", ImGuiTableColumnFlags_WidthFixed, 80.0f);
+        ImGui::TableHeadersRow();
+
+        for (int i = 0; i < rowCount; i++) {
+            ComboSpoilerRow row;
+            if (!Combo_SpoilerRowAt(i, &row)) {
+                break;
+            }
+
+            ImGui::TableNextRow();
+            ImGui::TableNextColumn();
+            ImGui::Text("0x%04X", (unsigned)row.mmCheckId);
+            ImGui::TableNextColumn();
+            // itemName is never NULL — the model substitutes a visible
+            // placeholder rather than hand "%s" an invalid pointer.
+            ImGui::TextUnformatted(row.itemName);
+            ImGui::TableNextColumn();
+            ImGui::TextUnformatted(row.redeemed ? "Yes" : "No");
+        }
+
+        ImGui::EndTable();
+    }
+}
+
+void RegisterComboSpoilerWindow(std::shared_ptr<Ship::Gui> gui) {
+    if (gui == nullptr) {
+        return;
+    }
+    // Idempotence, the #457 guard: the production entry point may be reached
+    // from more than one bring-up path, and AddGuiWindow rejects duplicates
+    // silently rather than loudly.
+    if (gui->GetGuiWindow(kComboSpoilerWindowName) != nullptr) {
+        return;
+    }
+
+    gui->AddGuiWindow(std::make_shared<ComboSpoilerWindow>(kComboSpoilerVisibilityCVar, kComboSpoilerWindowName));
+}
+
+} // namespace ComboGui
+
+extern "C" void Combo_SpoilerWindow_Init(void) {
+    auto ctx = Ship::Context::GetInstance();
+    if (ctx == nullptr || ctx->GetWindow() == nullptr) {
+        // ROM-free unit harness: shared subsystems without a window/Gui.
+        return;
+    }
+    auto gui = ctx->GetWindow()->GetGui();
+    if (gui == nullptr) {
+        return;
+    }
+    ComboGui::RegisterComboSpoilerWindow(gui);
+}

--- a/src/common/ComboSpoilerWindow.h
+++ b/src/common/ComboSpoilerWindow.h
@@ -1,0 +1,85 @@
+/**
+ * @file ComboSpoilerWindow.h
+ * @brief The in-game cross-game spoiler panel (#496 steps 3-4; ADR 0008).
+ *
+ * Renders src/common/combo_spoiler_view.h's model: which MM check hosts which
+ * OoT item, and whether it has been collected yet. Before this, the paired
+ * world's spoiler existed only as `randomizer-mm/RSBSPAIR<masterSeed>.json`
+ * and the operator had to be told an absolute path to read their own seed.
+ *
+ * This is the first common-owned Gui window (ADR 0008). It reads `gComboCtx`
+ * and NOTHING else — no `gSaveContext` through either game's layout — which is
+ * what makes it safe to draw under GAME_OOT, GAME_MM and GAME_NONE alike, and
+ * why it needs no equivalent of MM's `MMActiveGated` wrapper.
+ *
+ * Openability: `Ship::GuiWindow` latches its visibility CVar in the ctor and
+ * nothing re-syncs CVar -> visibility per frame, so `Draw()` reads the CVar
+ * live the way MM's check tracker does (#489 cause 1, same defect class).
+ *
+ * Locked ROM-free by the ComboSpoilerWindow CTest: registration, idempotence,
+ * name de-collision, and Draw()/Update() under all three GameIds with no ImGui
+ * context. Its APPEARANCE is operator verification — no headless test can
+ * assert on pixels.
+ */
+
+#ifndef RSBS_COMMON_COMBO_SPOILER_WINDOW_H
+#define RSBS_COMMON_COMBO_SPOILER_WINDOW_H
+
+#ifdef __cplusplus
+
+#include <memory>
+#include <ship/window/gui/GuiWindow.h>
+
+namespace Ship {
+class Gui;
+}
+
+namespace ComboGui {
+
+// Registration name on the shared Gui. Distinct from SoH's unprefixed tracker
+// names and MM's "MM "-prefixed ones: Gui::AddGuiWindow rejects duplicates
+// SILENTLY from the caller's side, so a collision here would present as a
+// window that simply never appears (ADR 0008).
+inline constexpr const char* kComboSpoilerWindowName = "Cross-Game Spoiler";
+
+// Visibility CVar. "gCombo.*" is neither OoT's "gOpenWindows.*" nor MM's
+// "gWindows.*", so there is no store collision.
+inline constexpr const char* kComboSpoilerVisibilityCVar = "gCombo.Windows.Spoiler";
+
+class ComboSpoilerWindow final : public Ship::GuiWindow {
+  public:
+    using Ship::GuiWindow::GuiWindow;
+
+    void Draw() override;
+
+  protected:
+    void DrawElement() override;
+    void InitElement() override {
+    }
+    void UpdateElement() override {
+    }
+};
+
+/**
+ * Register the spoiler window on `gui` under kComboSpoilerWindowName.
+ * Idempotent (the #457 GetGuiWindow guard); a null `gui` is a no-op.
+ */
+void RegisterComboSpoilerWindow(std::shared_ptr<Ship::Gui> gui);
+
+} // namespace ComboGui
+
+extern "C" {
+#endif // __cplusplus
+
+/**
+ * Production entry point. Registers the spoiler window on the shared
+ * Ship::Context Gui. Safe no-op when the context has no window/Gui, which is
+ * the state every ROM-free harness runs in.
+ */
+void Combo_SpoilerWindow_Init(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // RSBS_COMMON_COMBO_SPOILER_WINDOW_H

--- a/src/common/combo_spoiler_view.c
+++ b/src/common/combo_spoiler_view.c
@@ -1,0 +1,89 @@
+/**
+ * @file combo_spoiler_view.c
+ * @brief Read-only view model over gComboCtx's cross-game placements (#496).
+ *
+ * See combo_spoiler_view.h for the contract. Everything here is a pure read of
+ * gComboCtx through the foreign_items.h accessors: no gSaveContext, no ImGui,
+ * no game headers, no caching. The view is recomputed per call so a crossing
+ * collected mid-frame shows up immediately, and so no stale copy can outlive a
+ * .redsave Load.
+ */
+
+#include "combo_spoiler_view.h"
+
+// RSBS_SHARED_ITEM_REDEEMED / RSBS_SHARED_ITEM_CAP come through context.h
+// (pulled in by combo_spoiler_view.h -> foreign_items.h); shared_items.h is
+// included for the documented meaning of the tagged-array contract this file
+// reads, not for a symbol.
+#include "shared_items.h"
+
+/**
+ * Has the origin game already awarded this crossing?
+ *
+ * gComboCtx.sharedItemsTagged has no index — matching is the same linear
+ * (originGame, id) scan the give path and Combo_CountSharedItems use. Flags
+ * are deliberately NOT part of the match: RSBS_SHARED_ITEM_SOURCED entries
+ * (ADR 0005) describe the same crossing and must still report their redeemed
+ * bit honestly.
+ *
+ * A crossing that was never picked up has no tagged entry at all, which reads
+ * as false — correct: the item is still sitting in the MM check.
+ */
+static bool SpoilerItemRedeemed(uint8_t originGame, uint16_t itemId) {
+    for (int i = 0; i < (int)RSBS_SHARED_ITEM_CAP; i++) {
+        const SharedItem* slot = &gComboCtx.sharedItemsTagged[i];
+        if (slot->originGame == originGame && slot->id == itemId) {
+            if ((slot->flags & RSBS_SHARED_ITEM_REDEEMED) != 0) {
+                return true;
+            }
+        }
+    }
+    return false;
+}
+
+int Combo_SpoilerRowCount(void) {
+    if (!Combo_ForeignPairingActive()) {
+        return 0; // "not paired", not "no crossings" — see the header
+    }
+    return Combo_CountForeignPlacements();
+}
+
+bool Combo_SpoilerRowAt(int index, ComboSpoilerRow* out) {
+    if (out == NULL || index < 0 || !Combo_ForeignPairingActive()) {
+        return false;
+    }
+
+    // Walk the table in SLOT order, counting only occupied slots, so row N is
+    // the Nth crossing as serialized rather than the Nth slot. Occupancy is
+    // derived from the item tag exactly the way Combo_CountForeignPlacements
+    // derives it — there is no count field to disagree with.
+    int seen = 0;
+    for (int i = 0; i < (int)RSBS_FOREIGN_PLACEMENT_CAP; i++) {
+        const ComboForeignPlacement* slot = &gComboCtx.foreignPlacements[i];
+        if (slot->item.originGame == (uint8_t)GAME_NONE) {
+            continue;
+        }
+        if (seen++ != index) {
+            continue;
+        }
+
+        const char* name = Combo_GetForeignItemName(slot->item);
+        out->mmCheckId = slot->mmCheckId;
+        out->originGame = slot->item.originGame;
+        out->itemId = slot->item.id;
+        out->itemName = (name != NULL) ? name : RSBS_SPOILER_UNKNOWN_ITEM_NAME;
+        out->redeemed = SpoilerItemRedeemed(slot->item.originGame, slot->item.id);
+        return true;
+    }
+    return false; // index past the last occupied slot
+}
+
+void Combo_SpoilerPairingSummary(ComboSpoilerSummary* out) {
+    if (out == NULL) {
+        return;
+    }
+    out->paired = Combo_ForeignPairingActive();
+    out->sharedRandoSeed = gComboCtx.sharedRandoSeed;
+    out->sharedRandoSettingsHash = gComboCtx.sharedRandoSettingsHash;
+    out->placementCount = Combo_SpoilerRowCount();
+}

--- a/src/common/combo_spoiler_view.h
+++ b/src/common/combo_spoiler_view.h
@@ -1,0 +1,97 @@
+/**
+ * @file combo_spoiler_view.h
+ * @brief Read-only view model over the paired world's cross-game placements
+ *        (#496, Lane C1 follow-up to #392).
+ *
+ * The paired-world spoiler already records every crossing, but only to a JSON
+ * file on disk (`randomizer-mm/RSBSPAIR<masterSeed>.json`) — the operator has
+ * to be told an absolute path to see their own seed. This is the in-game
+ * *view*: "which MM check hosts which OoT item, and has it been collected".
+ *
+ * WHY THIS IS NOT THE GENERATOR. `Rando::Spoiler::GenerateFromSaveContext`
+ * reads `gSaveContext` and `RANDO_SAVE_CHECKS` through MM's layout, so calling
+ * it while OoT is active would read MM's layout over OoT's bytes. This model
+ * reads `gComboCtx` only — game-neutral by construction (ADR 0002) — which is
+ * what lets the view render safely under GAME_OOT, GAME_MM and GAME_NONE
+ * alike. It touches no `gSaveContext`, no ImGui and no game headers.
+ *
+ * NOT PAIRED IS NOT THE SAME AS NO CROSSINGS. When
+ * `Combo_ForeignPairingActive()` is false the model reports zero rows AND a
+ * summary with `paired == false`. A caller that renders an empty list without
+ * checking the summary would tell the player "this world has no crossings"
+ * when the truth is "these two worlds were never paired".
+ *
+ * MM CHECK IDS ARE IDS, NOT NAMES. `ComboSpoilerRow.mmCheckId` is the raw
+ * `RandoCheckId`. Common code has no MM check-name table and must not acquire
+ * one by including an MM header; resolving ids to names needs the MM adapter
+ * (#458) and is deliberately out of scope. Label them as ids.
+ *
+ * Locked ROM-free by the ComboSpoilerView CTest
+ * (src/common/tests/test_combo_spoiler_view.c).
+ */
+
+#ifndef RSBS_COMMON_COMBO_SPOILER_VIEW_H
+#define RSBS_COMMON_COMBO_SPOILER_VIEW_H
+
+#include "foreign_items.h" // SharedItem, gComboCtx, the placement-table accessors
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * One cross-game crossing, as the view renders it: MM check `mmCheckId` hosts
+ * the foreign item `(originGame, itemId)`, displayed as `itemName`.
+ */
+typedef struct {
+    uint16_t mmCheckId;    // MM RandoCheckId hosting the foreign item (never 0)
+    uint8_t originGame;    // GameId owning itemId's id-space (GAME_OOT today)
+    uint16_t itemId;       // RG_* when originGame == GAME_OOT
+    const char* itemName;  // pinned-pool display name; never NULL (see below)
+    bool redeemed;         // the origin game has already awarded this crossing
+} ComboSpoilerRow;
+
+/**
+ * Fallback `ComboSpoilerRow.itemName` for a placement whose item is not in the
+ * pinned pool. `Combo_GetForeignItemName` returns NULL there, and a view that
+ * propagated the NULL would hand a printf-family "%s" an invalid pointer.
+ * Reaching this string means the placement table and the pinned pool have
+ * diverged — a bug worth seeing on screen rather than crashing on.
+ */
+#define RSBS_SPOILER_UNKNOWN_ITEM_NAME "Unknown Foreign Item"
+
+/**
+ * Header for the view: the pairing key and how many crossings exist.
+ * `paired == false` means the worlds were never paired at all — the seed and
+ * hash are then whatever `gComboCtx` holds (typically 0) and must not be shown
+ * as a real pairing.
+ */
+typedef struct {
+    bool paired;                      // Combo_ForeignPairingActive()
+    uint32_t sharedRandoSeed;         // gComboCtx.sharedRandoSeed
+    uint32_t sharedRandoSettingsHash; // gComboCtx.sharedRandoSettingsHash
+    int placementCount;               // == Combo_SpoilerRowCount()
+} ComboSpoilerSummary;
+
+/**
+ * Number of rows the view should render: the occupied placement slots, or 0
+ * when the worlds are not paired.
+ */
+int Combo_SpoilerRowCount(void);
+
+/**
+ * Fill `out` with row `index` (0-based, in placement-SLOT order so the view is
+ * stable across calls and matches the serialized table).
+ * @return true on success; false for a NULL `out`, an out-of-range index, or
+ *         an unpaired world (in which case `out` is untouched).
+ */
+bool Combo_SpoilerRowAt(int index, ComboSpoilerRow* out);
+
+/** Fill `out` with the pairing header. NULL `out` is ignored. */
+void Combo_SpoilerPairingSummary(ComboSpoilerSummary* out);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // RSBS_COMMON_COMBO_SPOILER_VIEW_H

--- a/src/common/test_runner.cpp
+++ b/src/common/test_runner.cpp
@@ -89,6 +89,10 @@ int MM_FlashFileNumOob_RunHeadless(void);
 // bring-up first (ConsoleVariables/Config/Console). Returns 0 on pass,
 // non-zero on fail.
 int MM_TrackersGui_RunHeadless(void);
+// src/common/tests/test_combo_spoiler_window.c — same bridge shape: the
+// spoiler window's ctor reads ConsoleVariables off the Ship::Context
+// singleton, so its body needs the display-free shared bring-up below.
+int Combo_SpoilerWindow_RunHeadless(void);
 // VB-affinity regression: MM's GameInteractor_* calls resolve to OoT's
 // extern "C" wrappers in single-exe builds, and the two games' vanilla-
 // behavior ordinals alias each other. The wrappers gate on the active game;
@@ -1224,6 +1228,25 @@ TestResult Test_MMTrackersGui(void) {
     }
 
     return MM_TrackersGui_RunHeadless() == 0 ? TEST_PASS : TEST_FAIL;
+}
+
+// Cross-game spoiler window (#496, ADR 0008). Same bring-up as the MM tracker
+// bridge above and for the same reason: the test constructs real
+// Ship::GuiWindow objects on a standalone Ship::Gui, and the GuiWindow ctor
+// reads its visibility CVar off the Ship::Context singleton's
+// ConsoleVariables. Without this the ctor dereferences a null singleton.
+TestResult Test_ComboSpoilerWindow(void) {
+    auto ctx = CreateHarnessStyleContext();
+    if (!ctx) {
+        printf("[TEST] FAIL: could not create Ship::Context singleton\n");
+        return TEST_FAIL;
+    }
+    if (OoT_InitSharedContextSubsystems() != 0) {
+        printf("[TEST] FAIL: shared bring-up reported failure\n");
+        return TEST_FAIL;
+    }
+
+    return Combo_SpoilerWindow_RunHeadless() == 0 ? TEST_PASS : TEST_FAIL;
 }
 
 TestResult Test_RoundtripIntegrity(void) {

--- a/src/common/test_runner.cpp
+++ b/src/common/test_runner.cpp
@@ -146,6 +146,19 @@ extern "C" {
 // pipeline symbols it drives are C-linkage and declared in the file.
 #include "tests/test_foreign_items.c"
 
+// Lane C1 in-game spoiler VIEW model (#496): the read-only projection of
+// gComboCtx.foreignPlacements the combo spoiler window renders — named
+// crossings in slot order, their collected state, and "not paired" reported
+// distinctly from "no crossings". FILE SCOPE (compiled as C++) for
+// rsbs::SaveManager, like test_foreign_items.c above.
+#include "tests/test_combo_spoiler_view.c"
+
+// The window that renders that model (#496 steps 3-4, ADR 0008): registration,
+// idempotence, name de-collision, and a hard tripwire that its draw path stays
+// out of ImGui under GAME_OOT/GAME_MM/GAME_NONE alike. FILE SCOPE — it drives
+// the C++-linkage ComboGui::RegisterComboSpoilerWindow.
+#include "tests/test_combo_spoiler_window.c"
+
 // Sourced-grant model locks (ADR 0005, netplay 1a #460): per-source cursor
 // idempotency, switch-free received-order redemption, loud overflow with
 // redeemed-slot reclamation, and .redsave durability including the
@@ -1361,6 +1374,10 @@ const TestDescriptor gTests[] = {
     // crossing awards exactly once, and the placement carve serializes.
     {"foreign-item-give", "Foreign give path tags shared structure; awards once; placements serialize (Lane C1)",
      Test_ForeignItemGive},
+    {"combo-spoiler-view", "In-game spoiler view model: named crossings, collected state, unpaired != empty (#496)",
+     Test_ComboSpoilerView},
+    {"combo-spoiler-window", "Common-owned spoiler window registers de-collided; inert under every active game (#496)",
+     Test_ComboSpoilerWindow},
     // Netplay 1a (ADR 0005, #460): the sourced-grant model, transport-free.
     {"grant-idempotency", "Retransmit delivers once; a second gift of the same item delivers twice (ADR 0005)",
      Test_GrantIdempotency},

--- a/src/common/tests/test_combo_spoiler_view.c
+++ b/src/common/tests/test_combo_spoiler_view.c
@@ -1,0 +1,211 @@
+/**
+ * @file test_combo_spoiler_view.c
+ * @brief ROM-free lock for the cross-game spoiler VIEW MODEL (#496).
+ *
+ * The model is the thing that turns "a JSON file on disk the operator has to
+ * be told the path to" into something the running game can render. This test
+ * does NOT stub it. It populates gComboCtx through the REAL
+ * Combo_SetForeignPlacement with entries drawn from the REAL pinned pool,
+ * records a crossing through the REAL give path (the same
+ * MM_Rando_Foreign_RecordPickup -> Combo_RedeemSharedItemsForGame pair
+ * test_foreign_items.c drives), and asserts on the model's output:
+ *
+ *  1. One row per occupied placement slot, in slot order, each carrying its
+ *     pinned-pool display name — not a placeholder, not an id rendered as text.
+ *  2. The crossed-and-awarded entry reports redeemed == true and the others
+ *     false. This is the assertion that makes the view worth having: a spoiler
+ *     that cannot distinguish "hosted" from "already collected" is a file dump.
+ *  3. With Combo_ForeignPairingActive() false, ZERO rows and a summary with
+ *     paired == false — the assertion that separates "no crossings" from "no
+ *     pairing". An unpaired world must never render as an empty crossing list.
+ *  4. The model round-trips a .redsave Save/Load unchanged, so a reloaded
+ *     session shows the same crossings (same Save/Load pair
+ *     test_foreign_items.c uses).
+ *
+ * Deliberately absent: any assertion about pixels. The model is pure C with no
+ * ImGui; the window that renders it is locked separately for registration and
+ * game-agnosticism, and its APPEARANCE is operator verification.
+ *
+ * Linkage note: #included into test_runner.cpp at FILE SCOPE (compiled as
+ * C++, like test_foreign_items.c) for the rsbs::SaveManager half; every model
+ * symbol it drives is C-linkage.
+ */
+
+#include "../combo_spoiler_view.h"
+#include "../context.h"
+#include "../foreign_items.h"
+#include "../save.h"
+#include "../shared_items.h"
+#include "../test_runner.h"
+
+#include <cstdio>
+#include <cstring>
+
+extern "C" {
+int MM_Rando_Foreign_RecordPickup(uint16_t randoCheckId);
+}
+
+#define CSV_ASSERT(cond)                                                                                               \
+    do {                                                                                                               \
+        if (!(cond)) {                                                                                                 \
+            printf("[TEST] FAIL: %s:%d: %s\n", __FILE__, __LINE__, #cond);                                             \
+            return TEST_FAIL;                                                                                          \
+        }                                                                                                              \
+    } while (0)
+
+namespace {
+// Arbitrary nonzero MM RandoCheckIds — the common layer stores them opaquely.
+const uint16_t kSpoilerCheckA = 0x0311;
+const uint16_t kSpoilerCheckB = 0x0312;
+const uint16_t kSpoilerCheckC = 0x0313;
+const char* const kSpoilerSaveDir = "rsbs_test_saves_spoiler_view";
+
+void SpoilerNoopAward(const SharedItem* item, void* ctx) {
+    (void)item;
+    (void)ctx;
+}
+} // namespace
+
+TestResult Test_ComboSpoilerView(void) {
+    printf("[TEST] combo-spoiler-view: the in-game view model reports crossings, their names and their collected "
+           "state, and distinguishes unpaired from empty (#496)\n");
+
+    const ComboForeignItemDef* pool = NULL;
+    const int poolCount = Combo_GetForeignItemPool(&pool);
+    CSV_ASSERT(pool != NULL);
+    CSV_ASSERT(poolCount >= 3); // this test places three distinct pool entries
+
+    // ------------------------------------------------------------------
+    // 3 (first, while the state is honestly unpaired): NOT PAIRED must not
+    // look like NO CROSSINGS.
+    // ------------------------------------------------------------------
+    ComboContext_Init();
+    Context_InitFrozenStates();
+    Context_ClearAllFrozenStates();
+    Combo_ClearSharedItemOutbox();
+    CSV_ASSERT(!Combo_ForeignPairingActive());
+
+    ComboSpoilerSummary summary;
+    memset(&summary, 0xA5, sizeof(summary));
+    Combo_SpoilerPairingSummary(&summary);
+    CSV_ASSERT(!summary.paired);
+    CSV_ASSERT(summary.placementCount == 0);
+    CSV_ASSERT(Combo_SpoilerRowCount() == 0);
+
+    ComboSpoilerRow row;
+    memset(&row, 0xA5, sizeof(row));
+    CSV_ASSERT(!Combo_SpoilerRowAt(0, &row));
+    CSV_ASSERT(row.mmCheckId == 0xA5A5); // untouched on failure
+
+    // Placements EXIST but pairing does not: the model must still report zero
+    // rows. This is the leg that would pass vacuously if the model simply
+    // counted the table.
+    gComboCtx.sourceIsRando = true;
+    gComboCtx.sharedRandoSeed = 0xC0FFEE96u;
+    CSV_ASSERT(!Combo_ForeignPairingActive()); // seed without settings digest
+    gComboCtx.sharedRandoSettingsHash = 0x5EED0496u;
+    CSV_ASSERT(Combo_ForeignPairingActive());
+    CSV_ASSERT(Combo_SetForeignPlacement(kSpoilerCheckA, pool[0].item) >= 0);
+    CSV_ASSERT(Combo_SpoilerRowCount() == 1);
+    gComboCtx.sharedRandoSettingsHash = 0; // un-pair, leaving the table populated
+    CSV_ASSERT(Combo_CountForeignPlacements() == 1);
+    CSV_ASSERT(Combo_SpoilerRowCount() == 0);
+    CSV_ASSERT(!Combo_SpoilerRowAt(0, &row));
+    Combo_SpoilerPairingSummary(&summary);
+    CSV_ASSERT(!summary.paired && summary.placementCount == 0);
+    gComboCtx.sharedRandoSettingsHash = 0x5EED0496u; // re-pair for the rest
+
+    // ------------------------------------------------------------------
+    // 1: one row per occupied slot, in slot order, with pinned-pool names.
+    // ------------------------------------------------------------------
+    CSV_ASSERT(Combo_SetForeignPlacement(kSpoilerCheckB, pool[1].item) >= 0);
+    CSV_ASSERT(Combo_SetForeignPlacement(kSpoilerCheckC, pool[2].item) >= 0);
+    CSV_ASSERT(Combo_SpoilerRowCount() == 3);
+
+    Combo_SpoilerPairingSummary(&summary);
+    CSV_ASSERT(summary.paired);
+    CSV_ASSERT(summary.sharedRandoSeed == 0xC0FFEE96u);
+    CSV_ASSERT(summary.sharedRandoSettingsHash == 0x5EED0496u);
+    CSV_ASSERT(summary.placementCount == 3);
+
+    const uint16_t expectedChecks[3] = { kSpoilerCheckA, kSpoilerCheckB, kSpoilerCheckC };
+    for (int i = 0; i < 3; i++) {
+        memset(&row, 0, sizeof(row));
+        CSV_ASSERT(Combo_SpoilerRowAt(i, &row));
+        CSV_ASSERT(row.mmCheckId == expectedChecks[i]);
+        CSV_ASSERT(row.originGame == (uint8_t)GAME_OOT);
+        CSV_ASSERT(row.itemId == pool[i].item.id);
+        // The pinned-pool display name, not a placeholder and not the fallback.
+        CSV_ASSERT(row.itemName != NULL);
+        CSV_ASSERT(strcmp(row.itemName, pool[i].name) == 0);
+        CSV_ASSERT(strcmp(row.itemName, RSBS_SPOILER_UNKNOWN_ITEM_NAME) != 0);
+        CSV_ASSERT(!row.redeemed); // nothing collected yet
+    }
+    CSV_ASSERT(!Combo_SpoilerRowAt(3, &row));  // one past the end
+    CSV_ASSERT(!Combo_SpoilerRowAt(-1, &row)); // negative index
+    CSV_ASSERT(!Combo_SpoilerRowAt(0, NULL));  // NULL out
+
+    // ------------------------------------------------------------------
+    // 2: the collected crossing reports redeemed; its neighbours do not.
+    //    Driven through the REAL give path, not by setting the flag.
+    // ------------------------------------------------------------------
+    CSV_ASSERT(MM_Rando_Foreign_RecordPickup(kSpoilerCheckB) == 1);
+    // Picked up but not yet awarded on the OoT side: the crossing is pending,
+    // not redeemed. The view must not call that "collected".
+    CSV_ASSERT(Combo_SpoilerRowAt(1, &row) && !row.redeemed);
+
+    CSV_ASSERT(Combo_RedeemSharedItemsForGame(GAME_OOT, SpoilerNoopAward, NULL) == 1);
+    for (int i = 0; i < 3; i++) {
+        memset(&row, 0, sizeof(row));
+        CSV_ASSERT(Combo_SpoilerRowAt(i, &row));
+        CSV_ASSERT(row.redeemed == (i == 1));
+    }
+    // The placement survives redemption — the world still hosts the item, so
+    // the spoiler stays truthful; only the crossing is marked done.
+    CSV_ASSERT(Combo_SpoilerRowCount() == 3);
+
+    // ------------------------------------------------------------------
+    // 4: the whole view round-trips a .redsave Save/Load unchanged.
+    // ------------------------------------------------------------------
+    ComboSpoilerRow expectedRows[3];
+    for (int i = 0; i < 3; i++) {
+        CSV_ASSERT(Combo_SpoilerRowAt(i, &expectedRows[i]));
+    }
+
+    rsbs::SaveManager& mgr = rsbs::SaveManager::Instance();
+    mgr.SetSaveDirectory(kSpoilerSaveDir);
+    mgr.DeleteSave(0);
+    CSV_ASSERT(mgr.Save(0));
+
+    ComboContext_Init(); // wipe live state...
+    CSV_ASSERT(Combo_SpoilerRowCount() == 0);
+    memset(gComboCtx.foreignPlacements, 0x5A, sizeof(gComboCtx.foreignPlacements)); // ...then scribble
+    CSV_ASSERT(mgr.Load(0));
+
+    CSV_ASSERT(Combo_SpoilerRowCount() == 3);
+    for (int i = 0; i < 3; i++) {
+        memset(&row, 0, sizeof(row));
+        CSV_ASSERT(Combo_SpoilerRowAt(i, &row));
+        CSV_ASSERT(row.mmCheckId == expectedRows[i].mmCheckId);
+        CSV_ASSERT(row.originGame == expectedRows[i].originGame);
+        CSV_ASSERT(row.itemId == expectedRows[i].itemId);
+        CSV_ASSERT(strcmp(row.itemName, expectedRows[i].itemName) == 0);
+        // The redeemed bit rides sharedItemsTagged, a different carve than the
+        // placements — a reloaded session must not forget what was collected.
+        CSV_ASSERT(row.redeemed == expectedRows[i].redeemed);
+    }
+    Combo_SpoilerPairingSummary(&summary);
+    CSV_ASSERT(summary.paired);
+    CSV_ASSERT(summary.sharedRandoSeed == 0xC0FFEE96u);
+    CSV_ASSERT(summary.sharedRandoSettingsHash == 0x5EED0496u);
+    mgr.DeleteSave(0);
+
+    // Leave global state clean for any subsequent test.
+    Context_ClearAllFrozenStates();
+    Combo_ClearSharedItemOutbox();
+    ComboContext_Init();
+
+    printf("[TEST] PASS: spoiler view reports named crossings in slot order with their collected state, survives a "
+           "save round trip, and reports unpaired distinctly from empty\n");
+    return TEST_PASS;
+}

--- a/src/common/tests/test_combo_spoiler_window.c
+++ b/src/common/tests/test_combo_spoiler_window.c
@@ -1,0 +1,155 @@
+/**
+ * @file test_combo_spoiler_window.c
+ * @brief ROM-free lock for the cross-game spoiler WINDOW (#496 steps 3-4).
+ *
+ * The model has its own lock (test_combo_spoiler_view.c). This one covers the
+ * window that renders it, in the shape of games/mm/2s2h/mm_trackers_gui_test.cpp:
+ *
+ * 1. REGISTRATION + IDEMPOTENCE + NAME DE-COLLISION. The window lands on a
+ *    bare Ship::Gui under kComboSpoilerWindowName, a second registration is a
+ *    no-op, and a stand-in already holding a SoH/MM tracker name is undisturbed.
+ *    Gui::AddGuiWindow rejects duplicates SILENTLY from the caller's side, so a
+ *    name collision would present only as a window that never appears.
+ *
+ * 2. GAME-AGNOSTICISM — the hard tripwire. ADR 0008's whole claim is that a
+ *    common-owned window reads gComboCtx and never gSaveContext, which is what
+ *    lets it draw under GAME_OOT, GAME_MM and GAME_NONE alike. This harness has
+ *    NO ImGui context, so any Draw() that reaches ImGui::Begin aborts the test
+ *    process. Draw()/Update() are called under all three GameIds with the
+ *    visibility CVar CLEARED (proving the live-CVar early-out holds) and the
+ *    surrounding gComboCtx in both paired and unpaired states.
+ *
+ * 3. VISIBILITY IS THE ONLY THING GATING DRAW. With the CVar SET, Draw() must
+ *    reach ImGui — which would abort here — so that case is deliberately NOT
+ *    driven. What is asserted instead is that clearing the CVar is sufficient
+ *    to keep it out of ImGui regardless of active game or pairing state.
+ *
+ * Deliberately absent: any assertion about appearance. What the panel LOOKS
+ * like — column widths, the unpaired copy, whether the collected column reads
+ * at a glance — is operator verification and no headless test can stand in for
+ * it.
+ *
+ * Linkage note: #included into test_runner.cpp at FILE SCOPE (compiled as
+ * C++) — it drives the C++-linkage ComboGui::RegisterComboSpoilerWindow.
+ */
+
+#include "../ComboSpoilerWindow.h"
+#include "../combo_spoiler_view.h"
+#include "../context.h"
+#include "../foreign_items.h"
+#include "../test_runner.h"
+
+#include <cstdio>
+#include <memory>
+
+#include <ship/window/gui/Gui.h>
+#include <ship/window/gui/GuiWindow.h>
+#include <libultraship/bridge/consolevariablebridge.h>
+
+#define CSW_ASSERT(cond)                                                                                               \
+    do {                                                                                                               \
+        if (!(cond)) {                                                                                                 \
+            printf("[TEST] FAIL: %s:%d: %s\n", __FILE__, __LINE__, #cond);                                             \
+            return TEST_FAIL;                                                                                          \
+        }                                                                                                              \
+    } while (0)
+
+namespace {
+
+// Inert stand-in, matching mm_trackers_gui_test.cpp's: empty cvar (no
+// ConsoleVariables traffic in the ctor) and no-op overrides.
+class SpoilerStandinWindow final : public Ship::GuiWindow {
+  public:
+    using GuiWindow::GuiWindow;
+
+    void InitElement() override {
+    }
+    void DrawElement() override {
+    }
+    void UpdateElement() override {
+    }
+};
+
+const char* const kSpoilerNeighbourNames[] = {
+    "Check Tracker",    // SoH-owned
+    "MM Check Tracker", // MM-owned
+};
+
+} // namespace
+
+TestResult Test_ComboSpoilerWindow(void) {
+    printf("[TEST] combo-spoiler-window: the common-owned spoiler window registers de-collided and is inert under "
+           "every active game (#496, ADR 0008)\n");
+
+    // Production entry point must be headless-safe: with no window on the
+    // shared context it returns without touching a Gui.
+    Combo_SpoilerWindow_Init();
+
+    auto gui = std::make_shared<Ship::Gui>();
+
+    std::shared_ptr<Ship::GuiWindow> neighbours[2];
+    for (int i = 0; i < 2; i++) {
+        neighbours[i] = std::make_shared<SpoilerStandinWindow>("", kSpoilerNeighbourNames[i]);
+        gui->AddGuiWindow(neighbours[i]);
+    }
+
+    // Keep the window shut for every Draw() below. This is what makes the
+    // tripwire survivable: the live-CVar early-out is the only thing between
+    // Draw() and ImGui::Begin in a process with no ImGui context.
+    CVarClear(ComboGui::kComboSpoilerVisibilityCVar);
+
+    ComboGui::RegisterComboSpoilerWindow(gui);
+    auto window = gui->GetGuiWindow(ComboGui::kComboSpoilerWindowName);
+    CSW_ASSERT(window != nullptr);
+
+    // Idempotence: a second registration must not replace the instance.
+    ComboGui::RegisterComboSpoilerWindow(gui);
+    CSW_ASSERT(gui->GetGuiWindow(ComboGui::kComboSpoilerWindowName) == window);
+
+    // De-collision: neither game's window names were disturbed, and the
+    // spoiler did not take one of them.
+    for (int i = 0; i < 2; i++) {
+        CSW_ASSERT(gui->GetGuiWindow(kSpoilerNeighbourNames[i]) == neighbours[i]);
+        CSW_ASSERT(gui->GetGuiWindow(kSpoilerNeighbourNames[i]) != window);
+    }
+
+    // ---- Game-agnosticism tripwire ---------------------------------------
+    const GameId prevGame = Context_GetCurrentGame();
+    const GameId allGames[] = { GAME_OOT, GAME_MM, GAME_NONE };
+
+    // Unpaired first (the zero-extended state), then a populated paired world:
+    // the window must be inert in both, and must not care which game is live.
+    for (int paired = 0; paired <= 1; paired++) {
+        ComboContext_Init();
+        if (paired) {
+            gComboCtx.sourceIsRando = true;
+            gComboCtx.sharedRandoSeed = 0xC0FFEE97u;
+            gComboCtx.sharedRandoSettingsHash = 0x5EED0497u;
+            const ComboForeignItemDef* pool = NULL;
+            const int poolCount = Combo_GetForeignItemPool(&pool);
+            CSW_ASSERT(poolCount >= 1);
+            CSW_ASSERT(Combo_SetForeignPlacement(0x0401, pool[0].item) >= 0);
+            CSW_ASSERT(Combo_SpoilerRowCount() == 1);
+        } else {
+            CSW_ASSERT(Combo_SpoilerRowCount() == 0);
+        }
+
+        for (GameId game : allGames) {
+            Context_SetCurrentGame(game);
+            // Surviving these IS the assertion: an ungated path reaches
+            // ImGui::Begin with no ImGui context and aborts the process.
+            window->Draw();
+            window->Update();
+        }
+    }
+
+    Context_SetCurrentGame(prevGame);
+
+    // Leave global state clean for any subsequent test.
+    CVarClear(ComboGui::kComboSpoilerVisibilityCVar);
+    ComboContext_Init();
+
+    printf("[TEST] PASS: spoiler window registers de-collided and idempotently, and its draw path is inert under "
+           "GAME_OOT/GAME_MM/GAME_NONE in both paired and unpaired worlds\n");
+    return TEST_PASS;
+}

--- a/src/common/tests/test_combo_spoiler_window.c
+++ b/src/common/tests/test_combo_spoiler_window.c
@@ -31,6 +31,13 @@
  *
  * Linkage note: #included into test_runner.cpp at FILE SCOPE (compiled as
  * C++) — it drives the C++-linkage ComboGui::RegisterComboSpoilerWindow.
+ *
+ * Entry point is a RunHeadless bridge, not a TestResult body, matching
+ * games/mm/2s2h/mm_trackers_gui_test.cpp: constructing a Ship::GuiWindow reads
+ * ConsoleVariables off the Ship::Context singleton, so this needs the same
+ * display-free shared bring-up MMTrackersGui does. That bring-up lives in
+ * test_runner.cpp (CreateHarnessStyleContext is static there); keeping it out
+ * of this file is what lets the file stay a pure exercise of the window.
  */
 
 #include "../ComboSpoilerWindow.h"
@@ -77,7 +84,7 @@ const char* const kSpoilerNeighbourNames[] = {
 
 } // namespace
 
-TestResult Test_ComboSpoilerWindow(void) {
+extern "C" int Combo_SpoilerWindow_RunHeadless(void) {
     printf("[TEST] combo-spoiler-window: the common-owned spoiler window registers de-collided and is inert under "
            "every active game (#496, ADR 0008)\n");
 


### PR DESCRIPTION
> **Stacked PR.** Based on Lane 3 (#503). Merge order: 3 → **5** → 1 → 2 → 6 → 4. This will be rebased onto `main` once #503 lands, so its diff reduces to just this lane.

Lane 5 of the Phase 3.1 tracker work (#492). It fixes the two independent defects that made MM's tracker windows useless in the single exe — three of the four could never be opened after MM's first boot, and every check-tracker row rendered a blank label — and it gives the paired world an in-game spoiler view so the cross-game placements stop being a JSON file the operator has to be pointed at by absolute path. The spoiler panel is the first Gui window owned by `src/common` rather than by either game, and ADR 0008 records that seam so #458's combo tracker inherits it instead of inventing a second one.

## What changed

**#489 cause 1 — MM tracker windows were unopenable**

- `games/mm/2s2h/TrackersGuiSingleExe.{h,cpp}`: new `S2H::TrackersGui::SyncVisibilityFromCVars()` reconciles each registered window with the live value of its `gWindows.*` CVar. `Ship::GuiWindow` reads that CVar exactly once in its constructor and `SyncVisibilityConsoleVariable` only ever writes visibility → CVar; the single exe has no BenMenu (upstream 2S2H's only route to `Show()`), so nothing could reopen a window after boot. Called from `MM_TrackersGui_Init` (honours a config persisted from a previous session) and per frame from the `MMActiveGated` `Draw` wrapper (runtime toggling). Safe without a real `Ship::Window`: it only ever drives visibility *to* the value the CVar already holds, so `SetVisibility`'s `shouldSave` is always false and the `Context::GetWindow()->GetGui()` deref is never reached.
- `games/mm/2s2h/TrackersGuiSingleExe.cpp`: `MMActiveGated` gains an explicit ctor that keeps its own copy of the visibility CVar string (`GuiWindow` keeps its copy private), plus a `gTrackerSlots` name/CVar/window table so lookups resolve on whichever `Ship::Gui` `RegisterWindows` was handed, not only the shared one.
- `games/mm/2s2h/TrackersGuiSingleExe.h`: the four `gWindows.*` CVar names are now named constants, shared by the ctor calls, the sync, and the live Draw-time read, so they cannot drift apart. New `MM_TrackersGui_ShouldShow(const char*)` predicate reports a window's own latched visibility (deliberately not a CVar read, so the test leg is not a tautology).
- `games/mm/2s2h/Enhancements/Trackers/ItemTracker/ItemTracker.cpp`: `ItemTrackerWindow::Draw` reads the CVar live instead of the ctor-latched `IsVisible()`, mirroring MM's check tracker. Guarded under `RSBS_SINGLE_EXECUTABLE` — this is a vendored 2S2H TU and an unguarded divergence is an upstream-sync landmine.

**#489 cause 2 — blank check-tracker labels**

- `games/mm/2s2h/TrackersGuiSingleExe.cpp`: `RegisterWindows` now calls `Rando::StaticData::PopulateCheckNames()`. `CheckNames` was `RC_MAX` empty strings because the function's only upstream caller is `BenPort.cpp`, which `games/mm/CMakeLists.txt` excludes — the same excluded-TU-initializer re-homing precedent as `InitSafeItemsForInventorySlot` (#457). Placed ahead of the idempotence return so re-registration can never leave windows without names. Display-only: `GetCheckIdFromName` compares `RandoStaticCheck.name`, so spoiler read/write is unaffected.

**#496 — in-game cross-game spoiler**

- `src/common/combo_spoiler_view.{h,c}`: read-only view model projecting `gComboCtx`'s placements into rows of `{mmCheckId, originGame, itemId, itemName, redeemed}` plus a pairing summary. Reads `gComboCtx` only — never `gSaveContext` through either game's layout, which is why the existing generation path could not be reused as a view. An unpaired world reports zero rows *and* `paired == false`, so "not paired" and "no crossings" never render the same way. MM check IDs stay ids and are labelled as such; names need the MM adapter (#458).
- `src/common/ComboSpoilerWindow.{h,cpp}`: the window that renders it, registered as `"Cross-Game Spoiler"` under the `gCombo.Windows.Spoiler` CVar — names disjoint from SoH's unprefixed and MM's `MM `-prefixed tracker spaces, since `Gui::AddGuiWindow` rejects duplicates silently. `Draw()` reads its CVar live for the same reason MM's trackers now do.
- `rsbs/src/main.cpp`: `Combo_SpoilerWindow_Init()` is called from the combo entry point after `Context_SetCurrentGame`, not from either game's boot.
- `docs/adr/0008-common-owned-gui-registration.md`: new ADR.
- `CMake/SingleExecutable.cmake`: adds the two new common sources/headers and registers the `ComboSpoilerView` and `ComboSpoilerWindow` CTests.

**Locks**

- `games/mm/2s2h/mm_trackers_gui_test.cpp`: two new legs, both RED before this change — an `MM_TrackersGui_ShouldShow` check over windows built by the real `RegisterWindows` with CVars cleared (including an assertion that the ctor latch is still real, so the leg cannot go vacuous), and a `CheckNames` leg asserting the whole `StaticData::Checks` map was walked into its readable-name form.
- `src/common/tests/test_combo_spoiler_view.c`: drives the real `Combo_SetForeignPlacement` over the real pinned pool and the real give path, asserting pinned names, the redeemed bit, unpaired-vs-empty, and a `.redsave` round trip.
- `src/common/tests/test_combo_spoiler_window.c`: asserts registration, idempotence and name de-collision, then calls `Draw()`/`Update()` under `GAME_OOT`/`GAME_MM`/`GAME_NONE` with no ImGui context — any path that reaches ImGui aborts the process.
- `src/common/test_runner.cpp`: registers both tests and hosts the display-free bring-up (`CreateHarnessStyleContext` + `OoT_InitSharedContextSubsystems`) for `Combo_SpoilerWindow_RunHeadless`. That bring-up cannot live in the test file: `CreateHarnessStyleContext` is static to `test_runner.cpp` and the test source is `#include`d above its definition. Without it the `GuiWindow` ctor null-derefs the `Ship::Context` singleton while reading its visibility CVar.

## Why

ADR 0008 (accepted 2026-07-22) settles where a Gui window that belongs to *neither* game registers. The ownership test is about data, not pixels: a window whose source is `gComboCtx` is owned by `src/common` and registers from a `src/common` lifecycle entry point; a window reading a game's `gSaveContext` stays with that game. Registering the spoiler from MM's boot is the tempting choice — the crossings are placed MM-side — and is exactly wrong, because the player who most needs the view is the one still in OoT wondering where their hookshot went; registering from OoT's boot loses MM-only sessions; registering from both is silently rejected by `AddGuiWindow`. Registration must also be idempotent and must no-op cleanly when the shared context has no window, since every ROM-free harness runs in that state. The ADR further notes that registration alone does not make a window reachable — `GuiWindow` latches its CVar in the ctor — which is the same defect #489 reports, so common-owned windows need their own openability route. Rejected alternatives: a `SohMenu` `WIDGET_WINDOW_BUTTON` row (re-creates the OoT-boot dependency) and a registry both games push into (a second source of truth about what is registered).

#489 was landed whole rather than split because the issue is emphatic that a partial fix turns one clear bug report into two ambiguous ones.

## Testing

- `ctest -L "^redship$"` passes locally at the stacked tip (52/52), including the new `ComboSpoilerView` and `ComboSpoilerWindow` tests and the two added `mm-trackers-gui` legs.
- Hosted CI covers the compile and ROM-free tiers only. The gameplay tier (`int-*`) is **not** exercised here — it needs a self-hosted ROM runner that is not configured.
- Not verifiable headless and left to operator verification: what the spoiler panel and the reopened tracker windows actually look like on screen.

Closes #489
Closes #496

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!--- section:artifacts:start -->
### Build Artifacts
  - [rsbs-windows.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/8573977016.zip)
  - [rsbs-linux.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/8572311341.zip)
<!--- section:artifacts:end -->