### PR TITLE
Wire MM's real foreign-item give and make cross-game arrivals visible in both games

### DIFF
--- a/.github/clang-format-paths.txt
+++ b/.github/clang-format-paths.txt
@@ -32,6 +32,7 @@ games/mm/2s2h/GameExports_SingleExe.cpp
 games/mm/2s2h/GameInteractorEventsSingleExe.cpp
 games/mm/2s2h/Rando/Foreign.cpp
 games/mm/2s2h/Rando/Foreign.h
+games/mm/2s2h/Rando/ForeignItemsSingleExe.cpp
 games/mm/2s2h/ShipInit.hpp
 games/mm/2s2h/TrackersGuiSingleExe.cpp
 games/mm/2s2h/TrackersGuiSingleExe.h

--- a/CMake/SingleExecutable.cmake
+++ b/CMake/SingleExecutable.cmake
@@ -360,6 +360,12 @@ if(BUILD_TESTING)
     # world unwinnable with no error. Drives the real selection predicate over
     # MM's real check table; also prints the eligible-host supply count.
     redship_add_test(NAME ForeignHostEligibility COMMAND redship --test foreign-host-eligibility)
+    # #502: MM's award callback was still the Lane A1 logging stub, so the whole
+    # consumer walk landed on a no-op. Drives the REAL MM_ConsumeSharedItems ->
+    # MM_AwardSharedItem -> MM_ForeignItem_Give chain and asserts one award per
+    # crossing, order preservation, origin filtering, and that a NULL PlayState
+    # defers the give instead of dereferencing it.
+    redship_add_test(NAME ForeignAwardMM COMMAND redship --test foreign-award-mm)
     redship_add_test(NAME ComboSpoilerView COMMAND redship --test combo-spoiler-view)
     redship_add_test(NAME ComboSpoilerWindow COMMAND redship --test combo-spoiler-window)
     # Cross-game session invalidation (#440). A soft reset or a new game must

--- a/games/mm/2s2h/GameExports_SingleExe.cpp
+++ b/games/mm/2s2h/GameExports_SingleExe.cpp
@@ -1760,19 +1760,36 @@ extern "C" bool MM_GameHooks_ExecuteShouldItemGive(u8 item) {
     return result;
 }
 
+// MM's foreign-item give (2s2h/Rando/ForeignItemsSingleExe.cpp). Declared here
+// rather than in src/common/foreign_items.h — which is where its OoT twin is
+// declared — because that header is Lane 1's and the MM pool surface lands in
+// it with the reverse-direction pool, not with this give. Fold this in then.
+extern "C" int MM_ForeignItem_Give(uint16_t riId);
+
 /**
  * Award a single MM-origin shared item (ADR 0002 / Lane A1 consumer callback),
  * the MM twin of OoT_AwardSharedItem. `item->id` is an MM RandoItemId (RI_*).
  *
- * Lane A1 scope: plumbing seam only — it logs; Combo_RedeemSharedItemsForGame
- * still marks the entry RSBS_SHARED_ITEM_REDEEMED so the crossing is single-use
- * once wired. Lane C replaces the log with MM's real give (Rando::GiveItem /
- * MM_Item_Give) for the chosen foreign-item class; do NOT clear the entry.
+ * The give itself lives in MM_ForeignItem_Give
+ * (2s2h/Rando/ForeignItemsSingleExe.cpp), which dispatches into Rando::GiveItem
+ * when a PlayState is live and otherwise QUEUES for the next gameplay frame.
+ * The queue is not incidental: this callback runs from
+ * MM_Play_ConsumeStartupEntrance (z_play.c:2406), which is BEFORE
+ * `MM_gPlayState = this` (z_play.c:2468), and MM's give path is not NULL-play
+ * tolerant the way OoT's starting-item give is. See that file's header for the
+ * full argument, including why the deferral window cannot lose an item.
+ *
+ * Combo_RedeemSharedItemsForGame marks the entry RSBS_SHARED_ITEM_REDEEMED
+ * after this returns, so the crossing stays single-use; the entry is never
+ * cleared (the durable record of the crossing). A give that reports failure is
+ * logged but still consumes the redemption — an unresolvable id is a data bug,
+ * not something to retry on every future arrival.
  */
 static void MM_AwardSharedItem(const SharedItem* item, void* ctx) {
     (void)ctx;
-    fprintf(stderr, "[MM] shared-item redeem (Lane A1 plumbing): RI id=%u — Lane C wires the MM give\n",
-            (unsigned)item->id);
+    int given = MM_ForeignItem_Give(item->id);
+    fprintf(stderr, "[MM] shared-item redeem: RI id=%u %s (Lane 6 foreign give)\n", (unsigned)item->id,
+            given ? "awarded or queued for the next gameplay frame" : "NOT awarded — no such MM item");
 }
 
 /**

--- a/games/mm/2s2h/Rando/ActorBehavior/EnBox.cpp
+++ b/games/mm/2s2h/Rando/ActorBehavior/EnBox.cpp
@@ -4,6 +4,10 @@
 #include "2s2h/Rando/StaticData/StaticData.h"
 #include "2s2h/ShipInit.hpp"
 #include "assets/2s2h_assets.h"
+#ifdef RSBS_SINGLE_EXECUTABLE
+#include "2s2h/Rando/Rando.h"    // Rando::DrawForeignCheckAura
+#include "2s2h/Rando/Foreign.h"  // Lane 6 (#494 slice 6): IsForeignCheck
+#endif
 
 extern "C" {
 #include "variables.h"
@@ -54,6 +58,29 @@ void EnBox_RandoPostLimbDraw(PlayState* play, s32 limbIndex, Gfx** dList, Vec3s*
     EnBox* enBox = (EnBox*)actor;
     RandoItemId randoItemId = Rando::ConvertItem(RANDO_SAVE_CHECKS[ENBOX_RC].randoItemId, (RandoCheckId)ENBOX_RC);
     RandoItemType randoItemType = Rando::StaticData::Items[randoItemId].randoItemType;
+#ifdef RSBS_SINGLE_EXECUTABLE
+    // Lane 6 (#494 slice 6). A chest hosting a cross-game item still holds its
+    // junk-class MM filler in RANDO_SAVE_CHECKS — the placement table overrides
+    // that only inside CheckQueue's give, i.e. AFTER the player has already
+    // opened it (ADR 0002: a raw RG_* must never enter an MM table). So without
+    // this the chest renders plain, and a pinned OoT progression item is
+    // indistinguishable in the world from a green rupee.
+    //
+    // Chests are also the ONLY class that can host one: Rando::Foreign's Tier A
+    // restricts eligible hosts to RCTYPE_CHEST (#488), which is why this is the
+    // one geometry that needs the override rather than a sweep over every draw
+    // path. If Tier A widens, the new classes need the same treatment —
+    // Rando::DrawItemForCheck is the generic form for those.
+    //
+    // RITYPE_MAJOR rather than a bespoke texture set: the ornate corner/lock
+    // already means "worth opening", which a pinned progression item is, and
+    // inventing a foreign-specific chest texture is the per-item asset tier
+    // #494 puts out of scope. The particle aura below is what makes it
+    // unambiguous — no other chest in the game sparkles.
+    if (Rando::Foreign::IsForeignCheck((RandoCheckId)ENBOX_RC)) {
+        randoItemType = RITYPE_MAJOR;
+    }
+#endif
     if (enBox->unk_1EC != 0 && actor->home.rot.z == 0) {
         actor->home.rot.z = randoItemType + 1;
     }
@@ -127,6 +154,15 @@ void EnBox_RandoPostLimbDraw(PlayState* play, s32 limbIndex, Gfx** dList, Vec3s*
 void EnBox_RandoDraw(Actor* actor, PlayState* play) {
     s32 pad;
     EnBox* enBox = (EnBox*)actor;
+
+#ifdef RSBS_SINGLE_EXECUTABLE
+    // The other half of the foreign-chest marker (see EnBox_RandoPostLimbDraw).
+    // Emitted here, once per frame, rather than in the post-limb callback,
+    // which runs per limb and would spawn the effect several times a frame.
+    if (Rando::Foreign::IsForeignCheck((RandoCheckId)ENBOX_RC)) {
+        Rando::DrawForeignCheckAura(actor);
+    }
+#endif
 
     OPEN_DISPS(play->state.gfxCtx);
 

--- a/games/mm/2s2h/Rando/DrawItem.cpp
+++ b/games/mm/2s2h/Rando/DrawItem.cpp
@@ -3,6 +3,9 @@
 #include "2s2h/ShipInit.hpp"
 #include "2s2h/Rando/DrawFuncs.h"
 #include "2s2h_assets.h"
+#ifdef RSBS_SINGLE_EXECUTABLE
+#include "2s2h/Rando/Foreign.h" // Lane 6 (#494 slice 6): IsForeignCheck, for the cross-game marker
+#endif
 
 extern "C" {
 #include "variables.h"
@@ -701,6 +704,49 @@ void Rando::DrawItem(RandoItemId randoItemId, Actor* actor) {
 }
 
 #ifdef RSBS_SINGLE_EXECUTABLE
+
+// ============================================================================
+// Cross-game marker (Lane 6, #494 slice 6)
+// ============================================================================
+//
+// THE BUG THIS CLOSES IS A CORRECTNESS BUG, NOT POLISH. Before this, no draw
+// path consulted Rando::Foreign::IsForeignCheck, so a check hosting a foreign
+// item sat in the MM world DISGUISED AS THE JUNK ITEM THE FILL LEFT THERE (the
+// placement table overrides the save's item only inside CheckQueue's give, and
+// only after the player has already committed to collecting it). A cross-game
+// progression item was therefore indistinguishable in the world from a green
+// rupee. That is true identically at 4 pool items and at 32.
+//
+// WHY AN AURA AND NOT THE ORIGIN GAME'S MODEL. Both o2r archives ARE
+// co-mounted — one flat ArchiveManager, additive, never unmounted
+// (rsbs/src/main.cpp EnsureGameArchivesLoaded; MM's LoadMMArchives adds to
+// OoT's manager) — so cross-game asset resolution is NOT ruled out and this
+// lane's "stop and report" condition does not fire. But the origin game's
+// archive only mounts once that game has been entered in this process, and a
+// real per-item 3D model is the one presentation tier that scales per pool
+// entry, which #494 puts explicitly out of scope. So the marker is generic:
+// one signal that means "this belongs to the other game", identical for every
+// foreign item.
+//
+// It is additive rather than a replacement model because the host geometry is
+// already carrying information. A chest states its item CLASS through its
+// corner/lock texture set, and a foreign host is upgraded to the ornate/major
+// set there (EnBox.cpp) — swapping the whole model would throw that away. The
+// aura is what makes it unambiguous rather than merely "a good chest": the
+// kirakira effect is otherwise reserved for a handful of model-less items, so
+// nothing else in the world sparkles at rest.
+//
+// The operator verifies the appearance; CI locks the RESOLUTION SURFACE (every
+// pool entry resolves to a non-null display descriptor), not the pixels.
+void Rando::DrawForeignCheckAura(Actor* actor) {
+    // Actor-gated: DrawSparkles spawns at the actor's world position and
+    // returns immediately without one (a cutscene / get-item draw passes no
+    // actor, and there the textbox already names the item and its origin).
+    if (actor != NULL) {
+        DrawSparkles(RI_NONE, actor);
+    }
+}
+
 // ROM-free harness guard (#392): with no mm.o2r registered,
 // ResourceMgr_LoadGfxByName null-derefs on a missing asset. The real boot
 // path loads MM archives before the ShipInit registrars run. Defined in

--- a/games/mm/2s2h/Rando/ForeignItemsSingleExe.cpp
+++ b/games/mm/2s2h/Rando/ForeignItemsSingleExe.cpp
@@ -1,0 +1,247 @@
+/**
+ * ForeignItemsSingleExe.cpp — the MM-side redemption give for cross-game items
+ * (Lane 6 / #502; ADR 0002, ADR 0005).
+ *
+ * The MM twin of soh/Enhancements/randomizer/ForeignItemsSingleExe.cpp. It is
+ * the ONE MM translation unit where the cross-game item class may name real
+ * RI_* enumerators, because everything leaves it as an origin-tagged SharedItem
+ * (or a display string) and a raw RI_* therefore never crosses a game boundary
+ * (ADR 0002, the #356 bug class). Lane 1 extends this same TU with
+ * kForeignPoolMMV1 — the reverse-direction SOURCE pool — plus its
+ * Combo_RegisterForeignItemPool file-scope registrar; this file deliberately
+ * stops at the give so that boundary stays obvious.
+ *
+ * Lives in 2s2h/Rando/, glob-collected into `2ship_rando`, which links
+ * WHOLE_ARCHIVE — so this TU survives the link with no CMake edit.
+ *
+ * ============================================================================
+ * WHY THE GIVE IS DEFERRED RATHER THAN IMMEDIATE
+ * ============================================================================
+ *
+ * MM's redemption point runs BEFORE MM_gPlayState is assigned:
+ * MM_ConsumeSharedItems() is called from MM_Play_ConsumeStartupEntrance at
+ * z_play.c:2406, while `MM_gPlayState = this` happens at z_play.c:2468. That is
+ * not an accident to be tidied away — the consume has to run after the frozen
+ * save is restored and before gameplay observes it, which is exactly where it
+ * sits.
+ *
+ * MM's give path is not NULL-play tolerant the way OoT's starting-item give is.
+ * Rando::GiveItem's default branch is `MM_Item_Give(MM_gPlayState, itemId)`,
+ * and Item_GiveImpl (z_parameter.c:4136) carries only PARTIAL 2S2H nullptr
+ * guards — the sword and shield branches, added so OnFileCreate could grant
+ * starting items outside gameplay. Three legs still deref `play` unguarded:
+ *
+ *   - Inventory_IncrementSkullTokenCount(play->sceneId)   (:4150, ITEM_SKULL_TOKEN)
+ *   - Interface_LoadItemIconImpl(play, EQUIP_SLOT_C_*) and its Dpad twin, in
+ *     the bottle-content loop                            (:4524-4550)
+ *   - the same pair in the trade-item branch             (:4575, :4583)
+ *
+ * The last two are the ones that make an item-by-item audit treacherous. They
+ * are reached only when the player ALREADY holds a bottle / trade item in that
+ * slot and has it C- or D-equipped — which is impossible at file creation and
+ * entirely ordinary on a mid-game arrival. That is precisely why
+ * Rando::GrantStartingItems' NULL-play gives have never tripped them, and why
+ * its success proves a NULL-play give works for SOME items in SOME save states
+ * rather than for any item. A redemption is the mid-game case by definition.
+ *
+ * The lane brief offers two ways out: restrict the pool to a hand-audited
+ * NULL-play-safe RI_* set, or move redemption to the gameplay-gated frame-tick
+ * safe point shared_items.h:52-64 already defines. This TU takes the second,
+ * for a reason specific to how the work is split: the reverse-direction pool
+ * (kForeignPoolMMV1) is authored by a DIFFERENT lane, later. An allowlist
+ * audited against today's pool would be a correctness guarantee that silently
+ * expires the moment somebody adds a row — the failure mode being a crash on
+ * the arrival path, i.e. the worst place to learn about it. Deferral is
+ * item-agnostic and O(1) in pool size, so it cannot rot that way.
+ *
+ * The deferral is scoped as tightly as it can be: MM_AwardSharedItem still
+ * runs at the presence-gated arrival point and still consumes the redemption
+ * there (Combo_RedeemSharedItemsForGame sets RSBS_SHARED_ITEM_REDEEMED on
+ * return, and we deliberately do NOT clear the entry). Only the give itself
+ * waits, in a process-global RAM queue, for the first gameplay frame with a
+ * live PlayState — a handful of frames later, in the same boot, with no player
+ * input possible in between.
+ *
+ * DURABILITY OF THAT WINDOW. The obvious objection is "redeemed in gComboCtx
+ * but not yet given — a crash there loses the item". It does not: the redeemed
+ * bit only becomes durable when a .redsave is WRITTEN, and no save can be taken
+ * between MM_Play_ConsumeStartupEntrance and the first Play frame. If the
+ * process dies inside that window, the .redsave on disk still shows the entry
+ * un-redeemed and the next arrival re-awards it. The queue therefore never has
+ * to survive a process, which is why it is RAM-only by design rather than by
+ * omission.
+ *
+ * ONE DEPENDENCY WORTH NAMING. The drain hangs off
+ * Rando::MiscBehavior::CheckQueue, which is a COND_ID_HOOK gated on IS_RANDO
+ * (MiscBehavior.cpp:25). A save whose IS_RANDO hooks are not armed therefore
+ * never drains — the #439/#487 class of bug, where an arrival path leaves the
+ * hooks matched against the wrong save. That is the correct coupling rather
+ * than a gap to paper over: a save with no randomizer identity has no business
+ * receiving cross-game randomizer items, and if the hooks are unarmed the
+ * player has much larger problems than one un-given item. It does mean this
+ * give inherits those locks' guarantees, so it is written down here.
+ */
+#ifdef RSBS_SINGLE_EXECUTABLE
+
+#include <cstdio>
+
+#include "Rando/Rando.h"
+#include "Rando/Types.h"
+#include "Rando/StaticData/StaticData.h"
+
+extern "C" {
+#include "variables.h" // MM_gPlayState
+#include "functions.h"
+}
+
+// src/common. Included OUTSIDE any extern "C" block: the header manages its
+// own linkage and pulls in <stdbool.h>/<stdint.h> (matching Foreign.cpp).
+#include "foreign_items.h"
+#include "shared_items.h" // RSBS_SHARED_ITEM_CAP (via context.h)
+
+namespace {
+
+// The pending-give queue. Capacity matches the durable array's, so a full
+// gComboCtx redeeming entirely into MM in one arrival can never overflow it —
+// the queue is not allowed to be the thing that loses an item.
+uint16_t sPendingGives[RSBS_SHARED_ITEM_CAP];
+int sPendingCount = 0;
+
+/**
+ * Is `riId` a real, giveable MM item id?
+ *
+ * RI_UNKNOWN is enumerator 0 — a zero-initialised slot — and RI_NONE is
+ * "literally nothing"; both are declared RITYPE_JUNK, so a type-based test
+ * accepts them (the #488 sentinel trap, same two values, different surface).
+ * An id at or past RI_MAX is out of the table entirely and would index
+ * Rando::StaticData::Items out of range inside the give.
+ */
+bool IsGiveableItemId(uint16_t riId) {
+    return riId != (uint16_t)RI_UNKNOWN && riId != (uint16_t)RI_NONE && riId < (uint16_t)RI_MAX;
+}
+
+/** The actual give. Precondition: MM_gPlayState != NULL and the id is real. */
+void GiveNow(uint16_t riId) {
+    Rando::GiveItem((RandoItemId)riId);
+}
+
+} // namespace
+
+// ============================================================================
+// Redemption give (called by MM_AwardSharedItem, the A1 consumer callback)
+// ============================================================================
+
+/**
+ * Award one MM-origin foreign item. Gives immediately when a PlayState is live,
+ * otherwise queues for MM_ForeignItem_FlushPending (see the file header for why
+ * that is the safe shape here).
+ *
+ * @return 1 if the item was given or queued for the next gameplay frame,
+ *         0 if the id names no real MM item (logged) or the queue is full.
+ *         The caller's consumer sets RSBS_SHARED_ITEM_REDEEMED either way — a
+ *         give we could not perform is a loud log, not a stalled arrival.
+ */
+extern "C" int MM_ForeignItem_Give(uint16_t riId) {
+    if (!IsGiveableItemId(riId)) {
+        fprintf(stderr, "[MM] foreign give: RI id=%u names no real MM item — not given\n", (unsigned)riId);
+        return 0;
+    }
+
+    if (MM_gPlayState != NULL) {
+        GiveNow(riId);
+        return 1;
+    }
+
+    if (sPendingCount >= (int)RSBS_SHARED_ITEM_CAP) {
+        // Unreachable while the queue is sized to the durable array (one
+        // arrival cannot redeem more entries than the array holds), so this is
+        // a guard against a future resize, not an expected path.
+        fprintf(stderr, "[MM] foreign give: pending queue full, dropping RI id=%u\n", (unsigned)riId);
+        return 0;
+    }
+    sPendingGives[sPendingCount++] = riId;
+    return 1;
+}
+
+/**
+ * Drain the pending queue once a PlayState is live. Called every frame from
+ * Rando::MiscBehavior::CheckQueue (the gameplay-gated per-frame rando hook),
+ * BEFORE its own early-out, so a queued give is not held behind a queued check.
+ *
+ * Order is preserved: Combo_RedeemSharedItemsForGame awards in slot order and
+ * that order is a contract (progressive items resolve against the live save, so
+ * order changes WHAT the player receives — shared_items.h). The queue is FIFO
+ * for the same reason.
+ *
+ * @return the number of items given this call (0 when there is nothing pending
+ *         or no live PlayState).
+ */
+extern "C" int MM_ForeignItem_FlushPending(void) {
+    if (sPendingCount == 0 || MM_gPlayState == NULL) {
+        return 0;
+    }
+
+    const int count = sPendingCount;
+    // Clear the queue BEFORE giving. A give re-entering this function (an item
+    // whose give path spins the frame loop) must not see the same entries
+    // again; re-entrancy that re-gave would be a duplicate the redeemed bit
+    // cannot catch, because the crossing was already consumed.
+    uint16_t drained[RSBS_SHARED_ITEM_CAP];
+    for (int i = 0; i < count; i++) {
+        drained[i] = sPendingGives[i];
+    }
+    sPendingCount = 0;
+
+    for (int i = 0; i < count; i++) {
+        fprintf(stderr, "[MM] foreign give (deferred to gameplay): RI id=%u\n", (unsigned)drained[i]);
+        GiveNow(drained[i]);
+    }
+    return count;
+}
+
+// ============================================================================
+// ROM-free test bridge (redship tier; src/common/tests/test_foreign_award.c).
+//
+// The give itself needs a PlayState and a loaded save, so the ROM-free tier
+// cannot observe it directly. What it CAN observe — and what the #502 lock is
+// actually about — is that the real consumer walk reaches the real
+// MM_AwardSharedItem, that the award lands here exactly once per crossing, and
+// that a NULL PlayState defers instead of dereferencing. These two accessors
+// are the observable for that; neither is reachable from gameplay.
+// ============================================================================
+
+/** How many gives are waiting for a live PlayState. */
+extern "C" int MM_ForeignItem_TestPendingCount(void) {
+    return sPendingCount;
+}
+
+/** The queued id at `index`, or 0 (RI_UNKNOWN) if out of range. */
+extern "C" uint16_t MM_ForeignItem_TestPendingAt(int index) {
+    if (index < 0 || index >= sPendingCount) {
+        return (uint16_t)RI_UNKNOWN;
+    }
+    return sPendingGives[index];
+}
+
+/** Drop the queue without giving. Test isolation only — `--test all` runs every
+ *  row in one process, and a queue left behind would leak into the next row. */
+extern "C" void MM_ForeignItem_TestResetPending(void) {
+    sPendingCount = 0;
+}
+
+/** RI_MAX — the exclusive upper bound for a RandoItemId walk, so a src/common
+ *  test can find real ids without importing MM's enum (the #488 bridge's
+ *  MM_Rando_Foreign_TestCheckIdMax, one enum over). */
+extern "C" int MM_ForeignItem_TestItemIdMax(void) {
+    return (int)RI_MAX;
+}
+
+/** The REAL id predicate MM_ForeignItem_Give gates on. Exposed rather than
+ *  re-derived in the test for the same reason MM_Rando_Foreign_IsEligibleHost
+ *  is: a lock that paraphrases the rule stops testing it the moment the rule
+ *  moves. */
+extern "C" int MM_ForeignItem_TestIsGiveableId(uint16_t riId) {
+    return IsGiveableItemId(riId) ? 1 : 0;
+}
+
+#endif // RSBS_SINGLE_EXECUTABLE

--- a/games/mm/2s2h/Rando/MiscBehavior/CheckQueue.cpp
+++ b/games/mm/2s2h/Rando/MiscBehavior/CheckQueue.cpp
@@ -104,7 +104,17 @@ void Rando::MiscBehavior::CheckQueue() {
                     .drawItem =
                         [](Actor* actor, PlayState* play) {
                             MM_Matrix_Scale(30.0f, 30.0f, 30.0f, MTXMODE_APPLY);
-                            Rando::DrawItem(RI_RUPEE_HUGE);
+                            // #494 slice 6: the same cross-game marker the
+                            // world draws for a foreign host, so the item does
+                            // not change identity between "seen in the chest"
+                            // and "held over Link's head". Unconditional rather
+                            // than via a check-keyed dispatch: this lambda only
+                            // ever runs for a foreign check, and
+                            // CUSTOM_ITEM_PARAM has already been rewritten from
+                            // the RC to an RI by the give above, so there is no
+                            // check id left here to ask about.
+                            Rando::DrawItem(RI_RUPEE_HUGE, actor);
+                            Rando::DrawForeignCheckAura(actor);
                         } });
                 return;
             }

--- a/games/mm/2s2h/Rando/MiscBehavior/CheckQueue.cpp
+++ b/games/mm/2s2h/Rando/MiscBehavior/CheckQueue.cpp
@@ -9,6 +9,8 @@
 #include "Traps.h"
 #ifdef RSBS_SINGLE_EXECUTABLE
 #include "2s2h/Rando/Foreign.h" // Lane C1 (#392): foreign-check lookup + shared-structure recording
+// Lane 6 (#502): drain of the deferred cross-game give (ForeignItemsSingleExe.cpp).
+extern "C" int MM_ForeignItem_FlushPending(void);
 #endif
 
 extern "C" {
@@ -30,6 +32,20 @@ static bool queued = false;
 // fine for both the giving/drawing, as we can call ConvertItem() inside the Give/Draw lambda, but the message we
 // pass to the queue is static and would need to be updated if we allowed multiple items to be queued at once.
 void Rando::MiscBehavior::CheckQueue() {
+#ifdef RSBS_SINGLE_EXECUTABLE
+    // Lane 6 (#502): the gameplay-gated frame tick MM's foreign-item give
+    // defers onto. MM's redemption point (MM_Play_ConsumeStartupEntrance)
+    // runs before `MM_gPlayState = this`, so the award callback queues rather
+    // than dereferencing a null play; this is where the queue drains. See
+    // 2s2h/Rando/ForeignItemsSingleExe.cpp for the full argument.
+    //
+    // ABOVE the `queued` early-out on purpose: a pending cross-game give must
+    // not be held behind an unrelated in-world check that happens to be
+    // mid-cutscene. The flush is a cheap counter read when nothing is pending,
+    // which is every frame but the handful after an arrival.
+    MM_ForeignItem_FlushPending();
+#endif
+
     if (queued) {
         return;
     }

--- a/games/mm/2s2h/Rando/Rando.h
+++ b/games/mm/2s2h/Rando/Rando.h
@@ -14,6 +14,14 @@ namespace Rando {
 
 void Init();
 void DrawItem(RandoItemId randoItemId, Actor* actor = nullptr);
+#ifdef RSBS_SINGLE_EXECUTABLE
+// Lane 6 (#494 slice 6): the particle aura that marks a check as holding a
+// cross-game item, so a player can SEE that before collecting it. An aura
+// rather than a replacement model because the host class already conveys item
+// class through its own geometry (a chest's ornate corner/lock set) and should
+// keep doing so. Defined in DrawItem.cpp; no-op without an actor.
+void DrawForeignCheckAura(Actor* actor);
+#endif
 void GiveItem(RandoItemId randoItemId);
 void RemoveItem(RandoItemId randoItemId);
 RandoItemId CurrentJunkItem();

--- a/games/oot/soh/GameExports_SingleExe.cpp
+++ b/games/oot/soh/GameExports_SingleExe.cpp
@@ -25,6 +25,7 @@
 #include "entrance.h"
 #include "soh/Enhancements/game-interactor/GameInteractor.h"
 #include "soh/Enhancements/game-interactor/GameInteractor_Hooks.h"
+#include "soh/Notification/Notification.h" // Lane 6 (#494): the foreign-arrival toast
 // SET_NEXT_GAMESTATE for the gameplay round-trip driver. Must come after
 // GameInteractor.h (-> z64.h): macros.h declares `extern GraphicsContext*`
 // and needs the type defined first.
@@ -1037,6 +1038,36 @@ static void OoT_AwardSharedItem(const SharedItem* item, void* ctx) {
     int given = OoT_ForeignItem_Give(item->id);
     fprintf(stderr, "[OoT] shared-item redeem: RG id=%u %s (Lane C1 foreign give)\n", (unsigned)item->id,
             given ? "awarded" : "NOT awarded — give path unavailable");
+
+    // #494: tell the player. Until this, a cross-game item arrived in OoT with
+    // NO in-game signal at all — the item simply appeared in the inventory, an
+    // arbitrary number of scenes after the MM check that granted it. The MM
+    // side has said "it will be awarded there!" since Lane C1; this is the
+    // other half of that sentence.
+    //
+    // A toast rather than a textbox on purpose: the redeem runs inside
+    // Play_Init (z_play.c:565), before the first frame, where there is no
+    // message context to drive and nothing to dismiss it with. The notification
+    // overlay is the one surface that works from here, and it is also the
+    // surface the arrival ALREADY renders over — MM's rando pickups cross-bind
+    // to this exact Emit (#427 item 1).
+    //
+    // No .itemIcon: resolving one needs a per-item icon-name accessor that
+    // src/common does not have yet (the Combo_GetForeignItemIconName tier of
+    // #494, which lands with Lane 1's pool surface). Emitting text-only is an
+    // existing idiom, not a degradation — the MOD_RANDOMIZER branch in
+    // hook_handlers.cpp omits the icon too — and it is the honest option: a
+    // wrong icon is worse than no icon for an item whose whole point is that it
+    // came from the other game.
+    //
+    // Name comes from the pinned pool via the origin-tagged SharedItem, so this
+    // never fabricates an id-space crossing. It returns NULL when the item's
+    // origin pool is not linked into this build, hence the fallback.
+    const char* foreignName = Combo_GetForeignItemName(*item);
+    Notification::Emit({
+        .prefix = "Received from Termina:",
+        .message = foreignName != nullptr ? foreignName : "a foreign item",
+    });
 }
 
 /**

--- a/src/common/test_runner.cpp
+++ b/src/common/test_runner.cpp
@@ -149,6 +149,7 @@ extern "C" {
 // serialization. FILE SCOPE (compiled as C++) for rsbs::SaveManager; the
 // pipeline symbols it drives are C-linkage and declared in the file.
 #include "tests/test_foreign_items.c"
+#include "tests/test_foreign_award.c"
 
 // Lane C1 in-game spoiler VIEW model (#496): the read-only projection of
 // gComboCtx.foreignPlacements the combo spoiler window renders — named
@@ -1408,6 +1409,11 @@ const TestDescriptor gTests[] = {
     {"foreign-host-eligibility",
      "Foreign hosts limited to game-armed check classes; skipped/sentinel slots rejected (#488)",
      Test_ForeignHostEligibility},
+    // #502: MM's half of the crossing. The reverse row above deliberately stops
+    // at a test award callback because MM_AwardSharedItem was a placeholder
+    // fprintf; this one drives the real one and the real give behind it.
+    {"foreign-award-mm", "MM's real award reaches the real give: once per crossing, deferred safely (#502)",
+     Test_ForeignAwardMM},
     {"combo-spoiler-view", "In-game spoiler view model: named crossings, collected state, unpaired != empty (#496)",
      Test_ComboSpoilerView},
     {"combo-spoiler-window", "Common-owned spoiler window registers de-collided; inert under every active game (#496)",

--- a/src/common/tests/test_foreign_award.c
+++ b/src/common/tests/test_foreign_award.c
@@ -1,0 +1,262 @@
+/**
+ * @file test_foreign_award.c
+ * @brief ROM-free lock for the MM-side foreign-item AWARD (Lane 6 / #502).
+ *
+ * The gap this closes is stated verbatim in test_foreign_items.c's reverse row:
+ * that lock drives Combo_RedeemSharedItemsForGame with a TEST award callback,
+ * "which is still a Lane-C placeholder fprintf, so asserting through it would
+ * assert nothing". This file asserts through the REAL one.
+ *
+ * The chain under test, end to end, with no stand-ins:
+ *
+ *   Combo_RecordSharedItem(GAME_MM, id)     the real in-process producer
+ *     -> MM_ConsumeSharedItems()            MM's real consumer hook (the exact
+ *                                           function z_play.c:2406 calls)
+ *       -> Combo_RedeemSharedItemsForGame   the real consumer walk
+ *         -> MM_AwardSharedItem             MM's real award callback
+ *           -> MM_ForeignItem_Give          the real give entry point
+ *
+ * WHAT IS OBSERVABLE AT THIS TIER, AND WHY THAT IS THE INTERESTING PART.
+ * The give's terminal step (Rando::GiveItem) needs a live PlayState and a
+ * loaded MM save, neither of which exists in a display-free test process. That
+ * is not a limitation being worked around — it is precisely the production
+ * condition #502 has to survive. MM's redemption point runs BEFORE
+ * `MM_gPlayState = this` (z_play.c:2406 vs :2468), and MM's give path is not
+ * NULL-play tolerant: Item_GiveImpl's Health_ChangeBy / Magic_Add /
+ * Inventory_IncrementSkullTokenCount legs deref `play` unguarded. So the give
+ * defers into a pending queue and drains on the first gameplay frame
+ * (2s2h/Rando/ForeignItemsSingleExe.cpp).
+ *
+ * A test process is therefore in EXACTLY the state the arrival point is in —
+ * MM_gPlayState == NULL — and the pending queue is a faithful observable for
+ * "the award reached the give". A build that regressed to the unguarded
+ * immediate give would not fail an assertion here; it would segfault, which is
+ * a louder red than any assertion.
+ *
+ * Linkage note: #included into test_runner.cpp at FILE SCOPE, compiled as C++
+ * like its siblings. Every symbol it drives is C-linkage.
+ */
+
+#include "../context.h"
+#include "../foreign_items.h"
+#include "../shared_items.h"
+#include "../test_runner.h"
+
+#include <cstdio>
+#include <cstring>
+
+extern "C" {
+// MM's real consumer hook (GameExports_SingleExe.cpp) — C linkage because
+// z_play.c calls it. Driving THIS rather than Combo_RedeemSharedItemsForGame
+// directly is what puts MM_AwardSharedItem, which is static, under test.
+void MM_ConsumeSharedItems(void);
+
+// The give's test surface (2s2h/Rando/ForeignItemsSingleExe.cpp).
+int MM_ForeignItem_Give(uint16_t riId);
+int MM_ForeignItem_FlushPending(void);
+int MM_ForeignItem_TestPendingCount(void);
+uint16_t MM_ForeignItem_TestPendingAt(int index);
+void MM_ForeignItem_TestResetPending(void);
+int MM_ForeignItem_TestItemIdMax(void);
+int MM_ForeignItem_TestIsGiveableId(uint16_t riId);
+
+// The RandoItemId sentinels, from the #488 bridge block in Rando/Foreign.cpp.
+void MM_Rando_Foreign_TestItemSentinels(uint16_t* outJunk, uint16_t* outNone, uint16_t* outUnknown);
+}
+
+#define FA_ASSERT(cond)                                                                                                \
+    do {                                                                                                               \
+        if (!(cond)) {                                                                                                 \
+            printf("[TEST] FAIL: %s:%d: %s\n", __FILE__, __LINE__, #cond);                                             \
+            return TEST_FAIL;                                                                                          \
+        }                                                                                                              \
+    } while (0)
+
+TestResult Test_ForeignAwardMM(void) {
+    printf("[TEST] foreign-award-mm: MM's real award callback reaches the real give, once per crossing (#502)\n");
+
+    uint16_t riJunk = 0xFFFF;
+    uint16_t riNone = 0xFFFF;
+    uint16_t riUnknown = 0xFFFF;
+    MM_Rando_Foreign_TestItemSentinels(&riJunk, &riNone, &riUnknown);
+    const int itemIdMax = MM_ForeignItem_TestItemIdMax();
+    FA_ASSERT(itemIdMax > 1);
+
+    // ------------------------------------------------------------------
+    // The id predicate, driven directly (it is the real one, not a copy).
+    // ------------------------------------------------------------------
+    // RI_UNKNOWN is enumerator 0 and RI_NONE is "literally nothing"; both are
+    // declared RITYPE_JUNK, so a type-based test accepts them — the same
+    // sentinel trap #488 found on the HOST side, here on the ITEM side. An id
+    // at or past RI_MAX would index StaticData::Items out of range inside the
+    // give, which is a read past the end of a real array, not a benign no-op.
+    FA_ASSERT(riUnknown == 0);
+    FA_ASSERT(!MM_ForeignItem_TestIsGiveableId(riUnknown));
+    FA_ASSERT(!MM_ForeignItem_TestIsGiveableId(riNone));
+    FA_ASSERT(!MM_ForeignItem_TestIsGiveableId((uint16_t)itemIdMax));
+    FA_ASSERT(!MM_ForeignItem_TestIsGiveableId((uint16_t)(itemIdMax + 1)));
+    FA_ASSERT(MM_ForeignItem_TestIsGiveableId(riJunk));
+
+    // Two distinct real ids for the order leg below, taken from the table
+    // rather than hardcoded so this does not rot against the enum.
+    uint16_t idA = 0;
+    uint16_t idB = 0;
+    for (int id = 1; id < itemIdMax; id++) {
+        if (!MM_ForeignItem_TestIsGiveableId((uint16_t)id)) {
+            continue;
+        }
+        if (idA == 0) {
+            idA = (uint16_t)id;
+        } else if (idB == 0) {
+            idB = (uint16_t)id;
+            break;
+        }
+    }
+    FA_ASSERT(idA != 0 && idB != 0 && idA != idB);
+
+    // ------------------------------------------------------------------
+    // Clean slate.
+    // ------------------------------------------------------------------
+    ComboContext_Init();
+    Combo_ClearSharedItemOutbox();
+    MM_ForeignItem_TestResetPending();
+    FA_ASSERT(MM_ForeignItem_TestPendingCount() == 0);
+
+    // ------------------------------------------------------------------
+    // (1) One crossing: real producer -> real consumer -> real award -> give.
+    // ------------------------------------------------------------------
+    FA_ASSERT(Combo_RecordSharedItem(GAME_MM, idA) >= 0);
+    FA_ASSERT(Combo_CountSharedItems(GAME_MM, /*includeRedeemed=*/false) == 1);
+
+    MM_ConsumeSharedItems();
+
+    // The award reached the give exactly once, carrying the right id.
+    FA_ASSERT(MM_ForeignItem_TestPendingCount() == 1);
+    FA_ASSERT(MM_ForeignItem_TestPendingAt(0) == idA);
+    // ...and the crossing is retired in gComboCtx: redeemed, still present.
+    FA_ASSERT(gComboCtx.sharedItemsTagged[0].originGame == (uint8_t)GAME_MM);
+    FA_ASSERT(gComboCtx.sharedItemsTagged[0].id == idA);
+    FA_ASSERT((gComboCtx.sharedItemsTagged[0].flags & RSBS_SHARED_ITEM_REDEEMED) != 0);
+    FA_ASSERT(Combo_CountSharedItems(GAME_MM, /*includeRedeemed=*/false) == 0);
+    FA_ASSERT(Combo_CountSharedItems(GAME_MM, /*includeRedeemed=*/true) == 1);
+
+    // ------------------------------------------------------------------
+    // (2) Single-use: a second arrival awards nothing.
+    // ------------------------------------------------------------------
+    // This is the assertion the placeholder fprintf could never make. A give
+    // that cleared the entry, or a consumer that re-awarded a redeemed one,
+    // shows up here as a second queue entry.
+    MM_ConsumeSharedItems();
+    FA_ASSERT(MM_ForeignItem_TestPendingCount() == 1);
+
+    // ------------------------------------------------------------------
+    // (3) The NULL-play deferral is real, not incidental.
+    // ------------------------------------------------------------------
+    // The flush must decline while MM_gPlayState is NULL — which it is, here
+    // and at MM's arrival point — and must NOT drop what it declined to give.
+    // A flush that fired anyway would not fail this assertion; it would crash
+    // inside Item_GiveImpl. Both outcomes are red; only one is legible.
+    FA_ASSERT(MM_ForeignItem_FlushPending() == 0);
+    FA_ASSERT(MM_ForeignItem_TestPendingCount() == 1);
+
+    // ------------------------------------------------------------------
+    // (4) Order is preserved across the whole chain.
+    // ------------------------------------------------------------------
+    // Received-order awarding is a contract, not an accident: the give paths
+    // resolve progressive items against the live save, so order changes WHAT
+    // the player receives (shared_items.h). Combo_RedeemSharedItemsForGame
+    // awards in slot order; the pending queue has to be FIFO or that contract
+    // is quietly reversed between the award and the frame that gives.
+    ComboContext_Init();
+    Combo_ClearSharedItemOutbox();
+    MM_ForeignItem_TestResetPending();
+    FA_ASSERT(Combo_RecordSharedItem(GAME_MM, idB) >= 0);
+    FA_ASSERT(Combo_RecordSharedItem(GAME_MM, idA) >= 0);
+    FA_ASSERT(Combo_CountSharedItems(GAME_MM, /*includeRedeemed=*/false) == 2);
+
+    MM_ConsumeSharedItems();
+    FA_ASSERT(MM_ForeignItem_TestPendingCount() == 2);
+    FA_ASSERT(MM_ForeignItem_TestPendingAt(0) == idB); // slot order, not id order
+    FA_ASSERT(MM_ForeignItem_TestPendingAt(1) == idA);
+
+    // ------------------------------------------------------------------
+    // (5) An OoT-origin entry is never awarded to MM.
+    // ------------------------------------------------------------------
+    // The forward direction's items live in the same array. MM's consumer must
+    // filter on originGame, or every OoT-bound crossing gets fed to MM's give
+    // as a raw RI_* — the #356 aliasing class, at the arrival point.
+    ComboContext_Init();
+    Combo_ClearSharedItemOutbox();
+    MM_ForeignItem_TestResetPending();
+    const ComboForeignItemDef* pool = NULL;
+    const int poolCount = Combo_GetForeignItemPool(&pool);
+    FA_ASSERT(poolCount > 0 && pool != NULL);
+    FA_ASSERT(Combo_RecordSharedItem(GAME_OOT, pool[0].item.id) >= 0);
+
+    MM_ConsumeSharedItems();
+    FA_ASSERT(MM_ForeignItem_TestPendingCount() == 0);
+    FA_ASSERT(Combo_CountSharedItems(GAME_OOT, /*includeRedeemed=*/false) == 1); // still owed to OoT
+
+    // ------------------------------------------------------------------
+    // (6) An unresolvable id consumes the redemption but queues nothing.
+    // ------------------------------------------------------------------
+    // A sentinel or out-of-range id in the durable array is a data bug (a
+    // corrupt .redsave, a pool that outgrew its id-space). It must not be
+    // retried on every future arrival, and it must never reach the give.
+    ComboContext_Init();
+    Combo_ClearSharedItemOutbox();
+    MM_ForeignItem_TestResetPending();
+    FA_ASSERT(Combo_RecordSharedItem(GAME_MM, (uint16_t)itemIdMax) >= 0);
+
+    MM_ConsumeSharedItems();
+    FA_ASSERT(MM_ForeignItem_TestPendingCount() == 0);
+    FA_ASSERT((gComboCtx.sharedItemsTagged[0].flags & RSBS_SHARED_ITEM_REDEEMED) != 0);
+    FA_ASSERT(Combo_CountSharedItems(GAME_MM, /*includeRedeemed=*/false) == 0);
+    // The direct entry point reports the refusal rather than swallowing it.
+    FA_ASSERT(MM_ForeignItem_Give(riNone) == 0);
+    FA_ASSERT(MM_ForeignItem_TestPendingCount() == 0);
+
+    // ------------------------------------------------------------------
+    // (7) The presentation RESOLUTION SURFACE (#494).
+    // ------------------------------------------------------------------
+    // Presentation is display-tier: what the player sees is the operator's to
+    // verify, and CI must not pretend otherwise. What CI can honestly lock is
+    // that every surface which HAS to name a foreign item can: the MM pickup
+    // textbox (Rando::Foreign::ForeignNameForCheck), the OoT arrival toast
+    // (Combo_GetForeignItemName in OoT_AwardSharedItem), and both spoilers all
+    // resolve through the same descriptor. An entry with no name degrades all
+    // four at once to "Foreign Treasure", silently.
+    //
+    // Deliberately RED-able: this walks EVERY registered origin's pool, so an
+    // entry added later without a name fails here rather than at whichever
+    // surface the player happens to reach first. It does NOT assert anything
+    // about the icon — that tier needs a per-item icon-name accessor that
+    // src/common does not have yet (see the report note on Lane 1), and
+    // asserting the current hardcoded RI_RUPEE_HUGE stand-in would lock in the
+    // placeholder rather than the contract.
+    for (uint8_t origin = 0; origin < (uint8_t)RSBS_FOREIGN_POOL_ORIGIN_COUNT; origin++) {
+        const ComboForeignItemDef* originPool = NULL;
+        const int n = Combo_GetForeignItemPoolFor(origin, &originPool);
+        if (n == 0) {
+            continue; // that origin's pool TU is not linked in this build
+        }
+        FA_ASSERT(originPool != NULL);
+        for (int i = 0; i < n; i++) {
+            FA_ASSERT(originPool[i].item.originGame == origin);
+            FA_ASSERT(originPool[i].name != NULL && originPool[i].name[0] != '\0');
+            // Through the real accessor the presentation surfaces call, not
+            // just the table field they happen to be stored in.
+            const char* resolved = Combo_GetForeignItemName(originPool[i].item);
+            FA_ASSERT(resolved != NULL && strcmp(resolved, originPool[i].name) == 0);
+        }
+    }
+
+    // Leave global state clean for any subsequent row.
+    MM_ForeignItem_TestResetPending();
+    Combo_ClearSharedItemOutbox();
+    ComboContext_Init();
+
+    printf("[TEST] PASS: MM's real award reaches the real give once per crossing, defers safely, "
+           "preserves order, and filters by origin\n");
+    return TEST_PASS;
+}


### PR DESCRIPTION
> **Stacked PR.** Based on Lane 2, and depends on Lane 1's foreign-pool TU. Merge order: 3 → 5 → 1 → 2 → **6** → 4. This will be rebased onto `main` once the lanes below it land, so its diff reduces to just this lane.

This lane finishes the MM end of a cross-game crossing and gives both ends of it a signal the player can actually see. `MM_AwardSharedItem` was still the Lane A1 logging stub, so every MM-origin crossing was marked `RSBS_SHARED_ITEM_REDEEMED` and then silently dropped — consumed, single-use, never given. On the presentation side, no MM draw path consulted `Rando::Foreign::IsForeignCheck`, so a chest hosting a pinned OoT progression item rendered as the junk item the fill left in `RANDO_SAVE_CHECKS`, and on the OoT side the arrival was silent apart from an stderr line. The give is deferred rather than immediate because MM's redemption point runs before `MM_gPlayState` is assigned and MM's give path is not NULL-play tolerant.

## What changed

**MM redemption give (new TU)**
- `games/mm/2s2h/Rando/ForeignItemsSingleExe.cpp` (new): `MM_ForeignItem_Give(riId)` gives immediately via `Rando::GiveItem` when a `PlayState` is live, otherwise queues into a RAM-only FIFO sized to `RSBS_SHARED_ITEM_CAP`. `MM_ForeignItem_FlushPending()` drains it. Ids are gated by `IsGiveableItemId`, which rejects `RI_UNKNOWN`/`RI_NONE` (both `RITYPE_JUNK`, so a type-based test would accept them) and anything at or past `RI_MAX`. The file header carries the full argument for deferral, including why the window cannot lose an item. This is the MM twin of `soh/Enhancements/randomizer/ForeignItemsSingleExe.cpp` and the one MM TU allowed to name real `RI_*` enumerators under ADR 0002.
- `games/mm/2s2h/GameExports_SingleExe.cpp`: `MM_AwardSharedItem` now calls `MM_ForeignItem_Give` instead of `fprintf`. A give that reports failure is logged but still consumes the redemption — an unresolvable id is a data bug, not something to retry on every arrival.
- `games/mm/2s2h/Rando/MiscBehavior/CheckQueue.cpp`: flush call placed **above** the `queued` early-out, so a pending crossing is not held behind an unrelated in-world check mid-cutscene.

**Why the deferral, concretely**: `Item_GiveImpl` has only partial 2S2H nullptr guards (sword/shield). Three legs still deref `play` unguarded — the skull-token scene read and the `Interface_LoadItemIconImpl` pairs in the bottle-content and trade-item branches. The last two only fire when the player already holds a bottle/trade item in that slot with it C- or D-equipped: impossible at file creation, ordinary on a mid-game arrival. That is why `Rando::GrantStartingItems`' NULL-play gives have never tripped them and why their success does not generalise. A hand-audited allowlist was rejected because the reverse-direction pool (`kForeignPoolMMV1`) is authored by another lane; deferral is item-agnostic and O(1) in pool size.

**MM world marker for a foreign check**
- `games/mm/2s2h/Rando/DrawItem.cpp`: new `Rando::DrawForeignCheckAura(Actor*)` — a kirakira sparkle emit, actor-gated (no-op without an actor). Declared in `games/mm/2s2h/Rando/Rando.h` under `RSBS_SINGLE_EXECUTABLE`.
- `games/mm/2s2h/Rando/ActorBehavior/EnBox.cpp`: `EnBox_RandoPostLimbDraw` forces `RITYPE_MAJOR` (ornate corner/lock texture set) when `Rando::Foreign::IsForeignCheck(ENBOX_RC)`; `EnBox_RandoDraw` emits the aura once per frame rather than per limb. Chests are the only class touched because `Rando::Foreign`'s Tier A restricts eligible hosts to `RCTYPE_CHEST` (#488).
- `games/mm/2s2h/Rando/MiscBehavior/CheckQueue.cpp`: the get-item draw lambda takes the same aura, so the check does not change identity between "seen in the chest" and "held over Link's head".

**OoT arrival toast**
- `games/oot/soh/GameExports_SingleExe.cpp`: `OoT_AwardSharedItem` now emits a `Notification::Emit` toast ("Received from Termina:" + the item name from `Combo_GetForeignItemName`, with a fallback when the origin pool is not linked into the build). A toast rather than a textbox because the redeem runs inside `Play_Init` before the first frame, where there is no message context to drive and nothing to dismiss it with.

**Test + build**
- `src/common/tests/test_foreign_award.c` (new) and `src/common/test_runner.cpp`: `foreign-award-mm` row drives the real chain end to end — `Combo_RecordSharedItem` → `MM_ConsumeSharedItems` → `MM_AwardSharedItem` → `MM_ForeignItem_Give` — asserting one award per crossing, single-use on a second arrival, FIFO order (order changes what a progressive resolves to), origin filtering, and that a NULL `PlayState` defers instead of dereferencing. Verified non-vacuous: stubbing the award back out turns the row red.
- Test-only bridges (`MM_ForeignItem_TestPendingCount/At/ResetPending/ItemIdMax/IsGiveableId`) live in the new TU; `TestIsGiveableId` exposes the real predicate rather than paraphrasing it, so the lock cannot drift from the rule.
- `CMake/SingleExecutable.cmake`: registers the `ForeignAwardMM` ctest row. `.github/clang-format-paths.txt`: adds the new TU.

## Why

CI locks the resolution surface, not the pixels: every entry in every registered pool must resolve to a non-null display name through the same accessor the toast, MM's textbox and both spoilers use. The visual appearance is the operator's to verify. The aura is additive rather than a model swap so the chest keeps stating item class through its own geometry — and the kirakira effect is otherwise reserved for a handful of model-less items, so nothing else in the world sparkles at rest.

The drain hangs off `Rando::MiscBehavior::CheckQueue`, a `COND_ID_HOOK` gated on `IS_RANDO`. A save whose IS_RANDO hooks are not armed therefore never drains (the #439/#487 class). That coupling is deliberate and documented in the TU header: a save with no randomizer identity has no business receiving cross-game randomizer items.

## Known follow-up (not a blocker)

The **#494 icon tier is deferred and unbuilt**. Putting an icon on the OoT arrival toast needs a `Combo_GetForeignItemIconName` accessor that does not exist in `src/common` yet; it lands with Lane 1's foreign-pool surface. Text-only emit is an existing idiom (the `MOD_RANDOMIZER` branch in `hook_handlers.cpp` omits the icon too), and a wrong icon is worse than none for an item whose whole point is that it came from the other game. Similarly out of scope: rendering the origin game's actual item model, which is the one presentation tier that scales per pool entry.

**Dependency**: this lane depends on Lane 1's foreign-pool translation unit. `Combo_GetForeignItemName` resolves through the origin-tagged `SharedItem` against a registered pool, and `kForeignPoolMMV1` plus its `Combo_RegisterForeignItemPool` registrar are authored by Lane 1 in this same MM TU. `MM_ForeignItem_Give` is declared locally in `GameExports_SingleExe.cpp` rather than in `src/common/foreign_items.h` (where its OoT twin lives) for the same reason; fold the declaration in when Lane 1's pool surface lands.

## Testing

The stacked tip passes `ctest -L "^redship$"` locally, including the new `ForeignAwardMM` row. Hosted CI covers the compile and ROM-free tiers only — the gameplay tier (`int-*`) is not exercised here, as it needs a self-hosted ROM runner that is not configured. In-world appearance of the chest marker and the arrival toast is operator-verified, not CI-verified.

Closes #502
Refs #494

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!--- section:artifacts:start -->
### Build Artifacts
  - [rsbs-windows.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/8575940447.zip)
  - [rsbs-linux.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/8575301428.zip)
<!--- section:artifacts:end -->