### PR TITLE
Carve the reverse foreign-item placement table, origin-key the pool lookups, and make a cap bump a build error (ADR 0009)

### DIFF
--- a/CMake/SingleExecutable.cmake
+++ b/CMake/SingleExecutable.cmake
@@ -353,6 +353,7 @@ if(BUILD_TESTING)
     # shared structure, the crossing awards exactly once on the OoT side, and
     # gComboCtx.foreignPlacements round-trips through the .redsave record.
     redship_add_test(NAME ForeignItemGive COMMAND redship --test foreign-item-give)
+    redship_add_test(NAME ForeignItemGiveReverse COMMAND redship --test foreign-item-give-reverse)
     redship_add_test(NAME ComboSpoilerView COMMAND redship --test combo-spoiler-view)
     redship_add_test(NAME ComboSpoilerWindow COMMAND redship --test combo-spoiler-window)
     # Cross-game session invalidation (#440). A soft reset or a new game must

--- a/docs/adr/0009-combo-settings-and-reverse-pool.md
+++ b/docs/adr/0009-combo-settings-and-reverse-pool.md
@@ -1,0 +1,232 @@
+# ADR 0009: Combo settings author in CVars and identify by digest; the reverse pool is a second origin-keyed table behind a pre-generation gate
+
+- Status: **Accepted** (2026-07-22)
+- For: #498 (combo-level settings), gating #493 (MM -> OoT foreign items); Phase
+  3.1 tracker #492, Lane 1
+- Depends on:
+  - **[ADR 0002](0002-origin-tagged-shared-items.md)** (Accepted) — the origin-tag
+    invariant and the `ComboContext` growth contract every carve below obeys.
+  - **[ADR 0003](0003-settings-namespace.md)** (Proposed) — CVar key naming; the
+    combo keys here are new tier-4 keys, not converged MM keys (ADR 0004 §3).
+  - **[ADR 0005](0005-sourced-grant-cursors.md)** (Accepted) — the DO-NOT-BUMP
+    prescription and the 672/736 offsets this ADR's budget preserves.
+- Amends: nothing. ADR 0002's `ComboForeignPlacement` shape is preserved
+  unchanged, which is decision 3's whole point.
+
+## Context
+
+Three decisions belong to #498. All three get made inside #493 whether or not
+anyone writes them down, and all three are format-affecting or
+determinism-affecting, so they are cheaper to make once than to retrofit:
+
+1. Where combo-level settings (direction, pool size, item class) live.
+2. What gates a *reverse* (MM -> OoT) generation pass, given that the pairing
+   stamp OoT publishes is written at the very end of `Playthrough_Init`.
+3. Whether the cross-game item class is one symmetric pool or two independent,
+   origin-keyed pools.
+
+A fourth thing has to be settled alongside them, because five separate work
+items are queued to carve from the same 264 bytes: the `reserved[]` budget.
+
+Measured against `claude/lane5-tracker-visibility` on 2026-07-22 by direct read.
+
+---
+
+## Decision 1 — CVars author the settings; a u32 digest carries the identity
+
+**Combo settings are authored in CVars (ADR 0003 tier-4 `gCombo.Rando.*` keys).
+The `.redsave` carries a single `uint32_t comboSettingsHash`, not the settings
+themselves.**
+
+The two framings in #498 were "per-save carve, so a `.redsave` carries its own
+pairing rules" versus "per-install CVars, per ADR 0003's one-store posture".
+They are not actually in tension, because they answer different questions:
+
+- The *authoring* question ("where does the player change this?") is settled by
+  ADR 0003. A settings surface carved into the save would be a second settings
+  store, which is exactly the posture ADR 0003 exists to prevent.
+- The *identity* question ("can two peers agree on seed and hash and still get
+  different cross-game rules?") does not require storing the settings. It
+  requires storing something that **differs whenever the rules differ**. A
+  digest does that in 4 bytes; the settings themselves would cost tens and would
+  have to be re-versioned every time an option is added.
+
+So the world identity gains one term and the format gains one field. This
+mirrors what `sharedRandoSettingsHash` already does for OoT's own settings
+(`playthrough.cpp:71`) — an established, already-shipped pattern rather than a
+new mechanism.
+
+**Consequence, stated plainly:** a `.redsave` moved to an install with different
+combo CVars will *detect* the mismatch (the digest disagrees) but cannot *repair*
+it — it cannot tell the player what the original rules were. That is accepted.
+Detection is the property that matters; ADR 0002's whole argument is that a
+silently-wrong pairing is worse than a loudly-refused one. If un-repairable
+mismatch later proves painful, the settings can be carved additively at that
+point under the growth contract, and the digest becomes a checksum over them.
+
+**Consequence for the digest:** `Rando_HeadlessSeedDeterminismDigest`
+(`3drando/menu.cpp:508`) must fold `comboSettingsHash`, or "changing a combo
+setting changes the derived world" is unassertable. That is #498's lock, not
+this ADR's.
+
+## Decision 2 — an explicit pre-generation gate; the pairing stamp does NOT move
+
+**Add a pre-generation opt-in read before `Fill()`. Leave the
+`sourceIsRando`/`sharedRandoSeed`/`sharedRandoSettingsHash` stamp exactly where
+it is, at the end of `Playthrough_Init`.**
+
+The tempting move — hoist the stamp above `Fill()`, since `rsbsSettingsHash` is
+already in hand at `playthrough.cpp:71` and `seed` is a parameter — is
+mechanically trivial and semantically wrong.
+
+The stamp is a **post-condition**, and its current position is what makes it one.
+`Playthrough_Init` reaches line 116 only on a fully successful fill *and* a
+successful spoiler write; `Fill()` can return `< 0` and take an early return at
+`:82-84`. Hoisting the stamp publishes a paired-world identity for a world that
+was never generated: `Combo_ForeignPairingActive()` would then answer "yes,
+paired" for a failed generation, and MM would key its own world off a seed and
+settings profile that produced nothing. That converts a clean generation failure
+into a silently mispaired pair of worlds — the failure class ADR 0002 is written
+against.
+
+It also perturbs the determinism digest for no gain: the digest observes when
+the Lane B carrier goes live, so moving the stamp changes pinned digests and
+costs a re-pin, purely to reuse a field for a purpose it does not have.
+
+The gate a reverse pass actually needs is a different predicate with a different
+tense. `Combo_ForeignPairingActive()` means *"a paired world exists"* (past).
+A generation pass needs *"a paired world is being asked for"* (future). Those are
+two predicates, and conflating them is the reason the hoist looked necessary:
+
+```
+Combo_ForeignPairingActive()     -- post-condition, unchanged, read at give time
+Combo_ForeignPairingRequested()  -- pre-condition, new, read before Fill()
+```
+
+`Combo_ForeignPairingRequested()` is derived from the decision-1 CVar opt-in and
+does not read `gComboCtx`'s stamp at all, so it is answerable before generation
+by construction and is immune to the ordering hazard entirely.
+
+**Consequence:** a reverse pass can run and place items into a world whose fill
+then fails. That is harmless and self-correcting — the placement table lives in
+`gComboCtx`, and `Context_InvalidateSessionState` / `ComboContext_Init` wipe it
+(`context.cpp:208-231`, `:273-310`); a failed generation never reaches the stamp,
+so `Combo_ForeignPairingActive()` stays false and nothing consumes the table.
+
+## Decision 3 — two independent origin-keyed pools; lookup keys on (origin, name)
+
+**Two pools, each defined in the single TU where its enum is in scope. The
+name -> item inverse gains an origin dimension. `ComboForeignPlacement` is not
+reshaped.**
+
+A single symmetric "cross-game item class v1" is cleaner for a spoiler renderer,
+and it is not available, for a concrete reason rather than a stylistic one:
+
+- `kForeignPoolV1` carries the literal display name `"Bomb Bag"`
+  (`ForeignItemsSingleExe.cpp:61`).
+- MM's `RI_BOMB_BAG_20` row is also literally `"Bomb Bag"`
+  (`StaticData/Items.cpp:37`).
+
+`Combo_GetForeignItemByName` (`foreign_items.c:22-44`) is the **spoiler-load
+inverse**. Keyed on display name alone across a merged pool, it resolves
+`"Bomb Bag"` to whichever entry it scans first and writes a **silently wrong
+origin tag** into the placement table — the #356 aliasing class that ADR 0002
+exists to prevent, arriving through the one path that reconstructs state from
+untrusted text on disk.
+
+The name collision is therefore not a hypothetical to be avoided by careful
+naming. It exists today, in the first two pools anyone would write, between two
+items that genuinely have the same name in both games. Any rule of the form
+"keep display names globally unique" asks two independently-evolving item tables
+to coordinate forever, and fails silently on the first violation.
+
+So the uniqueness invariant is stated per-origin, and the origin travels with the
+name everywhere the name travels:
+
+> **(originGame, name) is unique.** Bare `name` is not a key. The spoiler's
+> foreign section records the origin alongside the name, and the load-side
+> inverse takes an origin argument.
+
+**Correction to #493's secondary lock.** #493 asks for an assertion of "no
+cross-pool name collision". That assertion is **not satisfiable** and must not be
+written: `"Bomb Bag"` collides in the very first MM pool anyone writes, so the
+assertion would go red on arrival and the natural fix — renaming one game's item
+away from its real name — degrades the spoiler to avoid a lookup bug rather than
+fixing the lookup. The correct assertion is `(origin, name)` uniqueness within
+and across pools, plus a test that a colliding bare name resolves differently
+under each origin. Recorded here because a lock that cannot pass gets "fixed" by
+weakening it.
+
+**Why not reshape `ComboForeignPlacement` to `{hostGame, checkId, item}`.** It is
+the more elegant table, and it costs an ADR 0002 amendment, a format generation,
+a migration hook that does not exist (`save.cpp:262-263` is a flat `memcpy`), and
+`RSBS_SAVE_VERSION` past 2 with a stated forward-incompatibility — a 2048-byte
+Tier-1 fails `h.comboSize > kComboSize` on every already-shipped binary. A second
+parallel table keyed by OoT `RandomizerCheck` costs 48 bytes and no version bump.
+The accepted cost of the parallel carve is stated explicitly below, because it is
+real and it is the thing most likely to rot.
+
+**Accepted cost of two tables.** Five accessors are duplicated, and *every* clear
+/ invalidate / serialize / spoiler site must retire both or they desynchronize
+(the #440 class). One mitigation is already in place and load-bearing:
+invalidation is not per-field. `Context_InvalidateSessionState` retires session
+state by calling `ComboContext_Init()`, which `memset`s the whole struct
+(`context.cpp:212`, `:299`), so **any** field carved from `reserved[]` is retired
+automatically. The sites that genuinely need pairing are the explicit
+`Combo_ClearForeignPlacements` callers, the spoiler write/read pair, and the
+determinism digest.
+
+---
+
+## The `reserved[264]` byte budget
+
+`reserved[]` begins at offset 740 and there are 20 further bytes of record slack
+(`sizeof(ComboContext)` 1004 vs. `RSBS_COMBO_CONTEXT_RECORD_SIZE` 1024), so
+Tier-1 growth capacity is **284 bytes**. Five work items are queued against it.
+Publishing the allocation once beats four sequential re-versions:
+
+| # | Claimant | Size | Status |
+|---|---|---|---|
+| 1 | `foreignPlacementsOoT[8]` (#493 step 2, Lane 1) | 48 B | **carved by this arc** |
+| 2 | `comboSettingsHash` (#498 decision 1, Lane 1) | 4 B | reserved |
+| 3 | MM option-profile digest (#497 step 7 / #499 step 4, Lane 4) | 4 B | **reserved, size not yet confirmed by Lane 4** |
+| 4 | Netplay grant fields (#460, ADR 0005/0007) | 64 B | reserved |
+| 5 | Unallocated floor | 164 B | must not drop below 64 |
+
+Total reserved-against: 120 B of 284. After claim 1 lands, `reserved[]` is 216
+bytes and 236 B of capacity remain.
+
+Two constraints on anyone spending from this:
+
+- **Keep `reserved[]` at 64 bytes or more.** `Test_SaveComboRecordFixed`'s
+  scribble loop (`test_save_roundtrip.c:512-538`) iterates `sizeof(reserved)`; at
+  zero it degenerates to zero iterations and passes vacuously, retiring the only
+  test that proves headroom round-trips at all.
+- **Claim 3's size is a placeholder.** Lane 4 must confirm its digest size before
+  carving, not after. 4 B assumes a u32 digest by analogy with
+  `sharedRandoSettingsHash`; a wider profile record changes the table and this
+  ADR should be amended rather than the floor quietly eaten.
+
+Nothing here raises `RSBS_SAVE_VERSION`, `RSBS_COMBO_CONTEXT_RECORD_SIZE`, or
+`RSBS_COMBO_CONTEXT_PRECARVE_SIZE`. Every claim is a front-of-`reserved[]` carve
+under the ADR 0002 growth contract: prior offsets fixed, zero means unset, a
+zero-extended legacy record reads every new field as absent.
+
+The capacity that does **not** exist, so nobody re-derives it hopefully: raising
+`RSBS_FOREIGN_PLACEMENT_CAP` in place is a build error as of #490, and a
+symmetric ~55-entry carve in both directions would consume the entire budget and
+leave nothing for claims 2-4.
+
+## Consequences
+
+- `Combo_ForeignPairingActive()` keeps its meaning and its position; a second,
+  cheaper predicate appears next to it. Reviewers must not "simplify" the two
+  back into one — decision 2 is the reason they are separate.
+- The spoiler format gains an origin field in its foreign section. A spoiler
+  written before that field exists loads with an absent origin; the loader must
+  refuse such an entry rather than guess, which is decision 3's invariant applied
+  to the one path that reads untrusted text.
+- `.redsave` format is unchanged in version terms. Two `.redsave` files written
+  by builds either side of the `foreignPlacementsOoT` carve interoperate: the
+  older one reads the new block as all-unset, which is correct.
+- Lane 4 owes a digest size against claim 3 before it carves.

--- a/games/oot/soh/Enhancements/randomizer/ForeignItemsSingleExe.cpp
+++ b/games/oot/soh/Enhancements/randomizer/ForeignItemsSingleExe.cpp
@@ -66,21 +66,24 @@ static constexpr int kForeignPoolCount = sizeof(kForeignPoolV1) / sizeof(kForeig
 static_assert(kForeignPoolCount <= (int)RSBS_FOREIGN_PLACEMENT_CAP,
               "the pinned foreign pool must fit the gComboCtx placement carve");
 
-extern "C" int Combo_GetForeignItemPool(const ComboForeignItemDef** outPool) {
-    if (outPool != nullptr) {
-        *outPool = kForeignPoolV1;
+// Publish the table into src/common's origin-indexed registry (ADR 0009
+// decision 3) rather than defining the lookups here. The pool DEFINITION still
+// lives in this TU — that is the ADR 0002 invariant, and the RG_* enumerators
+// above are why — but the lookups now have to serve two pools, and src/common
+// cannot call into either game. Registration inverts that: each pool TU hands
+// its static table down, and neither game has to be linkable from the other.
+//
+// File-scope initializer, so it runs before main() and before any gameplay or
+// test code can ask for the pool. This TU lives in soh_rando, which links
+// WHOLE_ARCHIVE, so the initializer is never dropped as unreferenced.
+namespace {
+struct ForeignPoolV1Registrar {
+    ForeignPoolV1Registrar() {
+        Combo_RegisterForeignItemPool((uint8_t)GAME_OOT, kForeignPoolV1, kForeignPoolCount);
     }
-    return kForeignPoolCount;
-}
-
-extern "C" const char* Combo_GetForeignItemName(SharedItem item) {
-    for (const ComboForeignItemDef& def : kForeignPoolV1) {
-        if (def.item.originGame == item.originGame && def.item.id == item.id) {
-            return def.name;
-        }
-    }
-    return nullptr;
-}
+};
+const ForeignPoolV1Registrar gForeignPoolV1Registrar;
+} // namespace
 
 // ============================================================================
 // Redemption give (called by OoT_AwardSharedItem, the A1 consumer callback)

--- a/src/common/context.h
+++ b/src/common/context.h
@@ -376,15 +376,44 @@ typedef struct {
     // Zero == unset (no refusal has ever happened), per the growth contract.
     uint32_t sharedItemOverflowCount;
 
+    // Phase 3.1 (#493): the REVERSE direction's placement table — OoT checks
+    // hosting MM items. Carved from the FRONT of the old reserved[264] under
+    // the growth contract (ADR 0009 claim 1): all-zero = no reverse
+    // placements, which is exactly what a zero-extended pre-3.1 record must
+    // read as.
+    //
+    // READ THE KEY CAREFULLY. This reuses ComboForeignPlacement, whose member
+    // is *named* mmCheckId, but in THIS table that u16 holds an OoT
+    // RandomizerCheck (RC_MAX fits a u16). The struct is reused rather than
+    // reshaped because its size and member offsets are static_asserted
+    // .redsave format and cannot gain a hostGame byte in place; giving the
+    // reverse direction its own 8-byte tagged struct would force the record
+    // size and RSBS_SAVE_VERSION up plus a migration hook that does not exist
+    // (save.cpp's Tier-1 parse is one flat memcpy). See ADR 0009 decision 3.
+    //
+    // The two tables are SEPARATE KEY SPACES, not one array split in two: an
+    // OoT RC and an MM RC are unrelated enumerations that collide freely as
+    // raw u16s, which is precisely why a single table with no host
+    // discriminator would false-positive across directions. Never look one up
+    // with the other's accessor. The direction IS the accessor.
+    ComboForeignPlacement foreignPlacementsOoT[RSBS_FOREIGN_PLACEMENT_CAP];
+
     // Headroom. Carve new fields from the FRONT of this array (as
-    // sharedItemsTagged, sharedRandoSettingsHash, foreignPlacements, and the
-    // grant cursors were) so the struct stays inside
+    // sharedItemsTagged, sharedRandoSettingsHash, foreignPlacements, the
+    // grant cursors, and the reverse placement table were) so the struct
+    // stays inside
     // RSBS_COMBO_CONTEXT_RECORD_SIZE; the on-disk record size does not change
     // either way, so old saves keep loading. Zeroed by ComboContext_Init,
     // which is what makes a zero-extended legacy record indistinguishable from
     // a freshly-initialized one — every field carved from here must keep
     // "zero means unset".
-    uint8_t reserved[264];
+    //
+    // 264 - 48 (foreignPlacementsOoT). ADR 0009 publishes the remaining
+    // allocation across the other claimants and sets a 64-byte floor:
+    // Test_SaveComboRecordFixed's scribble loop iterates sizeof(reserved), so
+    // at zero it degenerates to zero iterations and passes vacuously, retiring
+    // the only test that proves headroom round-trips at all.
+    uint8_t reserved[216];
 } ComboContext;
 
 /**
@@ -455,11 +484,31 @@ RSBS_CTX_STATIC_ASSERT(offsetof(ComboContext, sharedItemOverflowCount) ==
                                RSBS_GRANT_SOURCE_CAP * sizeof(ComboGrantSourceCursor),
                        "sharedItemOverflowCount must sit immediately after the grant cursors; moving "
                        "it changes .redsave format");
-RSBS_CTX_STATIC_ASSERT(offsetof(ComboContext, reserved) ==
+// The reverse placement table is the next carve from the front of reserved[]:
+// it must sit immediately after the overflow count with no gap, occupying
+// bytes every shipped .redsave stored as zero (unset). Pinned to the literal
+// 740 for the same reason 672 and 736 are — anything carved after it (ADR
+// 0009's claims 2 through 4) inherits its position, so a field growing in
+// place ahead of it must break the build rather than slide them.
+RSBS_CTX_STATIC_ASSERT(offsetof(ComboContext, foreignPlacementsOoT) == 740u,
+                       "foreignPlacementsOoT lives at .redsave byte offset 740; if this fires, a "
+                       "field before it grew in place - carve from reserved[] instead");
+RSBS_CTX_STATIC_ASSERT(offsetof(ComboContext, foreignPlacementsOoT) ==
                            offsetof(ComboContext, sharedItemOverflowCount) + sizeof(uint32_t),
-                       "the tagged-item array, the settings digest, the foreign-placement table, the "
-                       "grant cursors, the overflow count, and the remaining headroom must stay "
+                       "foreignPlacementsOoT must be carved from the FRONT of reserved[] (contiguous "
+                       "with the overflow count); moving it changes .redsave format");
+RSBS_CTX_STATIC_ASSERT(offsetof(ComboContext, reserved) ==
+                           offsetof(ComboContext, foreignPlacementsOoT) +
+                               RSBS_FOREIGN_PLACEMENT_CAP * sizeof(ComboForeignPlacement),
+                       "the tagged-item array, the settings digest, both foreign-placement tables, "
+                       "the grant cursors, the overflow count, and the remaining headroom must stay "
                        "contiguous (no padding, no fields slipped between them)");
+// ADR 0009's floor. reserved[] is what Test_SaveComboRecordFixed scribbles to
+// prove Tier-1 headroom round-trips; at zero that loop runs zero times and the
+// test passes vacuously, so the carve budget stops here rather than there.
+RSBS_CTX_STATIC_ASSERT(sizeof(((ComboContext*)0)->reserved) >= 64u,
+                       "reserved[] must keep at least 64 bytes: Test_SaveComboRecordFixed's headroom "
+                       "round-trip degenerates to a vacuous pass when it empties (ADR 0009)");
 
 #ifdef __cplusplus
 // The raw-assignment-fails proof (ADR 0002). In C this is a constraint

--- a/src/common/context.h
+++ b/src/common/context.h
@@ -159,10 +159,33 @@ void Context_UpdateShadowCopy(GameId game, const void* saveContext, size_t size)
 #define RSBS_SHARED_ITEM_SOURCED 0x02u
 
 /**
- * Capacity of ComboContext.foreignPlacements (Lane C1, #392). The MVP pins ~4
- * OoT progression items into MM checks; 8 slots leave headroom without
- * spending reserved[] bytes we would rather keep (growing later is legal under
- * the growth contract).
+ * Capacity of ComboContext.foreignPlacements (Lane C1, #392): how many MM
+ * checks can host a foreign item at once. The MVP pins ~4 OoT progression
+ * items into MM checks, so 8 is generous for the shipped pool.
+ *
+ * DO NOT BUMP THIS CONSTANT to get more capacity. grantCursors (ADR 0005) and
+ * sharedItemOverflowCount are carved immediately after foreignPlacements, so
+ * widening the array in place moves both of them (and anything carved after)
+ * off the offset every shipped .redsave stored them at. That break has no
+ * runtime signal whatsoever: Load's only content check is the inner
+ * COMBO_CONTEXT_MAGIC at offset 0, which survives any tail shift, and the CRC
+ * passes because the bytes are unchanged - only their interpretation moved.
+ * Per ADR 0005 section 1 a shifted cursor means either re-accepting duplicate
+ * grants or permanently refusing legitimate ones.
+ *
+ * The offset asserts below are written as LITERAL byte offsets (672, 736)
+ * precisely so that a bump breaks the build. An earlier revision expressed
+ * them in terms of this constant, which made them follow the bump instead of
+ * catching it - a widen from 8 to 40 compiled completely clean and silently
+ * orphaned every shipped save's grant cursors.
+ *
+ * To add capacity, carve a SECOND placement block from the front of reserved[]
+ * (ComboForeignPlacement foreignPlacementsExt[N], declared immediately before
+ * reserved[]) and span BOTH blocks in every accessor in foreign_items.c - the
+ * duplicate scan and the first-free scan must each cover the whole logical
+ * array in one pass, or a cross-block duplicate escapes. Append-only, prior
+ * offsets fixed, zero still unset. Same prescription as RSBS_GRANT_SOURCE_CAP
+ * below; see ADR 0005 section 1 for the identical hazard on the cursor array.
  */
 #define RSBS_FOREIGN_PLACEMENT_CAP 8u
 
@@ -406,15 +429,27 @@ RSBS_CTX_STATIC_ASSERT(offsetof(ComboContext, foreignPlacements) ==
                                sizeof(uint32_t),
                        "foreignPlacements must be carved from the FRONT of the old reserved[] "
                        "(contiguous with the settings digest); moving it changes .redsave format");
-// grantCursors is the next carve from the front of the old reserved[]: it must
-// sit immediately after the foreign-placement table with no gap, occupying
-// bytes every shipped .redsave stored as zero (unset).
-RSBS_CTX_STATIC_ASSERT(offsetof(ComboContext, grantCursors) ==
-                           RSBS_COMBO_CONTEXT_PRECARVE_SIZE + RSBS_SHARED_ITEM_CAP * sizeof(SharedItem) +
-                               sizeof(uint32_t) +
-                               RSBS_FOREIGN_PLACEMENT_CAP * sizeof(ComboForeignPlacement),
-                       "grantCursors must be carved from the FRONT of the old reserved[] (contiguous "
-                       "with the foreign-placement table); moving it changes .redsave format");
+// grantCursors and sharedItemOverflowCount are pinned to LITERAL byte offsets,
+// deliberately not to expressions in RSBS_FOREIGN_PLACEMENT_CAP. Both fields
+// are carved AFTER foreignPlacements, so an in-place widen of that array moves
+// them; an assert phrased in terms of the cap moves with the bump and never
+// fires, which is exactly the silent .redsave break #490 describes. Written as
+// integers, the same bump is a build error. ADR 0005 names 672 explicitly.
+//
+// If either literal ever has to change, the field genuinely moved and every
+// shipped .redsave is being reinterpreted: that is a format generation, not an
+// assert edit. Raise RSBS_SAVE_VERSION and write the migration first.
+RSBS_CTX_STATIC_ASSERT(offsetof(ComboContext, grantCursors) == 672u,
+                       "grantCursors lives at .redsave byte offset 672 in every shipped save; if this "
+                       "fires, a field before it grew in place - carve from reserved[] instead");
+RSBS_CTX_STATIC_ASSERT(offsetof(ComboContext, sharedItemOverflowCount) == 736u,
+                       "sharedItemOverflowCount lives at .redsave byte offset 736 in every shipped "
+                       "save; if this fires, a field before it grew in place - carve from reserved[] "
+                       "instead");
+// Kept alongside the literals: this one states the CONTIGUITY intent (no gap,
+// no field slipped between the placement table and the cursors) that a bare
+// integer does not express. The literals catch an in-place widen; this catches
+// a field inserted between them.
 RSBS_CTX_STATIC_ASSERT(offsetof(ComboContext, sharedItemOverflowCount) ==
                            offsetof(ComboContext, grantCursors) +
                                RSBS_GRANT_SOURCE_CAP * sizeof(ComboGrantSourceCursor),

--- a/src/common/foreign_items.c
+++ b/src/common/foreign_items.c
@@ -19,19 +19,91 @@ bool Combo_ForeignPairingActive(void) {
     return gComboCtx.sourceIsRando && gComboCtx.sharedRandoSettingsHash != 0;
 }
 
-bool Combo_GetForeignItemByName(const char* name, SharedItem* outItem) {
-    // Reverse of the OoT-side Combo_GetForeignItemName: walk the same pinned
-    // pool and hand back the origin-tagged SharedItem. Reused (not re-derived)
-    // so the spoiler-LOAD reconstruction shares one source of truth with
-    // generation, and so a raw RG_* is never fabricated MM-side (ADR 0002).
+// ============================================================================
+// Pool registry, indexed by origin game (ADR 0009 decision 3)
+// ============================================================================
+//
+// Each pool's table is defined in the TU where its enum is in scope and lands
+// here through a file-scope registration, so neither game has to be linkable
+// from the other and a build with only one pool present still resolves. See
+// foreign_items.h for why (originGame, name) is the key and a bare name is not.
+
+static const ComboForeignItemDef* sForeignPools[RSBS_FOREIGN_POOL_ORIGIN_COUNT];
+static int sForeignPoolCounts[RSBS_FOREIGN_POOL_ORIGIN_COUNT];
+
+void Combo_RegisterForeignItemPool(uint8_t originGame, const ComboForeignItemDef* pool, int count) {
+    if (originGame == (uint8_t)GAME_NONE || originGame >= RSBS_FOREIGN_POOL_ORIGIN_COUNT) {
+        fprintf(stderr, "[ForeignItem] pool registration rejected: origin %u is not a game id-space\n",
+                (unsigned)originGame);
+        return;
+    }
+    if (pool == NULL && count == 0) {
+        // Explicit un-register. Exists so a test can install a synthetic pool
+        // for an origin whose real pool TU is not linked yet and then put the
+        // registry back, rather than leaving process-global state behind for
+        // whichever test runs next.
+        sForeignPools[originGame] = NULL;
+        sForeignPoolCounts[originGame] = 0;
+        return;
+    }
+    if (pool == NULL || count <= 0) {
+        fprintf(stderr, "[ForeignItem] pool registration rejected: empty pool for origin %u\n", (unsigned)originGame);
+        return;
+    }
+    if (sForeignPools[originGame] != NULL) {
+        // Two tables claiming one id-space is exactly the ambiguity this
+        // surface exists to prevent; it must not pass silently even though the
+        // last writer wins.
+        fprintf(stderr, "[ForeignItem] pool for origin %u re-registered (%d entries replace %d)\n",
+                (unsigned)originGame, count, sForeignPoolCounts[originGame]);
+    }
+    sForeignPools[originGame] = pool;
+    sForeignPoolCounts[originGame] = count;
+}
+
+int Combo_GetForeignItemPoolFor(uint8_t originGame, const ComboForeignItemDef** outPool) {
+    if (originGame == (uint8_t)GAME_NONE || originGame >= RSBS_FOREIGN_POOL_ORIGIN_COUNT) {
+        return 0;
+    }
+    if (sForeignPools[originGame] == NULL) {
+        return 0; // that origin's pool TU is not linked into this build
+    }
+    if (outPool != NULL) {
+        *outPool = sForeignPools[originGame];
+    }
+    return sForeignPoolCounts[originGame];
+}
+
+int Combo_GetForeignItemPool(const ComboForeignItemDef** outPool) {
+    return Combo_GetForeignItemPoolFor((uint8_t)GAME_OOT, outPool);
+}
+
+const char* Combo_GetForeignItemName(SharedItem item) {
+    // Origin-aware by construction: the SharedItem carries its own tag, so the
+    // only thing the origin dimension changes is WHICH pool gets walked. An
+    // untagged item resolves to no pool and therefore to no name, which is the
+    // correct answer rather than a lucky match in whichever table came first.
+    const ComboForeignItemDef* pool = NULL;
+    const int poolCount = Combo_GetForeignItemPoolFor(item.originGame, &pool);
+    for (int i = 0; i < poolCount; i++) {
+        if (pool[i].item.originGame == item.originGame && pool[i].item.id == item.id) {
+            return pool[i].name;
+        }
+    }
+    return NULL;
+}
+
+bool Combo_GetForeignItemByNameFor(uint8_t originGame, const char* name, SharedItem* outItem) {
+    // The spoiler-LOAD inverse. Reused (not re-derived) so reconstruction shares
+    // one source of truth with generation, and so a raw RG_*/RI_* is never
+    // fabricated on the far side (ADR 0002). Scoped to ONE origin's pool: the
+    // display names are not unique across pools ("Bomb Bag" is in both), so a
+    // merged scan would resolve to a wrong origin tag rather than to nothing.
     if (name == NULL) {
         return false;
     }
     const ComboForeignItemDef* pool = NULL;
-    const int poolCount = Combo_GetForeignItemPool(&pool);
-    if (poolCount <= 0 || pool == NULL) {
-        return false;
-    }
+    const int poolCount = Combo_GetForeignItemPoolFor(originGame, &pool);
     for (int i = 0; i < poolCount; i++) {
         if (pool[i].name != NULL && strcmp(pool[i].name, name) == 0) {
             if (outItem != NULL) {
@@ -41,6 +113,10 @@ bool Combo_GetForeignItemByName(const char* name, SharedItem* outItem) {
         }
     }
     return false;
+}
+
+bool Combo_GetForeignItemByName(const char* name, SharedItem* outItem) {
+    return Combo_GetForeignItemByNameFor((uint8_t)GAME_OOT, name, outItem);
 }
 
 int Combo_SetForeignPlacement(uint16_t mmCheckId, SharedItem item) {

--- a/src/common/foreign_items.c
+++ b/src/common/foreign_items.c
@@ -119,69 +119,137 @@ bool Combo_GetForeignItemByName(const char* name, SharedItem* outItem) {
     return Combo_GetForeignItemByNameFor((uint8_t)GAME_OOT, name, outItem);
 }
 
-int Combo_SetForeignPlacement(uint16_t mmCheckId, SharedItem item) {
-    if (mmCheckId == 0 || item.originGame == (uint8_t)GAME_NONE) {
-        return -1; // RC_UNKNOWN never hosts; an untagged item must not enter the table
+// ============================================================================
+// Placement tables — one per DIRECTION (#493, ADR 0009 decision 3)
+// ============================================================================
+//
+// There are two tables and they are separate key spaces, not one array split
+// in two:
+//
+//   gComboCtx.foreignPlacements     keyed by MM   RandoCheckId -> OoT item
+//   gComboCtx.foreignPlacementsOoT  keyed by OoT  RandomizerCheck -> MM item
+//
+// An OoT RC and an MM RC are unrelated enumerations that collide freely as raw
+// u16s, which is exactly why one table with no host discriminator would
+// false-positive across directions. ComboForeignPlacement cannot gain a host
+// byte in place (its size and member offsets are static_asserted .redsave
+// format), so the DIRECTION IS THE ACCESSOR: the table you pass is the host
+// discriminator, and no lookup ever consults the other one.
+//
+// The bodies below are shared between directions on purpose. #493 names the
+// duplication of five accessors as the accepted cost of the parallel carve;
+// taking the table as a parameter pays it once instead of five times, so a fix
+// to the duplicate scan cannot land in one direction and miss the other.
+
+// A direction, for the log lines only. Behavior must never branch on this.
+static const char* ForeignHostName(const ComboForeignPlacement* table) {
+    return (table == gComboCtx.foreignPlacementsOoT) ? "OoT" : "MM";
+}
+
+static int ForeignPlaceInto(ComboForeignPlacement* table, uint16_t hostCheckId, SharedItem item) {
+    if (hostCheckId == 0 || item.originGame == (uint8_t)GAME_NONE) {
+        return -1; // check id 0 is each game's RC_UNKNOWN and never hosts; an untagged item must not enter
     }
 
+    // ONE pass finds both the duplicate and the first free slot. Splitting it
+    // into two passes is how a cross-block duplicate escapes when a second
+    // block is carved later (see the RSBS_FOREIGN_PLACEMENT_CAP note in
+    // context.h) — keep them fused.
     int firstFree = -1;
     for (int i = 0; i < (int)RSBS_FOREIGN_PLACEMENT_CAP; i++) {
-        ComboForeignPlacement* slot = &gComboCtx.foreignPlacements[i];
+        ComboForeignPlacement* slot = &table[i];
         if (slot->item.originGame == (uint8_t)GAME_NONE) {
             if (firstFree < 0) {
                 firstFree = i;
             }
             continue;
         }
-        if (slot->mmCheckId == mmCheckId) {
-            fprintf(stderr, "[ForeignItem] placement rejected: MM check %u already hosts origin=%u id=%u\n",
-                    (unsigned)mmCheckId, (unsigned)slot->item.originGame, (unsigned)slot->item.id);
+        if (slot->mmCheckId == hostCheckId) {
+            fprintf(stderr, "[ForeignItem] placement rejected: %s check %u already hosts origin=%u id=%u\n",
+                    ForeignHostName(table), (unsigned)hostCheckId, (unsigned)slot->item.originGame,
+                    (unsigned)slot->item.id);
             return -1; // one check hosts at most one foreign item
         }
     }
 
     if (firstFree < 0) {
-        fprintf(stderr, "[ForeignItem] placement dropped: table full (%u slots), check=%u id=%u\n",
-                RSBS_FOREIGN_PLACEMENT_CAP, (unsigned)mmCheckId, (unsigned)item.id);
+        fprintf(stderr, "[ForeignItem] placement dropped: %s table full (%u slots), check=%u id=%u\n",
+                ForeignHostName(table), RSBS_FOREIGN_PLACEMENT_CAP, (unsigned)hostCheckId, (unsigned)item.id);
         return -1;
     }
 
-    ComboForeignPlacement* dst = &gComboCtx.foreignPlacements[firstFree];
-    dst->mmCheckId = mmCheckId;
+    ComboForeignPlacement* dst = &table[firstFree];
+    dst->mmCheckId = hostCheckId;
     dst->item = item;
-    fprintf(stderr, "[ForeignItem] placed origin=%u id=%u at MM check %u (slot %d)\n", (unsigned)item.originGame,
-            (unsigned)item.id, (unsigned)mmCheckId, firstFree);
+    fprintf(stderr, "[ForeignItem] placed origin=%u id=%u at %s check %u (slot %d)\n", (unsigned)item.originGame,
+            (unsigned)item.id, ForeignHostName(table), (unsigned)hostCheckId, firstFree);
     return firstFree;
 }
 
-const SharedItem* Combo_GetForeignPlacementForCheck(uint16_t mmCheckId) {
-    if (mmCheckId == 0) {
+static const SharedItem* ForeignLookupIn(const ComboForeignPlacement* table, uint16_t hostCheckId) {
+    if (hostCheckId == 0) {
         return NULL;
     }
     for (int i = 0; i < (int)RSBS_FOREIGN_PLACEMENT_CAP; i++) {
-        const ComboForeignPlacement* slot = &gComboCtx.foreignPlacements[i];
-        if (slot->item.originGame != (uint8_t)GAME_NONE && slot->mmCheckId == mmCheckId) {
+        const ComboForeignPlacement* slot = &table[i];
+        if (slot->item.originGame != (uint8_t)GAME_NONE && slot->mmCheckId == hostCheckId) {
             return &slot->item;
         }
     }
     return NULL;
 }
 
-int Combo_CountForeignPlacements(void) {
+static int ForeignCountIn(const ComboForeignPlacement* table) {
     int count = 0;
     for (int i = 0; i < (int)RSBS_FOREIGN_PLACEMENT_CAP; i++) {
-        if (gComboCtx.foreignPlacements[i].item.originGame != (uint8_t)GAME_NONE) {
+        if (table[i].item.originGame != (uint8_t)GAME_NONE) {
             count++;
         }
     }
     return count;
 }
 
-void Combo_ClearForeignPlacements(void) {
+static void ForeignClear(ComboForeignPlacement* table) {
     for (int i = 0; i < (int)RSBS_FOREIGN_PLACEMENT_CAP; i++) {
-        gComboCtx.foreignPlacements[i].mmCheckId = 0;
-        gComboCtx.foreignPlacements[i].item.originGame = (uint8_t)GAME_NONE;
-        gComboCtx.foreignPlacements[i].item.flags = 0;
-        gComboCtx.foreignPlacements[i].item.id = 0;
+        table[i].mmCheckId = 0;
+        table[i].item.originGame = (uint8_t)GAME_NONE;
+        table[i].item.flags = 0;
+        table[i].item.id = 0;
     }
+}
+
+// ---- Forward direction: MM checks host OoT items -----------------------------
+
+int Combo_SetForeignPlacement(uint16_t mmCheckId, SharedItem item) {
+    return ForeignPlaceInto(gComboCtx.foreignPlacements, mmCheckId, item);
+}
+
+const SharedItem* Combo_GetForeignPlacementForCheck(uint16_t mmCheckId) {
+    return ForeignLookupIn(gComboCtx.foreignPlacements, mmCheckId);
+}
+
+int Combo_CountForeignPlacements(void) {
+    return ForeignCountIn(gComboCtx.foreignPlacements);
+}
+
+void Combo_ClearForeignPlacements(void) {
+    ForeignClear(gComboCtx.foreignPlacements);
+}
+
+// ---- Reverse direction: OoT checks host MM items -----------------------------
+
+int Combo_SetForeignPlacementOoT(uint16_t ootCheckId, SharedItem item) {
+    return ForeignPlaceInto(gComboCtx.foreignPlacementsOoT, ootCheckId, item);
+}
+
+const SharedItem* Combo_GetForeignPlacementForOoTCheck(uint16_t ootCheckId) {
+    return ForeignLookupIn(gComboCtx.foreignPlacementsOoT, ootCheckId);
+}
+
+int Combo_CountForeignPlacementsOoT(void) {
+    return ForeignCountIn(gComboCtx.foreignPlacementsOoT);
+}
+
+void Combo_ClearForeignPlacementsOoT(void) {
+    ForeignClear(gComboCtx.foreignPlacementsOoT);
 }

--- a/src/common/foreign_items.h
+++ b/src/common/foreign_items.h
@@ -173,10 +173,49 @@ const SharedItem* Combo_GetForeignPlacementForCheck(uint16_t mmCheckId);
 int Combo_CountForeignPlacements(void);
 
 /**
- * Wipe the placement table. Called by MM's placement pass before re-placing
- * (a re-generated MM world must not inherit a previous world's placements).
+ * Wipe the MM-hosted placement table. Called by MM's placement pass before
+ * re-placing (a re-generated MM world must not inherit a previous world's
+ * placements). Does NOT touch the OoT-hosted table — the two directions are
+ * generated independently, and session-wide retirement is handled by
+ * Context_InvalidateSessionState / ComboContext_Init, which memset the whole
+ * struct and therefore cover both (ADR 0009).
  */
 void Combo_ClearForeignPlacements(void);
+
+// ============================================================================
+// Reverse-direction placement table (gComboCtx.foreignPlacementsOoT, #493)
+// ============================================================================
+//
+// The mirror of the four accessors above, keyed by an OoT RandomizerCheck
+// hosting an MM item. A SEPARATE KEY SPACE, not a second half of the same
+// array: an OoT RC and an MM RC are unrelated enumerations that collide freely
+// as raw u16s, so nothing may look one table up with the other's accessor. The
+// direction is the accessor; that is what stands in for the host-discriminator
+// byte ComboForeignPlacement cannot grow (ADR 0009 decision 3).
+
+/**
+ * Record "OoT check `ootCheckId` hosts `item`" (item.originGame == GAME_MM for
+ * the reverse direction). Same rejections as the forward accessor: an unset
+ * item tag, a check id of 0 (RC_UNKNOWN), a full table, or a duplicate check id.
+ * @return the slot index used (>= 0), or -1.
+ */
+int Combo_SetForeignPlacementOoT(uint16_t ootCheckId, SharedItem item);
+
+/**
+ * The foreign item hosted by OoT check `ootCheckId`, or NULL if that check
+ * hosts none. The returned pointer aliases gComboCtx (read-only use).
+ */
+const SharedItem* Combo_GetForeignPlacementForOoTCheck(uint16_t ootCheckId);
+
+/** Number of occupied OoT-hosted placement slots. */
+int Combo_CountForeignPlacementsOoT(void);
+
+/**
+ * Wipe the OoT-hosted placement table. Called by OoT's placement pass before
+ * re-placing. Does NOT touch the MM-hosted table — see the note on
+ * Combo_ClearForeignPlacements.
+ */
+void Combo_ClearForeignPlacementsOoT(void);
 
 /**
  * OoT-side redemption give (defined in ForeignItemsSingleExe.cpp): resolve the

--- a/src/common/foreign_items.h
+++ b/src/common/foreign_items.h
@@ -49,31 +49,97 @@ typedef struct {
     const char* name; // e.g. "Progressive Hookshot"
 } ComboForeignItemDef;
 
+// ============================================================================
+// The pinned pools, indexed by ORIGIN game (ADR 0009 decision 3)
+// ============================================================================
+//
+// There is one pool PER ORIGIN GAME, not one merged pool, and each pool's table
+// is defined in the single TU where its enum is in scope — OoT's in
+// soh/Enhancements/randomizer/ForeignItemsSingleExe.cpp, MM's in
+// 2s2h/Rando/ForeignItemsSingleExe.cpp. Neither game ever sees the other's
+// header, which is the ADR 0002 / #356 constraint.
+//
+// Those TUs cannot be *called* from here without linking each game against the
+// other, so they REGISTER instead: each pool TU hands its static table to
+// Combo_RegisterForeignItemPool from a file-scope initializer, and the lookups
+// below dispatch through the registry. That also means a build with only one
+// pool linked resolves cleanly — the missing origin simply has no entries,
+// rather than failing to link.
+//
+// (originGame, name) IS THE KEY. Bare `name` is not: "Bomb Bag" is literally
+// present in BOTH pools (OoT's RG_BOMB_BAG row and MM's RI_BOMB_BAG_20 row), so
+// a name-only inverse silently resolves to whichever pool it scans first and
+// writes a WRONG ORIGIN TAG into the placement table — the #356 aliasing class,
+// arriving through the one path that rebuilds state from untrusted text on
+// disk. See ADR 0009 decision 3.
+
+/** Highest origin id the pool registry indexes, exclusive (GAME_NONE..GAME_MM). */
+#define RSBS_FOREIGN_POOL_ORIGIN_COUNT 3u
+
 /**
- * The pinned foreign-item pool (defined OoT-side, see the file header).
- * @param outPool receives a pointer to the static pool table (never NULL on a
- *                nonzero return)
- * @return the number of pool entries
+ * Publish `pool` as the pinned foreign-item pool for `originGame`. Called once
+ * per pool from its defining TU's file-scope initializer, before main(). A
+ * second registration for the same origin replaces the first and is logged —
+ * two tables claiming one id-space is the ambiguity this whole surface exists
+ * to prevent, so it must not pass silently.
+ *
+ * GAME_NONE is rejected: an untagged pool has no id-space and nothing could
+ * safely be resolved out of it.
+ *
+ * Passing (NULL, 0) un-registers that origin, so a test can install a synthetic
+ * pool for an origin whose real pool TU is not linked yet and then restore the
+ * registry instead of leaving process-global state behind.
+ */
+void Combo_RegisterForeignItemPool(uint8_t originGame, const ComboForeignItemDef* pool, int count);
+
+/**
+ * The pinned foreign-item pool for one origin game.
+ * @param originGame GAME_OOT or GAME_MM
+ * @param outPool receives a pointer to that origin's static pool table (never
+ *                NULL on a nonzero return; untouched on a zero return)
+ * @return the number of pool entries, or 0 if that origin has no pool linked.
+ */
+int Combo_GetForeignItemPoolFor(uint8_t originGame, const ComboForeignItemDef** outPool);
+
+/**
+ * The OoT pool. Retained as the original single-pool entry point so the call
+ * sites that predate the origin dimension keep compiling and keep their exact
+ * previous behavior; new code should say which origin it means.
  */
 int Combo_GetForeignItemPool(const ComboForeignItemDef** outPool);
 
 /**
  * Display/spoiler name for a foreign item, or NULL if (originGame, id) is not
- * in the pinned pool. Flags are ignored on purpose: a redeemed entry keeps its
- * name.
+ * in that origin's pinned pool. Already origin-aware by construction — the
+ * SharedItem carries its own tag — so this signature is unchanged; only the
+ * pool it consults now depends on item.originGame. Flags are ignored on
+ * purpose: a redeemed entry keeps its name.
  */
 const char* Combo_GetForeignItemName(SharedItem item);
 
 /**
- * The inverse of Combo_GetForeignItemName: resolve a pinned-pool display name
- * back to its origin-tagged SharedItem. Used by the spoiler-LOAD path
- * (Rando::Spoiler::ReconstructForeignPlacements) to rebuild
- * gComboCtx.foreignPlacements from the spoiler's "foreign" section without an
- * OoT header in scope — the SharedItem is copied straight out of the pinned
- * pool, so a raw RG_* is never reconstructed on the MM side (ADR 0002).
- * @param name    the display name to look up (NULL is rejected)
- * @param outItem receives the tagged SharedItem on a match (may be NULL)
- * @return true if a pool entry has this name, false otherwise.
+ * The inverse of Combo_GetForeignItemName, keyed on (originGame, name). Used by
+ * both spoiler-LOAD paths to rebuild the placement tables from a spoiler's
+ * "foreign" section without either game's header in scope — the SharedItem is
+ * copied straight out of the pinned pool, so a raw RG_* (or RI_*) is never
+ * fabricated on the far side (ADR 0002).
+ *
+ * The origin argument is REQUIRED and is not a convenience: see the key note
+ * above. A spoiler entry that does not carry an origin must be refused by its
+ * caller, never guessed.
+ *
+ * @param originGame GAME_OOT or GAME_MM (GAME_NONE is rejected)
+ * @param name       the display name to look up (NULL is rejected)
+ * @param outItem    receives the tagged SharedItem on a match (may be NULL)
+ * @return true if that origin's pool has an entry with this name.
+ */
+bool Combo_GetForeignItemByNameFor(uint8_t originGame, const char* name, SharedItem* outItem);
+
+/**
+ * The OoT-pool name inverse. Retained so the call sites that predate the origin
+ * dimension keep compiling with their exact previous behavior (they all pass
+ * names that came from the OoT pool). New code should use the _For form and
+ * carry the origin explicitly.
  */
 bool Combo_GetForeignItemByName(const char* name, SharedItem* outItem);
 

--- a/src/common/test_runner.cpp
+++ b/src/common/test_runner.cpp
@@ -1397,6 +1397,11 @@ const TestDescriptor gTests[] = {
     // crossing awards exactly once, and the placement carve serializes.
     {"foreign-item-give", "Foreign give path tags shared structure; awards once; placements serialize (Lane C1)",
      Test_ForeignItemGive},
+    // #493: the reverse direction's OoT-keyed placement carve is a separate key
+    // space from the MM-keyed one, serializes byte-exact, and zero-extends.
+    {"foreign-item-give-reverse",
+     "Reverse (MM->OoT) placement carve: separate key space, serializes, redeems once (#493)",
+     Test_ForeignItemGiveReverse},
     {"combo-spoiler-view", "In-game spoiler view model: named crossings, collected state, unpaired != empty (#496)",
      Test_ComboSpoilerView},
     {"combo-spoiler-window", "Common-owned spoiler window registers de-collided; inert under every active game (#496)",

--- a/src/common/tests/test_foreign_items.c
+++ b/src/common/tests/test_foreign_items.c
@@ -37,6 +37,10 @@
 
 #include <cstdio>
 #include <cstring>
+#include <filesystem>
+#include <fstream>
+#include <string>
+#include <vector>
 
 // The C-linkage pipeline pieces this test drives (declared locally like
 // test_shared_state_roundtrip.c does for the switch policy).
@@ -73,6 +77,41 @@ void ForeignTestAward(const SharedItem* item, void* ctx) {
     c->awardCount++;
     c->lastId = item->id;
     c->lastOrigin = item->originGame;
+}
+
+// Write a slot file whose Tier-1 record is truncated to `comboSize`, taking the
+// bytes from the front of the CURRENT gComboCtx. That is byte-for-byte what an
+// older build wrote, as long as fields are only ever appended — the growth
+// contract. Local rather than shared with test_save_roundtrip.c's equivalent so
+// this file does not reach into another test's internals; the OoT/MM tiers are
+// zero-filled because nothing here reads them.
+bool ForeignTestWriteShortRecord(const std::string& path, uint32_t comboSize) {
+    std::vector<uint8_t> payload;
+    const uint8_t* comboBytes = reinterpret_cast<const uint8_t*>(&gComboCtx);
+    payload.insert(payload.end(), comboBytes, comboBytes + comboSize);
+    payload.insert(payload.end(), OOT_SAVE_CONTEXT_SIZE, 0u);
+    payload.insert(payload.end(), MM_SAVE_CONTEXT_SIZE, 0u);
+
+    rsbs::RsbsSaveHeader h;
+    memset(&h, 0, sizeof(h));
+    memcpy(h.magic, RSBS_SAVE_MAGIC, sizeof(h.magic));
+    h.version = RSBS_SAVE_VERSION_MIN;
+    h.endian = RSBS_SAVE_ENDIAN_LE;
+    h.slot = 0;
+    h.headerSize = sizeof(rsbs::RsbsSaveHeader);
+    h.comboSize = comboSize;
+    h.ootSize = (uint32_t)OOT_SAVE_CONTEXT_SIZE;
+    h.mmSize = (uint32_t)MM_SAVE_CONTEXT_SIZE;
+    h.crc32 = rsbs::SaveManager::Crc32(payload.data(), payload.size());
+
+    std::filesystem::create_directories(kForeignSaveDir);
+    std::ofstream out(path, std::ios::binary | std::ios::trunc);
+    if (!out) {
+        return false;
+    }
+    out.write(reinterpret_cast<const char*>(&h), sizeof(h));
+    out.write(reinterpret_cast<const char*>(payload.data()), (std::streamsize)payload.size());
+    return (bool)out;
 }
 } // namespace
 
@@ -298,5 +337,200 @@ TestResult Test_ForeignItemGive(void) {
     ComboContext_Init();
 
     printf("[TEST] PASS: foreign give path tags + de-dups; crossing awards once; placements serialize\n");
+    return TEST_PASS;
+}
+
+TestResult Test_ForeignItemGiveReverse(void) {
+    printf("[TEST] foreign-item-give-reverse: OoT-hosted placement carve is a separate key space, serializes, "
+           "and redeems once (#493)\n");
+
+    // The reverse twin of Test_ForeignItemGive. What it locks is the half of
+    // #493 that is NOT a mirror: a SECOND placement table, keyed by an OoT
+    // RandomizerCheck, sharing a struct whose member is named mmCheckId and
+    // sharing a .redsave record with the forward table.
+    //
+    // Scope note, stated because a reader will look for it: the production
+    // give-path bridge (OoT_Rando_Foreign_RecordPickup -> the same core
+    // Randomizer_Item_Give's foreign branch calls) and MM's real award are
+    // #493 steps 5-8 and Lane 6's MM_AwardSharedItem, neither of which exists
+    // yet. This row therefore drives the real ACCESSORS, the real
+    // SaveManager::Load, and the real Combo_RedeemSharedItemsForGame walk; it
+    // does not yet enter the OoT give path. It must gain that leg when the
+    // interception lands, or it locks the carve without locking the give.
+
+    ComboContext_Init();
+    Context_InitFrozenStates();
+    Context_ClearAllFrozenStates();
+    Combo_ClearSharedItemOutbox();
+
+    // An MM item, in MM's id-space. Deliberately NOT drawn from the OoT pool:
+    // the whole point of the reverse direction is that the hosted item belongs
+    // to the other game.
+    SharedItem mmItem;
+    mmItem.originGame = (uint8_t)GAME_MM;
+    mmItem.flags = 0;
+    mmItem.id = 0x0037;
+
+    // ------------------------------------------------------------------
+    // The reverse accessors: same rejections, same de-dup.
+    // ------------------------------------------------------------------
+    SharedItem untagged;
+    untagged.originGame = (uint8_t)GAME_NONE;
+    untagged.flags = 0;
+    untagged.id = 7;
+    FI_ASSERT(Combo_SetForeignPlacementOoT(kForeignTestCheckA, untagged) < 0); // untagged rejected
+    FI_ASSERT(Combo_SetForeignPlacementOoT(0, mmItem) < 0);                    // RC_UNKNOWN rejected
+    FI_ASSERT(Combo_CountForeignPlacementsOoT() == 0);
+
+    FI_ASSERT(Combo_SetForeignPlacementOoT(kForeignTestCheckA, mmItem) >= 0);
+    FI_ASSERT(Combo_SetForeignPlacementOoT(kForeignTestCheckA, mmItem) < 0); // duplicate check rejected
+    FI_ASSERT(Combo_CountForeignPlacementsOoT() == 1);
+
+    const SharedItem* hostedOoT = Combo_GetForeignPlacementForOoTCheck(kForeignTestCheckA);
+    FI_ASSERT(hostedOoT != NULL);
+    FI_ASSERT(hostedOoT->originGame == (uint8_t)GAME_MM && hostedOoT->id == mmItem.id);
+
+    // ------------------------------------------------------------------
+    // THE hazard: two tables, one raw-u16 key space each, and they collide.
+    // ------------------------------------------------------------------
+    // kForeignTestCheckA is a valid check id in BOTH games' enumerations —
+    // that is not a contrived value, it is the normal case, because an OoT
+    // RandomizerCheck and an MM RandoCheckId are unrelated enumerations that
+    // overlap freely as integers. A single shared table with no host
+    // discriminator, or an accessor that consulted both, would answer this
+    // lookup with the wrong game's item. RED against exactly that mistake.
+    FI_ASSERT(Combo_GetForeignPlacementForCheck(kForeignTestCheckA) == NULL);
+    FI_ASSERT(Combo_CountForeignPlacements() == 0);
+
+    // And symmetrically, once the forward table holds the same key.
+    const ComboForeignItemDef* pool = NULL;
+    const int poolCount = Combo_GetForeignItemPool(&pool);
+    FI_ASSERT(poolCount >= 1 && pool != NULL);
+    FI_ASSERT(Combo_SetForeignPlacement(kForeignTestCheckA, pool[0].item) >= 0);
+    FI_ASSERT(Combo_CountForeignPlacements() == 1);
+    FI_ASSERT(Combo_CountForeignPlacementsOoT() == 1);
+
+    const SharedItem* fwd = Combo_GetForeignPlacementForCheck(kForeignTestCheckA);
+    const SharedItem* rev = Combo_GetForeignPlacementForOoTCheck(kForeignTestCheckA);
+    FI_ASSERT(fwd != NULL && rev != NULL);
+    FI_ASSERT(fwd->originGame == (uint8_t)GAME_OOT); // OoT item, hosted in an MM check
+    FI_ASSERT(rev->originGame == (uint8_t)GAME_MM);  // MM item, hosted in an OoT check
+    FI_ASSERT(fwd != rev);
+
+    // Clearing one direction must not retire the other: they are generated
+    // independently, and only session invalidation retires both.
+    Combo_ClearForeignPlacements();
+    FI_ASSERT(Combo_CountForeignPlacements() == 0);
+    FI_ASSERT(Combo_CountForeignPlacementsOoT() == 1);
+    FI_ASSERT(Combo_GetForeignPlacementForOoTCheck(kForeignTestCheckA) != NULL);
+
+    FI_ASSERT(Combo_SetForeignPlacement(kForeignTestCheckB, pool[0].item) >= 0);
+    Combo_ClearForeignPlacementsOoT();
+    FI_ASSERT(Combo_CountForeignPlacementsOoT() == 0);
+    FI_ASSERT(Combo_CountForeignPlacements() == 1);
+    Combo_ClearForeignPlacements();
+
+    // ------------------------------------------------------------------
+    // Carve serialization: the OoT-keyed block round-trips byte-exact.
+    // ------------------------------------------------------------------
+    FI_ASSERT(Combo_SetForeignPlacementOoT(kForeignTestCheckA, mmItem) >= 0);
+    SharedItem mmItemB;
+    mmItemB.originGame = (uint8_t)GAME_MM;
+    mmItemB.flags = 0;
+    mmItemB.id = 0x0041;
+    FI_ASSERT(Combo_SetForeignPlacementOoT(kForeignTestCheckB, mmItemB) >= 0);
+
+    gComboCtx.sourceIsRando = true;
+    gComboCtx.sharedRandoSeed = 0xC0FFEE02u;
+    gComboCtx.sharedRandoSettingsHash = 0x5EED5A5Bu;
+
+    ComboForeignPlacement expectedOoT[RSBS_FOREIGN_PLACEMENT_CAP];
+    memcpy(expectedOoT, gComboCtx.foreignPlacementsOoT, sizeof(expectedOoT));
+
+    rsbs::SaveManager& mgr = rsbs::SaveManager::Instance();
+    mgr.SetSaveDirectory(kForeignSaveDir);
+    mgr.DeleteSave(0);
+    FI_ASSERT(mgr.Save(0));
+
+    ComboContext_Init();
+    memset(gComboCtx.foreignPlacementsOoT, 0x5A, sizeof(gComboCtx.foreignPlacementsOoT));
+    FI_ASSERT(mgr.Load(0));
+    FI_ASSERT(memcmp(expectedOoT, gComboCtx.foreignPlacementsOoT, sizeof(expectedOoT)) == 0);
+    // Typed spot-checks, so a memcmp-passing-but-misread layout fails loudly.
+    FI_ASSERT(gComboCtx.foreignPlacementsOoT[0].mmCheckId == kForeignTestCheckA);
+    FI_ASSERT(gComboCtx.foreignPlacementsOoT[0].item.originGame == (uint8_t)GAME_MM);
+    FI_ASSERT(gComboCtx.foreignPlacementsOoT[0].item.id == mmItem.id);
+    FI_ASSERT(gComboCtx.foreignPlacementsOoT[1].mmCheckId == kForeignTestCheckB);
+    FI_ASSERT(gComboCtx.foreignPlacementsOoT[1].item.id == mmItemB.id);
+    // Unset slots read unset (growth contract: zero means absent).
+    const int lastSlot = (int)RSBS_FOREIGN_PLACEMENT_CAP - 1;
+    FI_ASSERT(gComboCtx.foreignPlacementsOoT[lastSlot].mmCheckId == 0 &&
+              gComboCtx.foreignPlacementsOoT[lastSlot].item.originGame == (uint8_t)GAME_NONE &&
+              gComboCtx.foreignPlacementsOoT[lastSlot].item.flags == 0 &&
+              gComboCtx.foreignPlacementsOoT[lastSlot].item.id == 0);
+    // The forward table did not acquire the reverse table's rows in transit.
+    FI_ASSERT(Combo_CountForeignPlacements() == 0);
+    mgr.DeleteSave(0);
+
+    // ------------------------------------------------------------------
+    // A pre-3.1 record reads the new block as all-unset.
+    // ------------------------------------------------------------------
+    // The growth contract's zero-extension, applied to this carve specifically:
+    // a .redsave written before foreignPlacementsOoT existed is shorter than
+    // the current struct, and Load stages it into a zero-filled buffer. Every
+    // slot must therefore read absent rather than as whatever the live struct
+    // held. Scribbled first so a pass cannot come from leftover zeros.
+    ComboContext_Init();
+    gComboCtx.saveSlot = 0x0BADF00D;
+    FI_ASSERT(ForeignTestWriteShortRecord(mgr.SlotPath(0), RSBS_COMBO_CONTEXT_PRECARVE_SIZE));
+
+    ComboContext_Init();
+    memset(gComboCtx.foreignPlacementsOoT, 0x5A, sizeof(gComboCtx.foreignPlacementsOoT));
+    FI_ASSERT(mgr.Load(0));
+    FI_ASSERT(gComboCtx.saveSlot == 0x0BADF00D); // the legacy prefix really did load
+    for (int i = 0; i < (int)RSBS_FOREIGN_PLACEMENT_CAP; i++) {
+        FI_ASSERT(gComboCtx.foreignPlacementsOoT[i].mmCheckId == 0);
+        FI_ASSERT(gComboCtx.foreignPlacementsOoT[i].item.originGame == (uint8_t)GAME_NONE);
+        FI_ASSERT(gComboCtx.foreignPlacementsOoT[i].item.flags == 0);
+        FI_ASSERT(gComboCtx.foreignPlacementsOoT[i].item.id == 0);
+    }
+    FI_ASSERT(Combo_CountForeignPlacementsOoT() == 0);
+    mgr.DeleteSave(0);
+
+    // ------------------------------------------------------------------
+    // The redeem walk: an MM-origin crossing awards exactly once, to MM.
+    // ------------------------------------------------------------------
+    // The real Combo_RedeemSharedItemsForGame, with a test award callback
+    // standing in for MM_AwardSharedItem (which is still a Lane-C placeholder
+    // fprintf, so asserting through it would assert nothing). What this locks
+    // is that an MM-tagged crossing is delivered to MM and not to OoT, and
+    // that redemption is single-use.
+    ComboContext_Init();
+    Combo_ClearSharedItemOutbox();
+    FI_ASSERT(Combo_RecordSharedItem(GAME_MM, mmItem.id) >= 0);
+
+    ForeignAwardCtx award;
+    memset(&award, 0, sizeof(award));
+    // Wrong game first: an MM-origin entry must not be awarded to OoT.
+    FI_ASSERT(Combo_RedeemSharedItemsForGame(GAME_OOT, ForeignTestAward, &award) == 0);
+    FI_ASSERT(award.awardCount == 0);
+
+    FI_ASSERT(Combo_RedeemSharedItemsForGame(GAME_MM, ForeignTestAward, &award) == 1);
+    FI_ASSERT(award.awardCount == 1);
+    FI_ASSERT(award.lastOrigin == (uint8_t)GAME_MM);
+    FI_ASSERT(award.lastId == mmItem.id);
+    FI_ASSERT(Combo_CountSharedItems(GAME_MM, /*includeRedeemed=*/false) == 0);
+    FI_ASSERT(Combo_CountSharedItems(GAME_MM, /*includeRedeemed=*/true) == 1);
+
+    memset(&award, 0, sizeof(award));
+    FI_ASSERT(Combo_RedeemSharedItemsForGame(GAME_MM, ForeignTestAward, &award) == 0);
+    FI_ASSERT(award.awardCount == 0);
+
+    // Leave global state clean for any subsequent test.
+    Context_ClearAllFrozenStates();
+    Combo_ClearSharedItemOutbox();
+    ComboContext_Init();
+
+    printf("[TEST] PASS: reverse carve is a separate key space, serializes byte-exact, zero-extends, redeems once\n");
     return TEST_PASS;
 }

--- a/src/common/tests/test_foreign_items.c
+++ b/src/common/tests/test_foreign_items.c
@@ -94,6 +94,99 @@ TestResult Test_ForeignItemGive(void) {
         FI_ASSERT(pool[i].name != NULL && pool[i].name[0] != '\0');
         FI_ASSERT(Combo_GetForeignItemName(pool[i].item) == pool[i].name);
     }
+    // (originGame, name) uniqueness WITHIN a pool. Two entries sharing a name
+    // in one id-space would make that origin's inverse ambiguous, which no
+    // amount of origin-dispatch can repair.
+    for (int i = 0; i < poolCount; i++) {
+        for (int j = i + 1; j < poolCount; j++) {
+            FI_ASSERT(strcmp(pool[i].name, pool[j].name) != 0);
+            FI_ASSERT(pool[i].item.id != pool[j].item.id);
+        }
+    }
+    // Round-trip through the origin-keyed inverse, and confirm the OoT pool is
+    // NOT reachable by asking for MM's id-space.
+    for (int i = 0; i < poolCount; i++) {
+        SharedItem back;
+        FI_ASSERT(Combo_GetForeignItemByNameFor((uint8_t)GAME_OOT, pool[i].name, &back));
+        FI_ASSERT(back.originGame == pool[i].item.originGame && back.id == pool[i].item.id);
+        FI_ASSERT(!Combo_GetForeignItemByNameFor((uint8_t)GAME_MM, pool[i].name, NULL));
+        FI_ASSERT(!Combo_GetForeignItemByNameFor((uint8_t)GAME_NONE, pool[i].name, NULL));
+    }
+
+    // ------------------------------------------------------------------
+    // ADR 0009 decision 3: (origin, name) is the key; bare name is NOT.
+    // ------------------------------------------------------------------
+    // The reason the lookups take an origin at all. "Bomb Bag" is a real
+    // display name in BOTH id-spaces — OoT's RG_BOMB_BAG row and MM's
+    // RI_BOMB_BAG_20 row — so a name-only inverse resolves it to whichever
+    // pool it happens to scan first and writes a WRONG ORIGIN TAG into the
+    // placement table. That is the #356 aliasing class arriving through the
+    // spoiler-LOAD path, which rebuilds state from untrusted text on disk.
+    //
+    // #493's issue text asks for a "no cross-pool name collision" assertion.
+    // That assertion is NOT satisfiable and is deliberately not written here:
+    // it would go red the moment a real MM pool exists, and the natural fix —
+    // renaming an item away from its real name — would degrade the spoiler to
+    // work around a lookup bug. We assert the collision is HANDLED instead.
+    //
+    // A synthetic MM pool stands in until the real one lands (Lane 6 creates
+    // 2s2h/Rando/ForeignItemsSingleExe.cpp; Lane 1 fills kForeignPoolMMV1 into
+    // it). When it does, switch this block to the real pool and drop the
+    // registry restore below.
+    {
+        static const ComboForeignItemDef kSyntheticMMPool[] = {
+            { { (uint8_t)GAME_MM, 0, 0x0037 }, "Bomb Bag" },   // deliberately collides with the OoT pool
+            { { (uint8_t)GAME_MM, 0, 0x0041 }, "Hero's Bow" },
+        };
+        FI_ASSERT(Combo_GetForeignItemPoolFor((uint8_t)GAME_MM, NULL) == 0); // nothing registered yet
+        Combo_RegisterForeignItemPool((uint8_t)GAME_MM, kSyntheticMMPool, 2);
+
+        const ComboForeignItemDef* mmPool = NULL;
+        FI_ASSERT(Combo_GetForeignItemPoolFor((uint8_t)GAME_MM, &mmPool) == 2 && mmPool == kSyntheticMMPool);
+
+        // The colliding bare name resolves to a DIFFERENT item under each
+        // origin — never to the same one, and never to nothing.
+        SharedItem fromOoT, fromMM;
+        FI_ASSERT(Combo_GetForeignItemByNameFor((uint8_t)GAME_OOT, "Bomb Bag", &fromOoT));
+        FI_ASSERT(Combo_GetForeignItemByNameFor((uint8_t)GAME_MM, "Bomb Bag", &fromMM));
+        FI_ASSERT(fromOoT.originGame == (uint8_t)GAME_OOT);
+        FI_ASSERT(fromMM.originGame == (uint8_t)GAME_MM);
+        FI_ASSERT(fromMM.id == 0x0037);
+        FI_ASSERT(fromOoT.id != fromMM.id || fromOoT.originGame != fromMM.originGame);
+
+        // The legacy bare-name entry point keeps its exact previous meaning:
+        // the OoT pool. Call sites that predate the origin dimension must not
+        // have silently changed behavior when the MM pool appeared.
+        SharedItem legacy;
+        FI_ASSERT(Combo_GetForeignItemByName("Bomb Bag", &legacy));
+        FI_ASSERT(legacy.originGame == (uint8_t)GAME_OOT && legacy.id == fromOoT.id);
+
+        // Forward direction dispatches on the item's own tag: two items with
+        // the SAME id in different id-spaces must not resolve to one name.
+        SharedItem mmBow;
+        mmBow.originGame = (uint8_t)GAME_MM;
+        mmBow.flags = 0;
+        mmBow.id = 0x0041;
+        FI_ASSERT(Combo_GetForeignItemName(mmBow) != NULL);
+        FI_ASSERT(strcmp(Combo_GetForeignItemName(mmBow), "Hero's Bow") == 0);
+        SharedItem ootSameId = mmBow;
+        ootSameId.originGame = (uint8_t)GAME_OOT;
+        // Same raw id, OoT id-space: must not borrow MM's name. (It may be a
+        // real OoT pool entry with its OWN name, or nothing; either is correct,
+        // borrowing MM's is not.)
+        const char* ootName = Combo_GetForeignItemName(ootSameId);
+        FI_ASSERT(ootName == NULL || strcmp(ootName, "Hero's Bow") != 0);
+
+        // An untagged item resolves to no pool and therefore to no name.
+        SharedItem untaggedName;
+        untaggedName.originGame = (uint8_t)GAME_NONE;
+        untaggedName.flags = 0;
+        untaggedName.id = 0x0037;
+        FI_ASSERT(Combo_GetForeignItemName(untaggedName) == NULL);
+
+        Combo_RegisterForeignItemPool((uint8_t)GAME_MM, NULL, 0); // restore process-global state
+        FI_ASSERT(Combo_GetForeignItemPoolFor((uint8_t)GAME_MM, NULL) == 0);
+    }
 
     // ------------------------------------------------------------------
     // Clean slate + the pairing gate (Lane B's carrier contract).

--- a/src/common/tests/test_foreign_items.c
+++ b/src/common/tests/test_foreign_items.c
@@ -191,7 +191,20 @@ TestResult Test_ForeignItemGive(void) {
         FI_ASSERT(fromOoT.originGame == (uint8_t)GAME_OOT);
         FI_ASSERT(fromMM.originGame == (uint8_t)GAME_MM);
         FI_ASSERT(fromMM.id == 0x0037);
-        FI_ASSERT(fromOoT.id != fromMM.id || fromOoT.originGame != fromMM.originGame);
+        // Pin the OoT side to the REAL pool row rather than asserting the two
+        // results merely differ. Comparing (id, origin) pairs would be
+        // tautological here — the two origins are already asserted distinct
+        // just above — and would still pass if the OoT lookup returned the
+        // wrong OoT item.
+        int ootBombBagIdx = -1;
+        for (int k = 0; k < poolCount; k++) {
+            if (strcmp(pool[k].name, "Bomb Bag") == 0) {
+                ootBombBagIdx = k;
+            }
+        }
+        FI_ASSERT(ootBombBagIdx >= 0); // the collision this block exists for must actually be present
+        FI_ASSERT(fromOoT.id == pool[ootBombBagIdx].item.id);
+        FI_ASSERT(fromOoT.id != fromMM.id); // the two id-spaces really did yield different items
 
         // The legacy bare-name entry point keeps its exact previous meaning:
         // the OoT pool. Call sites that predate the origin dimension must not

--- a/src/common/tests/test_grant_sources.c
+++ b/src/common/tests/test_grant_sources.c
@@ -94,6 +94,19 @@ int GrantTestOccupiedTotal(void) {
 // gComboCtx. That is byte-for-byte what a pre-carve build wrote, per the
 // growth contract. Mirrors test_save_roundtrip.c's SaveTestWriteCraftedSlot
 // but is kept local so this file does not reach into another test's internals.
+//
+// Why the offsetof is a legitimate boundary here and not a tautology (#490):
+// it is correct ONLY because every legal carve lands AFTER
+// sharedItemOverflowCount, from the front of reserved[]. Such a carve leaves
+// offsetof(grantCursors) at 672, so this truncation keeps meaning "the
+// pre-netplay prefix". An in-place widen of a field BEFORE grantCursors — a
+// bump of RSBS_FOREIGN_PLACEMENT_CAP being the realistic one — would instead
+// drag this boundary forward with it, silently redefining "legacy" to include
+// bytes no pre-netplay build ever wrote, and this test would keep passing
+// while the format broke. That is why context.h pins 672 and 736 as literals
+// and why bumping the cap is a build error rather than a comment violation.
+// Test_SaveComboLegacyRecord's v2 fixed-offset case is the runtime half of the
+// same lock: it drives literal bytes at 672/676/736 through the real Load.
 bool GrantTestWriteLegacySlot(const std::string& path) {
     const uint32_t comboSize = (uint32_t)offsetof(ComboContext, grantCursors);
     std::vector<uint8_t> payload;

--- a/src/common/tests/test_save_roundtrip.c
+++ b/src/common/tests/test_save_roundtrip.c
@@ -497,8 +497,78 @@ TestResult Test_SaveComboLegacyRecord(void) {
     SAVE_ASSERT(SaveTestOoTShadowMatchesPattern(), "OoT blob not restored from legacy-record file");
     SAVE_ASSERT(SaveTestMMShadowMatchesPattern(), "MM blob not restored from legacy-record file");
 
+    // ------------------------------------------------------------------
+    // v2 case: FIXED BYTE OFFSETS, not offsetof-against-offsetof (#490)
+    // ------------------------------------------------------------------
+    // The prefix case above proves appended fields zero-extend. It says
+    // nothing about the fields already shipped BEHIND foreignPlacements, and
+    // that is where the live hazard is: RSBS_FOREIGN_PLACEMENT_CAP is carved
+    // ahead of grantCursors and sharedItemOverflowCount, so widening the array
+    // in place slides both off the offsets every shipped .redsave stored them
+    // at. Nothing at runtime notices — the inner COMBO_CONTEXT_MAGIC sits at
+    // offset 0 and survives any tail shift, and the CRC passes because the
+    // bytes are unchanged; only their interpretation moved.
+    //
+    // So: place the bytes by LITERAL INTEGER offset into the record image,
+    // load it through the real SaveManager::Load, and read the result out of
+    // the named struct members. The expected offsets are integers matching
+    // bytes physically placed in a crafted file — never offsetof compared
+    // against offsetof, which would move in lockstep with the mistake.
+    //
+    // RED against any in-place cap bump (8 -> 12 is enough): the crafted
+    // cursor is then read out of the middle of the widened placement array,
+    // this test fails, and the build plus every other test stays green. That
+    // is the exact failure mode nothing else catches.
+    static const size_t kGrantCursorsOffset = 672u;          // grantCursors[0].sourceKey
+    static const size_t kGrantCursorsLastSeqOffset = 676u;   // grantCursors[0].lastSeq
+    static const size_t kOverflowCountOffset = 736u;         // sharedItemOverflowCount
+    static const uint32_t kCraftedSourceKey = 0xC0FFEE01u;
+    static const uint32_t kCraftedLastSeq = 0x00000205u;
+    static const uint32_t kCraftedOverflow = 0x00BADBEDu;
+
+    SaveTestSeed(tag);  // re-inits gComboCtx and restamps the magic/version
+    {
+        // Write through a byte pointer at the literal offsets. Deliberately
+        // NOT gComboCtx.grantCursors[0].sourceKey = ...: assigning through the
+        // member would place the bytes wherever the current layout happens to
+        // put them, which is precisely the thing under test.
+        uint8_t* image = reinterpret_cast<uint8_t*>(&gComboCtx);
+        std::memcpy(image + kGrantCursorsOffset, &kCraftedSourceKey, sizeof(kCraftedSourceKey));
+        std::memcpy(image + kGrantCursorsLastSeqOffset, &kCraftedLastSeq, sizeof(kCraftedLastSeq));
+        std::memcpy(image + kOverflowCountOffset, &kCraftedOverflow, sizeof(kCraftedOverflow));
+    }
+
     mgr.DeleteSave(0);
-    printf("[TEST] PASS: pre-headroom Tier-1 loads, added fields read as zero\n");
+    SAVE_ASSERT(SaveTestWriteCraftedSlot(mgr.SlotPath(0), RSBS_SAVE_VERSION, (uint32_t)sizeof(ComboContext)),
+                "could not write v2 fixed-offset slot file");
+
+    // Scribble the whole carve region so a pass cannot come from leftovers.
+    ComboContext_Init();
+    std::memset(gComboCtx.grantCursors, 0x5A, sizeof(gComboCtx.grantCursors));
+    gComboCtx.sharedItemOverflowCount = 0x5A5A5A5Au;
+    std::memset(gComboCtx.foreignPlacements, 0x5A, sizeof(gComboCtx.foreignPlacements));
+
+    SAVE_ASSERT(mgr.Load(0), "Load refused a full-length v2 Tier-1 record");
+
+    SAVE_ASSERT(gComboCtx.grantCursors[0].sourceKey == kCraftedSourceKey,
+                "byte 672 did not land in grantCursors[0].sourceKey — a field ahead of the ADR 0005 "
+                "carve grew in place and orphaned every shipped save's cursors");
+    SAVE_ASSERT(gComboCtx.grantCursors[0].lastSeq == kCraftedLastSeq,
+                "byte 676 did not land in grantCursors[0].lastSeq — see above");
+    SAVE_ASSERT(gComboCtx.sharedItemOverflowCount == kCraftedOverflow,
+                "byte 736 did not land in sharedItemOverflowCount — a field ahead of it grew in place");
+
+    // Companion runtime assertions on the layout itself. These are the cheap
+    // half; the crafted-bytes assertions above are the half that cannot be
+    // satisfied by a self-consistent wrong layout.
+    SAVE_ASSERT(offsetof(ComboContext, grantCursors) == kGrantCursorsOffset,
+                "grantCursors moved off .redsave byte offset 672");
+    SAVE_ASSERT(offsetof(ComboContext, sharedItemOverflowCount) == kOverflowCountOffset,
+                "sharedItemOverflowCount moved off .redsave byte offset 736");
+
+    mgr.DeleteSave(0);
+    printf("[TEST] PASS: pre-headroom Tier-1 loads, added fields read as zero, "
+           "and bytes 672/676/736 still land in the ADR 0005 carve\n");
     return TEST_PASS;
 }
 


### PR DESCRIPTION
> **Stacked PR.** Based on Lane 5. Merge order: 3 → 5 → **1** → 2 → 6 → 4. This will be rebased onto `main` once the lanes below it land, so its diff reduces to just this lane.

This lane lays the serialization spine for the MM → OoT (reverse) foreign-item direction and records the decisions that shape it. It closes a live silent-save-break hazard around `RSBS_FOREIGN_PLACEMENT_CAP`, writes ADR 0009 to settle three format- and determinism-affecting questions before #493 carves anything, gives the foreign-item pool surface an origin dimension, and carves `foreignPlacementsOoT[8]` from the front of `reserved[]` as its own key space. No `RSBS_SAVE_VERSION` bump and no record-size change: every carve is additive under the ADR 0002 growth contract, so saves written either side of this change interoperate.

## What changed

**Save-format hardening — an in-place cap bump is now a build error (`src/common/context.h`)**
- `RSBS_FOREIGN_PLACEMENT_CAP`'s comment no longer promises that growing it later is legal. It stopped being legal when ADR 0005 landed `grantCursors` and `sharedItemOverflowCount` *behind* `foreignPlacements`; widening the array in place relocates two shipped fields in every existing `.redsave`.
- The break had no signal at all: the two offset asserts were expressed in terms of the cap, so they moved with the bump instead of firing, `Load`'s only content check is the inner `COMBO_CONTEXT_MAGIC` at offset 0 (survives any tail shift), and the CRC passes because the bytes are unchanged and only their interpretation moved. A bump from 8 to 40 compiled clean and silently orphaned every shipped save's grant cursors.
- `grantCursors` and `sharedItemOverflowCount` are now pinned to the **literal** offsets `672` and `736`; `foreignPlacementsOoT` is pinned to the literal `740`. Verified by probe: bumping the cap to 12 now fails the build on those asserts plus the record-budget assert. The contiguity asserts (expressed relative to the preceding field) are kept alongside the literals — the literals catch an in-place widen, the relative ones catch a field slipped in between.
- The comment now carries the same DO-NOT-BUMP + second-block prescription `RSBS_GRANT_SOURCE_CAP` has, including the requirement that the duplicate scan and the first-free scan each span both blocks in one pass.
- `reserved[]` gains a `>= 64` byte floor assert, because `Test_SaveComboRecordFixed`'s scribble loop iterates `sizeof(reserved)` and would pass vacuously at zero.

**ADR 0009 (`docs/adr/0009-combo-settings-and-reverse-pool.md`)** — settles the three #498 decisions and the `reserved[]` budget:
- *Decision 1:* combo settings are authored in CVars (ADR 0003 tier-4 `gCombo.Rando.*`); the `.redsave` carries a single `uint32_t comboSettingsHash`, not the settings. Authoring and identity are different questions; identity only needs something that differs when the rules differ. Accepted consequence: a save on an install with different combo CVars *detects* the mismatch but cannot repair it.
- *Decision 2:* add a pre-generation opt-in read before `Fill()`; the `sourceIsRando`/`sharedRandoSeed`/`sharedRandoSettingsHash` stamp does **not** move. Its position at the end of `Playthrough_Init` is what makes it a post-condition; hoisting it would publish a paired-world identity for a world whose `Fill()` failed. `Combo_ForeignPairingActive()` (past tense) and a new `Combo_ForeignPairingRequested()` (future tense) are two predicates and must not be merged back.
- *Decision 3:* two independent origin-keyed pools with `(originGame, name)` as the lookup key; `ComboForeignPlacement` is not reshaped. Also corrects a lock #493 asks for: a "no cross-pool name collision" assertion is not satisfiable — `"Bomb Bag"` is literally present in both `kForeignPoolV1` and MM's `RI_BOMB_BAG_20` row — and would get "fixed" by renaming an item away from its real name.
- Publishes the `reserved[264]` allocation across all five queued claimants (284 B of Tier-1 capacity, 120 B reserved-against, 64 B floor) so lanes size against a number instead of carving into each other's bytes. Lane 4 owes a confirmed digest size against claim 3.

**Origin-keyed pool registry (`src/common/foreign_items.c`, `src/common/foreign_items.h`, `games/oot/soh/Enhancements/randomizer/ForeignItemsSingleExe.cpp`)**
- `src/common` cannot call into either game's pool TU without making each game linkable from the other, so the pools **register**: each pool TU hands its static table to `Combo_RegisterForeignItemPool` from a file-scope initializer, and lookups dispatch through an origin-indexed registry. A build with only one pool linked resolves cleanly (the missing origin has no entries), and the MM pool can land later without touching `foreign_items.c`.
- New `Combo_GetForeignItemPoolFor(originGame, ...)` and `Combo_GetForeignItemByNameFor(originGame, name, ...)`. `Combo_GetForeignItemName` needed no signature change — a `SharedItem` already carries its tag — only a dispatch on it; an untagged item now resolves to no pool and therefore to no name.
- Additive by design: four call sites live in other lanes' files (`Foreign.cpp`, `Spoiler/Apply.cpp`, `mm_rando_gen_test.cpp`, `test_foreign_items.c`), so `Combo_GetForeignItemPool` / `Combo_GetForeignItemByName` remain as thin wrappers over the OoT origin with their exact previous behavior. This commit lands standalone.
- `(NULL, 0)` un-registers an origin so a test can install a synthetic pool and restore the registry rather than leaving process-global state behind; a re-registration for an already-claimed origin is logged.

**Reverse placement table (`src/common/context.h`, `src/common/foreign_items.c/.h`)**
- `ComboForeignPlacement foreignPlacementsOoT[8]` carved from the front of `reserved[]` (264 → 216). It cannot share the existing table: `ComboForeignPlacement`'s key is a bare `uint16_t` with no host discriminator, and an OoT `RandomizerCheck` and an MM check id are unrelated enumerations that overlap freely as integers, so an OoT-hosted row in the same array would answer an MM lookup with the wrong game's item. Adding a `hostGame` byte in place is unavailable — the struct's size and member offsets are static_asserted `.redsave` format, and growing it would force the record size and `RSBS_SAVE_VERSION` up plus a migration hook that does not exist (the Tier-1 parse is one flat `memcpy`).
- **The direction is the accessor**: `Combo_SetForeignPlacementOoT`, `Combo_GetForeignPlacementForOoTCheck`, `Combo_CountForeignPlacementsOoT`, `Combo_ClearForeignPlacementsOoT`. The bodies are shared via a table parameter (`ForeignPlaceInto` etc.) so a fix to the fused duplicate/first-free scan cannot land in one direction and miss the other. Note the reuse: the struct member is still named `mmCheckId` but in this table holds an OoT `RandomizerCheck` — documented at the field, at the accessors, and in the ADR.
- Session-wide retirement needed no new code: `Context_InvalidateSessionState` calls `ComboContext_Init`, which memsets the whole struct, so any field carved from `reserved[]` is covered.

**Tests (`src/common/tests/`, `src/common/test_runner.cpp`, `CMake/SingleExecutable.cmake`)**
- New `ForeignItemGiveReverse` row (redship label, ROM-free): the same rejections and de-dup on the reverse accessors; one check id present in **both** tables resolving to a different item through each; clearing one direction not retiring the other; byte-exact `.redsave` round trip of the new block with unset slots reading absent; and a pre-3.1 short record zero-extending the whole block. Verified non-vacuous by probe — pointing the reverse accessors at the forward table fails the row.
- `Test_SaveComboLegacyRecord` gains a v2 fixed-offset case placing bytes at literal offsets 672/676/736 into a crafted 1024-byte Tier-1 record, driving it through the real `SaveManager::Load` and reading them back out of the named members. Not offsetof-against-offsetof: the expected offsets are integers matching bytes physically in a file, so a self-consistent wrong layout cannot satisfy it.
- The existing `ForeignItemGive` row locks the origin dimension: a synthetic MM pool that deliberately collides on `"Bomb Bag"` must resolve to a different item under each origin; the legacy bare-name entry point must still mean the OoT pool; an id shared across id-spaces must not borrow the other game's name. The OoT half of that collision lock now looks up the real "Bomb Bag" row in the pinned pool and asserts the collision is actually present, so the block cannot quietly stop testing anything if the pool is edited (the earlier form compared `(id, origin)` pairs whose origins were asserted distinct three lines above, and could never fail).
- `test_grant_sources.c`'s legacy boundary gets the explanation it was missing: its `offsetof(grantCursors)` truncation is correct only because every legal carve lands after `sharedItemOverflowCount`.

## Why

The scope here is deliberately the spine, not the feature. This lands the carve, the accessors, the registry, and serialization for the reverse direction. The production give-path bridge (#493 steps 6-8) and MM's real award (Lane 6's `MM_AwardSharedItem`, still a placeholder `fprintf`) are **not** here, so the redeem leg drives the real `Combo_RedeemSharedItemsForGame` walk with a test award callback rather than through MM's give.

The two format-facing pieces are the ones that matter most to a reviewer. The cap-bump commit converts a change that compiled clean and silently orphaned shipped saves into two loud build failures, and the reverse carve deliberately reuses `ComboForeignPlacement` rather than reshaping it, precisely to avoid a `.redsave` format generation — the elegant `{hostGame, checkId, item}` table costs an ADR 0002 amendment, a version bump past 2, and a stated forward-incompatibility, versus 48 bytes for a parallel table.

## Testing

The stacked tip passes `ctest -L "^redship$"` locally, including the new `ForeignItemGiveReverse` row and the extended save-roundtrip / legacy-record cases. Both new test rows were verified non-vacuous by probe (pointing the reverse accessors at the forward table fails; making the name inverse ignore its origin argument fails), and the literal offset asserts were verified by probe-bumping the cap to 12 and confirming the build breaks.

Hosted CI covers the compile and ROM-free tiers only. The gameplay tier (`int-*`) is not exercised — that requires a self-hosted ROM runner which is not configured — so no gameplay-tier coverage is claimed for this change.

Closes #490

Refs #493 (steps 2-4), #498, #492, #356

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!--- section:artifacts:start -->
### Build Artifacts
  - [rsbs-windows.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/8574468873.zip)
  - [rsbs-linux.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/8574141103.zip)
<!--- section:artifacts:end -->