### PR TITLE
Restrict foreign-item hosts to game-armed check classes and fail generation on a shortfall

### DIFF
--- a/CMake/SingleExecutable.cmake
+++ b/CMake/SingleExecutable.cmake
@@ -354,6 +354,12 @@ if(BUILD_TESTING)
     # gComboCtx.foreignPlacements round-trips through the .redsave record.
     redship_add_test(NAME ForeignItemGive COMMAND redship --test foreign-item-give)
     redship_add_test(NAME ForeignItemGiveReverse COMMAND redship --test foreign-item-give-reverse)
+    # #488: a foreign item may only be hosted by a check class the GAME arms.
+    # CheckQueue's foreign branch is nested inside `if (eligible)`, so an
+    # unarmed host strands a pinned OoT progression item and makes the paired
+    # world unwinnable with no error. Drives the real selection predicate over
+    # MM's real check table; also prints the eligible-host supply count.
+    redship_add_test(NAME ForeignHostEligibility COMMAND redship --test foreign-host-eligibility)
     redship_add_test(NAME ComboSpoilerView COMMAND redship --test combo-spoiler-view)
     redship_add_test(NAME ComboSpoilerWindow COMMAND redship --test combo-spoiler-window)
     # Cross-game session invalidation (#440). A soft reset or a new game must

--- a/games/mm/2s2h/Rando/Foreign.cpp
+++ b/games/mm/2s2h/Rando/Foreign.cpp
@@ -92,6 +92,115 @@ static uint32_t SelectNext() {
     return sSelectState;
 }
 
+// ---------------------------------------------------------------------------
+// Host eligibility (#488).
+//
+// The predicate this replaced was a BLOCKLIST — "shuffled, holds a junk-class
+// item, and is not a shop" — evaluated over a check table (RandoStaticCheck:
+// {id, name, type, scene, flagType, flag, item}) that carries no give-path
+// information whatsoever. That shape is the structural defect: CheckQueue's
+// foreign branch is a fork nested INSIDE `if (randoSaveCheck.eligible)`
+// (MiscBehavior/CheckQueue.cpp:39-53), so any host whose `.eligible` bit is
+// never armed strands a pinned OoT progression item forever. Nothing logs,
+// nothing errors, and the paired world is unwinnable by construction.
+//
+// So it is an ALLOWLIST now: a check class is a legal host only once someone
+// has traced its arming chain. Ship Tier A only.
+//
+// TIER A — RCTYPE_CHEST carrying FLAG_CYCL_SCENE_CHEST. The arming chain,
+// traced end to end: z_en_box.c:488-495 (MM_EnBox_WaitOpen) calls
+// MM_Flags_SetTreasure, which at z_actor.c:860-869 fires
+// GameInteractor_ExecuteOnSceneFlagSet(sceneId, FLAG_CYCL_SCENE_CHEST, flag),
+// which MiscBehavior/OnFlagSet.cpp:19-33 turns into `.eligible = true` for the
+// resolved check. All 128 chest rows carry FLAG_CYCL_SCENE_CHEST today; the
+// flagType is re-checked per row rather than assumed, because 60
+// RCTYPE_SKULL_TOKEN rows share that flag space and a future FLAG_NONE chest
+// row must not silently inherit Tier A's guarantee.
+//
+// One honest caveat, since the point of this predicate is not to overclaim:
+// 31 of the 128 chest rows hold a stray fairy in vanilla, and z_en_box.c:488
+// routes GI_STRAY_FAIRY down a branch that never calls Flags_SetTreasure.
+// Those chests arm because the rando EnBox ShouldActorInit hook
+// (ActorBehavior/EnBox.cpp:176-197) first rewrites the contained item to
+// GI_RECOVERY_HEART, putting them back on the flag-setting branch. That hook
+// bails on `!RANDO_SAVE_CHECKS[id].shuffled` — the SAME bit this predicate
+// requires below — so it always runs for a check we would host on. The
+// guarantee is therefore "armed for every check this predicate accepts", not
+// "armed with zero rando code involved"; the distinction matters only if the
+// EnBox hook's registration condition ever diverges from `.shuffled`.
+//
+// TIER B — every non-shop check with `flagType != FLAG_NONE` minus the false
+// friend FLAG_RANDO_INF (rando-inf flags are written by rando code, not by
+// vanilla actors — z_actor.c:1026). Compiled out. It is NOT audited: the
+// FLAG_WEEK_EVENT_REG-backed NPC/MINIGAME rows have not been checked for a
+// rando VB hook that replaces the NPC's give AND suppresses the vanilla flag
+// write, which is exactly the failure this whole predicate exists to prevent.
+// Do not define RSBS_FOREIGN_HOST_TIER_B until that audit lands (#488).
+static bool IsAllowedHostClass(const Rando::StaticData::RandoStaticCheck& randoStaticCheck) {
+    // Kept explicit even though the allowlist below already excludes them: the
+    // shop give/price flow and spoiler shape differ from the ordinary
+    // eligible->CheckQueue path the generic foreign presentation targets, so
+    // this exclusion must survive any future widening of the tiers.
+    if (randoStaticCheck.randoCheckType == RCTYPE_SHOP || randoStaticCheck.randoCheckType == RCTYPE_TINGLE_SHOP) {
+        return false;
+    }
+
+    // Tier A.
+    if (randoStaticCheck.randoCheckType == RCTYPE_CHEST && randoStaticCheck.flagType == FLAG_CYCL_SCENE_CHEST) {
+        return true;
+    }
+
+#ifdef RSBS_FOREIGN_HOST_TIER_B
+    if (randoStaticCheck.flagType != FLAG_NONE && randoStaticCheck.flagType != FLAG_RANDO_INF) {
+        return true;
+    }
+#endif
+
+    return false;
+}
+
+bool IsEligibleHost(RandoCheckId randoCheckId) {
+    if (randoCheckId <= RC_UNKNOWN || randoCheckId >= RC_MAX) {
+        return false;
+    }
+
+    const auto staticIt = Rando::StaticData::Checks.find(randoCheckId);
+    if (staticIt == Rando::StaticData::Checks.end() || staticIt->second.randoCheckId == RC_UNKNOWN) {
+        return false;
+    }
+    if (!IsAllowedHostClass(staticIt->second)) {
+        return false;
+    }
+
+    const RandoSaveCheck& randoSaveCheck = RANDO_SAVE_CHECKS[randoCheckId];
+
+    // `.shuffled` alone was the old predicate's only save-side test, and it is
+    // not sufficient in either direction. A USER-EXCLUDED check is marked
+    // `shuffled = true; randoItemId = RI_JUNK; skipped = true` by
+    // Logic/GeneratePools.cpp and is deliberately kept OUT of checkPool — so
+    // under the old predicate an excluded check was a top-priority host for a
+    // pinned progression item. `.skipped` is the bit that says so.
+    if (!randoSaveCheck.shuffled || randoSaveCheck.skipped) {
+        return false;
+    }
+
+    // RI_UNKNOWN (enumerator 0, i.e. a zero-initialised or unresolvable slot)
+    // and RI_NONE ("literally nothing") are both declared RITYPE_JUNK, so a
+    // type-only test accepts an item that is not an item. Rejecting them keeps
+    // ADR 0002's host invariant honest: a foreign host must physically hold a
+    // LEGAL junk-class MM item, because that is what the check degrades to if
+    // the placement table is ever absent.
+    const RandoItemId heldItem = randoSaveCheck.randoItemId;
+    if (heldItem == RI_UNKNOWN || heldItem == RI_NONE) {
+        return false;
+    }
+    const auto itemIt = Rando::StaticData::Items.find(heldItem);
+    if (itemIt == Rando::StaticData::Items.end()) {
+        return false;
+    }
+    return itemIt->second.randoItemType == RITYPE_JUNK;
+}
+
 int PlaceForeignItems() {
     Combo_ClearForeignPlacements();
 
@@ -105,33 +214,28 @@ int PlaceForeignItems() {
         return 0;
     }
 
-    // Candidates: shuffled checks the fill left holding a JUNK-CLASS item
-    // (RITYPE_JUNK — ammo, rupees, and the RI_JUNK filler sentinel alike), in
-    // ascending RandoCheckId order (std::map). The literal RI_JUNK sentinel
-    // alone is NOT the criterion: the pool balancer only injects it when the
-    // check pool outnumbers the item pool, so most fills carry few or none
-    // (a measured CI fill had 2), while junk-class items are plentiful.
-    // Shop-type checks are excluded: their give/price flow and spoiler shape
-    // differ, and the MVP's generic presentation targets the ordinary
-    // eligible->CheckQueue path.
+    // Candidates: checks IsEligibleHost accepts, in ascending RandoCheckId
+    // order (std::map), so selection stays deterministic. The predicate is a
+    // named function rather than an inline condition precisely so the CI lock
+    // can drive it directly — see IsEligibleHost above for what it enforces and
+    // why the previous inline blocklist was unsound.
+    //
+    // The junk-class requirement inside it is the one part carried over
+    // unchanged: the literal RI_JUNK sentinel alone is NOT the criterion,
+    // because the pool balancer only injects it when the check pool outnumbers
+    // the item pool (a measured CI fill had 2), while junk-class items are
+    // plentiful.
     std::vector<RandoCheckId> candidates;
     for (auto& [randoCheckId, randoStaticCheck] : Rando::StaticData::Checks) {
-        if (randoStaticCheck.randoCheckId == RC_UNKNOWN) {
-            continue;
-        }
-        if (randoStaticCheck.randoCheckType == RCTYPE_SHOP || randoStaticCheck.randoCheckType == RCTYPE_TINGLE_SHOP) {
-            continue;
-        }
-        if (!RANDO_SAVE_CHECKS[randoCheckId].shuffled) {
-            continue;
-        }
-        const RandoItemId heldItem = RANDO_SAVE_CHECKS[randoCheckId].randoItemId;
-        if (Rando::StaticData::Items[heldItem].randoItemType == RITYPE_JUNK) {
+        if (IsEligibleHost(randoCheckId)) {
             candidates.push_back(randoCheckId);
         }
     }
 
-    fprintf(stderr, "[MM] foreign placement: %d pool items over %zu junk-holding candidate checks\n", poolCount,
+    // Printed every generation on purpose: Tier A drops the candidate set from
+    // ~2000 to a few dozen, so host supply is now a number worth watching in
+    // CI logs and playtest output BEFORE it becomes a shortfall.
+    fprintf(stderr, "[MM] foreign placement: %d pool items over %zu eligible host checks\n", poolCount,
             candidates.size());
 
     sSelectState =
@@ -155,7 +259,7 @@ int PlaceForeignItems() {
     }
 
     if (placed < poolCount) {
-        fprintf(stderr, "[MM] foreign placement: only %d of %d pool items placed (junk candidates exhausted)\n", placed,
+        fprintf(stderr, "[MM] foreign placement: only %d of %d pool items placed (eligible hosts exhausted)\n", placed,
                 poolCount);
     }
     return placed;
@@ -203,6 +307,82 @@ bool RecordForeignPickup(RandoCheckId randoCheckId) {
 // ============================================================================
 extern "C" int MM_Rando_Foreign_RecordPickup(uint16_t randoCheckId) {
     return Rando::Foreign::RecordForeignPickup((RandoCheckId)randoCheckId) ? 1 : 0;
+}
+
+// #488's host-eligibility lock. This is the bridge that makes the lock
+// non-vacuous: it calls the SAME function PlaceForeignItems' candidate loop
+// calls, so a test that drives it is testing selection, not a paraphrase of
+// selection. Without the extraction above, the only observable for "was this a
+// safe host?" would be a whole generated world.
+extern "C" int MM_Rando_Foreign_IsEligibleHost(uint16_t randoCheckId) {
+    return Rando::Foreign::IsEligibleHost((RandoCheckId)randoCheckId) ? 1 : 0;
+}
+
+// ---------------------------------------------------------------------------
+// Test-support surface for the same lock (src/common/tests/test_foreign_items.c).
+//
+// The predicate reads two things the ROM-free tier cannot reach from
+// src/common: Rando::StaticData::Checks (MM C++ static data) and
+// RANDO_SAVE_CHECKS (a field deep inside MM's gSaveContext). These accessors
+// exist so the test can build a synthetic save over the REAL check table
+// rather than a mock one. They are inspection/stamping only — none of them is
+// reachable from gameplay, and none duplicates predicate logic.
+// ---------------------------------------------------------------------------
+
+/** RC_MAX — the exclusive upper bound for a RandoCheckId walk. */
+extern "C" int MM_Rando_Foreign_TestCheckIdMax(void) {
+    return (int)RC_MAX;
+}
+
+/** Static classification of one check row. Returns 1 if the id names a real
+ *  row, 0 otherwise. Reports the two facts Tier A is defined in terms of, so
+ *  the test can assert the table invariant (every chest row carries
+ *  FLAG_CYCL_SCENE_CHEST) without importing MM's enums into src/common. */
+extern "C" int MM_Rando_Foreign_TestCheckClass(uint16_t randoCheckId, int* outIsChestType, int* outHasChestFlag) {
+    const auto it = Rando::StaticData::Checks.find((RandoCheckId)randoCheckId);
+    if (it == Rando::StaticData::Checks.end() || it->second.randoCheckId == RC_UNKNOWN) {
+        return 0;
+    }
+    if (outIsChestType != nullptr) {
+        *outIsChestType = (it->second.randoCheckType == RCTYPE_CHEST) ? 1 : 0;
+    }
+    if (outHasChestFlag != nullptr) {
+        *outHasChestFlag = (it->second.flagType == FLAG_CYCL_SCENE_CHEST) ? 1 : 0;
+    }
+    return 1;
+}
+
+/** Stamp one row's save-side state (the three fields the predicate reads). */
+extern "C" void MM_Rando_Foreign_TestStampCheck(uint16_t randoCheckId, int shuffled, int skipped, uint16_t itemId) {
+    if (randoCheckId == 0 || randoCheckId >= (uint16_t)RC_MAX) {
+        return;
+    }
+    RandoSaveCheck& randoSaveCheck = RANDO_SAVE_CHECKS[(RandoCheckId)randoCheckId];
+    randoSaveCheck.shuffled = (shuffled != 0);
+    randoSaveCheck.skipped = (skipped != 0);
+    randoSaveCheck.randoItemId = (RandoItemId)itemId;
+}
+
+/** Stamp every row — the "synthetic all-shuffled save" the whole-table sweep
+ *  runs over, and the reset the test leaves behind. */
+extern "C" void MM_Rando_Foreign_TestStampAllChecks(int shuffled, int skipped, uint16_t itemId) {
+    for (int i = 1; i < (int)RC_MAX; i++) {
+        MM_Rando_Foreign_TestStampCheck((uint16_t)i, shuffled, skipped, itemId);
+    }
+}
+
+/** The three RandoItemId values the predicate treats specially: the legal junk
+ *  filler, and the two sentinels that are RITYPE_JUNK but are not items. */
+extern "C" void MM_Rando_Foreign_TestItemSentinels(uint16_t* outJunk, uint16_t* outNone, uint16_t* outUnknown) {
+    if (outJunk != nullptr) {
+        *outJunk = (uint16_t)RI_JUNK;
+    }
+    if (outNone != nullptr) {
+        *outNone = (uint16_t)RI_NONE;
+    }
+    if (outUnknown != nullptr) {
+        *outUnknown = (uint16_t)RI_UNKNOWN;
+    }
 }
 
 #endif // RSBS_SINGLE_EXECUTABLE

--- a/games/mm/2s2h/Rando/Foreign.h
+++ b/games/mm/2s2h/Rando/Foreign.h
@@ -32,6 +32,19 @@ std::string PairedInputSeedString();
  *  contract). Call AFTER the options are persisted into RANDO_SAVE_OPTIONS. */
 uint32_t MixPairedFinalSeed();
 
+/** True if this MM check is a SAFE host for a foreign (cross-game) item —
+ *  i.e. the check is in the fill, holds a legal junk-class MM item, and belongs
+ *  to a check class whose `.eligible` bit is armed by GAME code rather than by
+ *  a rando hook that might not exist. #488: the previous inline predicate was a
+ *  blocklist over a check table that carries no give-path information at all,
+ *  so a host with no runtime give-path stranded its pinned OoT item forever —
+ *  invisible, unwinnable, indistinguishable from a missing item.
+ *
+ *  Extracted (rather than left inline) so the CI lock can drive the REAL
+ *  selection predicate through MM_Rando_Foreign_IsEligibleHost instead of
+ *  re-deriving it; see the bridge block at the bottom of Foreign.cpp. */
+bool IsEligibleHost(RandoCheckId randoCheckId);
+
 /** Swap deterministically-chosen junk placements for the pinned foreign pool
  *  and record them in gComboCtx.foreignPlacements. Call after the fill/logic
  *  apply populated RANDO_SAVE_CHECKS. Returns the number placed. */

--- a/games/mm/2s2h/Rando/MiscBehavior/OnFileCreate.cpp
+++ b/games/mm/2s2h/Rando/MiscBehavior/OnFileCreate.cpp
@@ -242,7 +242,34 @@ void Rando::MiscBehavior::OnFileCreate(s16 fileNum) {
                     // gComboCtx.foreignPlacements (the MM table keeps its
                     // junk-class MM item — ADR 0002). Runs before the spoiler write so the
                     // spoiler's foreign section describes this world.
-                    Rando::Foreign::PlaceForeignItems();
+                    //
+                    // #488: a SHORT placement is a fatal generation failure,
+                    // not a warning. Every pool item is pinned OoT progression;
+                    // one that never got a host is not "missing loot", it is a
+                    // world the player cannot finish, and before this throw the
+                    // return value was simply discarded. Tier A host
+                    // eligibility cut the candidate set from ~2000 to a few
+                    // dozen, so exhaustion is now plausible rather than
+                    // theoretical. Throwing lands in the outer catch, which
+                    // reverts the file to vanilla exactly as any fill dead-end
+                    // does — the "no retries, revert" contract stated in
+                    // Foreign.cpp's header. A retry here would make the world
+                    // identity depend on runtime state the settings digest
+                    // cannot see.
+                    const ComboForeignItemDef* pool = nullptr;
+                    const int poolCount = Combo_GetForeignItemPool(&pool);
+                    const int placed = Rando::Foreign::PlaceForeignItems();
+                    if (placed < poolCount) {
+                        // Two distinct causes land here — the eligible-host
+                        // candidate set ran dry, or Combo_SetForeignPlacement
+                        // refused an insert (cap/duplicate). PlaceForeignItems
+                        // logs which to stderr immediately above; this message
+                        // names both rather than asserting one.
+                        throw std::runtime_error("Paired world could not host every foreign item: placed " +
+                                                 std::to_string(placed) + " of " + std::to_string(poolCount) +
+                                                 " (eligible hosts exhausted, or the placement table refused an "
+                                                 "insert — see the [MM] foreign placement log above)");
+                    }
                 }
 #endif
 

--- a/games/mm/2s2h/Rando/Spoiler/Apply.cpp
+++ b/games/mm/2s2h/Rando/Spoiler/Apply.cpp
@@ -8,6 +8,7 @@
 #include <stdexcept>
 #include <vector>
 #include "foreign_items.h" // src/common — placement table + pinned-pool reverse lookup (Lane C1, #392)
+#include "Rando/Foreign.h" // Rando::Foreign::IsEligibleHost — the host rule the LOAD path must reapply (#488)
 #endif
 
 extern "C" {
@@ -117,25 +118,93 @@ int ReconstructForeignPlacements(const nlohmann::json& spoiler) {
     // no-duplicate / bounded invariants are enforced by one code path.
     Combo_ClearForeignPlacements();
     int placed = 0;
+    int rejected = 0;
     for (const Pending& p : pending) {
+        RandoSaveCheck& hostSaveCheck = RANDO_SAVE_CHECKS[(RandoCheckId)p.checkId];
+
+        // ADR 0002 host invariant, restored on load: the MM save table must
+        // keep a LEGAL junk-class MM item at a foreign host check (never a
+        // raw RG_*). The spoiler's human-readable "checks" map stored this
+        // check as "<item> (Ocarina of Time)", which GetItemIdFromName
+        // cannot resolve, so ApplyToSaveContext just left RI_UNKNOWN there;
+        // the underlying junk item is not recoverable from the spoiler, so
+        // normalize to the canonical junk sentinel. Inert while the
+        // placement stands (the give path reads foreignPlacements, not this
+        // item), but it keeps the table legal and makes the check degrade to
+        // junk — not RI_UNKNOWN — if the placement is ever absent.
+        //
+        // Applied BEFORE the eligibility gate below, not after, because the
+        // gate reads exactly these two fields: un-normalized, every host would
+        // be rejected for holding RI_UNKNOWN, which says nothing about the
+        // host's give path.
+        const bool priorShuffled = hostSaveCheck.shuffled;
+        hostSaveCheck.randoItemId = RI_JUNK;
+        hostSaveCheck.shuffled = true;
+
+        // #488, step 6: the LOAD path must apply the same host-eligibility rule
+        // generation does. Combo_SetForeignPlacement enforces tagged-only /
+        // no-duplicate / bounded and nothing about MM check semantics — it is a
+        // deliberately game-agnostic layer — so without this gate a spoiler
+        // written by a pre-#488 build reconstructs placements onto hosts whose
+        // `.eligible` bit is never armed, and the crossing strands exactly as
+        // it would have before the tightening. Reject loudly rather than
+        // throw: the surrounding ApplyToSaveContext load is otherwise sound,
+        // and aborting it would take a playable MM world down with the
+        // unreachable crossings. Runs here rather than after the loop because
+        // ApplyToSaveContext has already populated RANDO_SAVE_CHECKS by the
+        // time ReconstructForeignPlacements is called.
+        //
+        // What this gate can and cannot see on the load path, stated precisely
+        // so nobody later mistakes it for the full generate-path rule:
+        //
+        //  - The item-class half asserts nothing here. It is satisfied by the
+        //    RI_JUNK this loop just wrote, and that is inherent — the spoiler
+        //    does not preserve the host's underlying MM item, so the
+        //    pre-normalization value is RI_UNKNOWN for every legitimate host.
+        //  - The `.skipped` half also asserts nothing here. ApplyToSaveContext
+        //    writes only randoItemId/shuffled/price, and the only writers of
+        //    `.skipped` anywhere are Logic/GeneratePools.cpp (generate path)
+        //    and CheckTracker.cpp (a user toggle on a live save), so on a load
+        //    it is uniformly false.
+        //  - The half that DOES bite is the check-class allowlist — which is
+        //    the one that matters, because it is the half that decides whether
+        //    the host can ever be armed.
+        if (!Rando::Foreign::IsEligibleHost((RandoCheckId)p.checkId)) {
+            // Restore `shuffled` only. randoItemId deliberately KEEPS the
+            // RI_JUNK written above: this branch is precisely the
+            // "placement is absent" case the normalization comment describes,
+            // and putting the unresolvable RI_UNKNOWN back would leave a
+            // shuffled check holding a non-item — which arms `.eligible` all
+            // the same (OnFlagSet gates on `.shuffled` alone) and then walks
+            // the give path with a sentinel. Degrading to junk is the whole
+            // point of the normalization; the reject path needs it most.
+            hostSaveCheck.shuffled = priorShuffled;
+            rejected++;
+            const auto staticIt = Rando::StaticData::Checks.find((RandoCheckId)p.checkId);
+            fprintf(stderr,
+                    "[MM] spoiler-load: REJECTING foreign placement on MM check %s — not an eligible host under the "
+                    "current rule (pre-#488 spoiler?); this crossing is NOT reachable in-game\n",
+                    staticIt != Rando::StaticData::Checks.end() ? staticIt->second.name : "<unknown>");
+            continue;
+        }
+
         if (Combo_SetForeignPlacement(p.checkId, p.item) >= 0) {
             placed++;
-            // ADR 0002 host invariant, restored on load: the MM save table must
-            // keep a LEGAL junk-class MM item at a foreign host check (never a
-            // raw RG_*). The spoiler's human-readable "checks" map stored this
-            // check as "<item> (Ocarina of Time)", which GetItemIdFromName
-            // cannot resolve, so ApplyToSaveContext just left RI_UNKNOWN there;
-            // the underlying junk item is not recoverable from the spoiler, so
-            // normalize to the canonical junk sentinel. Inert while the
-            // placement stands (the give path reads foreignPlacements, not this
-            // item), but it keeps the table legal and makes the check degrade to
-            // junk — not RI_UNKNOWN — if the placement is ever absent.
-            RANDO_SAVE_CHECKS[(RandoCheckId)p.checkId].randoItemId = RI_JUNK;
-            RANDO_SAVE_CHECKS[(RandoCheckId)p.checkId].shuffled = true;
+        } else {
+            // Same reasoning as the reject branch: an insert refusal is also
+            // an absent placement, so the host keeps RI_JUNK rather than
+            // reverting to the unresolvable RI_UNKNOWN.
+            hostSaveCheck.shuffled = priorShuffled;
         }
     }
     fprintf(stderr, "[MM] spoiler-load: reconstructed %d foreign placement(s) from the spoiler's foreign section\n",
             placed);
+    if (rejected > 0) {
+        fprintf(stderr,
+                "[MM] spoiler-load: %d foreign placement(s) rejected as ineligible hosts — this world was generated "
+                "by a build predating the #488 host rule and cannot deliver those items; regenerate it\n",
+                rejected);
+    }
     return placed;
 }
 #endif

--- a/games/mm/2s2h/mm_rando_gen_test.cpp
+++ b/games/mm/2s2h/mm_rando_gen_test.cpp
@@ -298,12 +298,54 @@ extern "C" int MM_Rando_HeadlessGenTest(void) {
             return 12;
         }
         const RandoCheckId hostCheck = (RandoCheckId)p.mmCheckId;
-        const RandoItemId heldItem = RANDO_SAVE_CHECKS[hostCheck].randoItemId;
-        if (!RANDO_SAVE_CHECKS[hostCheck].shuffled ||
-            Rando::StaticData::Items[heldItem].randoItemType != RITYPE_JUNK) {
+
+        // #488, part 1 — the INDEPENDENT restatement, and the load-bearing one.
+        //
+        // A post-condition that calls IsEligibleHost cannot fail for a wrong
+        // host rule: PlaceForeignItems selected these very checks by calling
+        // IsEligibleHost, and nothing between selection and here mutates either
+        // of its inputs (Rando::StaticData::Checks is static; the only
+        // RANDO_SAVE_CHECKS writes in between are `.eligible` on two starting-
+        // item rows, a field the predicate never reads). Loosen the predicate
+        // and both sides move together. The condition this replaced —
+        // "shuffled && holds a junk-class item" — had the same defect; it was
+        // simply a textual copy of the selector rather than a call to it.
+        //
+        // So state the property #488 is actually about, read straight from the
+        // static table with no reference to the predicate: the host belongs to
+        // a check class whose `.eligible` bit is armed by game code. Tier A is
+        // RCTYPE_CHEST carrying FLAG_CYCL_SCENE_CHEST (z_en_box.c ->
+        // Flags_SetTreasure -> OnFlagSet). If someone widens IsEligibleHost
+        // without widening the audit, THIS is the assertion that catches it, on
+        // an actual paired fill rather than the synthetic table the ROM-free
+        // ForeignHostEligibility lock uses.
+        const auto staticIt = Rando::StaticData::Checks.find(hostCheck);
+        if (staticIt == Rando::StaticData::Checks.end() ||
+            staticIt->second.randoCheckType != RCTYPE_CHEST ||
+            staticIt->second.flagType != FLAG_CYCL_SCENE_CHEST) {
             fprintf(stderr,
-                    "[MM-RANDO-GEN] FAIL(12): hosting check %u does not hold a junk-class MM item (holds %d)\n",
-                    (unsigned)p.mmCheckId, (int)heldItem);
+                    "[MM-RANDO-GEN] FAIL(12): hosting check %u is not a Tier A (chest/FLAG_CYCL_SCENE_CHEST) host — "
+                    "its .eligible bit is not game-armed, so this placement would strand\n",
+                    (unsigned)p.mmCheckId);
+            return 12;
+        }
+
+        // #488, part 2 — the cheap consistency tie-back. Tautological w.r.t.
+        // the selector as argued above, and kept anyway for the one thing it
+        // does catch: a placement whose mmCheckId did not survive the u16
+        // round-trip through the placement table would fail the predicate here
+        // even though part 1's static lookup might land on some other real row.
+        // (Calls the C++ predicate directly rather than the
+        // MM_Rando_Foreign_IsEligibleHost bridge: this is an MM C++ TU that
+        // already includes Foreign.h, and the bridge is a one-line forwarder to
+        // exactly this function. The bridge exists for src/common, which cannot
+        // see the namespace.)
+        if (!Rando::Foreign::IsEligibleHost(hostCheck)) {
+            fprintf(stderr,
+                    "[MM-RANDO-GEN] FAIL(12): hosting check %u is a chest row but fails the host predicate (held item "
+                    "%d, skipped=%d) — placement/table inconsistency\n",
+                    (unsigned)p.mmCheckId, (int)RANDO_SAVE_CHECKS[hostCheck].randoItemId,
+                    RANDO_SAVE_CHECKS[hostCheck].skipped ? 1 : 0);
             return 12;
         }
     }
@@ -466,6 +508,71 @@ extern "C" int MM_Rando_HeadlessGenTest(void) {
         }
     }
 
+    // #488, step 6: a spoiler written by a PRE-tightening build can name a host
+    // the current rule rejects — the old predicate accepted every non-shop
+    // check type, and ~94% of its candidate pool was non-chest. Reconstruction
+    // must drop that placement rather than rebuild a crossing the give path can
+    // never deliver, and must leave the host holding the legal junk sentinel
+    // (not the unresolvable RI_UNKNOWN that ApplyToSaveContext leaves at a
+    // foreign host, which would arm `.eligible` and then give nothing).
+    //
+    // Without this leg the reject branch ships untested: the ROM-free
+    // ForeignHostEligibility lock drives the predicate, not the load path.
+    {
+        Combo_ClearForeignPlacements();
+
+        // First non-chest row in the table, chosen at runtime so this does not
+        // pin a check name that a future table edit could remove.
+        const Rando::StaticData::RandoStaticCheck* ineligible = nullptr;
+        for (auto& [randoCheckId, randoStaticCheck] : Rando::StaticData::Checks) {
+            if (randoStaticCheck.randoCheckId != RC_UNKNOWN && randoStaticCheck.randoCheckType != RCTYPE_CHEST &&
+                randoStaticCheck.randoCheckType != RCTYPE_SHOP &&
+                randoStaticCheck.randoCheckType != RCTYPE_TINGLE_SHOP) {
+                ineligible = &randoStaticCheck;
+                break;
+            }
+        }
+        if (ineligible == nullptr) {
+            fprintf(stderr, "[MM-RANDO-GEN] FAIL(22): no non-chest check row to build the stale-host case from\n");
+            return 22;
+        }
+
+        nlohmann::json staleHost = loadedSpoiler;
+        nlohmann::json foreignEntry;
+        for (auto& [checkName, entry] : staleHost["foreign"].items()) {
+            foreignEntry = entry;
+            break;
+        }
+        staleHost["foreign"] = nlohmann::json::object();
+        staleHost["foreign"][ineligible->name] = foreignEntry;
+
+        // The state ApplyToSaveContext leaves at a foreign host: shuffled, with
+        // the "<item> (Ocarina of Time)" name unresolvable to a RandoItemId.
+        RANDO_SAVE_CHECKS[ineligible->randoCheckId].randoItemId = RI_UNKNOWN;
+        RANDO_SAVE_CHECKS[ineligible->randoCheckId].shuffled = true;
+        RANDO_SAVE_CHECKS[ineligible->randoCheckId].skipped = false;
+
+        const int staleReconstructed = Rando::Spoiler::ReconstructForeignPlacements(staleHost);
+        if (staleReconstructed != 0 || Combo_CountForeignPlacements() != 0 ||
+            Combo_GetForeignPlacementForCheck((uint16_t)ineligible->randoCheckId) != NULL) {
+            fprintf(stderr,
+                    "[MM-RANDO-GEN] FAIL(22): stale spoiler host %s (type %d) was reconstructed anyway (returned %d, "
+                    "table holds %d)\n",
+                    ineligible->name, (int)ineligible->randoCheckType, staleReconstructed,
+                    Combo_CountForeignPlacements());
+            return 22;
+        }
+        const RandoItemId heldAfterReject = RANDO_SAVE_CHECKS[ineligible->randoCheckId].randoItemId;
+        if (Rando::StaticData::Items[heldAfterReject].randoItemType != RITYPE_JUNK ||
+            heldAfterReject == RI_UNKNOWN || heldAfterReject == RI_NONE) {
+            fprintf(stderr,
+                    "[MM-RANDO-GEN] FAIL(22): rejected host %s left holding %d — must degrade to a legal junk item, "
+                    "not a sentinel that arms .eligible and gives nothing\n",
+                    ineligible->name, (int)heldAfterReject);
+            return 22;
+        }
+    }
+
     // Wiring: the REAL apply path (ApplyToSaveContext, the spoiler-LOAD entry
     // point OnFileCreate's load branch invokes) must itself drive reconstruction
     // — not just the focused helper above. Clear, apply the whole spoiler, and
@@ -491,7 +598,7 @@ extern "C" int MM_Rando_HeadlessGenTest(void) {
     memset(&gComboCtx.sharedItemsTagged[0], 0, sizeof(SharedItem));
 
     fprintf(stderr, "[MM-RANDO-GEN] spoiler-LOAD reconstruction verified: preserve-live, rebuild-exact, "
-                    "redemption-safe, malformed-refused, absent-ok, apply-wired\n");
+                    "redemption-safe, malformed-refused, absent-ok, stale-host-rejected, apply-wired\n");
 
     // OnSaveLoad chain lock (Lane C1): dispatching the real save-load bridge
     // with the rando save live must arm the rando behaviors — the

--- a/src/common/test_runner.cpp
+++ b/src/common/test_runner.cpp
@@ -1402,6 +1402,12 @@ const TestDescriptor gTests[] = {
     {"foreign-item-give-reverse",
      "Reverse (MM->OoT) placement carve: separate key space, serializes, redeems once (#493)",
      Test_ForeignItemGiveReverse},
+    // #488: host selection must reject any check class the game does not arm —
+    // the give path is gated on `.eligible`, so an unarmed host strands a
+    // pinned OoT progression item and no error is ever raised.
+    {"foreign-host-eligibility",
+     "Foreign hosts limited to game-armed check classes; skipped/sentinel slots rejected (#488)",
+     Test_ForeignHostEligibility},
     {"combo-spoiler-view", "In-game spoiler view model: named crossings, collected state, unpaired != empty (#496)",
      Test_ComboSpoilerView},
     {"combo-spoiler-window", "Common-owned spoiler window registers de-collided; inert under every active game (#496)",

--- a/src/common/tests/test_foreign_items.c
+++ b/src/common/tests/test_foreign_items.c
@@ -48,6 +48,18 @@ extern "C" {
 int MM_Rando_Foreign_RecordPickup(uint16_t randoCheckId);
 int Switch_PrepareHotSwap(GameId departing, const void* saveContext, size_t size);
 int Combo_ConsumeFrozenState(const char* gameId, void* saveContext, size_t size);
+
+// #488 host-eligibility lock. The first is the REAL selection predicate
+// PlaceForeignItems' candidate loop calls — driving it here is what makes this
+// lock a test of selection rather than of a paraphrase. The rest are the
+// inspection/stamping accessors that let a src/common test build a synthetic
+// save over MM's real check table (Rando/Foreign.cpp's bridge block).
+int MM_Rando_Foreign_IsEligibleHost(uint16_t randoCheckId);
+int MM_Rando_Foreign_TestCheckIdMax(void);
+int MM_Rando_Foreign_TestCheckClass(uint16_t randoCheckId, int* outIsChestType, int* outHasChestFlag);
+void MM_Rando_Foreign_TestStampCheck(uint16_t randoCheckId, int shuffled, int skipped, uint16_t itemId);
+void MM_Rando_Foreign_TestStampAllChecks(int shuffled, int skipped, uint16_t itemId);
+void MM_Rando_Foreign_TestItemSentinels(uint16_t* outJunk, uint16_t* outNone, uint16_t* outUnknown);
 }
 
 #define FI_ASSERT(cond)                                                                                                \
@@ -545,5 +557,165 @@ TestResult Test_ForeignItemGiveReverse(void) {
     ComboContext_Init();
 
     printf("[TEST] PASS: reverse carve is a separate key space, serializes byte-exact, zero-extends, redeems once\n");
+    return TEST_PASS;
+}
+
+// ============================================================================
+// #488: foreign-HOST eligibility.
+//
+// The give path only reaches a foreign placement from inside
+// `if (randoSaveCheck.eligible)` (MM's MiscBehavior/CheckQueue.cpp:39-53), so a
+// host whose `.eligible` bit is never armed strands its pinned OoT progression
+// item permanently â€” invisible, unwinnable, and indistinguishable in-game from
+// an item that was never placed. The old host predicate said nothing about
+// arming: it required only the fill-time `.shuffled` bit plus "holds a
+// junk-class item", and excluded only shops.
+//
+// This drives MM_Rando_Foreign_IsEligibleHost â€” the SAME function
+// PlaceForeignItems' candidate loop calls, which is the whole reason the
+// predicate was extracted â€” over MM's REAL Rando::StaticData::Checks table with
+// a synthetic all-shuffled save. It is not a reimplementation of the rule; if
+// the rule changes, this moves with it.
+//
+// The negatives that were GREEN-on-a-bug before #488 are the `.skipped` leg,
+// the two sentinel legs (RI_UNKNOWN/RI_NONE are both declared RITYPE_JUNK, so
+// a type-only test accepted them), and the whole-table class sweep (the old
+// predicate accepted every non-shop check type). The `.shuffled` and
+// RC_UNKNOWN legs are NOT new — the old inline predicate tested both — and are
+// kept as positive/negative controls rather than as regression evidence.
+// ============================================================================
+TestResult Test_ForeignHostEligibility(void) {
+    printf("[TEST] foreign-host-eligibility: only game-armed check classes can host a foreign item (#488)\n");
+
+    const int checkIdMax = MM_Rando_Foreign_TestCheckIdMax();
+    FI_ASSERT(checkIdMax > 1);
+
+    uint16_t riJunk = 0xFFFF;
+    uint16_t riNone = 0xFFFF;
+    uint16_t riUnknown = 0xFFFF;
+    MM_Rando_Foreign_TestItemSentinels(&riJunk, &riNone, &riUnknown);
+    // RI_UNKNOWN is enumerator 0 â€” a zero-initialised slot. That it is a
+    // DISTINCT value from the legal junk filler is the premise of the sentinel
+    // rejection below; assert it rather than assume it.
+    FI_ASSERT(riUnknown == 0);
+    FI_ASSERT(riJunk != riUnknown && riJunk != riNone);
+
+    // The synthetic save: every check shuffled, not skipped, holding the legal
+    // junk filler. Under the OLD predicate this made nearly every row in the
+    // table a legal host; under the new one only the armed classes survive.
+    MM_Rando_Foreign_TestStampAllChecks(/*shuffled=*/1, /*skipped=*/0, riJunk);
+
+    // ------------------------------------------------------------------
+    // Whole-table sweep. Two facts at once: what the predicate accepts, and
+    // the static-table invariant Tier A is defined in terms of.
+    // ------------------------------------------------------------------
+    int acceptedCount = 0;
+    int chestRowCount = 0;
+    int chestRowsMissingFlag = 0;
+    int firstChestId = 0;
+    int firstNonChestAcceptedId = 0;
+    int firstRejectedNonChestId = 0;
+    for (int id = 1; id < checkIdMax; id++) {
+        int isChestType = 0;
+        int hasChestFlag = 0;
+        if (MM_Rando_Foreign_TestCheckClass((uint16_t)id, &isChestType, &hasChestFlag) == 0) {
+            continue; // not a real row (RC_UNKNOWN sentinel / gap)
+        }
+        if (isChestType) {
+            chestRowCount++;
+            if (!hasChestFlag) {
+                chestRowsMissingFlag++;
+            }
+            if (firstChestId == 0) {
+                firstChestId = id;
+            }
+        } else if (firstRejectedNonChestId == 0) {
+            firstRejectedNonChestId = id;
+        }
+
+        if (MM_Rando_Foreign_IsEligibleHost((uint16_t)id)) {
+            acceptedCount++;
+            if (!isChestType && firstNonChestAcceptedId == 0) {
+                firstNonChestAcceptedId = id;
+            }
+        }
+    }
+
+    // This number sizes the foreign pool â€” it is the input #495 (the
+    // rule-defined pool) needs, so print it whether or not anything fails.
+    printf("[TEST] foreign-host-eligibility: %d eligible hosts over %d chest rows (table has %d check ids)\n",
+           acceptedCount, chestRowCount, checkIdMax - 1);
+
+    // Tier A ships alone: nothing outside RCTYPE_CHEST may be accepted.
+    FI_ASSERT(firstNonChestAcceptedId == 0);
+    // ...and the sweep must have actually exercised a non-chest row, or the
+    // assertion above passed for want of anything to reject.
+    FI_ASSERT(firstRejectedNonChestId != 0);
+    FI_ASSERT(MM_Rando_Foreign_IsEligibleHost((uint16_t)firstRejectedNonChestId) == 0);
+
+    // Static-table invariant: every chest row carries FLAG_CYCL_SCENE_CHEST.
+    // A FLAG_NONE chest row added later would have no vanilla setter and would
+    // strand â€” and nothing else in the tree would notice.
+    FI_ASSERT(chestRowCount > 0);
+    FI_ASSERT(chestRowsMissingFlag == 0);
+    // Because the predicate's other conditions are all satisfied by the
+    // synthetic save, acceptance must be exactly the chest rows. An inequality
+    // here means the class rule and the table have drifted apart.
+    FI_ASSERT(acceptedCount == chestRowCount);
+
+    // Supply: the tightened predicate must still be able to host the whole
+    // pinned pool. Falling under this is the "stop and report" condition, not
+    // a cue to widen the predicate until the number is comfortable.
+    const ComboForeignItemDef* pool = NULL;
+    const int poolCount = Combo_GetForeignItemPool(&pool);
+    FI_ASSERT(poolCount > 0);
+    FI_ASSERT(acceptedCount >= poolCount);
+
+    // ------------------------------------------------------------------
+    // Per-condition negatives, on a real chest row. The positive control is
+    // re-asserted between each one, so a negative can never pass because the
+    // host became ineligible for an unrelated reason.
+    // ------------------------------------------------------------------
+    FI_ASSERT(firstChestId != 0);
+    const uint16_t chest = (uint16_t)firstChestId;
+    FI_ASSERT(MM_Rando_Foreign_IsEligibleHost(chest) == 1);
+
+    // RC_UNKNOWN is never a host, and neither is an out-of-range id.
+    FI_ASSERT(MM_Rando_Foreign_IsEligibleHost(0) == 0);
+    FI_ASSERT(MM_Rando_Foreign_IsEligibleHost((uint16_t)checkIdMax) == 0);
+
+    // Defect A: a user-EXCLUDED check is marked `shuffled = true;
+    // randoItemId = RI_JUNK; skipped = true` by GeneratePools and kept out of
+    // checkPool â€” so under the old predicate it was a top-priority host for a
+    // pinned progression item.
+    MM_Rando_Foreign_TestStampCheck(chest, /*shuffled=*/1, /*skipped=*/1, riJunk);
+    FI_ASSERT(MM_Rando_Foreign_IsEligibleHost(chest) == 0);
+    MM_Rando_Foreign_TestStampCheck(chest, 1, 0, riJunk);
+    FI_ASSERT(MM_Rando_Foreign_IsEligibleHost(chest) == 1);
+
+    // Defect B: RI_UNKNOWN (a zero-initialised or unresolvable slot) and
+    // RI_NONE ("literally nothing") are both declared RITYPE_JUNK, so a
+    // type-only test accepts an item that is not an item.
+    MM_Rando_Foreign_TestStampCheck(chest, 1, 0, riUnknown);
+    FI_ASSERT(MM_Rando_Foreign_IsEligibleHost(chest) == 0);
+    MM_Rando_Foreign_TestStampCheck(chest, 1, 0, riNone);
+    FI_ASSERT(MM_Rando_Foreign_IsEligibleHost(chest) == 0);
+    MM_Rando_Foreign_TestStampCheck(chest, 1, 0, riJunk);
+    FI_ASSERT(MM_Rando_Foreign_IsEligibleHost(chest) == 1);
+
+    // Carried over unchanged from the old predicate: a check outside the fill
+    // is not a host. (The non-junk-item rejection is covered by the sentinel
+    // legs above and by the whole-table sweep, which stamps only junk.)
+    MM_Rando_Foreign_TestStampCheck(chest, /*shuffled=*/0, 0, riJunk);
+    FI_ASSERT(MM_Rando_Foreign_IsEligibleHost(chest) == 0);
+    MM_Rando_Foreign_TestStampCheck(chest, 1, 0, riJunk);
+    FI_ASSERT(MM_Rando_Foreign_IsEligibleHost(chest) == 1);
+
+    // Leave MM's check table as a fresh save would: nothing shuffled, nothing
+    // held. `--test all` runs every row in one process.
+    MM_Rando_Foreign_TestStampAllChecks(/*shuffled=*/0, /*skipped=*/0, riUnknown);
+    FI_ASSERT(MM_Rando_Foreign_IsEligibleHost(chest) == 0);
+
+    printf("[TEST] PASS: only chest-class hosts with a live, non-skipped, legal-junk slot can host a foreign item\n");
     return TEST_PASS;
 }


### PR DESCRIPTION
> **Stacked PR.** Based on Lane 1. Merge order: 3 → 5 → 1 → **2** → 6 → 4. This will be rebased onto `main` once the lanes below it land, so its diff reduces to just this lane.

MM's CheckQueue only reaches a foreign (cross-game) placement from inside `if (randoSaveCheck.eligible)`, so a host check whose `.eligible` bit is never armed strands its pinned OoT progression item permanently — invisible in-game, unwinnable, and indistinguishable from an item that was never placed. Host selection previously used a blocklist ("shuffled, holds a junk-class item, not a shop") over a check table that carries no give-path information at all, which admitted user-excluded checks and the RI_UNKNOWN/RI_NONE sentinels. This lane replaces that with an allowlist of check classes whose arming chain has actually been traced, reapplies the same rule on the spoiler-load path, and turns a short placement into a failed generation instead of a log line.

## What changed

- **Host-eligibility predicate** — `games/mm/2s2h/Rando/Foreign.cpp`, `games/mm/2s2h/Rando/Foreign.h`: new `Rando::Foreign::IsEligibleHost(RandoCheckId)`, backed by `IsAllowedHostClass`. Ships Tier A only: `RCTYPE_CHEST` carrying `FLAG_CYCL_SCENE_CHEST` (arming chain `z_en_box.c` → `Flags_SetTreasure` → `OnFlagSet`), with shops/tingle shops still excluded explicitly. Also rejects `.skipped` rows (a user-EXCLUDED check is written `shuffled = true; randoItemId = RI_JUNK; skipped = true` by `Logic/GeneratePools.cpp` and kept out of checkPool — under the old rule it was a *top-priority* host) and the `RI_UNKNOWN` / `RI_NONE` sentinels, both of which are declared `RITYPE_JUNK` but are not items. Tier B (`flagType != FLAG_NONE` minus `FLAG_RANDO_INF`) is written but compiled out behind `RSBS_FOREIGN_HOST_TIER_B`; the `FLAG_WEEK_EVENT_REG`-backed NPC/MINIGAME rows have not been audited for a rando VB hook that replaces the give and suppresses the vanilla flag write.
- **Selection loop** — `games/mm/2s2h/Rando/Foreign.cpp`: `PlaceForeignItems`' candidate loop now calls the extracted predicate rather than an inline condition, preserving ascending-`RandoCheckId` determinism. The per-generation stderr line now reports eligible host supply, since Tier A drops the candidate set from ~2000 to a few dozen.
- **Shortfall is fatal** — `games/mm/2s2h/Rando/MiscBehavior/OnFileCreate.cpp`: **note for reviewers of adjacent work — this adds roughly a 15-line block (plus comment) at the `PlaceForeignItems()` call site.** The previously discarded return value is now compared against `Combo_GetForeignItemPool`'s count, and a shortfall throws inside the existing try so the file reverts to vanilla exactly as any fill dead-end does ("no retries, revert"). The message names both possible causes (hosts exhausted, or `Combo_SetForeignPlacement` refusing an insert). It cannot fire when pairing is inactive — an empty pool makes the comparison `0 < 0`.
- **Spoiler-load path reapplies the rule** — `games/mm/2s2h/Rando/Spoiler/Apply.cpp`: `ReconstructForeignPlacements` now gates each pending placement on `IsEligibleHost` before `Combo_SetForeignPlacement` (which enforces only tagged-only / no-duplicate / bounded, being deliberately game-agnostic). The `RI_JUNK` normalization was moved *before* the gate, because the gate reads exactly the fields it writes — un-normalized, every legitimate host would be rejected for holding the `RI_UNKNOWN` that `ApplyToSaveContext` leaves behind. On rejection only `shuffled` is restored; the host keeps `RI_JUNK` deliberately, since restoring `RI_UNKNOWN` at a still-shuffled check would arm `.eligible` (OnFlagSet gates on `.shuffled` alone) and then walk the give path with a sentinel. Rejection is loud, not fatal: a summary line names the cause and tells the player to regenerate.
- **ROM-free lock** — `src/common/tests/test_foreign_items.c`, `src/common/test_runner.cpp`, `CMake/SingleExecutable.cmake`: new `foreign-host-eligibility` test (`ForeignHostEligibility` CTest target). It drives `MM_Rando_Foreign_IsEligibleHost` — the same function the candidate loop calls — over MM's real `Rando::StaticData::Checks` map with a synthetic all-shuffled save, asserting acceptance is exactly the `RCTYPE_CHEST` rows, that every chest row carries `FLAG_CYCL_SCENE_CHEST`, and that accepted supply covers the pinned pool. Supported by new inspection/stamping bridges at the bottom of `Foreign.cpp` (`MM_Rando_Foreign_TestCheckIdMax`, `TestCheckClass`, `TestStampCheck`, `TestStampAllChecks`, `TestItemSentinels`), which exist only so `src/common` can reach MM static data and `RANDO_SAVE_CHECKS`.
- **Gameplay-tier post-condition repaired** — `games/mm/2s2h/mm_rando_gen_test.cpp`: `FAIL(12)` previously asserted "shuffled && holds a junk-class item", a textual copy of the selector, so it could not catch a bad host class by construction. It now reads the property straight from the static table (`RCTYPE_CHEST` + `FLAG_CYCL_SCENE_CHEST`), independent of the predicate; the `IsEligibleHost` call is kept beside it and labelled as what it is — a tie-back catching an `mmCheckId` corrupted in the u16 round trip. New `FAIL(22)` covers the spoiler-load reject path, which otherwise shipped untested.

## Why

The order matters: the load-path gate has to land with the tightening, not after it. A spoiler written by a build predating this change names hosts the give path can never deliver, so reconstruction without the gate would strand crossings exactly as before — and the operator has been playtesting on real slots since 2026-07-21.

A note on what Tier A guarantees: 31 of the 128 chest rows hold a stray fairy in vanilla and take a `z_en_box.c` branch that never calls `Flags_SetTreasure`. They arm because the rando `EnBox` ShouldActorInit hook rewrites the contained item first, and that hook bails on `!shuffled` — the same bit this predicate requires. The guarantee is "armed for every check this predicate accepts", not "armed with zero rando code involved". The code comments say so rather than overclaiming.

Measured on a real paired fill: **35 eligible foreign-item hosts** (128 chest rows before the fill's junk distribution), with all 4 pinned pool items placed.

## Testing

- The stacked tip passes `ctest -L "^redship$"` locally (54/54), including the new `ForeignHostEligibility` target.
- Hosted CI covers the compile and ROM-free tiers only. The gameplay tier (`int-*`) — which is where `MM_Rando_HeadlessGenTest`'s `FAIL(12)`/`FAIL(22)` legs and the 35-host measurement actually run — requires a self-hosted ROM runner that is not configured, so that tier is not exercised by CI on this PR.

Closes #488

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!--- section:artifacts:start -->
### Build Artifacts
  - [rsbs-windows.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/8574940674.zip)
  - [rsbs-linux.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/8574630170.zip)
<!--- section:artifacts:end -->