### PR TITLE
Give MM's 47 randomizer options a settable host, and make the paired MM profile a decision with a recorded identity

### DIFF
--- a/CMake/SingleExecutable.cmake
+++ b/CMake/SingleExecutable.cmake
@@ -39,6 +39,12 @@ set(REDSHIP_COMMON_SOURCES
     ${CMAKE_SOURCE_DIR}/src/common/combo_spoiler_view.c
     # The window that renders it — the first common-owned Gui element (ADR 0008)
     ${CMAKE_SOURCE_DIR}/src/common/ComboSpoilerWindow.cpp
+    # MM randomizer options: the registry + value accessors over the descriptor
+    # table MM publishes (#497 step 4, #499), and the pane that draws it. The
+    # pane is common-owned because it must be reachable while OoT is running —
+    # the paired MM profile snapshots at MM's arrival and is never regenerated
+    ${CMAKE_SOURCE_DIR}/src/common/combo_mm_options_view.c
+    ${CMAKE_SOURCE_DIR}/src/common/ComboMmOptionsWindow.cpp
     ${CMAKE_SOURCE_DIR}/src/common/entrance.cpp
     ${CMAKE_SOURCE_DIR}/src/common/test_runner.cpp
     ${CMAKE_SOURCE_DIR}/src/common/integration_test_hooks.cpp
@@ -96,6 +102,8 @@ set(REDSHIP_COMMON_HEADERS
     ${CMAKE_SOURCE_DIR}/src/common/foreign_items.h
     ${CMAKE_SOURCE_DIR}/src/common/combo_spoiler_view.h
     ${CMAKE_SOURCE_DIR}/src/common/ComboSpoilerWindow.h
+    ${CMAKE_SOURCE_DIR}/src/common/combo_mm_options_view.h
+    ${CMAKE_SOURCE_DIR}/src/common/ComboMmOptionsWindow.h
     ${CMAKE_SOURCE_DIR}/src/common/entrance.h
     ${CMAKE_SOURCE_DIR}/src/common/test_runner.h
     ${CMAKE_SOURCE_DIR}/src/common/integration_test_hooks.h
@@ -368,6 +376,13 @@ if(BUILD_TESTING)
     redship_add_test(NAME ForeignAwardMM COMMAND redship --test foreign-award-mm)
     redship_add_test(NAME ComboSpoilerView COMMAND redship --test combo-spoiler-view)
     redship_add_test(NAME ComboSpoilerWindow COMMAND redship --test combo-spoiler-window)
+    # MM randomizer options (#497 step 4, #499). Display-free: the option table
+    # is a static global in the WHOLE_ARCHIVE'd 2ship_rando, the profile resolver
+    # runs over a zeroed MM SaveContext with no fill, and the pane's window lock
+    # never reaches ImGui.
+    redship_add_test(NAME MMRandoOptions COMMAND redship --test mm-rando-options)
+    redship_add_test(NAME MMPairedProfile COMMAND redship --test mm-paired-profile)
+    redship_add_test(NAME ComboMMOptionsWindow COMMAND redship --test combo-mm-options-window)
     # Cross-game session invalidation (#440). A soft reset or a new game must
     # retire the previous session's frozen blobs, shadows and gComboCtx
     # crossings — while a cross-game arrival and a legitimate existing-slot

--- a/docs/adr/0003-settings-namespace.md
+++ b/docs/adr/0003-settings-namespace.md
@@ -1,8 +1,11 @@
 # ADR 0003: One shared CVar store, classified deliberately — settings are unified by default
 
-- Status: **Proposed** (2026-07-21)
+- Status: **Accepted** (2026-07-23, #497 step 1)
 - For: #34 (settings migration), gating #35; the settings decision in
   `docs/unified-surface-findings.md` §6.1
+- Corrected on acceptance: §4.1's `gDeveloperTools.DebugSaveFileMode` row was
+  **wrong** and is struck below; §5 gains the `TimeSavers` casing decision
+  ADR 0004 asked this document to make.
 - Measured against `origin/main` on 2026-07-21 by exhaustive grep of both
   trees (method and its one correction in Appendix A — the numbers below are
   reproducible, not quoted)
@@ -337,7 +340,7 @@ No action. Documented as deliberate; see the §2.3 guard.
 |---|---|
 | `gCheats.{InfiniteHealth, InfiniteMagic, MoonJumpOnL, NoClip, EasyFrameAdvance}` | Identical meaning in both games. Maintainer decision. |
 | `gDeveloperTools.{DebugEnabled, FrameAdvanceTick, LogLevel}` | Host/debug state. `FrameAdvanceTick` is a transient both games set and clear; only one game is active at a time, so no interleaving. |
-| `gDeveloperTools.DebugSaveFileMode` | Value spaces align: `0`/`1`/`2` = none-or-off / vanilla-debug / maxed-or-100% in both (`SohMenuDevTools.cpp:53` vs `DeveloperTools.h:7`). **Footnote:** defaults differ — OoT `1`, MM `DEBUG_SAVE_INFO_NONE` (`0`). Once written the shared value governs both; only the unwritten fallback differs. Acceptable, worth knowing. |
+| ~~`gDeveloperTools.DebugSaveFileMode`~~ | **STRUCK 2026-07-23 — this row was wrong; the key is class (P).** It said: *"Value spaces align… only the unwritten fallback differs. Acceptable, worth knowing."* The value spaces do align, but the key is never left unwritten: `games/mm/2s2h/DeveloperTools/DeveloperTools.cpp`'s `RegisterDebugMode()` does `CVarSetInteger(CVAR_SAVE_FILE_MODE_NAME, DEBUG_SAVE_INFO_NONE)` whenever debug mode is off — the default state — so MM's registrar destroys OoT's `1` on every launch. ADR 0004 §2d holds the record; the key sits in `kDisputedClassificationKeys` until MM's write is retired and its read default aligned. Dormant today only because `2s2h/DeveloperTools/` is excluded from the single-exe link. **Class (S) count is 25 here, not 26.** |
 | `gEnhancements.Graphics.{IncreaseActorDrawDistance, ActorCullingAccountsForWidescreen}` | Same multiplier semantics, same default (`1`), same widescreen-culling boolean. |
 | `gAudioEditor.{EnemyBGMDisable, LowHpAlarm, SeqNameNotification, SeqNameNotificationDuration}` | Same audio-editor behaviours. |
 | `gSettings.{CursorVisibility, DisableChanges}` | Host UI state. |
@@ -377,6 +380,30 @@ Everything in §1.5. No renames.
 
 For each: MM's current key → OoT's key, with the justification for calling it
 shared-intent. **MM moves in every case** (§2.4).
+
+### 5.0 Canonical family spelling: `TimeSavers`, capital S (decided 2026-07-23)
+
+ADR 0004's open call 5 asked this document to state which casing wins. It is
+`gEnhancements.TimeSavers.` — OoT's, capital `S`.
+
+Measured rather than preferred: capital-S holds 148:1 in `games/oot`, five MM
+keys have **already** converged onto it via #462
+(`SkipCutscene.{Story,Intro,OnePoint,Entrances}`, `DisableTitleCard`), and the
+single lowercase hit anywhere in `games/oot` is a migration row retiring one of
+MM's spellings. MM's remaining lowercase family is 8 keys — `AutoBankDeposit`,
+`DampeDiggingSkip`, `FasterSceneTransitions`, `GalleryTwofer`, `MarineLabHP`,
+`PowderKegCertification`, `SkipBalladOfWindfish`, `SwampBoatSpeed` — plus the
+`games/mm/2s2h/Enhancements/Timesavers/` directory. That is the cheaper side to
+move, and the two spellings do not collide in a case-sensitive store, so nothing
+is broken while the move is pending.
+
+**Mechanics, when the rename pass runs (not in this ADR's PR):** add the 8 keys
+to `kConvergedKeys` under a `ConfigVersion9Updater` group, add
+`"gEnhancements.Timesavers."` to `kRetiredKeyPrefixes`, and **in the same commit**
+delete `kParkedCasingPrefixMM` and its assertion in
+`src/common/tests/test_cvar_classification.c`. That assertion requires MM to
+still contain the lowercase prefix and goes red the moment the last key moves —
+by design, so the parked hazard cannot be quietly half-resolved.
 
 ### 5.1 Tier 1 — recommended now: 9 sites, 8 renames
 

--- a/docs/adr/0004-menu-information-architecture.md
+++ b/docs/adr/0004-menu-information-architecture.md
@@ -1,7 +1,10 @@
 # ADR 0004: Menu information architecture — one shell, four tiers, capability-gated MM entries
 
-- Status: **Proposed** (2026-07-21)
-- For: #392 (Phase 3.0 tracker), #34 (settings migration)
+- Status: **Accepted** (2026-07-23, #497 step 1)
+- For: #392 (Phase 3.0 tracker), #34 (settings migration), #497, #499
+- Amended on acceptance: §4.1 (scope and host of the MM randomizer pane — see
+  §4.1a), §2d (the #454 disagreement, now ruled), and "What this ADR does not
+  decide" (all five calls resolved).
 - Depends on:
   - **[ADR 0003](0003-settings-namespace.md)** (settings namespace) — owns CVar key naming and
     the rename/migration rule; this ADR consumes its decisions rather than restating them.
@@ -91,15 +94,36 @@ resolving it"* — is discharged, provided MM's menu is never revived as a secon
 proviso is now load-bearing for both documents, which is the second reason §3 tier 1 flags the
 sidebar-name caveat.
 
-**One live disagreement, deliberately preserved.** On `gDeveloperTools.DebugSaveFileMode`,
-ADR 0003 §4.1 classifies (S) — value spaces align, only the unwritten fallback differs,
-"acceptable, worth knowing". This document classifies it **(P)** and files it as
-[#454](https://github.com/spencerduncan/redshipblueship/issues/454). The disagreement is real
-and narrow: 0003 is right that once the key is written the games agree, and this ADR is
-taking the more conservative line that two different defaults on one shared key is a
-behaviour decision someone should make rather than inherit. **The rename pass is safe under
-either reading** — the key name already matches, so nothing renames. Whoever closes #454
-should update whichever document ends up wrong.
+**~~One live disagreement, deliberately preserved.~~ RULED (P) on acceptance, 2026-07-23.** On
+`gDeveloperTools.DebugSaveFileMode`, ADR 0003 §4.1 classified (S) — value spaces align, only the
+unwritten fallback differs, "acceptable, worth knowing" — and this document classified it **(P)**,
+filed as [#454](https://github.com/spencerduncan/redshipblueship/issues/454).
+
+**#454 never decided it.** It was auto-closed by the squash-merge of PR #456, a docs-only change
+whose own text says #454 is the thing that will settle the question. The close is an artifact.
+
+**This ADR's (P) reading is upheld, on evidence neither document had.** The argument ADR 0003 §4.1
+rests on — "once written the shared value governs both; only the *unwritten* fallback differs" — is
+false on its own terms, because MM does not merely read the key with a different default. It
+*writes* one:
+
+```c
+// games/mm/2s2h/DeveloperTools/DeveloperTools.cpp, RegisterDebugMode()
+if (!CVAR_DEBUG_MODE) {
+    CVarSetInteger(CVAR_SAVE_FILE_MODE_NAME, DEBUG_SAVE_INFO_NONE);
+```
+
+MM's registrar unconditionally writes `0` into the shared cell whenever debug mode is off, which is
+the default state — so the key is never left unwritten once MM's devtools link, and OoT's `1` is
+destroyed on every launch. **ADR 0003 §4.1's row is therefore wrong and is corrected there.**
+
+Dormant but armed: `games/mm/CMakeLists.txt` excludes `2s2h/DeveloperTools/` from the single-exe
+build, so the clobber does not run today. It arms on the same un-elision work §5's gate 4
+schedules. The rename pass remains safe under either reading — the key name already matches — so
+this is a behaviour fix (retire MM's write, align MM's read default to OoT's `1`) owed by whichever
+lane un-elides `DeveloperTools`, not a namespace change. `kDisputedClassificationKeys` keeps the key
+until that fix lands, because the manifest must not claim (S) while the source still contains the
+write that makes it (P).
 
 ### 3. The four tiers
 
@@ -163,9 +187,9 @@ controls are what a player sees by default and the per-game ones read as excepti
 |---|---|---|
 | **Settings** | General, Audio, Graphics, Controls, Input Viewer, Notifications, Mod Menu | Tier 1. **Relabel to state these apply to both games.** No per-game split — there is nothing to split. |
 | **Enhancements** | Quality of Life, Skips & Speed-ups, Graphics, Items, Fixes, Difficulty, Minigames, Extra Modes | Shared-intent entries first in each sidebar; then `— Ocarina of Time —` and `— Majora's Mask —` separators for tier-3 entries |
-| **Cheats** | (promoted out of Enhancements) | Shared-intent block first (the 5 matched + 5 converged cheats), then per-game |
+| **Cheats** | ~~(promoted out of Enhancements)~~ **stays an Enhancements sidebar** | Superseded on acceptance — see resolved call 1. Shared-intent block first (the 5 matched + 5 converged cheats), then per-game |
 | **Cosmetics** | Cosmetics Editor, Audio Editor, HUD Editor | Mostly (O) per game; MM's 3 tunic keys converge — see classification §3.3 BUG 1 |
-| **Randomizer** | OoT, MM, **Paired** | See §4.1 |
+| **Randomizer** | OoT, MM, **Paired** | See §4.1 and **§4.1a** — MM's half is a common-owned window, not a SohMenu sidebar, for the timing reason given there |
 | **Trackers** | Item, Check, Entrance, Combo | Per findings §3, MM trackers are nearly free — blocked on registration surface + selective un-elision, not hook migration |
 | **Combo** | Pairing status, Save slots, Entrance links, Hot-swap | Tier 4. Absorbs `ComboMenuBar`'s working `.redsave` file-select panel |
 | **Dev Tools** | (existing) | Shared where already shared; MM's viewers gated per §5 |
@@ -187,6 +211,44 @@ paired world is opted into by generating on the OoT side; MM's half derives from
 `sharedRandoSeed` + `sharedRandoSettingsHash`. The cheapest honest increment is a **read-only
 "Paired" summary + MM logic-mode picker** inside the existing OoT rando pane — no MM menu port
 required.
+
+#### 4.1a Superseded on acceptance: the FULL option set, in a common-owned window
+
+**Decided 2026-07-23 (#497's open scope question, maintainer call). §4.1's minimum above is
+recorded as the 3.0 position and is superseded for 3.1.** Two changes:
+
+**(i) Scope: the full option set, not a logic-mode picker.** All 47 `RandoOptionId`s are exposed.
+The minimum was the right 3.0 increment when the alternative was porting BenMenu; it is the wrong
+3.1 one, because #499 established that *nothing in the shipped link ever writes a
+`gRando.Options.*` CVar* — so a logic-mode picker would leave 46 options still unreachable and
+still silently defaulted, which is the same defect with one fewer instance.
+
+**(ii) Host: a common-owned `Ship::Gui` window (ADR 0008), not a pane inside `SohMenu`.** This is
+the one place this ADR's "one shell, extend SohMenu" rule does not apply, and the reason is
+timing rather than taste. The paired MM profile is snapshotted when MM's cross-game arrival
+dispatches `OnSaveInit`, and an existing MM save is never regenerated (#499). The chooser must
+therefore be reachable **while OoT is the running game, before the switch** — which is exactly
+the property ADR 0008 rule 1 buys by owning a window in `src/common` rather than hanging it off
+either game's boot.
+
+The "one shell" rule is unweakened by this. ADR 0008 already distinguishes *registering* a
+game-neutral window from *opening* it, and explicitly leaves a `SohMenu` `WIDGET_WINDOW_BUTTON`
+row as a fine way to do the opening. What §3's rule forbids is a **second menu shell**; a
+common-owned window is not one, and in particular it reads no `gSettings.Menu.*` key, so #451's
+arming condition is untouched (mechanized as the MM-side reader allowlist in
+`src/common/tests/test_cvar_classification.c`).
+
+**Consequence accepted: §4.2's shared-intent marker does not apply to this pane.** All 47 options
+are tier-3 (O) MM-only keys; none is in `kSharedIntentKeys`, so there is no "applies to both
+games" claim to mark. §6's three presentation states DO apply and are implemented: live,
+editable-but-not-active ("Majora's Mask — suspended"), and disabled-by-capability with a reason.
+
+**Consequence accepted: the options are a CHOICE, and the defaults do not change.** No raised
+profile ships. Every `RO_SHUFFLE_*` and `RO_HINTS_*` row keeps its `RO_GENERIC_OFF` default, so
+generation dead-end rates are unchanged for anyone who does not touch the pane — which is the
+honest answer to #499's "measure dead-end rates before shipping a raised profile", rather than
+measuring a profile nobody chose. The one previously-hardcoded value, the paired `RO_LOGIC` pin
+to Nearly No Logic (#426), becomes a default that an explicit choice overrides.
 
 #### 4.2 Shared-intent entries must be visibly marked (required, not cosmetic)
 
@@ -263,25 +325,51 @@ capability gating (§5) makes an un-dispatched MM entry a legitimate disabled ro
 land ahead of the functionality it will eventually expose. That is the main practical benefit
 of adopting the gating rule up front rather than retrofitting it.
 
-## What this ADR does not decide
+## What this ADR left open — all five resolved on acceptance (2026-07-23, #497 step 1)
 
-Genuinely open, and deliberately left to the maintainer:
+Each was measured against the tree rather than argued from the documents. The original wording is
+kept so the decision trail stays legible.
 
-1. **Cheats section placement.** §4 promotes Cheats to a top-level section (it is currently an
-   Enhancements sidebar in both games). Cosmetic; flag if unwanted.
-2. **(P) row P2 — ISG.** OoT files `gCheats.EasyISG` as a **cheat**; MM files
-   `gEnhancements.Restorations.TatlISG` as a **restoration**. Same underlying behaviour, opposite
-   framing. Which section wins is a taxonomy call, not a technical one, and the rename pass must
-   not merge these until it is made.
-3. **(P) row P5 — `gDeveloperTools.DebugSaveFileMode` defaults.** The games share the key but
-   disagree on the default (OoT 1 "Vanilla", MM 0 "Empty"). Reconciling requires picking one
-   behaviour; it is not a rename. **ADR 0003 §4.1 reaches the opposite conclusion** and calls
-   this acceptable — see §2d and #454. Deciding it settles which document is right.
-4. **Group B rename confirmations.** Two rows need a semantic check before renaming:
-   `InfiniteAmmo`/`InfiniteConsumables` (MM's scope may be wider) and
-   `NoRestrictItems`/`UnrestrictedItems` (OoT drops age gating, MM drops form gating).
-5. **`TimeSavers` vs `Timesavers` casing.** OoT capitalises the `S`, MM does not. One spelling
-   must win; the namespace ADR should state which.
+1. **Cheats section placement.** *Was:* §4 promotes Cheats to a top-level section (currently an
+   Enhancements sidebar in both games); cosmetic, flag if unwanted.
+   **RESOLVED: do NOT promote. Cheats stays an Enhancements sidebar.** Both upstreams already
+   agree on that placement (`SohMenuEnhancements.cpp` `AddSidebarEntry("Enhancements", "Cheats", 3)`;
+   `BenMenu.cpp` the same), and sidebar selection persists **by display-name string** into
+   `gSettings.Menu.EnhancementsSidebarSection`. Promotion is purely cosmetic yet strands every
+   config holding `EnhancementsSidebarSection == "Cheats"` and mints a fifth menu-index key while
+   #451 is still open on the four that exist. §4's table row is superseded by this.
+2. **(P) row P2 — ISG.** *Was:* OoT files `gCheats.EasyISG` as a cheat, MM files
+   `gEnhancements.Restorations.TatlISG` as a restoration; which section wins is a taxonomy call.
+   **RESOLVED: keep both keys distinct; file ISG under Cheats, and surface MM's as its own row
+   labelled "Tatl ISG (restoration)".** The behaviour matches but the *gate* does not — OoT's is an
+   unconditional passive grant, MM's restores a behaviour the N64 game had. One merged control
+   would silently switch a restoration on for players who asked for neither. Stays in
+   `kMustStayDistinct`.
+3. **(P) row P5 — `gDeveloperTools.DebugSaveFileMode` defaults.**
+   **RESOLVED (P), against ADR 0003 §4.1 — see §2d for the evidence.** Not on the default
+   divergence: on MM's `DeveloperTools.cpp` write into the shared cell, which falsifies 0003's
+   "only the unwritten fallback differs" outright. The fix is a behaviour change owed by whichever
+   lane un-elides `2s2h/DeveloperTools/`; until then the key stays in
+   `kDisputedClassificationKeys`.
+4. **Group B rename confirmations.** *Was:* `InfiniteAmmo`/`InfiniteConsumables` and
+   `NoRestrictItems`/`UnrestrictedItems` need a semantic check before renaming.
+   **RESOLVED: neither converges. Both stay in `kMustStayDistinct`, and the recorded reasons are
+   sharpened** — the parked entries were directionally right and understated the divergence.
+   - *Ammo/Consumables:* OoT's refill is unconditional; MM's gates every item on `INV_CONTENT`, has
+     no slingshot row, uses `CUR_CAPACITY(UPG_BOMB_BAG)` where OoT hardcodes 50, and additionally
+     covers **Magic Beans and Powder Kegs** — consumables that are not ammo. MM's scope is genuinely
+     wider, confirming the suspicion this row was filed on.
+   - *NoRestrictItems/UnrestrictedItems:* OoT zeroes the interface restrictions bitfield every
+     frame **with a hardcoded Sun's Song carve-out**; MM is a single `VB_ITEM_BE_RESTRICTED` veto
+     with none. Different mechanism, different scope, and the carve-out is the concrete thing a
+     merge would lose.
+5. **`TimeSavers` vs `Timesavers` casing.**
+   **RESOLVED: `TimeSavers` (capital S) is canonical.** Counted in the tree: 148:1 in `games/oot`,
+   and five MM keys have already converged onto it. MM's lowercase set is 8 keys, the cheaper side
+   to move. ADR 0003 §5 now states this. Mechanically it is a `ConfigVersion9Updater` group plus a
+   `kRetiredKeyPrefixes` entry — and the same commit must delete `kParkedCasingPrefixMM` and its
+   assertion, which *requires* the lowercase prefix to still exist and goes red as the last key
+   moves. Not done here: it is a rename pass in files this lane does not own.
 
 > Two questions that *were* open when this work started are now settled and recorded in §2:
 > shared-intent uses one shared CVar (not a fan-out), and cheats are shared-intent. They are

--- a/docs/adr/0009-combo-settings-and-reverse-pool.md
+++ b/docs/adr/0009-combo-settings-and-reverse-pool.md
@@ -189,12 +189,21 @@ Publishing the allocation once beats four sequential re-versions:
 |---|---|---|---|
 | 1 | `foreignPlacementsOoT[8]` (#493 step 2, Lane 1) | 48 B | **carved by this arc** |
 | 2 | `comboSettingsHash` (#498 decision 1, Lane 1) | 4 B | reserved |
-| 3 | MM option-profile digest (#497 step 7 / #499 step 4, Lane 4) | 4 B | **reserved, size not yet confirmed by Lane 4** |
+| 3 | MM option-profile digest (#497 step 7 / #499 step 4, Lane 4) | 4 B | **carved by Lane 4; size CONFIRMED at 4 B** |
 | 4 | Netplay grant fields (#460, ADR 0005/0007) | 64 B | reserved |
 | 5 | Unallocated floor | 164 B | must not drop below 64 |
 
-Total reserved-against: 120 B of 284. After claim 1 lands, `reserved[]` is 216
-bytes and 236 B of capacity remain.
+Total reserved-against: 120 B of 284. After claims 1 and 3 land, `reserved[]` is
+212 bytes and 232 B of capacity remain.
+
+**Claim 3, settled (Lane 4, 2026-07-23).** The digest is a single `uint32_t
+mmProfileDigest` at `.redsave` byte offset 788, computed by
+`Rando::Foreign::ResolvePairedProfile()` over the same option string
+`MixPairedFinalSeed()` already hashes. 4 B was the placeholder and 4 B is the
+answer, so the table above is confirmed rather than amended. A wider *record* of
+the profile was rejected for decision 1's reason: the settings are authored in
+CVars, and storing them would be a second settings store that has to be
+re-versioned every time an option is added.
 
 Two constraints on anyone spending from this:
 
@@ -229,4 +238,5 @@ leave nothing for claims 2-4.
 - `.redsave` format is unchanged in version terms. Two `.redsave` files written
   by builds either side of the `foreignPlacementsOoT` carve interoperate: the
   older one reads the new block as all-unset, which is correct.
-- Lane 4 owes a digest size against claim 3 before it carves.
+- ~~Lane 4 owes a digest size against claim 3 before it carves.~~ Paid: 4 B,
+  carved as `ComboContext.mmProfileDigest` at offset 788 (see the budget table).

--- a/games/mm/2s2h/Rando/Foreign.cpp
+++ b/games/mm/2s2h/Rando/Foreign.cpp
@@ -30,6 +30,10 @@
 #include "Foreign.h"
 #include "Rando/Rando.h"
 #include "2s2h/ShipUtils.h"
+// ResolvePairedProfile reads the option CVars (and asks CVarExists whether the
+// player ever set one) and logs which branch of the logic pin it took.
+#include <libultraship/bridge/consolevariablebridge.h>
+#include <spdlog/spdlog.h>
 
 // src/common — placement table + pinned pool surface, and the A1 producer
 // (Combo_RecordSharedItem). Included OUTSIDE any extern "C" block: they pull
@@ -37,6 +41,9 @@
 // (see context.h's header comment).
 #include "foreign_items.h"
 #include "shared_items.h"
+// Combo_CVarIsExplicitInt — "did the player choose this, or is it just the
+// default", which is what the paired logic pin now turns on.
+#include "combo_mm_options_view.h"
 
 #include <cstddef>
 #include <cstdio>
@@ -45,6 +52,10 @@
 
 extern "C" {
 #include "variables.h"
+// SPIDER_HOUSE_TOKENS_REQUIRED — the vanilla token requirement the profile
+// falls back to when skulltulas are unshuffled (same include OnFileCreate.cpp
+// carries for the same constant).
+#include "overlays/actors/ovl_En_Sth/z_en_sth.h"
 }
 
 namespace Rando {
@@ -71,6 +82,72 @@ static std::string MMOptionsString() {
         s += ';';
     }
     return s;
+}
+
+uint32_t ResolvePairedProfile(bool paired) {
+    // (1) The generic copy: every registered option's CVar, with the
+    // StaticData row's default as the fallback. Unchanged from the loop this
+    // was extracted from — it is what makes the pane's CVars the profile.
+    for (auto& [randoOptionId, randoStaticOption] : Rando::StaticData::Options) {
+        RANDO_SAVE_OPTIONS[randoOptionId] =
+            (uint32_t)CVarGetInteger(randoStaticOption.cvar, randoStaticOption.defaultValue);
+    }
+
+    // (2) Derived correction: with skulltulas unshuffled the token requirement
+    // is the vanilla one, whatever the slider says. Runs for solo and paired
+    // files alike, as it always has.
+    if (!RANDO_SAVE_OPTIONS[RO_SHUFFLE_GOLD_SKULLTULAS]) {
+        RANDO_SAVE_OPTIONS[RO_MINIMUM_SKULLTULA_TOKENS] = SPIDER_HOUSE_TOKENS_REQUIRED;
+    }
+
+    if (!paired) {
+        // A solo MM rando file has no cross-game identity to publish, and must
+        // not stamp one: gComboCtx.mmProfileDigest is read as "the paired
+        // world was generated under this profile", and writing it here would
+        // make an unpaired file claim a pairing it does not have.
+        return 0;
+    }
+
+    // (3) The logic pin (#426 rationale), now a DEFAULT rather than a law
+    // (#499 step 3). The pin exists because the MVP pairs under Nearly No
+    // Logic — free-form placement, with the spoiler carrying what logic would
+    // otherwise carry. That is the right default and the wrong law: once the
+    // options pane can express a choice, overriding an explicit one would make
+    // the control a lie in exactly ADR 0004 section 5's sense (it flips a CVar
+    // and changes nothing).
+    //
+    // EXISTENCE, not "is the value already extreme". The old condition could
+    // not tell "the player chose Glitchless" from "nobody has ever touched
+    // this key and the StaticData default is Glitchless", so it pinned both.
+    // Existence is the only signal that distinguishes them. (Combo_ prefixed
+    // rather than libultraship's CVarExists, which is declared but undefined in
+    // the pinned submodule — see combo_mm_options_view.h.)
+    if (!Combo_CVarIsExplicitInt(Rando::StaticData::Options[RO_LOGIC].cvar)) {
+        SPDLOG_INFO("Paired-world generation: no explicit MM logic choice; defaulting to Nearly No Logic (#426)");
+        RANDO_SAVE_OPTIONS[RO_LOGIC] = RO_LOGIC_NEARLY_NO_LOGIC;
+    } else {
+        SPDLOG_INFO("Paired-world generation: honouring explicit MM logic choice ({})",
+                    (unsigned)RANDO_SAVE_OPTIONS[RO_LOGIC]);
+    }
+
+    // (4) Publish the profile's identity. Seed-INDEPENDENT on purpose: this
+    // answers "were both halves generated under the same MM rules", which is a
+    // question about the rules alone. MixPairedFinalSeed() folds the master
+    // seed into the same option string for the different question of "which
+    // world does this seed derive"; sharing MMOptionsString() between them is
+    // what stops the two from drifting apart.
+    uint32_t digest = Ship_Hash(MMOptionsString());
+    if (digest == 0) {
+        // Zero is the growth contract's "unset" for every field carved from
+        // reserved[] (context.h), so a real profile that happened to hash to 0
+        // would read as "no profile recorded" — a mismatch that silently
+        // cannot be detected. Displace it to a fixed non-zero constant; the
+        // collision this introduces is with one other profile out of 2^32,
+        // against a certainty of a false negative.
+        digest = 0x4D4D5044u; // 'MMPD'
+    }
+    gComboCtx.mmProfileDigest = digest;
+    return digest;
 }
 
 uint32_t MixPairedFinalSeed() {

--- a/games/mm/2s2h/Rando/Foreign.h
+++ b/games/mm/2s2h/Rando/Foreign.h
@@ -27,6 +27,27 @@ bool PairingActive();
  *  world (and one spoiler file). */
 std::string PairedInputSeedString();
 
+/** Resolve MM's randomizer option profile into RANDO_SAVE_OPTIONS and, for a
+ *  paired world, publish its digest into gComboCtx.mmProfileDigest
+ *  (#499 steps 2-4; ADR 0009 claim 3).
+ *
+ *  This is the ONE place the profile is decided. It was three inline blocks in
+ *  MiscBehavior/OnFileCreate.cpp, reachable only by running a whole fill, which
+ *  is why the profile could not be locked without a display: extracting it is
+ *  what lets the display-free MMPairedProfile CTest drive the REAL resolution
+ *  rather than a copy of it.
+ *
+ *  @param paired  true on the cross-game path (Foreign::PairingActive()). Only
+ *                 a paired world gets the logic pin and the digest; a solo MM
+ *                 rando file resolves its options and nothing else, exactly as
+ *                 before.
+ *  @return the profile digest (0 when `paired` is false).
+ *
+ *  ORDERING CONTRACT, unchanged and load-bearing: call this BEFORE
+ *  MixPairedFinalSeed(), which hashes the finalized options. Resolving after
+ *  the mix would derive the world from a profile it does not describe. */
+uint32_t ResolvePairedProfile(bool paired);
+
 /** The paired final seed: Ship_Hash(master seed + MM's persisted options),
  *  mirroring OoT's own Hash(seed + settingsStr) double-reseed (Lane B
  *  contract). Call AFTER the options are persisted into RANDO_SAVE_OPTIONS. */

--- a/games/mm/2s2h/Rando/MiscBehavior/OnFileCreate.cpp
+++ b/games/mm/2s2h/Rando/MiscBehavior/OnFileCreate.cpp
@@ -109,6 +109,15 @@ void Rando::MiscBehavior::OnFileCreate(s16 fileNum) {
 
                 // Persist options to the save
                 gSaveContext.save.shipSaveInfo.rando.finalSeed = finalSeed;
+#ifdef RSBS_SINGLE_EXECUTABLE
+                // The profile — the option copy, the skulltula correction, the
+                // paired logic default and the profile digest — is resolved by
+                // ONE callable (#499 step 2). It used to be three inline blocks
+                // here, so the only way to observe it was to run a whole fill;
+                // the display-free MMPairedProfile lock drives this function
+                // directly. See Rando/Foreign.h for the ordering contract.
+                Rando::Foreign::ResolvePairedProfile(rsbsPaired);
+#else
                 for (auto& [randoOptionId, randoStaticOption] : Rando::StaticData::Options) {
                     RANDO_SAVE_OPTIONS[randoOptionId] =
                         (uint32_t)CVarGetInteger(randoStaticOption.cvar, randoStaticOption.defaultValue);
@@ -118,23 +127,10 @@ void Rando::MiscBehavior::OnFileCreate(s16 fileNum) {
                 if (!RANDO_SAVE_OPTIONS[RO_SHUFFLE_GOLD_SKULLTULAS]) {
                     RANDO_SAVE_OPTIONS[RO_MINIMUM_SKULLTULA_TOKENS] = SPIDER_HOUSE_TOKENS_REQUIRED;
                 }
+#endif
 
 #ifdef RSBS_SINGLE_EXECUTABLE
                 if (rsbsPaired) {
-                    // Pinned MM profile for the paired world (#392): the MVP
-                    // pairs under Nearly No Logic — free-form placement, with
-                    // the spoiler log carrying what logic would otherwise
-                    // carry (Lane D). Glitchless generation itself works (the
-                    // #426 Deku Palace edge fix, locked by MMRandoGen's
-                    // gating glitchless phase); this pin is an MVP-scope
-                    // choice, not a workaround. Pinned BEFORE the settings
-                    // mix below so the profile is part of the world identity.
-                    if (RANDO_SAVE_OPTIONS[RO_LOGIC] != RO_LOGIC_NEARLY_NO_LOGIC &&
-                        RANDO_SAVE_OPTIONS[RO_LOGIC] != RO_LOGIC_NO_LOGIC &&
-                        RANDO_SAVE_OPTIONS[RO_LOGIC] != RO_LOGIC_VANILLA) {
-                        SPDLOG_INFO("Paired-world generation: pinning MM logic to Nearly No Logic (#426)");
-                        RANDO_SAVE_OPTIONS[RO_LOGIC] = RO_LOGIC_NEARLY_NO_LOGIC;
-                    }
                     // Re-seed with Hash(master seed + MM's finalized options),
                     // mirroring OoT's Hash(seed + settingsStr) double-reseed
                     // (Lane B contract): the same master seed reproduces this

--- a/games/mm/2s2h/Rando/OptionsUiSingleExe.cpp
+++ b/games/mm/2s2h/Rando/OptionsUiSingleExe.cpp
@@ -1,0 +1,433 @@
+/**
+ * OptionsUiSingleExe.cpp — MM's randomizer options, described for the combo
+ * options pane (#497 step 4, #499 step 5; ADR 0004, ADR 0009 decision 3).
+ *
+ * ============================================================================
+ * WHY THIS TABLE EXISTS AND WHY IT LIVES HERE
+ * ============================================================================
+ *
+ * `Rando::StaticData::Options` carries `{id, name, cvar, defaultValue}` and
+ * nothing else — the `RO(id, default)` macro stores only the STRINGIFIED
+ * enumerator, so the "label" for RO_SHUFFLE_COWS is the literal
+ * "RO_SHUFFLE_COWS". Two things a menu needs are therefore missing from it:
+ * human labels with value enums, and the 9-group taxonomy MM's own rando menu
+ * uses. Both live in `games/mm/2s2h/Rando/Menu.cpp`, which is elided into
+ * `2ship_rando_ui` and cannot be linked without dragging `BenMenu` — the exact
+ * condition #451 is armed by. So the labels are re-stated here, in a TU that
+ * links, rather than the menu being revived.
+ *
+ * This file is the MM half of the seam; `src/common/combo_mm_options_view.h` is
+ * the common half. The split follows ADR 0009 decision 3's rule for the foreign
+ * pools: a table whose enums are MM's is defined in the single TU where those
+ * enums are in scope, and crosses into common code as flat data. Common code
+ * gains no MM header, and the combo pane gains no MM knowledge.
+ *
+ * Lives in 2s2h/Rando/, glob-collected into `2ship_rando`, which links
+ * WHOLE_ARCHIVE — so the file-scope registrar at the bottom runs with no CMake
+ * edit, exactly as ForeignItemsSingleExe.cpp's pool registrar does.
+ *
+ * ============================================================================
+ * CAPABILITY GATING IS DATA, NOT DECORATION (ADR 0004 section 5)
+ * ============================================================================
+ *
+ * Every row carries a liveness class measured against the single-exe link on
+ * 2026-07-23, and a reason string when it is not live. The measurement is the
+ * ADR's three-part test — TU links, registrar runs, hook type has an MM
+ * dispatch point — and for this table only the third leg ever fails:
+ * `2ship_rando` is WHOLE_ARCHIVE'd so every behaviour TU links, and
+ * `MM_Rando_Init` -> `Rando::Init` runs every registrar.
+ *
+ * The states that matter, and why the distinction is not pedantry:
+ *
+ *   GENERATION_ONLY — consumed by the fill or by starting state. No runtime
+ *     hook, so it cannot be half-armed. Always honest.
+ *   LIVE — pool widening plus every hook it rides is dispatched.
+ *   PARTIAL — some legs live, at least one dormant. Enabling it widens the
+ *     check pool but part of the behaviour never arms.
+ *   DORMANT — the hook type it rides has no MM dispatch point (#438).
+ *
+ * PARTIAL and DORMANT are both drawn disabled BECAUSE OF WHAT THEY DO, not out
+ * of caution. `Logic/GeneratePools.cpp:60-130` skips whole check classes when
+ * their option is off; turning one on adds those checks to the pool, the fill
+ * places real items on them, and then the hook that would award the item never
+ * runs. The result is an unwinnable world with items sitting on checks the game
+ * cannot pay out — strictly worse than leaving the option off, which is why ADR
+ * 0004 calls this the worst state available and why a disabled row with a
+ * reason is the honest presentation.
+ *
+ * Three rows are the pure form of that trap and are flagged as such below:
+ * crate, barrel and grass drops. Their identify-the-check helpers have NO call
+ * site outside the undispatched OnActorInit hooks, and the surviving VB legs
+ * bail on RC_UNKNOWN — so the dormancy is total rather than cosmetic.
+ *
+ * Two rows are worse than inert: RO_HINTS_GOSSIP_STONES / RO_HINTS_PURCHASEABLE
+ * force a mask-of-truth verdict and redirect the textbox to a message whose
+ * filler is the undispatched OnOpenText handler, and RO_ACCESS_TRIALS' VB leg
+ * returns "unlocked" for every trial while the text leg that would gate it is
+ * dead. Enabling those is a REGRESSION against vanilla behaviour, not a no-op.
+ *
+ * #438 IS STALE IN ONE DIRECTION and this table follows the tree, not the
+ * issue: `OnSceneInit` IS dispatched (MM_GameHooks_ExecuteOnSceneInit,
+ * GameExports_SingleExe.cpp, called from z_play.c), so RO_ACCESS_DUNGEONS is
+ * fully live. Re-measure before trusting either document.
+ *
+ * ONE HAZARD THAT IS NOT PER-ROW. `BeforeEndOfCycleSave` / `AfterEndOfCycleSave`
+ * are registered unconditionally under IS_RANDO and are dormant, and their body
+ * (Rando/MiscBehavior/OnCycleSave.cpp) is what carries dungeon items, keys,
+ * stray fairies and trade slots across a cycle reset and clears the per-cycle
+ * check flags. With it dead, a cycle reset degrades rando state for EVERY
+ * option. That belongs in a pane-wide banner rather than 47 identical reason
+ * strings; the window draws it as one.
+ */
+#ifdef RSBS_SINGLE_EXECUTABLE
+
+#include <vector>
+
+#include "Rando/Rando.h"
+#include "Rando/Types.h"
+#include "Rando/StaticData/StaticData.h"
+
+extern "C" {
+// SPIDER_HOUSE_TOKENS_REQUIRED and STRAY_FAIRY_SCATTERED_TOTAL — the two
+// slider ceilings that are game constants rather than UI choices. Same include
+// StaticData/Options.cpp carries for the same two.
+#include "overlays/actors/ovl_En_Sth/z_en_sth.h"
+}
+
+// src/common. Included OUTSIDE any extern "C" block: the header manages its own
+// linkage and pulls <stdbool.h>/<stdint.h> (matching Foreign.cpp).
+#include "combo_mm_options_view.h"
+
+namespace {
+
+// ---------------------------------------------------------------------------
+// Value labels for the four combo-valued options. Order is ENUMERATOR order
+// (index 0 first) because the pane writes the selected index straight into the
+// CVar and MM reads it back as the enumerator — a re-ordered array here would
+// silently map "Glitchless" onto RO_LOGIC_NO_LOGIC.
+// ---------------------------------------------------------------------------
+
+const char* const kLogicLabels[] = {
+    "Glitchless",       // RO_LOGIC_GLITCHLESS
+    "No Logic",         // RO_LOGIC_NO_LOGIC
+    "Nearly No Logic",  // RO_LOGIC_NEARLY_NO_LOGIC
+    "Vanilla",          // RO_LOGIC_VANILLA
+};
+
+const char* const kDungeonAccessLabels[] = {
+    "Requires Transformation & Song", // RO_ACCESS_DUNGEONS_FORM_AND_SONG
+    "Requires Transformation or Song", // RO_ACCESS_DUNGEONS_FORM_OR_SONG
+    "Requires Only Transformation",    // RO_ACCESS_DUNGEONS_FORM_ONLY
+    "Requires Only Song",              // RO_ACCESS_DUNGEONS_SONG_ONLY
+    "Open",                            // RO_ACCESS_DUNGEONS_OPEN
+};
+
+const char* const kTrialsAccessLabels[] = {
+    "2-6-12-20 Masks",                    // RO_ACCESS_TRIALS_20_MASKS
+    "Requires Associated Remains",        // RO_ACCESS_TRIALS_REMAINS
+    "Requires Associated Transformation", // RO_ACCESS_TRIALS_FORMS
+    "Open",                               // RO_ACCESS_TRIALS_OPEN
+};
+
+const char* const kClockProgressiveLabels[] = {
+    "Random",                  // RO_CLOCK_SHUFFLE_RANDOM
+    "Progressive: Ascending",  // RO_CLOCK_SHUFFLE_ASCENDING
+    "Progressive: Descending", // RO_CLOCK_SHUFFLE_DESCENDING
+};
+
+/**
+ * UI metadata for one option. Deliberately does NOT restate the id's cvar
+ * string or its default: both are copied from the `Rando::StaticData::Options`
+ * row at registration time, so the pane cannot bind a widget to a key MM does
+ * not read, and a default changed in Options.cpp cannot go stale here. The
+ * MMRandoOptions lock asserts that equality anyway, because "cannot drift" is
+ * worth proving rather than asserting in a comment.
+ */
+struct OptionUi {
+    RandoOptionId id;
+    ComboMMOptionGroup group;
+    ComboMMOptionWidget widget;
+    const char* label;
+    const char* tooltip;
+    int32_t minValue;
+    int32_t maxValue;
+    const char* const* valueLabels;
+    uint8_t valueCount;
+    ComboMMOptionLiveness liveness;
+    const char* disabledReason;
+};
+
+#define UI_COUNT(a) (uint8_t)(sizeof(a) / sizeof((a)[0]))
+
+// Reason strings shared by several rows, so a wording change stays one edit.
+constexpr const char* kReasonOpenText = "Not yet available: MM OnOpenText dispatch not placed (#438)";
+constexpr const char* kReasonActorInitDrop =
+    "Would strand items: the drop's OnActorInit dispatch is not placed (#438)";
+
+// clang-format off
+const OptionUi kOptionUi[] = {
+    // ---- Logic & Conditions ------------------------------------------------
+    { RO_LOGIC, COMBO_MM_GROUP_LOGIC, COMBO_MM_WIDGET_COMBO,
+      "Logic",
+      "Glitchless guarantees a beatable seed; No Logic and Nearly No Logic place freely; Vanilla does not shuffle.",
+      0, 0, kLogicLabels, UI_COUNT(kLogicLabels),
+      COMBO_MM_LIVENESS_GENERATION_ONLY, "" },
+    { RO_ACCESS_DUNGEONS, COMBO_MM_GROUP_LOGIC, COMBO_MM_WIDGET_COMBO,
+      "Dungeon Access",
+      "What a dungeon entrance requires: form and song, form or song, form only, song only, or nothing.",
+      0, 0, kDungeonAccessLabels, UI_COUNT(kDungeonAccessLabels),
+      COMBO_MM_LIVENESS_LIVE, "" },
+    { RO_ACCESS_TRIALS, COMBO_MM_GROUP_LOGIC, COMBO_MM_WIDGET_COMBO,
+      "Trials Access",
+      "What the Moon trials require. Mask counts, associated remains, associated transformation, or open.",
+      0, 0, kTrialsAccessLabels, UI_COUNT(kTrialsAccessLabels),
+      // Worse than inert: the VB leg reports every trial unlocked while the
+      // text leg that would gate it is dead, so a setting here reads as "Open"
+      // whatever it says.
+      COMBO_MM_LIVENESS_PARTIAL, "Trials read as Open regardless: gating needs MM OnOpenText dispatch (#438)" },
+    { RO_ACCESS_MOON_MASKS_COUNT, COMBO_MM_GROUP_LOGIC, COMBO_MM_WIDGET_SLIDER,
+      "Moon Access: Masks Required", "How many masks are needed to enter the Moon.",
+      0, 20, nullptr, 0, COMBO_MM_LIVENESS_LIVE, "" },
+    { RO_ACCESS_MOON_REMAINS_COUNT, COMBO_MM_GROUP_LOGIC, COMBO_MM_WIDGET_SLIDER,
+      "Moon Access: Remains Required", "How many boss remains are needed to enter the Moon.",
+      0, 4, nullptr, 0, COMBO_MM_LIVENESS_LIVE, "" },
+    { RO_ACCESS_MAJORA_MASKS_COUNT, COMBO_MM_GROUP_LOGIC, COMBO_MM_WIDGET_SLIDER,
+      "Majora Access: Masks Required", "How many masks are needed to reach Majora.",
+      0, 20, nullptr, 0,
+      COMBO_MM_LIVENESS_PARTIAL, "Logic only: the Majora gate needs MM OnOpenText dispatch (#438)" },
+    { RO_ACCESS_MAJORA_REMAINS_COUNT, COMBO_MM_GROUP_LOGIC, COMBO_MM_WIDGET_SLIDER,
+      "Majora Access: Remains Required", "How many boss remains are needed to reach Majora.",
+      0, 4, nullptr, 0,
+      COMBO_MM_LIVENESS_PARTIAL, "Logic only: the Majora gate needs MM OnOpenText dispatch (#438)" },
+    { RO_ACCESS_MAJORA_REMAINS, COMBO_MM_GROUP_LOGIC, COMBO_MM_WIDGET_CHECKBOX,
+      "Majora Access: Remains (unimplemented)",
+      "Declared but never implemented: no code in MM's randomizer reads this option.",
+      0, 0, nullptr, 0,
+      // The 47th id. Given a StaticData row so the option id space is total
+      // (#499 step 5), and shown disabled because it has no consumer at all —
+      // a control that writes a CVar nothing reads is the vacuous gate ADR
+      // 0004 section 5 forbids.
+      COMBO_MM_LIVENESS_DORMANT, "Not implemented: no code reads this option" },
+
+    // ---- Shuffle Options ---------------------------------------------------
+    { RO_SHUFFLE_COWS, COMBO_MM_GROUP_SHUFFLE, COMBO_MM_WIDGET_CHECKBOX,
+      "Shuffle Cows", "Adds the reward for playing Epona's Song for a cow to the check pool.",
+      0, 0, nullptr, 0, COMBO_MM_LIVENESS_LIVE, "" },
+    { RO_SHUFFLE_OWL_STATUES, COMBO_MM_GROUP_SHUFFLE, COMBO_MM_WIDGET_CHECKBOX,
+      "Shuffle Owl Statues", "Adds activating each Owl Statue to the check pool.",
+      0, 0, nullptr, 0, COMBO_MM_LIVENESS_LIVE, "" },
+    { RO_SHUFFLE_FREESTANDING_ITEMS, COMBO_MM_GROUP_SHUFFLE, COMBO_MM_WIDGET_CHECKBOX,
+      "Shuffle Freestanding Items", "Adds collectibles lying loose in the world to the check pool.",
+      0, 0, nullptr, 0, COMBO_MM_LIVENESS_LIVE, "" },
+    { RO_SHUFFLE_POT_DROPS, COMBO_MM_GROUP_SHUFFLE, COMBO_MM_WIDGET_CHECKBOX,
+      "Shuffle Pot Drops", "Adds the item dropped by breaking a pot to the check pool.",
+      0, 0, nullptr, 0, COMBO_MM_LIVENESS_LIVE, "" },
+    { RO_SHUFFLE_SNOWBALL_DROPS, COMBO_MM_GROUP_SHUFFLE, COMBO_MM_WIDGET_CHECKBOX,
+      "Shuffle Snowball Drops", "Adds the item dropped by breaking a snowball to the check pool.",
+      0, 0, nullptr, 0, COMBO_MM_LIVENESS_LIVE, "" },
+    { RO_SHUFFLE_BOSS_REMAINS, COMBO_MM_GROUP_SHUFFLE, COMBO_MM_WIDGET_CHECKBOX,
+      "Shuffle Boss Remains", "Shuffles the four Boss Remains into the item pool.",
+      0, 0, nullptr, 0, COMBO_MM_LIVENESS_LIVE, "" },
+    { RO_SHUFFLE_GOLD_SKULLTULAS, COMBO_MM_GROUP_SHUFFLE, COMBO_MM_WIDGET_CHECKBOX,
+      "Shuffle Gold Skulltula Tokens", "Adds the Spider House tokens to the check pool.",
+      0, 0, nullptr, 0,
+      COMBO_MM_LIVENESS_PARTIAL, "Token count is lost on a cycle reset: EndOfCycleSave dispatch missing (#438)" },
+    { RO_MINIMUM_SKULLTULA_TOKENS, COMBO_MM_GROUP_SHUFFLE, COMBO_MM_WIDGET_SLIDER,
+      "Minimum Gold Skulltula Tokens",
+      "Tokens needed for the Spider House reward. Forced to the vanilla value when tokens are not shuffled.",
+      1, SPIDER_HOUSE_TOKENS_REQUIRED, nullptr, 0, COMBO_MM_LIVENESS_LIVE, "" },
+    { RO_MINIMUM_STRAY_FAIRIES, COMBO_MM_GROUP_SHUFFLE, COMBO_MM_WIDGET_SLIDER,
+      "Minimum Stray Fairies",
+      "Stray Fairies needed for a Great Fairy reward. Does not affect the Clock Town fairy.",
+      1, STRAY_FAIRY_SCATTERED_TOTAL, nullptr, 0,
+      COMBO_MM_LIVENESS_PARTIAL, "Custom fairy counts need MM OnActorInit dispatch (#438)" },
+    { RO_SHUFFLE_FROGS, COMBO_MM_GROUP_SHUFFLE, COMBO_MM_WIDGET_CHECKBOX,
+      "Shuffle Frogs", "Adds the Frog Choir frogs to the check pool.",
+      0, 0, nullptr, 0,
+      COMBO_MM_LIVENESS_PARTIAL, "Frog checks need MM OnActorInit/OnOpenText dispatch (#438)" },
+    { RO_SHUFFLE_SHOPS, COMBO_MM_GROUP_SHUFFLE, COMBO_MM_WIDGET_CHECKBOX,
+      "Shuffle Shops", "Adds purchaseable shop slots to the check pool.",
+      0, 0, nullptr, 0,
+      COMBO_MM_LIVENESS_PARTIAL, "Shop text and pricing need MM OnOpenText/OnActorInit dispatch (#438)" },
+    { RO_SHUFFLE_TINGLE_SHOPS, COMBO_MM_GROUP_SHUFFLE, COMBO_MM_WIDGET_CHECKBOX,
+      "Shuffle Tingle Maps", "Adds the maps Tingle sells to the check pool.",
+      0, 0, nullptr, 0,
+      COMBO_MM_LIVENESS_PARTIAL, "Tingle shop text needs MM OnOpenText dispatch (#438)" },
+    { RO_SHUFFLE_CRATE_DROPS, COMBO_MM_GROUP_SHUFFLE, COMBO_MM_WIDGET_CHECKBOX,
+      "Shuffle Crate Drops", "Adds the item dropped by breaking a crate to the check pool.",
+      0, 0, nullptr, 0,
+      // Total dormancy, not cosmetic: the identify-the-check helper has no
+      // call site outside the undispatched hook, and the surviving VB legs
+      // bail on RC_UNKNOWN. Items placed here can never be collected.
+      COMBO_MM_LIVENESS_DORMANT, kReasonActorInitDrop },
+    { RO_SHUFFLE_BARREL_DROPS, COMBO_MM_GROUP_SHUFFLE, COMBO_MM_WIDGET_CHECKBOX,
+      "Shuffle Barrel Drops", "Adds the item dropped by breaking a barrel to the check pool.",
+      0, 0, nullptr, 0, COMBO_MM_LIVENESS_DORMANT, kReasonActorInitDrop },
+    { RO_SHUFFLE_GRASS_DROPS, COMBO_MM_GROUP_SHUFFLE, COMBO_MM_WIDGET_CHECKBOX,
+      "Shuffle Grass Drops", "Adds the item dropped by cutting grass to the check pool.",
+      0, 0, nullptr, 0, COMBO_MM_LIVENESS_DORMANT, kReasonActorInitDrop },
+
+    // ---- Items -------------------------------------------------------------
+    { RO_PLENTIFUL_ITEMS, COMBO_MM_GROUP_ITEMS, COMBO_MM_WIDGET_CHECKBOX,
+      "Plentiful Items", "Major items, masks and keys get an extra copy in the pool.",
+      0, 0, nullptr, 0, COMBO_MM_LIVENESS_GENERATION_ONLY, "" },
+    { RO_SHUFFLE_TRAPS, COMBO_MM_GROUP_ITEMS, COMBO_MM_WIDGET_CHECKBOX,
+      "Shuffle Traps", "Mixes Ice Traps into the item pool.",
+      0, 0, nullptr, 0, COMBO_MM_LIVENESS_LIVE, "" },
+    { RO_TRAP_AMOUNT, COMBO_MM_GROUP_ITEMS, COMBO_MM_WIDGET_SLIDER,
+      "Trap Count", "How many traps are shuffled into the item pool. Only used when traps are shuffled.",
+      1, 100, nullptr, 0, COMBO_MM_LIVENESS_GENERATION_ONLY, "" },
+    { RO_SHUFFLE_BOSS_SOULS, COMBO_MM_GROUP_ITEMS, COMBO_MM_WIDGET_CHECKBOX,
+      "Boss Souls", "Boss Souls enter the item pool; a boss does not spawn until its soul is found.",
+      0, 0, nullptr, 0, COMBO_MM_LIVENESS_LIVE, "" },
+    { RO_SHUFFLE_ENEMY_SOULS, COMBO_MM_GROUP_ITEMS, COMBO_MM_WIDGET_CHECKBOX,
+      "Enemy Souls", "Enemy Souls enter the item pool; an enemy is immune until its soul is found.",
+      0, 0, nullptr, 0, COMBO_MM_LIVENESS_LIVE, "" },
+    { RO_SHUFFLE_ENEMY_DROPS, COMBO_MM_GROUP_ITEMS, COMBO_MM_WIDGET_CHECKBOX,
+      "Enemy Drops", "Shuffles the first drop from a non-boss enemy.",
+      0, 0, nullptr, 0,
+      COMBO_MM_LIVENESS_PARTIAL, "Partly live: the kill-drop leg needs MM OnActorKill dispatch (#438)" },
+    { RO_SHUFFLE_OCARINA_BUTTONS, COMBO_MM_GROUP_ITEMS, COMBO_MM_WIDGET_CHECKBOX,
+      "Shuffle Ocarina Buttons", "Ocarina buttons become items; a song is unplayable until its notes are found.",
+      0, 0, nullptr, 0, COMBO_MM_LIVENESS_LIVE, "" },
+    { RO_SHUFFLE_SWIM, COMBO_MM_GROUP_ITEMS, COMBO_MM_WIDGET_CHECKBOX,
+      "Shuffle Swim", "Swimming becomes an item; deep water respawns Link until it is found.",
+      0, 0, nullptr, 0, COMBO_MM_LIVENESS_LIVE, "" },
+    { RO_SHUFFLE_TRIFORCE_PIECES, COMBO_MM_GROUP_ITEMS, COMBO_MM_WIDGET_CHECKBOX,
+      "Triforce Hunt", "Scatters Triforce Pieces through the pool; collecting enough of them wins the seed.",
+      0, 0, nullptr, 0, COMBO_MM_LIVENESS_LIVE, "" },
+    { RO_TRIFORCE_PIECES_MAX, COMBO_MM_GROUP_ITEMS, COMBO_MM_WIDGET_SLIDER,
+      "Triforce Pieces Shuffled",
+      "How many pieces are placed. Reduced automatically if the pool cannot hold that many.",
+      1, 1000, nullptr, 0, COMBO_MM_LIVENESS_GENERATION_ONLY, "" },
+    { RO_TRIFORCE_PIECES_REQUIRED, COMBO_MM_GROUP_ITEMS, COMBO_MM_WIDGET_SLIDER,
+      "Triforce Pieces Required", "How many pieces win the seed. Capped at the number shuffled.",
+      1, 15, nullptr, 0, COMBO_MM_LIVENESS_LIVE, "" },
+    { RO_CLOCK_SHUFFLE, COMBO_MM_GROUP_ITEMS, COMBO_MM_WIDGET_CHECKBOX,
+      "Shuffle Time", "Breaks the three-day cycle into six half-days that must be unlocked as items.",
+      0, 0, nullptr, 0,
+      COMBO_MM_LIVENESS_PARTIAL, "Partly live: half-day prompts need MM OnOpenText dispatch (#438)" },
+    { RO_CLOCK_SHUFFLE_PROGRESSIVE, COMBO_MM_GROUP_ITEMS, COMBO_MM_WIDGET_COMBO,
+      "Time Progression", "Random shuffles all six half-days; Ascending and Descending unlock them in order.",
+      0, 0, kClockProgressiveLabels, UI_COUNT(kClockProgressiveLabels),
+      COMBO_MM_LIVENESS_LIVE, "" },
+    { RO_CLOCK_TERMINAL_TIME, COMBO_MM_GROUP_ITEMS, COMBO_MM_WIDGET_TIME,
+      "Final Hours Start Time",
+      "When the Final Hours begin, 00:00 to 05:59. Baked into the seed and fixed once generated.",
+      0, 359, nullptr, 0, COMBO_MM_LIVENESS_LIVE, "" },
+
+    // ---- Starting Items ----------------------------------------------------
+    { RO_STARTING_HEALTH, COMBO_MM_GROUP_STARTING, COMBO_MM_WIDGET_SLIDER,
+      "Starting Hearts", "How many hearts a new file begins with.",
+      1, 20, nullptr, 0, COMBO_MM_LIVENESS_GENERATION_ONLY, "" },
+    { RO_STARTING_CONSUMABLES, COMBO_MM_GROUP_STARTING, COMBO_MM_WIDGET_CHECKBOX,
+      "Start With Full Consumables", "Begin with full Deku Sticks and Deku Nuts.",
+      0, 0, nullptr, 0, COMBO_MM_LIVENESS_GENERATION_ONLY, "" },
+    { RO_STARTING_RUPEES, COMBO_MM_GROUP_STARTING, COMBO_MM_WIDGET_CHECKBOX,
+      "Start With Full Wallet", "Begin with a full wallet.",
+      0, 0, nullptr, 0, COMBO_MM_LIVENESS_GENERATION_ONLY, "" },
+    { RO_STARTING_MAPS_AND_COMPASSES, COMBO_MM_GROUP_STARTING, COMBO_MM_WIDGET_CHECKBOX,
+      "Start With Maps & Compasses", "Begin with every dungeon map and compass.",
+      0, 0, nullptr, 0, COMBO_MM_LIVENESS_GENERATION_ONLY, "" },
+
+    // ---- Hints -------------------------------------------------------------
+    // Every hint family registers on OnOpenText, which has no MM dispatch
+    // point at all (#438's largest dormant surface, 98 registrations). None of
+    // these can do anything today, and two of them make things worse.
+    { RO_HINTS_GOSSIP_STONES, COMBO_MM_GROUP_HINTS, COMBO_MM_WIDGET_CHECKBOX,
+      "Gossip Stone Hints", "Each gossip stone gives a fixed hint about one location's contents.",
+      0, 0, nullptr, 0,
+      COMBO_MM_LIVENESS_PARTIAL, "Breaks stones: the verdict fires but the hint text needs OnOpenText (#438)" },
+    { RO_HINTS_PURCHASEABLE, COMBO_MM_GROUP_HINTS, COMBO_MM_WIDGET_CHECKBOX,
+      "Purchaseable Gossip Hints", "Gossip stones sell a hint for a scaling rupee cost.",
+      0, 0, nullptr, 0,
+      COMBO_MM_LIVENESS_PARTIAL, "Breaks stones: the purchase prompt needs OnOpenText dispatch (#438)" },
+    { RO_HINTS_SPIDER_HOUSES, COMBO_MM_GROUP_HINTS, COMBO_MM_WIDGET_CHECKBOX,
+      "Spider House Hints", "Hints for the two Spider House rewards.",
+      0, 0, nullptr, 0, COMBO_MM_LIVENESS_DORMANT, kReasonOpenText },
+    { RO_HINTS_HOOKSHOT, COMBO_MM_GROUP_HINTS, COMBO_MM_WIDGET_CHECKBOX,
+      "Hookshot Hint", "The Zora on Great Bay Coast hints where the Hookshot is.",
+      0, 0, nullptr, 0, COMBO_MM_LIVENESS_DORMANT, kReasonOpenText },
+    { RO_HINTS_BOSS_REMAINS, COMBO_MM_GROUP_HINTS, COMBO_MM_WIDGET_CHECKBOX,
+      "Boss Remains Hints", "The Clock Town recruitment posters hint where the Boss Remains are.",
+      0, 0, nullptr, 0, COMBO_MM_LIVENESS_DORMANT, kReasonOpenText },
+    { RO_HINTS_OATH_TO_ORDER, COMBO_MM_GROUP_HINTS, COMBO_MM_WIDGET_CHECKBOX,
+      "Oath to Order Hint", "Skull Kid hints where Oath to Order is once the Moon is reachable.",
+      0, 0, nullptr, 0,
+      COMBO_MM_LIVENESS_PARTIAL, "Partly live: the hint text needs MM OnOpenText dispatch (#438)" },
+};
+// clang-format on
+
+#undef UI_COUNT
+
+/**
+ * The descriptor table handed to src/common, built once at registration.
+ *
+ * Built rather than written out because `cvar` and `defaultValue` are COPIED
+ * from the matching `Rando::StaticData::Options` row: restating them here would
+ * create a second place for a key name to live, and the failure mode of that
+ * drift is a pane whose widgets write CVars the generator never reads — which
+ * looks exactly like a working menu.
+ *
+ * A `RO_*` id present in kOptionUi but absent from StaticData::Options is
+ * skipped rather than guessed at; the MMRandoOptions lock turns that skip into
+ * a test failure, since a silently shorter table is the same class of quiet
+ * incompleteness the 47-vs-46 skew was.
+ */
+std::vector<ComboMMOptionDesc>& DescriptorTable() {
+    static std::vector<ComboMMOptionDesc> sDescriptors;
+    if (!sDescriptors.empty()) {
+        return sDescriptors;
+    }
+    sDescriptors.reserve(sizeof(kOptionUi) / sizeof(kOptionUi[0]));
+    for (const OptionUi& ui : kOptionUi) {
+        auto it = Rando::StaticData::Options.find(ui.id);
+        if (it == Rando::StaticData::Options.end()) {
+            continue;
+        }
+        const Rando::StaticData::RandoStaticOption& row = it->second;
+
+        ComboMMOptionDesc desc = {};
+        desc.id = (uint16_t)ui.id;
+        desc.name = row.name;
+        desc.cvar = row.cvar;
+        desc.label = ui.label;
+        desc.tooltip = ui.tooltip;
+        desc.group = (uint8_t)ui.group;
+        desc.widget = (uint8_t)ui.widget;
+        desc.defaultValue = (int32_t)row.defaultValue;
+        desc.minValue = ui.minValue;
+        desc.maxValue = ui.maxValue;
+        desc.valueLabels = ui.valueLabels;
+        desc.valueCount = ui.valueCount;
+        desc.liveness = (uint8_t)ui.liveness;
+        desc.disabledReason = ui.disabledReason;
+        sDescriptors.push_back(desc);
+    }
+    return sDescriptors;
+}
+
+} // namespace
+
+/**
+ * Publish the table to src/common.
+ *
+ * DELIBERATELY NOT a file-scope registrar, which is what the foreign-item pools
+ * use. Those register a table of literals; this one READS
+ * `Rando::StaticData::Options`, a namespace-scope std::map in another
+ * translation unit. Static initialization order across TUs is unspecified, so a
+ * file-scope registrar could publish a table built from an empty map — and it
+ * would fail as "the pane has no rows", with nothing pointing at the cause.
+ *
+ * Called instead from Combo_MMOptionsWindow_Init(), which runs from the combo
+ * entry point after both games' statics are constructed. Idempotent: the
+ * descriptor vector is built once and re-registering the same pointer is
+ * harmless (the registry logs a replacement, which is why the window calls this
+ * once rather than per frame).
+ */
+extern "C" void MM_RandoOptionsUi_Register(void) {
+    auto& table = DescriptorTable();
+    Combo_RegisterMMOptionTable(table.data(), (int)table.size());
+}
+
+#endif // RSBS_SINGLE_EXECUTABLE

--- a/games/mm/2s2h/Rando/StaticData/Options.cpp
+++ b/games/mm/2s2h/Rando/StaticData/Options.cpp
@@ -20,6 +20,20 @@ std::map<RandoOptionId, RandoStaticOption> Options = {
     RO(RO_ACCESS_DUNGEONS,             RO_ACCESS_DUNGEONS_FORM_AND_SONG),
     RO(RO_ACCESS_MAJORA_MASKS_COUNT,   0),
     RO(RO_ACCESS_MAJORA_REMAINS_COUNT, 0),
+    // 47 ids, 46 rows: RO_ACCESS_MAJORA_REMAINS was declared (Types.h) and never
+    // given a row, so the snapshot loop skipped its RANDO_SAVE_OPTIONS slot, the
+    // spoiler never recorded it, and every iteration over the id space was
+    // partial. #499 step 5 required settling that BEFORE a table-driven surface
+    // existed, and the two candidates were "add the row" and "delete the
+    // enumerator". Deleting it renumbers the 44 enumerators after it, and
+    // RANDO_SAVE_OPTIONS is indexed BY that number in every already-written MM
+    // rando save — a silent value shift across a save format, to tidy dead
+    // surface. Adding the row costs one always-zero slot and makes the id space
+    // total. NOTE the option has no consumer anywhere in MM; the combo options
+    // pane therefore draws it disabled-with-reason rather than as a working
+    // control (ADR 0004 §5), which is exactly the honest presentation of a row
+    // that exists for table completeness.
+    RO(RO_ACCESS_MAJORA_REMAINS,       RO_GENERIC_OFF),
     RO(RO_ACCESS_MOON_MASKS_COUNT,     0),
     RO(RO_ACCESS_MOON_REMAINS_COUNT,   4),
     RO(RO_ACCESS_TRIALS,               RO_ACCESS_TRIALS_20_MASKS),

--- a/games/mm/2s2h/mm_rando_options_test.cpp
+++ b/games/mm/2s2h/mm_rando_options_test.cpp
@@ -1,0 +1,391 @@
+/**
+ * ROM-free locks for MM's randomizer option surface (#497 step 4, #499).
+ * CTest label "redship" (display-free); rows `mm-rando-options` and
+ * `mm-paired-profile` in src/common/test_runner.cpp.
+ *
+ * Lives MM-side because it is the ONE place where both tables are in scope:
+ * `Rando::StaticData::Options` (MM's, needing MM's headers) and the flat
+ * descriptor table the combo pane consumes (`src/common/combo_mm_options_view.h`).
+ * Asserting they agree from src/common would require common code to acquire an
+ * MM header, which is exactly what the seam exists to avoid.
+ *
+ * ============================================================================
+ * mm-rando-options — the table lock
+ * ============================================================================
+ *
+ * Drives the REAL registrar, not a copy, and asserts:
+ *
+ *  (a) every `RandoOptionId < RO_MAX` has a `StaticData::Options` row. RED
+ *      before this arc: RO_ACCESS_MAJORA_REMAINS was declared and never given
+ *      one (47 ids, 46 rows), so the snapshot loop skipped its
+ *      RANDO_SAVE_OPTIONS slot and every iteration over the id space was
+ *      silently partial.
+ *  (b) every id also has a DESCRIPTOR row, and the descriptor's `cvar`,
+ *      `name` and `defaultValue` are the StaticData row's own. This is the
+ *      lock that matters: a pane bound to a key MM does not read is a control
+ *      that flips a CVar and changes nothing — ADR 0004 §5's vacuous gate, in
+ *      the form hardest to notice, because the widget works.
+ *  (c) the emitted set covers the table EXACTLY — no duplicate ids, no rows
+ *      for ids outside the table, count equal on both sides.
+ *  (d) capability-gating honesty, both directions: a PARTIAL/DORMANT row must
+ *      carry a non-empty reason, and a LIVE/GENERATION_ONLY row must carry an
+ *      empty one. A dormant row with no reason reads as a broken port; a live
+ *      row with a reason reads as broken and is not.
+ *  (e) widget well-formedness: combo rows have >= 2 value labels and a default
+ *      inside them, slider/time rows have min < max and a default inside them.
+ *      A combo whose default sits outside its label array indexes out of
+ *      bounds in the pane's preview.
+ *  (f) the value accessors round-trip through the real CVar store, and clamp:
+ *      an out-of-range write must not reach RANDO_SAVE_OPTIONS, which is
+ *      indexed by generation code.
+ *
+ * ============================================================================
+ * mm-paired-profile — the profile lock (#499 Tier 1)
+ * ============================================================================
+ *
+ * Drives the REAL `Rando::Foreign::ResolvePairedProfile()` — the same function
+ * OnFileCreate calls, not a re-derivation — over a zeroed MM SaveContext, with
+ * no fill and no display. It asserts the profile, the logic default's new
+ * honour-an-explicit-choice rule, and the `gComboCtx.mmProfileDigest` carve.
+ *
+ * THE TRAP THIS DESIGN AVOIDS, stated because the obvious test is vacuous: an
+ * assertion of the form "set a CVar, generate, observe it in the save" passes
+ * TODAY — that path has always worked — and proves nothing about the profile
+ * being chosen rather than defaulted. What is asserted instead is the thing
+ * that was not true before: that an explicitly-set option survives the paired
+ * pin, that an unset one gets the pinned default, and that the two produce
+ * DIFFERENT digests.
+ */
+
+#ifdef RSBS_SINGLE_EXECUTABLE
+
+#include <cstdarg>
+#include <cstdio>
+#include <cstring>
+#include <string>
+
+#include <libultraship/bridge/consolevariablebridge.h>
+
+#include "Rando/Rando.h"
+#include "Rando/Types.h"
+#include "Rando/Foreign.h"
+#include "Rando/StaticData/StaticData.h"
+
+// src/common — outside any extern "C" block; these headers manage their own
+// linkage (matching Foreign.cpp).
+#include "combo_mm_options_view.h"
+#include "foreign_items.h"
+
+extern "C" {
+#include "variables.h"
+// SPIDER_HOUSE_TOKENS_REQUIRED — the vanilla token requirement the derived
+// correction falls back to.
+#include "overlays/actors/ovl_En_Sth/z_en_sth.h"
+}
+
+namespace {
+
+int Fail(int code, const char* fmt, ...) {
+    va_list args;
+    va_start(args, fmt);
+    fprintf(stderr, "[MM-RANDO-OPTIONS] FAIL(%d): ", code);
+    vfprintf(stderr, fmt, args);
+    fprintf(stderr, "\n");
+    va_end(args);
+    return code;
+}
+
+/** Clear every option CVar so a run starts from "nobody has chosen anything". */
+void ClearAllOptionCVars() {
+    for (auto& [randoOptionId, row] : Rando::StaticData::Options) {
+        (void)randoOptionId;
+        CVarClear(row.cvar);
+    }
+}
+
+} // namespace
+
+extern "C" int MM_RandoOptions_RunHeadless(void) {
+    printf("[TEST] mm-rando-options: MM's 47 rando options have rows, labels, honest gating, and CVar-bound "
+           "widgets (#497 step 4, #499 step 5)\n");
+
+    // Drive the real registrar. Combo_MMOptionsWindow_Init also calls this;
+    // calling it directly is what keeps this test a lock on the TABLE rather
+    // than on the window.
+    MM_RandoOptionsUi_Register();
+
+    // ---- (a) every id has a StaticData row --------------------------------
+    // This is the 47-vs-46 skew. It must be checked over the ENUM, not over the
+    // map: iterating the map can only ever find rows that exist.
+    for (int id = 0; id < RO_MAX; id++) {
+        if (Rando::StaticData::Options.find((RandoOptionId)id) == Rando::StaticData::Options.end()) {
+            return Fail(23, "RandoOptionId %d has no Rando::StaticData::Options row (the 47-vs-46 skew)", id);
+        }
+    }
+    if ((int)Rando::StaticData::Options.size() != RO_MAX) {
+        return Fail(24, "Options table holds %d rows for %d ids", (int)Rando::StaticData::Options.size(), (int)RO_MAX);
+    }
+
+    // ---- (b)(c) descriptor coverage, exactness, and binding ---------------
+    const int descCount = Combo_MMOptionCount();
+    if (descCount != RO_MAX) {
+        return Fail(25, "descriptor table holds %d rows for %d option ids — the pane would silently omit options",
+                    descCount, (int)RO_MAX);
+    }
+
+    bool seen[RO_MAX] = { false };
+    for (int i = 0; i < descCount; i++) {
+        const ComboMMOptionDesc* desc = Combo_MMOptionAt(i);
+        if (desc == NULL) {
+            return Fail(26, "descriptor index %d is NULL below the reported count", i);
+        }
+        if (desc->id >= (uint16_t)RO_MAX) {
+            return Fail(27, "descriptor %d carries id %u, outside the option id space", i, (unsigned)desc->id);
+        }
+        if (seen[desc->id]) {
+            return Fail(28, "descriptor id %u appears twice — the pane would draw two widgets on one CVar",
+                        (unsigned)desc->id);
+        }
+        seen[desc->id] = true;
+
+        const auto& row = Rando::StaticData::Options.at((RandoOptionId)desc->id);
+        if (desc->cvar == NULL || strcmp(desc->cvar, row.cvar) != 0) {
+            return Fail(29, "descriptor for %s binds cvar '%s', but MM reads '%s'", row.name,
+                        desc->cvar ? desc->cvar : "(null)", row.cvar);
+        }
+        if (desc->name == NULL || strcmp(desc->name, row.name) != 0) {
+            return Fail(30, "descriptor for %s carries name '%s'", row.name, desc->name ? desc->name : "(null)");
+        }
+        if (desc->defaultValue != (int32_t)row.defaultValue) {
+            return Fail(31, "descriptor for %s carries default %d, StaticData says %u", row.name,
+                        (int)desc->defaultValue, (unsigned)row.defaultValue);
+        }
+        if (desc->label == NULL || desc->label[0] == '\0') {
+            return Fail(32, "descriptor for %s has no human label", row.name);
+        }
+        if (desc->tooltip == NULL) {
+            return Fail(33, "descriptor for %s has a NULL tooltip (ImGui would be handed an invalid pointer)",
+                        row.name);
+        }
+        if (desc->group >= (uint8_t)COMBO_MM_GROUP_COUNT) {
+            return Fail(34, "descriptor for %s is in group %u, outside the taxonomy", row.name,
+                        (unsigned)desc->group);
+        }
+
+        // ---- (d) capability-gating honesty, BOTH directions ---------------
+        const bool blocked =
+            desc->liveness == COMBO_MM_LIVENESS_PARTIAL || desc->liveness == COMBO_MM_LIVENESS_DORMANT;
+        if (desc->disabledReason == NULL) {
+            return Fail(35, "descriptor for %s has a NULL reason string", row.name);
+        }
+        if (blocked && desc->disabledReason[0] == '\0') {
+            return Fail(36, "%s is gated (liveness %u) but carries no reason — the row would read as broken",
+                        row.name, (unsigned)desc->liveness);
+        }
+        if (!blocked && desc->disabledReason[0] != '\0') {
+            return Fail(37, "%s is live but carries a disabled reason ('%s')", row.name, desc->disabledReason);
+        }
+
+        // ---- (e) widget well-formedness ------------------------------------
+        switch ((ComboMMOptionWidget)desc->widget) {
+            case COMBO_MM_WIDGET_CHECKBOX:
+                if (desc->defaultValue < 0 || desc->defaultValue > 1) {
+                    return Fail(38, "%s is a checkbox with default %d", row.name, (int)desc->defaultValue);
+                }
+                break;
+            case COMBO_MM_WIDGET_COMBO:
+                if (desc->valueLabels == NULL || desc->valueCount < 2) {
+                    return Fail(39, "%s is a combo with %u value labels", row.name, (unsigned)desc->valueCount);
+                }
+                if (desc->defaultValue < 0 || desc->defaultValue >= (int32_t)desc->valueCount) {
+                    return Fail(40, "%s defaults to %d, outside its %u value labels — the pane would index out "
+                                    "of bounds drawing the preview",
+                                row.name, (int)desc->defaultValue, (unsigned)desc->valueCount);
+                }
+                for (int v = 0; v < (int)desc->valueCount; v++) {
+                    if (desc->valueLabels[v] == NULL || desc->valueLabels[v][0] == '\0') {
+                        return Fail(41, "%s value label %d is empty", row.name, v);
+                    }
+                }
+                break;
+            case COMBO_MM_WIDGET_SLIDER:
+            case COMBO_MM_WIDGET_TIME:
+                if (desc->minValue >= desc->maxValue) {
+                    return Fail(42, "%s is a slider with range [%d, %d]", row.name, (int)desc->minValue,
+                                (int)desc->maxValue);
+                }
+                if (desc->defaultValue < desc->minValue || desc->defaultValue > desc->maxValue) {
+                    return Fail(43, "%s defaults to %d, outside its range [%d, %d]", row.name,
+                                (int)desc->defaultValue, (int)desc->minValue, (int)desc->maxValue);
+                }
+                break;
+            default:
+                return Fail(44, "%s carries widget kind %u", row.name, (unsigned)desc->widget);
+        }
+    }
+    for (int id = 0; id < RO_MAX; id++) {
+        if (!seen[id]) {
+            return Fail(45, "option id %d (%s) has no descriptor row — the pane cannot show it", id,
+                        Rando::StaticData::Options.at((RandoOptionId)id).name);
+        }
+    }
+
+    // ---- (f) the value accessors actually reach the CVar store ------------
+    {
+        const ComboMMOptionDesc* logic = Combo_MMOptionById((uint16_t)RO_LOGIC);
+        if (logic == NULL) {
+            return Fail(46, "RO_LOGIC has no descriptor");
+        }
+        CVarClear(logic->cvar);
+        if (Combo_MMOptionIsExplicit(logic)) {
+            return Fail(47, "RO_LOGIC reads as explicitly set after CVarClear");
+        }
+        if (Combo_MMOptionGetValue(logic) != logic->defaultValue) {
+            return Fail(48, "an unset option does not read back its default");
+        }
+        Combo_MMOptionSetValue(logic, RO_LOGIC_VANILLA);
+        if (!Combo_MMOptionIsExplicit(logic) || Combo_MMOptionGetValue(logic) != RO_LOGIC_VANILLA) {
+            return Fail(49, "a written option does not read back its value");
+        }
+        // Clamping: RO_LOGIC has 4 values, so 99 must land on 3, not on 99.
+        // An unclamped write reaches RANDO_SAVE_OPTIONS and is then used as an
+        // index by generation code.
+        Combo_MMOptionSetValue(logic, 99);
+        if (Combo_MMOptionGetValue(logic) != (int32_t)logic->valueCount - 1) {
+            return Fail(50, "an over-range combo write was not clamped (read back %d)",
+                        (int)Combo_MMOptionGetValue(logic));
+        }
+        Combo_MMOptionSetValue(logic, -7);
+        if (Combo_MMOptionGetValue(logic) != 0) {
+            return Fail(51, "an under-range combo write was not clamped (read back %d)",
+                        (int)Combo_MMOptionGetValue(logic));
+        }
+        Combo_MMOptionClear(logic);
+        if (Combo_MMOptionIsExplicit(logic)) {
+            return Fail(52, "Combo_MMOptionClear left the option explicitly set");
+        }
+    }
+
+    ClearAllOptionCVars();
+    printf("[TEST] PASS: %d option ids all have StaticData rows and descriptor rows, every widget is bound to the "
+           "row's own cvar, and every gated row names its reason\n",
+           (int)RO_MAX);
+    return 0;
+}
+
+extern "C" int MM_PairedProfile_RunHeadless(void) {
+    printf("[TEST] mm-paired-profile: the real ResolvePairedProfile decides the paired MM profile and publishes its "
+           "digest (#499 steps 2-4)\n");
+
+    const GameId prevGame = Context_GetCurrentGame();
+    ClearAllOptionCVars();
+
+    // A zeroed MM SaveContext, no fill, no display — the whole point of
+    // extracting the resolver is that this is enough to drive it.
+    memset(&gSaveContext, 0, sizeof(gSaveContext));
+    ComboContext_Init();
+
+    // ---- unpaired: options resolve, nothing else happens -------------------
+    Rando::Foreign::ResolvePairedProfile(false);
+    for (auto& [randoOptionId, row] : Rando::StaticData::Options) {
+        if (RANDO_SAVE_OPTIONS[randoOptionId] != row.defaultValue &&
+            !(randoOptionId == RO_MINIMUM_SKULLTULA_TOKENS)) {
+            return Fail(53, "unpaired resolution wrote %u to %s, expected its default %u",
+                        (unsigned)RANDO_SAVE_OPTIONS[randoOptionId], row.name, (unsigned)row.defaultValue);
+        }
+    }
+    if (RANDO_SAVE_OPTIONS[RO_LOGIC] != RO_LOGIC_GLITCHLESS) {
+        return Fail(54, "unpaired resolution applied the paired logic pin (RO_LOGIC = %u)",
+                    (unsigned)RANDO_SAVE_OPTIONS[RO_LOGIC]);
+    }
+    if (gComboCtx.mmProfileDigest != 0) {
+        // A solo file claiming a paired identity is the mispairing class ADR
+        // 0002 exists to prevent, arriving from the cheapest possible mistake.
+        return Fail(55, "unpaired resolution stamped a profile digest (%08X)", gComboCtx.mmProfileDigest);
+    }
+
+    // ---- paired, nothing chosen: the #426 default applies ------------------
+    // Stamp the Lane B carrier the way OoT's producer would, so
+    // Combo_ForeignPairingActive() is true for the summary read below.
+    gComboCtx.sourceIsRando = true;
+    gComboCtx.sharedRandoSeed = 0xC0FFEE11u;
+    gComboCtx.sharedRandoSettingsHash = 0x5EED0411u;
+
+    const uint32_t defaultDigest = Rando::Foreign::ResolvePairedProfile(true);
+    if (RANDO_SAVE_OPTIONS[RO_LOGIC] != RO_LOGIC_NEARLY_NO_LOGIC) {
+        return Fail(56, "with no explicit choice, the paired profile did not default RO_LOGIC to Nearly No Logic "
+                        "(got %u)",
+                    (unsigned)RANDO_SAVE_OPTIONS[RO_LOGIC]);
+    }
+    if (defaultDigest == 0 || gComboCtx.mmProfileDigest != defaultDigest) {
+        return Fail(57, "paired resolution did not publish a non-zero digest (returned %08X, ctx holds %08X)",
+                    defaultDigest, gComboCtx.mmProfileDigest);
+    }
+
+    // Stability: same inputs, same digest. Without this, "the digest detects a
+    // mismatch" is unprovable — an unstable digest reports a mismatch between
+    // a world and itself.
+    const uint32_t repeatDigest = Rando::Foreign::ResolvePairedProfile(true);
+    if (repeatDigest != defaultDigest) {
+        return Fail(58, "the profile digest is not stable across runs (%08X then %08X)", defaultDigest,
+                    repeatDigest);
+    }
+
+    // The summary the pane reads must agree with the context.
+    ComboMMProfileSummary summary;
+    Combo_MMProfileSummary(&summary);
+    if (!summary.paired || summary.mmProfileDigest != defaultDigest) {
+        return Fail(59, "the pane's summary disagrees with gComboCtx (paired=%d digest=%08X)", summary.paired ? 1 : 0,
+                    summary.mmProfileDigest);
+    }
+
+    // ---- paired, logic explicitly chosen: the choice survives --------------
+    // This is the behaviour #499 step 3 asked for and the reason the pin moved
+    // from "unless already extreme" to "unless the player chose". The old
+    // condition could not tell a chosen Glitchless from an untouched key whose
+    // StaticData default happens to be Glitchless, and pinned both.
+    CVarSetInteger(Rando::StaticData::Options[RO_LOGIC].cvar, RO_LOGIC_GLITCHLESS);
+    const uint32_t chosenDigest = Rando::Foreign::ResolvePairedProfile(true);
+    if (RANDO_SAVE_OPTIONS[RO_LOGIC] != RO_LOGIC_GLITCHLESS) {
+        return Fail(60, "an explicitly chosen RO_LOGIC was overridden by the paired pin (got %u)",
+                    (unsigned)RANDO_SAVE_OPTIONS[RO_LOGIC]);
+    }
+    if (chosenDigest == defaultDigest) {
+        return Fail(61, "changing the profile did not change its digest — two different MM worlds would carry one "
+                        "identity");
+    }
+
+    // ---- a flipped shuffle row also moves the digest -----------------------
+    CVarClear(Rando::StaticData::Options[RO_LOGIC].cvar);
+    CVarSetInteger(Rando::StaticData::Options[RO_SHUFFLE_COWS].cvar, RO_GENERIC_ON);
+    const uint32_t cowsDigest = Rando::Foreign::ResolvePairedProfile(true);
+    if (RANDO_SAVE_OPTIONS[RO_SHUFFLE_COWS] != RO_GENERIC_ON) {
+        return Fail(62, "an explicitly enabled shuffle did not reach RANDO_SAVE_OPTIONS");
+    }
+    if (cowsDigest == defaultDigest) {
+        return Fail(63, "flipping RO_SHUFFLE_COWS did not change the profile digest");
+    }
+
+    // ---- the derived correction still applies -----------------------------
+    // With skulltulas unshuffled the token requirement is the vanilla one
+    // whatever the slider says. Regressing this makes an unreachable check.
+    CVarSetInteger(Rando::StaticData::Options[RO_SHUFFLE_GOLD_SKULLTULAS].cvar, RO_GENERIC_OFF);
+    CVarSetInteger(Rando::StaticData::Options[RO_MINIMUM_SKULLTULA_TOKENS].cvar, 5);
+    Rando::Foreign::ResolvePairedProfile(true);
+    if (RANDO_SAVE_OPTIONS[RO_MINIMUM_SKULLTULA_TOKENS] != SPIDER_HOUSE_TOKENS_REQUIRED) {
+        return Fail(64, "with skulltulas unshuffled the token requirement was not forced to vanilla (got %u)",
+                    (unsigned)RANDO_SAVE_OPTIONS[RO_MINIMUM_SKULLTULA_TOKENS]);
+    }
+
+    // Leave global state clean for whatever runs next.
+    ClearAllOptionCVars();
+    memset(&gSaveContext, 0, sizeof(gSaveContext));
+    ComboContext_Init();
+    Context_SetCurrentGame(prevGame);
+
+    printf("[TEST] PASS: the paired profile honours an explicit choice, defaults the rest, and publishes a stable "
+           "digest that moves when the profile does\n");
+    return 0;
+}
+
+#endif // RSBS_SINGLE_EXECUTABLE

--- a/rsbs/src/main.cpp
+++ b/rsbs/src/main.cpp
@@ -25,7 +25,8 @@
 #include "game.h"
 #include "game_lifecycle.h"
 #include "context.h"
-#include "ComboSpoilerWindow.h" // Combo_SpoilerWindow_Init (#496, ADR 0008)
+#include "ComboSpoilerWindow.h"   // Combo_SpoilerWindow_Init (#496, ADR 0008)
+#include "ComboMmOptionsWindow.h" // Combo_MMOptionsWindow_Init (#497/#499, ADR 0004+0008)
 #include "entrance.h"
 #include "rsbs_version.h"
 #include "test_runner.h"
@@ -497,6 +498,14 @@ int main(int argc, char** argv) {
     // (ADR 0008). Whichever game started has created the Ship::Context and
     // its Gui by now; the call is a safe no-op if it has not.
     Combo_SpoilerWindow_Init();
+
+    // MM randomizer options pane (#497 step 4, #499). Same seam, same reason —
+    // but the timing argument is stronger here than for the spoiler: the paired
+    // MM profile is snapshotted at MM's cross-game arrival and an existing MM
+    // save is never regenerated, so a chooser hung off MM's boot would only
+    // exist after the point at which it could still change anything. It has to
+    // be reachable while OoT is the running game.
+    Combo_MMOptionsWindow_Init();
 
     // Belt and braces: re-assert the unattended-safe handlers after game init.
     // The claim above already makes Ship::Context::InitCrashHandler a no-op

--- a/src/common/ComboMmOptionsWindow.cpp
+++ b/src/common/ComboMmOptionsWindow.cpp
@@ -1,0 +1,310 @@
+/**
+ * @file ComboMmOptionsWindow.cpp
+ * @brief Renders MM's randomizer option set in-game (#497 step 4, #499).
+ *
+ * See ComboMmOptionsWindow.h for the contract. Every value drawn here comes
+ * from combo_mm_options_view.h; this file holds no state of its own and caches
+ * nothing, so a CVar changed anywhere else shows up on the next frame.
+ */
+
+#include "ComboMmOptionsWindow.h"
+
+#include <cstdio>
+
+#include <imgui.h>
+#include <ship/Context.h>
+#include <ship/window/Window.h>
+#include <ship/window/gui/Gui.h>
+#include <libultraship/bridge/consolevariablebridge.h>
+
+#include "combo_mm_options_view.h"
+#include "context.h" // Context_GetCurrentGame — for the "MM is suspended" state
+
+namespace ComboGui {
+
+namespace {
+
+/**
+ * Draw the pane-wide warnings.
+ *
+ * These are pane-wide because their causes are: they are properties of the
+ * paired-generation pipeline and of MM's dormant cycle-save hooks, not of any
+ * one option. Repeating them 47 times as per-row reason strings would bury the
+ * per-row reasons that ARE specific.
+ */
+void DrawStandingWarnings() {
+    const ImVec4 warn(0.98f, 0.76f, 0.24f, 1.0f);
+
+    // (1) The timing constraint (#499). The profile is snapshotted when MM's
+    // cross-game arrival dispatches OnSaveInit, and an existing MM save is
+    // never regenerated. Changing an option after crossing does nothing at
+    // all, which is exactly the kind of silent no-op this pane exists to stop
+    // being possible.
+    ImGui::TextColored(warn, "These apply to the NEXT Majora's Mask file.");
+    ImGui::TextWrapped("The paired MM world snapshots these options the first time you cross into Majora's Mask. An "
+                       "MM save that already exists is never regenerated, so set them before you cross.");
+    ImGui::Spacing();
+
+    // (2) The silent-vanilla-revert hazard. A paired generation that throws
+    // reverts the save to vanilla with no retry and no error surface; the
+    // player just gets a vanilla MM. Logic mode is the setting most likely to
+    // cause it, so the warning lives next to the options rather than in a log.
+    ImGui::TextColored(warn, "A failed generation falls back to vanilla Majora's Mask.");
+    ImGui::TextWrapped("Paired generation is attempt-free by design. If your settings make the fill dead-end, the MM "
+                       "file becomes an ordinary vanilla file rather than reporting an error. Glitchless logic is the "
+                       "setting most likely to do this.");
+    ImGui::Spacing();
+
+    // (3) The cycle-save hazard, which is rando-wide rather than per-option:
+    // Before/AfterEndOfCycleSave are registered unconditionally under IS_RANDO
+    // and dormant, and their body is what carries dungeon items, keys, stray
+    // fairies and trade slots across a cycle reset.
+    ImGui::TextColored(warn, "Cycle resets are not yet rando-aware.");
+    ImGui::TextWrapped("MM's end-of-cycle save hooks have no dispatch point in this build (#438), so playing the Song "
+                       "of Time can lose randomizer progress regardless of the options below.");
+    ImGui::Separator();
+}
+
+/** The pairing header: which world these options describe, if any. */
+void DrawPairingSummary() {
+    ComboMMProfileSummary summary;
+    Combo_MMProfileSummary(&summary);
+
+    if (!summary.paired) {
+        // "Not paired" and "paired with a default profile" are different facts.
+        // Rendering a seedless header would tell the player these options
+        // belong to a world that does not exist.
+        ImGui::TextWrapped("No paired world yet. Generate a randomized Ocarina of Time world; the Majora's Mask half "
+                           "derives from it, using the options below.");
+        ImGui::Separator();
+        return;
+    }
+
+    ImGui::Text("Paired seed: %u", (unsigned)summary.sharedRandoSeed);
+    ImGui::Text("OoT settings digest: %08X", (unsigned)summary.sharedRandoSettingsHash);
+    if (summary.mmProfileDigest == 0) {
+        // Zero is "unset", not "broken": the MM half has not been generated
+        // yet, which is the normal state for a player still in OoT.
+        ImGui::TextUnformatted("MM profile digest: not resolved yet (no MM file generated)");
+    } else {
+        ImGui::Text("MM profile digest: %08X", (unsigned)summary.mmProfileDigest);
+    }
+    ImGui::Separator();
+}
+
+/**
+ * The third presentation state (ADR 0004 section 6): editable, but not the
+ * running game. Distinct from "live" and from "disabled by capability" —
+ * collapsing it into either would misdescribe it.
+ */
+void DrawActiveGameState() {
+    if (Context_GetCurrentGame() == GAME_MM) {
+        ImGui::TextUnformatted("Majora's Mask - running");
+    } else {
+        ImGui::TextDisabled("Majora's Mask - suspended (these stay editable)");
+    }
+    ImGui::Spacing();
+}
+
+/** Tooltip helper: MM's own menu attaches these on hover, so this one does too. */
+void HoverTooltip(const char* text) {
+    if (text != nullptr && text[0] != '\0' && ImGui::IsItemHovered()) {
+        ImGui::SetTooltip("%s", text);
+    }
+}
+
+/** True when the row must be drawn disabled with its reason (ADR 0004 §5). */
+bool IsCapabilityBlocked(const ComboMMOptionDesc* desc) {
+    return desc->liveness == COMBO_MM_LIVENESS_PARTIAL || desc->liveness == COMBO_MM_LIVENESS_DORMANT;
+}
+
+void DrawOptionRow(const ComboMMOptionDesc* desc) {
+    const bool blocked = IsCapabilityBlocked(desc);
+
+    if (blocked) {
+        ImGui::BeginDisabled();
+    }
+
+    int32_t value = Combo_MMOptionGetValue(desc);
+
+    switch ((ComboMMOptionWidget)desc->widget) {
+        case COMBO_MM_WIDGET_CHECKBOX: {
+            bool on = value != 0;
+            if (ImGui::Checkbox(desc->label, &on)) {
+                Combo_MMOptionSetValue(desc, on ? 1 : 0);
+            }
+            break;
+        }
+        case COMBO_MM_WIDGET_COMBO: {
+            // valueCount is asserted non-zero for every combo row by the
+            // MMRandoOptions lock; the guard is here so a broken table
+            // degrades to an unusable row rather than indexing out of bounds.
+            const char* preview = "(no values)";
+            if (desc->valueLabels != NULL && desc->valueCount > 0 && value >= 0 && value < (int32_t)desc->valueCount) {
+                preview = desc->valueLabels[value];
+            }
+            if (desc->valueLabels != NULL && ImGui::BeginCombo(desc->label, preview)) {
+                for (int i = 0; i < (int)desc->valueCount; i++) {
+                    const bool selected = (value == i);
+                    if (ImGui::Selectable(desc->valueLabels[i], selected)) {
+                        Combo_MMOptionSetValue(desc, i);
+                    }
+                    if (selected) {
+                        ImGui::SetItemDefaultFocus();
+                    }
+                }
+                ImGui::EndCombo();
+            }
+            break;
+        }
+        case COMBO_MM_WIDGET_SLIDER: {
+            int v = (int)value;
+            if (ImGui::SliderInt(desc->label, &v, (int)desc->minValue, (int)desc->maxValue)) {
+                Combo_MMOptionSetValue(desc, (int32_t)v);
+            }
+            break;
+        }
+        case COMBO_MM_WIDGET_TIME: {
+            // Minutes since midnight, shown as the clock time the player sees.
+            int v = (int)value;
+            char label[32];
+            snprintf(label, sizeof(label), "%02d:%02d", v / 60, v % 60);
+            if (ImGui::SliderInt(desc->label, &v, (int)desc->minValue, (int)desc->maxValue, label)) {
+                Combo_MMOptionSetValue(desc, (int32_t)v);
+            }
+            break;
+        }
+        default:
+            ImGui::TextDisabled("%s (unsupported widget)", desc->label);
+            break;
+    }
+
+    HoverTooltip(desc->tooltip);
+
+    if (blocked) {
+        ImGui::EndDisabled();
+        // The reason is NOT a tooltip. ADR 0004 §5 requires the explanation to
+        // be legible without hovering, because a disabled control with no
+        // visible cause reads as a bug in the port.
+        ImGui::SameLine();
+        ImGui::TextDisabled("- %s", desc->disabledReason);
+    }
+}
+
+} // namespace
+
+void ComboMmOptionsWindow::Draw() {
+    // Read the visibility CVar LIVE rather than trusting the ctor-latched
+    // IsVisible(): Ship::GuiWindow reads the CVar exactly once, in its ctor,
+    // and only ever writes visibility -> CVar afterwards, so a window with no
+    // menu row could otherwise never be opened after registration (#489 cause
+    // 1; the spoiler window and MM's check tracker do the same).
+    if (!CVarGetInteger(kComboMMOptionsVisibilityCVar, 0)) {
+        return;
+    }
+
+    ImGui::SetNextWindowSize(ImVec2(620.0f, 560.0f), ImGuiCond_FirstUseEver);
+    if (!ImGui::Begin(kComboMMOptionsWindowName, nullptr, ImGuiWindowFlags_NoFocusOnAppearing)) {
+        ImGui::End();
+        return;
+    }
+
+    DrawElement();
+
+    ImGui::End();
+}
+
+void ComboMmOptionsWindow::DrawElement() {
+    const int count = Combo_MMOptionCount();
+    if (count == 0) {
+        // The MM descriptor table did not register. Say so rather than
+        // rendering an empty pane, which would read as "MM has no options".
+        ImGui::TextWrapped("Majora's Mask option table is not available in this build.");
+        return;
+    }
+
+    DrawPairingSummary();
+    DrawActiveGameState();
+    DrawStandingWarnings();
+
+    // Grouped in MM's own taxonomy rather than in id order: id order is the
+    // enum's, which interleaves access conditions with hints with shuffles.
+    for (uint8_t group = 0; group < (uint8_t)COMBO_MM_GROUP_COUNT; group++) {
+        // Count first so an empty group draws no header at all — a permanently
+        // empty section implies options are missing from it.
+        int inGroup = 0;
+        for (int i = 0; i < count; i++) {
+            const ComboMMOptionDesc* desc = Combo_MMOptionAt(i);
+            if (desc != NULL && desc->group == group) {
+                inGroup++;
+            }
+        }
+        if (inGroup == 0) {
+            continue;
+        }
+
+        if (!ImGui::CollapsingHeader(Combo_MMOptionGroupName(group), ImGuiTreeNodeFlags_DefaultOpen)) {
+            continue;
+        }
+        ImGui::PushID((int)group);
+        for (int i = 0; i < count; i++) {
+            const ComboMMOptionDesc* desc = Combo_MMOptionAt(i);
+            if (desc == NULL || desc->group != group) {
+                continue;
+            }
+            ImGui::PushID(i);
+            DrawOptionRow(desc);
+            ImGui::PopID();
+        }
+        ImGui::PopID();
+    }
+
+    ImGui::Separator();
+    if (ImGui::Button("Reset all to defaults")) {
+        // Clears the CVars rather than writing the defaults back. The two are
+        // NOT the same: ResolvePairedProfile distinguishes "the player chose
+        // this" from "nobody ever touched it" via CVarExists, and writing a
+        // value equal to the default would make the pin think a choice was
+        // made.
+        for (int i = 0; i < count; i++) {
+            Combo_MMOptionClear(Combo_MMOptionAt(i));
+        }
+    }
+}
+
+void RegisterComboMmOptionsWindow(std::shared_ptr<Ship::Gui> gui) {
+    if (gui == nullptr) {
+        return;
+    }
+    // Idempotence, the #457 guard: the production entry point may be reached
+    // from more than one bring-up path, and AddGuiWindow rejects duplicates
+    // silently rather than loudly.
+    if (gui->GetGuiWindow(kComboMMOptionsWindowName) != nullptr) {
+        return;
+    }
+
+    gui->AddGuiWindow(
+        std::make_shared<ComboMmOptionsWindow>(kComboMMOptionsVisibilityCVar, kComboMMOptionsWindowName));
+}
+
+} // namespace ComboGui
+
+extern "C" void Combo_MMOptionsWindow_Init(void) {
+    // Publish MM's descriptor table first. Done here rather than from a
+    // file-scope registrar in the MM TU because that table is derived from a
+    // std::map in another translation unit — see MM_RandoOptionsUi_Register.
+    // This runs unconditionally, even in the headless case below, so the model
+    // is populated for tests that never construct a Gui.
+    MM_RandoOptionsUi_Register();
+
+    auto ctx = Ship::Context::GetInstance();
+    if (ctx == nullptr || ctx->GetWindow() == nullptr) {
+        // ROM-free unit harness: shared subsystems without a window/Gui.
+        return;
+    }
+    auto gui = ctx->GetWindow()->GetGui();
+    if (gui == nullptr) {
+        return;
+    }
+    ComboGui::RegisterComboMmOptionsWindow(gui);
+}

--- a/src/common/ComboMmOptionsWindow.h
+++ b/src/common/ComboMmOptionsWindow.h
@@ -1,0 +1,112 @@
+/**
+ * @file ComboMmOptionsWindow.h
+ * @brief The Majora's Mask randomizer options pane (#497 step 4, #499; ADR
+ *        0004, ADR 0008).
+ *
+ * Renders src/common/combo_mm_options_view.h's model: MM's full randomizer
+ * option set, grouped the way MM's own (link-elided) rando menu groups it, with
+ * every row capability-gated per ADR 0004 section 5.
+ *
+ * WHY THIS EXISTS. Before it, MM's 47 options had no host — the one live menu
+ * in the binary is OoT's SohMenu and all of its headers are OoT-only, MM's
+ * BenMenu shell is in no CMake target, and MM's own rando pane is elided into
+ * `2ship_rando_ui`. So the paired MM world generated on `StaticData::Options`
+ * defaults, every shuffle and every hint off, and the player had no way to say
+ * otherwise (#499).
+ *
+ * WHY A COMMON-OWNED WINDOW AND NOT A SohMenu PANE. Two reasons, and the second
+ * is the load-bearing one:
+ *
+ *  1. ADR 0008 already settled that a panel belonging to neither game is owned
+ *     by src/common and registered on the shared Ship::Context Gui. This pane
+ *     reads `gComboCtx` and CVars — never either game's `gSaveContext` — so it
+ *     satisfies ADR 0008 rule 5 and needs no active-game gating to be SAFE.
+ *  2. The paired profile is snapshotted when MM's cross-game arrival dispatches
+ *     `OnSaveInit`, and an existing MM save is never regenerated. The chooser
+ *     therefore has to be reachable **while OoT is active, before the switch**
+ *     (#499's timing constraint). A common-owned window is reachable in every
+ *     session state; that is the property being bought.
+ *
+ * THREE PRESENTATION STATES, per ADR 0004 section 6 — and they are three, not
+ * two:
+ *
+ *  - LIVE: the option's behaviour is dispatched. Editable, unmarked.
+ *  - EDITABLE BUT NOT ACTIVE: MM is not the running game. Still fully editable
+ *    (that is the whole point — you set these before you cross), but the pane
+ *    says so, because "editable" and "in effect right now" are different facts.
+ *  - DISABLED BY CAPABILITY: the behaviour has no MM dispatch point (#438), so
+ *    the row is drawn disabled WITH ITS REASON. A control that flips a CVar and
+ *    changes nothing is the vacuous gate in UI form; collapsing this into
+ *    "editable" would produce exactly that.
+ *
+ * Openability: `Ship::GuiWindow` latches its visibility CVar in the ctor and
+ * nothing re-syncs CVar -> visibility per frame, so `Draw()` reads the CVar live
+ * the way the spoiler window and MM's check tracker do (#489 cause 1).
+ *
+ * Locked ROM-free by the ComboMMOptionsWindow CTest: registration, idempotence,
+ * name de-collision, and Draw()/Update() under all three GameIds with no ImGui
+ * context. Its APPEARANCE — grouping, readability of the disabled rows, whether
+ * the warnings land — is operator verification; no headless test can assert on
+ * pixels.
+ */
+
+#ifndef RSBS_COMMON_COMBO_MM_OPTIONS_WINDOW_H
+#define RSBS_COMMON_COMBO_MM_OPTIONS_WINDOW_H
+
+#ifdef __cplusplus
+
+#include <memory>
+#include <ship/window/gui/GuiWindow.h>
+
+namespace Ship {
+class Gui;
+}
+
+namespace ComboGui {
+
+// Registration name on the shared Gui. Distinct from SoH's unprefixed window
+// names and MM's "MM "-prefixed ones: Gui::AddGuiWindow rejects duplicates
+// SILENTLY from the caller's side, so a collision here would present as a
+// window that simply never appears (ADR 0008 rule 2).
+inline constexpr const char* kComboMMOptionsWindowName = "Majora's Mask Randomizer Options";
+
+// Visibility CVar, in the same "gCombo.Windows.*" space as the spoiler view's.
+inline constexpr const char* kComboMMOptionsVisibilityCVar = "gCombo.Windows.MMOptions";
+
+class ComboMmOptionsWindow final : public Ship::GuiWindow {
+  public:
+    using Ship::GuiWindow::GuiWindow;
+
+    void Draw() override;
+
+  protected:
+    void DrawElement() override;
+    void InitElement() override {
+    }
+    void UpdateElement() override {
+    }
+};
+
+/**
+ * Register the options pane on `gui` under kComboMMOptionsWindowName.
+ * Idempotent (the #457 GetGuiWindow guard); a null `gui` is a no-op.
+ */
+void RegisterComboMmOptionsWindow(std::shared_ptr<Ship::Gui> gui);
+
+} // namespace ComboGui
+
+extern "C" {
+#endif // __cplusplus
+
+/**
+ * Production entry point. Registers the options pane on the shared
+ * Ship::Context Gui. Safe no-op when the context has no window/Gui, which is
+ * the state every ROM-free harness runs in.
+ */
+void Combo_MMOptionsWindow_Init(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // RSBS_COMMON_COMBO_MM_OPTIONS_WINDOW_H

--- a/src/common/combo_mm_options_view.c
+++ b/src/common/combo_mm_options_view.c
@@ -1,0 +1,171 @@
+/**
+ * @file combo_mm_options_view.c
+ * @brief Registry + value accessors for MM's randomizer option descriptors.
+ *
+ * See combo_mm_options_view.h for the contract. This file deliberately knows
+ * nothing about MM: it stores a pointer to a table someone else built and
+ * forwards value reads/writes to the CVar the descriptor names.
+ */
+
+#include "combo_mm_options_view.h"
+#include "foreign_items.h" // gComboCtx (via context.h) + Combo_ForeignPairingActive
+
+#include <stdio.h>
+#include <string.h>
+
+#include <libultraship/bridge/consolevariablebridge.h>
+
+static const ComboMMOptionDesc* sOptionTable = NULL;
+static int sOptionCount = 0;
+
+void Combo_RegisterMMOptionTable(const ComboMMOptionDesc* table, int count) {
+    if (table == NULL && count == 0) {
+        // Explicit un-register (see the header): a test that installs a
+        // synthetic table must be able to put the registry back.
+        sOptionTable = NULL;
+        sOptionCount = 0;
+        return;
+    }
+    if (table == NULL || count <= 0) {
+        fprintf(stderr, "[MMOptions] table registration rejected: empty table (%d entries)\n", count);
+        return;
+    }
+    if (sOptionTable != NULL) {
+        // Last writer wins, but not silently: two tables describing one option
+        // id space means the pane's labels and the save's values can disagree
+        // with no way to tell which is authoritative.
+        fprintf(stderr, "[MMOptions] option table re-registered (%d entries replace %d)\n", count, sOptionCount);
+    }
+    sOptionTable = table;
+    sOptionCount = count;
+}
+
+int Combo_MMOptionCount(void) {
+    return sOptionCount;
+}
+
+const ComboMMOptionDesc* Combo_MMOptionAt(int index) {
+    if (sOptionTable == NULL || index < 0 || index >= sOptionCount) {
+        return NULL;
+    }
+    return &sOptionTable[index];
+}
+
+const ComboMMOptionDesc* Combo_MMOptionById(uint16_t id) {
+    for (int i = 0; i < sOptionCount; i++) {
+        if (sOptionTable[i].id == id) {
+            return &sOptionTable[i];
+        }
+    }
+    return NULL;
+}
+
+const char* Combo_MMOptionGroupName(uint8_t group) {
+    switch ((ComboMMOptionGroup)group) {
+        case COMBO_MM_GROUP_LOGIC:
+            return "Logic & Conditions";
+        case COMBO_MM_GROUP_SHUFFLE:
+            return "Shuffle Options";
+        case COMBO_MM_GROUP_ITEMS:
+            return "Items";
+        case COMBO_MM_GROUP_STARTING:
+            return "Starting Items";
+        case COMBO_MM_GROUP_HINTS:
+            return "Hints";
+        default:
+            // Visible placeholder rather than NULL: every caller here is a
+            // printf-family or ImGui text call, and a NULL would be an invalid
+            // pointer rather than an empty section header.
+            return "(unknown group)";
+    }
+}
+
+/** The descriptor's legal value range, as [lo, hi]. */
+static void OptionRange(const ComboMMOptionDesc* desc, int32_t* lo, int32_t* hi) {
+    switch ((ComboMMOptionWidget)desc->widget) {
+        case COMBO_MM_WIDGET_CHECKBOX:
+            *lo = 0;
+            *hi = 1;
+            return;
+        case COMBO_MM_WIDGET_COMBO:
+            *lo = 0;
+            // A zero-length combo would give hi == -1 and clamp every write to
+            // -1. The table lock forbids that shape; this keeps a broken table
+            // from writing a negative index into RANDO_SAVE_OPTIONS anyway.
+            *hi = (desc->valueCount > 0) ? (int32_t)desc->valueCount - 1 : 0;
+            return;
+        case COMBO_MM_WIDGET_SLIDER:
+        case COMBO_MM_WIDGET_TIME:
+        default:
+            *lo = desc->minValue;
+            *hi = desc->maxValue;
+            return;
+    }
+}
+
+int32_t Combo_MMOptionGetValue(const ComboMMOptionDesc* desc) {
+    if (desc == NULL) {
+        return 0;
+    }
+    return CVarGetInteger(desc->cvar, desc->defaultValue);
+}
+
+void Combo_MMOptionSetValue(const ComboMMOptionDesc* desc, int32_t value) {
+    if (desc == NULL) {
+        return;
+    }
+    int32_t lo = 0;
+    int32_t hi = 0;
+    OptionRange(desc, &lo, &hi);
+    if (value < lo) {
+        value = lo;
+    }
+    if (value > hi) {
+        value = hi;
+    }
+    CVarSetInteger(desc->cvar, value);
+}
+
+bool Combo_CVarIsExplicitInt(const char* cvar) {
+    if (cvar == NULL) {
+        return false;
+    }
+    // See the header for why this is a probe rather than CVarExists. The two
+    // sentinels must differ from each other and be values no option can hold;
+    // the integer extremes satisfy both by construction.
+    const int32_t lo = CVarGetInteger(cvar, INT32_MIN);
+    const int32_t hi = CVarGetInteger(cvar, INT32_MAX);
+    return lo == hi;
+}
+
+bool Combo_MMOptionIsExplicit(const ComboMMOptionDesc* desc) {
+    if (desc == NULL) {
+        return false;
+    }
+    return Combo_CVarIsExplicitInt(desc->cvar);
+}
+
+void Combo_MMOptionClear(const ComboMMOptionDesc* desc) {
+    if (desc == NULL) {
+        return;
+    }
+    CVarClear(desc->cvar);
+}
+
+void Combo_MMProfileSummary(ComboMMProfileSummary* out) {
+    if (out == NULL) {
+        return;
+    }
+    memset(out, 0, sizeof(*out));
+    // Same predicate the spoiler view uses: "a paired world exists" is a
+    // post-condition of a successful generation, not an intent (ADR 0009
+    // decision 2). An unpaired world must not present gComboCtx's zeros as a
+    // real seed.
+    out->paired = Combo_ForeignPairingActive();
+    if (!out->paired) {
+        return;
+    }
+    out->sharedRandoSeed = gComboCtx.sharedRandoSeed;
+    out->sharedRandoSettingsHash = gComboCtx.sharedRandoSettingsHash;
+    out->mmProfileDigest = gComboCtx.mmProfileDigest;
+}

--- a/src/common/combo_mm_options_view.h
+++ b/src/common/combo_mm_options_view.h
@@ -1,0 +1,236 @@
+/**
+ * @file combo_mm_options_view.h
+ * @brief View model over MM's randomizer option table for the combo options
+ *        pane (#497 step 4, #499; ADR 0004, ADR 0008).
+ *
+ * WHAT PROBLEM THIS SOLVES. There is exactly one menu in the binary and all of
+ * it is OoT's, so none of MM's 47 randomizer options could be seen or set by a
+ * player: the paired MM world generated on whatever `Rando::StaticData::Options`
+ * defaults happened to be, and no translation unit in the shipped link ever
+ * wrote a `gRando.Options.*` CVar (#499). This is the surface that makes them
+ * settable.
+ *
+ * WHY THE TABLE IS REGISTERED RATHER THAN DEFINED HERE. The option ids, their
+ * defaults and their value enums are MM's (`games/mm/2s2h/Rando/Types.h`), and
+ * common code must not acquire an MM header to see them — the same rule the
+ * foreign-item pools follow (ADR 0009 decision 3: "each defined in the single TU
+ * where its enum is in scope"). So the descriptor table is built MM-side, in
+ * `games/mm/2s2h/Rando/OptionsUiSingleExe.cpp`, and handed here through
+ * Combo_RegisterMMOptionTable from a file-scope registrar. This file holds no
+ * MM knowledge at all; it holds a flat array of strings and integers.
+ *
+ * WHY NOT A SohMenu PANE. ADR 0008 settled the seam for panels that belong to
+ * neither game: they are owned by src/common and registered on the shared
+ * Ship::Context Gui. This pane must be reachable **while OoT is active, before
+ * the switch**, because the paired profile is snapshotted when MM's arrival
+ * dispatches OnSaveInit and an existing MM save is never regenerated (#499's
+ * timing constraint). A pane hung off MM's boot would only exist after the point
+ * at which it can still change anything.
+ *
+ * CAPABILITY GATING IS PART OF THE MODEL, NOT THE WIDGET (ADR 0004 section 5).
+ * Every descriptor carries a liveness class and, when it is not live, a reason
+ * string. An option whose behaviour hook has no MM dispatch point (#438) widens
+ * the check pool but never arms — items land on checks the game cannot award,
+ * which ADR 0004 calls the worst state available. A control that flips a CVar
+ * and changes nothing is the vacuous gate in UI form; the table refuses to
+ * describe one as enabled.
+ *
+ * VALUES LIVE IN CVars, NOT HERE. Per ADR 0009 decision 1, CVars author the
+ * settings and the save carries only a digest. This model reads and writes
+ * `gRando.Options.*` directly and caches nothing, so a value changed anywhere
+ * else is visible on the next call.
+ *
+ * Locked ROM-free by the MMRandoOptions CTest (table coverage and honesty,
+ * driven MM-side where both tables are in scope) and the ComboMMOptionsWindow
+ * CTest (the window that renders it).
+ */
+
+#ifndef RSBS_COMMON_COMBO_MM_OPTIONS_VIEW_H
+#define RSBS_COMMON_COMBO_MM_OPTIONS_VIEW_H
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * Presentation groups, taken from the 9-sidebar taxonomy MM's own (link-elided)
+ * rando menu uses at `games/mm/2s2h/Rando/Menu.cpp:988-1028`.
+ *
+ * Five, not nine. MM's other four sidebars carry no `RO_*` option at all:
+ * General holds seed/spoiler controls (not options), Check Filter drives a
+ * tracker filter held in separate CVars, and Item Tracker / Check Tracker are
+ * window buttons. Inventing empty groups for them would put four permanently
+ * blank sections in the pane and imply options are missing from it.
+ */
+typedef enum {
+    COMBO_MM_GROUP_LOGIC,    // logic mode and the access/entry conditions
+    COMBO_MM_GROUP_SHUFFLE,  // the RO_SHUFFLE_* family and its thresholds
+    COMBO_MM_GROUP_ITEMS,    // item-pool shaping
+    COMBO_MM_GROUP_STARTING, // what the file starts with
+    COMBO_MM_GROUP_HINTS,    // the RO_HINTS_* family
+    COMBO_MM_GROUP_COUNT
+} ComboMMOptionGroup;
+
+/** How the pane should draw an option's value. */
+typedef enum {
+    COMBO_MM_WIDGET_CHECKBOX, // two-valued (RO_GENERIC_OFF/ON, NO/YES)
+    COMBO_MM_WIDGET_COMBO,    // pick one of `valueLabels[0..valueCount)`
+    COMBO_MM_WIDGET_SLIDER,   // integer in [minValue, maxValue]
+    COMBO_MM_WIDGET_TIME      // minutes-since-midnight, rendered as HH:MM
+} ComboMMOptionWidget;
+
+/**
+ * Whether the behaviour behind an option is actually reachable in this binary
+ * (ADR 0004 section 5's three-part test: the TU links, its registrar runs, and
+ * its hook type has an MM dispatch point placed).
+ */
+typedef enum {
+    /** Consumed only by generation — pools, starting state, logic. No runtime
+     *  hook is needed, so it cannot be half-armed and is always honest. */
+    COMBO_MM_LIVENESS_GENERATION_ONLY,
+    /** Pool widening AND every hook it needs is dispatched. */
+    COMBO_MM_LIVENESS_LIVE,
+    /** Some legs live, at least one dormant. Enabling it widens the pool but
+     *  part of the behaviour never arms — draw it disabled, with the reason. */
+    COMBO_MM_LIVENESS_PARTIAL,
+    /** The hook type it rides has no MM dispatch point (#438). */
+    COMBO_MM_LIVENESS_DORMANT
+} ComboMMOptionLiveness;
+
+/**
+ * One option, as the pane renders it.
+ *
+ * `id`, `name`, `cvar` and `defaultValue` mirror the MM `RandoStaticOption` row
+ * exactly and are asserted equal to it by the MMRandoOptions lock — the pane
+ * must never bind a widget to a key MM does not read.
+ */
+typedef struct {
+    uint16_t id;         // RandoOptionId
+    const char* name;    // stringified enumerator, e.g. "RO_SHUFFLE_COWS"
+    const char* cvar;    // "gRando.Options.<name>"; never NULL
+    const char* label;   // human label; never NULL or empty
+    const char* tooltip; // one sentence; never NULL
+    uint8_t group;       // ComboMMOptionGroup
+    uint8_t widget;      // ComboMMOptionWidget
+    int32_t defaultValue;
+    int32_t minValue; // SLIDER/TIME only; 0 otherwise
+    int32_t maxValue; // SLIDER/TIME only; 0 otherwise
+    const char* const* valueLabels; // COMBO only, else NULL
+    uint8_t valueCount;             // COMBO only, else 0
+    uint8_t liveness;               // ComboMMOptionLiveness
+    /** Operator-facing explanation, e.g. "Not yet available: MM OnOpenText
+     *  dispatch not placed (#438)". EMPTY (never NULL) exactly when liveness is
+     *  LIVE or GENERATION_ONLY — the lock asserts both directions, because a
+     *  dormant row with no reason is a control that looks broken and a live row
+     *  with a reason is one that looks broken and is not. */
+    const char* disabledReason;
+} ComboMMOptionDesc;
+
+/**
+ * Install MM's descriptor table. Called from a file-scope registrar in the MM
+ * TU that owns it, so the pane works with no explicit bring-up call. Passing
+ * (NULL, 0) un-registers, which exists so a test can restore the registry
+ * rather than leave process-global state behind.
+ *
+ * A second registration replaces the first and complains on stderr: two tables
+ * claiming one id space is the ambiguity this surface exists to prevent.
+ */
+void Combo_RegisterMMOptionTable(const ComboMMOptionDesc* table, int count);
+
+/**
+ * Build and register MM's descriptor table. DEFINED MM-SIDE
+ * (games/mm/2s2h/Rando/OptionsUiSingleExe.cpp), declared here because the combo
+ * entry point is what calls it.
+ *
+ * It is a call rather than a file-scope registrar on purpose: the table is
+ * derived from `Rando::StaticData::Options`, a namespace-scope std::map in
+ * another translation unit, and static initialization order across TUs is
+ * unspecified. A registrar could publish a table built from an empty map, and
+ * the symptom would be "the pane has no rows" with nothing naming the cause.
+ */
+void MM_RandoOptionsUi_Register(void);
+
+/** Number of registered descriptors; 0 when the MM table did not link. */
+int Combo_MMOptionCount(void);
+
+/** Descriptor at `index` in table order, or NULL if out of range. */
+const ComboMMOptionDesc* Combo_MMOptionAt(int index);
+
+/** Descriptor for `id` (a RandoOptionId), or NULL if the table has no row. */
+const ComboMMOptionDesc* Combo_MMOptionById(uint16_t id);
+
+/** Display name for a ComboMMOptionGroup; never NULL (out-of-range yields a
+ *  visible placeholder rather than a crash in a printf-family call). */
+const char* Combo_MMOptionGroupName(uint8_t group);
+
+/**
+ * The option's current authored value: its CVar if set, else `defaultValue`.
+ * A NULL descriptor yields 0.
+ */
+int32_t Combo_MMOptionGetValue(const ComboMMOptionDesc* desc);
+
+/**
+ * Write `value` to the option's CVar, clamped into the descriptor's legal range
+ * (checkbox 0..1, combo 0..valueCount-1, slider/time min..max).
+ *
+ * Clamping rather than rejecting is deliberate: the value is persisted to
+ * `RANDO_SAVE_OPTIONS` and then indexed by generation code, so an out-of-range
+ * write reaches MM's tables as an out-of-range index. Refusing silently would
+ * leave the pane showing a value the save does not hold.
+ */
+void Combo_MMOptionSetValue(const ComboMMOptionDesc* desc, int32_t value);
+
+/**
+ * True when `cvar` has an explicitly authored integer value, as opposed to
+ * being absent and falling through to whatever default a reader supplies.
+ *
+ * WHY THIS IS NOT `CVarExists`. libultraship DECLARES `CVarExists` in
+ * `bridge/consolevariablebridge.h` but the submodule pinned here defines it
+ * nowhere — a declaration with no definition, which links only if nobody calls
+ * it. So the existence question is answered by probing instead: read the key
+ * twice with two different defaults. An absent key returns each default and the
+ * two reads disagree; a present key returns its own value both times and they
+ * agree. No new libultraship symbol, and nothing to un-break when the real
+ * `CVarExists` eventually lands.
+ *
+ * Scope honesty: this answers the question for INTEGER cvars, which is all the
+ * option keys are. A string- or float-valued key would read as absent.
+ */
+bool Combo_CVarIsExplicitInt(const char* cvar);
+
+/** True when the option has an explicitly authored CVar (the player chose it),
+ *  as opposed to falling through to `defaultValue`. This is the distinction the
+ *  paired logic default turns on — see Rando::Foreign::ResolvePairedProfile. */
+bool Combo_MMOptionIsExplicit(const ComboMMOptionDesc* desc);
+
+/** Clear the option's CVar, returning it to "never chosen". */
+void Combo_MMOptionClear(const ComboMMOptionDesc* desc);
+
+/**
+ * Pairing header for the pane: whether a paired world exists, its identity, and
+ * the MM profile digest it was generated under.
+ *
+ * `paired == false` means the worlds were never paired; the other fields are
+ * then whatever `gComboCtx` holds (typically 0) and must not be shown as a real
+ * pairing. `mmProfileDigest == 0` means no paired profile has been resolved
+ * yet — which is the normal state while the player is still in OoT choosing
+ * options, and is NOT an error.
+ */
+typedef struct {
+    bool paired;
+    uint32_t sharedRandoSeed;
+    uint32_t sharedRandoSettingsHash;
+    uint32_t mmProfileDigest;
+} ComboMMProfileSummary;
+
+/** Fill `out` with the pairing header. NULL `out` is ignored. */
+void Combo_MMProfileSummary(ComboMMProfileSummary* out);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // RSBS_COMMON_COMBO_MM_OPTIONS_VIEW_H

--- a/src/common/context.h
+++ b/src/common/context.h
@@ -398,6 +398,31 @@ typedef struct {
     // with the other's accessor. The direction IS the accessor.
     ComboForeignPlacement foreignPlacementsOoT[RSBS_FOREIGN_PLACEMENT_CAP];
 
+    // Phase 3.1 Lane 4 (#497 step 7 / #499 step 4): the digest of the MM
+    // randomizer option profile the paired world was generated under. ADR 0009
+    // claim 3, size CONFIRMED at 4 bytes — a u32 by analogy with
+    // sharedRandoSettingsHash, not a record of the options themselves (ADR 0009
+    // decision 1: CVars author, a digest identifies).
+    //
+    // WHY IT HAS TO EXIST AT ALL. sharedRandoSettingsHash fingerprints *OoT's*
+    // settings string only (playthrough.cpp). Once the MM profile is a player
+    // CHOICE rather than the StaticData defaults falling through, two peers can
+    // agree on sharedRandoSeed AND sharedRandoSettingsHash and still generate
+    // different MM halves — with nothing able to detect it. This field is the
+    // missing term: the paired world's identity now covers both halves.
+    //
+    // Computed by Rando::Foreign::ResolvePairedProfile() from the SAME string
+    // MixPairedFinalSeed() hashes, so "changing an MM option changes the derived
+    // MM world" and "changing an MM option changes the recorded identity" cannot
+    // drift apart — they are one input.
+    //
+    // Zero == unset (no paired profile has been resolved), the growth contract's
+    // required meaning: a non-rando or zero-extended legacy record reads 0.
+    // Carved from the FRONT of the old reserved[216] under that contract, so
+    // every field above keeps its shipped offset and the record size is
+    // unchanged.
+    uint32_t mmProfileDigest;
+
     // Headroom. Carve new fields from the FRONT of this array (as
     // sharedItemsTagged, sharedRandoSettingsHash, foreignPlacements, the
     // grant cursors, and the reverse placement table were) so the struct
@@ -408,12 +433,12 @@ typedef struct {
     // a freshly-initialized one — every field carved from here must keep
     // "zero means unset".
     //
-    // 264 - 48 (foreignPlacementsOoT). ADR 0009 publishes the remaining
+    // 264 - 48 (foreignPlacementsOoT) - 4 (mmProfileDigest). ADR 0009 publishes the remaining
     // allocation across the other claimants and sets a 64-byte floor:
     // Test_SaveComboRecordFixed's scribble loop iterates sizeof(reserved), so
     // at zero it degenerates to zero iterations and passes vacuously, retiring
     // the only test that proves headroom round-trips at all.
-    uint8_t reserved[216];
+    uint8_t reserved[212];
 } ComboContext;
 
 /**
@@ -497,12 +522,24 @@ RSBS_CTX_STATIC_ASSERT(offsetof(ComboContext, foreignPlacementsOoT) ==
                            offsetof(ComboContext, sharedItemOverflowCount) + sizeof(uint32_t),
                        "foreignPlacementsOoT must be carved from the FRONT of reserved[] (contiguous "
                        "with the overflow count); moving it changes .redsave format");
-RSBS_CTX_STATIC_ASSERT(offsetof(ComboContext, reserved) ==
+// The MM option-profile digest is the next carve (ADR 0009 claim 3, 4 bytes).
+// Pinned to the literal 788 for the same reason 672, 736 and 740 are: anything
+// carved after it inherits its position, so a field growing in place ahead of
+// it must break the build rather than slide it.
+RSBS_CTX_STATIC_ASSERT(offsetof(ComboContext, mmProfileDigest) == 788u,
+                       "mmProfileDigest lives at .redsave byte offset 788; if this fires, a field "
+                       "before it grew in place - carve from reserved[] instead");
+RSBS_CTX_STATIC_ASSERT(offsetof(ComboContext, mmProfileDigest) ==
                            offsetof(ComboContext, foreignPlacementsOoT) +
                                RSBS_FOREIGN_PLACEMENT_CAP * sizeof(ComboForeignPlacement),
+                       "mmProfileDigest must be carved from the FRONT of reserved[] (contiguous with "
+                       "the reverse placement table); moving it changes .redsave format");
+RSBS_CTX_STATIC_ASSERT(offsetof(ComboContext, reserved) ==
+                           offsetof(ComboContext, mmProfileDigest) + sizeof(uint32_t),
                        "the tagged-item array, the settings digest, both foreign-placement tables, "
-                       "the grant cursors, the overflow count, and the remaining headroom must stay "
-                       "contiguous (no padding, no fields slipped between them)");
+                       "the grant cursors, the overflow count, the MM profile digest, and the "
+                       "remaining headroom must stay contiguous (no padding, no fields slipped "
+                       "between them)");
 // ADR 0009's floor. reserved[] is what Test_SaveComboRecordFixed scribbles to
 // prove Tier-1 headroom round-trips; at zero that loop runs zero times and the
 // test passes vacuously, so the carve budget stops here rather than there.

--- a/src/common/cvar_shared_keys.h
+++ b/src/common/cvar_shared_keys.h
@@ -354,18 +354,45 @@ inline constexpr const char* kDeliberateSharedCheatKeys[] = {
 };
 
 /**
- * Keys the two governing documents classify DIFFERENTLY. Recorded, not
- * reconciled, so neither document silently overrides the other — and asserted
- * on by nothing, because asserting either reading would prejudge the issue.
+ * Keys the two governing documents classified DIFFERENTLY. Kept as a table, and
+ * asserted on only to the extent both readings agree: a key here is never swept
+ * into the convergence set.
  *
- * `gDeveloperTools.DebugSaveFileMode`: ADR 0003 §4.1 calls it (S) — "value
- * spaces align, only the unwritten fallback differs, acceptable". The
- * inventory §3.3 BUG 2 takes the more conservative (P) line: the DEFAULTS
- * disagree (OoT 1 = "vanilla debug save", MM 0 = "empty save"), so the first
- * game to write the key silently changes the other's debug-save behaviour away
- * from its own default. No rename either way, so the disagreement is narrow
- * and safe. **Issue #454 decides it.** Do not converge, split, or re-default
- * this key as a side effect of other work.
+ * `gDeveloperTools.DebugSaveFileMode`. ADR 0003 §4.1 called it (S) — "value
+ * spaces align, only the unwritten fallback differs, acceptable". The inventory
+ * §3.3 BUG 2 and ADR 0004 §2d took the (P) line on the strength of the
+ * defaults disagreeing (OoT 1 = "vanilla debug save", MM 0 = "empty save").
+ *
+ * RULED (P), 2026-07-23 (#497 step 1, Lane 4) — and NOT on the defaults.
+ * #454 was auto-closed by the merge of the docs-only PR #456, which itself says
+ * #454 is the thing that will settle the question; nothing decided it. Lane 4
+ * measured the tree instead and found the argument ADR 0003 §4.1 rests on is
+ * false on its own terms:
+ *
+ *   games/mm/2s2h/DeveloperTools/DeveloperTools.cpp, in RegisterDebugMode():
+ *       if (!CVAR_DEBUG_MODE) {
+ *           CVarSetInteger(CVAR_SAVE_FILE_MODE_NAME, DEBUG_SAVE_INFO_NONE);
+ *
+ * MM does not merely READ the shared key with a different default — it WRITES 0
+ * into it at ShipInit whenever debug mode is off, which is the default state.
+ * "Once written the shared value governs both; only the unwritten fallback
+ * differs" is therefore not a benign observation: MM's registrar is the writer,
+ * so the key is never left unwritten and OoT's default is destroyed on every
+ * launch.
+ *
+ * DORMANT BUT ARMED. games/mm/CMakeLists.txt excludes 2s2h/DeveloperTools/
+ * wholesale from the single-exe build, so the clobber does not run today. It
+ * arms on the same un-elision work ADR 0004 §5 schedules — which is precisely
+ * why it is recorded rather than left to be discovered then.
+ *
+ * The key stays HERE rather than moving into kSharedIntentKeys, because the
+ * table should not claim (S) while games/mm still contains the write that makes
+ * it (P). Retiring MM's clobber and aligning its read default is a BEHAVIOUR
+ * change in a different lane's file; when it lands, move this key into
+ * kSharedIntentKeys (count 25 -> 26) in the same commit as the fix, so the diff
+ * is verifiable against the fixed source.
+ *
+ * Do not converge, split, or re-default this key as a side effect of other work.
  */
 inline constexpr const char* kDisputedClassificationKeys[] = {
     "gDeveloperTools.DebugSaveFileMode",
@@ -415,8 +442,15 @@ static_assert(kConvergedKeyCount == 32, "tier 1 (9) + inventory §5.3 remainder 
 // inventory reclassified it (P) and #454 has not settled it. Pinning the count
 // makes a silent drop a compile error rather than a quietly weaker lock.
 static_assert(kSharedIntentKeyCount == 25,
-              "ADR 0003 Appendix B's 26 class-(S) keys, less DebugSaveFileMode (disputed, #454)");
+              "ADR 0003 Appendix B's 26 class-(S) keys, less DebugSaveFileMode — ruled (P) by #497 step 1 on "
+              "MM's DeveloperTools.cpp write, not on the default divergence");
 static_assert(kMenuIndexKeyCount == 4, "four menu-index keys — #451");
+// The disputed table had no pinned count, so a silent drop would have retired
+// the one thing both readings agree on (never converge this key) with no
+// compile error. Pinned like every other table here.
+static_assert(kDisputedClassificationKeyCount == 1,
+              "one disputed key — gDeveloperTools.DebugSaveFileMode, ruled (P) and held here until MM's "
+              "clobber is retired (#497 step 1)");
 
 } // namespace RSBS
 

--- a/src/common/test_runner.cpp
+++ b/src/common/test_runner.cpp
@@ -93,6 +93,16 @@ int MM_TrackersGui_RunHeadless(void);
 // spoiler window's ctor reads ConsoleVariables off the Ship::Context
 // singleton, so its body needs the display-free shared bring-up below.
 int Combo_SpoilerWindow_RunHeadless(void);
+// src/common/tests/test_combo_mm_options_window.c — the MM options pane's
+// window lock; same bridge shape and the same reason (GuiWindow ctor reads
+// ConsoleVariables off the Ship::Context singleton).
+int Combo_MMOptionsWindow_RunHeadless(void);
+// games/mm/2s2h/mm_rando_options_test.cpp (#497 step 4, #499): the option TABLE
+// and the paired PROFILE. Both bodies live in an MM TU because they drive
+// Rando::StaticData::Options and Rando::Foreign::ResolvePairedProfile, which
+// need MM's headers — this file must never acquire them. Return 0 on pass.
+int MM_RandoOptions_RunHeadless(void);
+int MM_PairedProfile_RunHeadless(void);
 // VB-affinity regression: MM's GameInteractor_* calls resolve to OoT's
 // extern "C" wrappers in single-exe builds, and the two games' vanilla-
 // behavior ordinals alias each other. The wrappers gate on the active game;
@@ -163,6 +173,12 @@ extern "C" {
 // out of ImGui under GAME_OOT/GAME_MM/GAME_NONE alike. FILE SCOPE — it drives
 // the C++-linkage ComboGui::RegisterComboSpoilerWindow.
 #include "tests/test_combo_spoiler_window.c"
+
+// The MM randomizer options pane's window (#497 step 4, ADR 0004 + 0008): same
+// registration/idempotence/de-collision shape, plus a tripwire that a pane which
+// deliberately READS the active game still never reads that game's save. FILE
+// SCOPE — it drives the C++-linkage ComboGui::RegisterComboMmOptionsWindow.
+#include "tests/test_combo_mm_options_window.c"
 
 // Sourced-grant model locks (ADR 0005, netplay 1a #460): per-source cursor
 // idempotency, switch-free received-order redemption, loud overflow with
@@ -1250,6 +1266,56 @@ TestResult Test_ComboSpoilerWindow(void) {
     return Combo_SpoilerWindow_RunHeadless() == 0 ? TEST_PASS : TEST_FAIL;
 }
 
+// MM randomizer options pane (#497 step 4, ADR 0004 + 0008). Same bring-up as
+// the two Gui bridges above and for the same reason.
+TestResult Test_ComboMMOptionsWindow(void) {
+    auto ctx = CreateHarnessStyleContext();
+    if (!ctx) {
+        printf("[TEST] FAIL: could not create Ship::Context singleton\n");
+        return TEST_FAIL;
+    }
+    if (OoT_InitSharedContextSubsystems() != 0) {
+        printf("[TEST] FAIL: shared bring-up reported failure\n");
+        return TEST_FAIL;
+    }
+
+    return Combo_MMOptionsWindow_RunHeadless() == 0 ? TEST_PASS : TEST_FAIL;
+}
+
+// MM option TABLE lock (#497 step 4, #499 step 5). No Gui, but it reads and
+// writes the option CVars through the real ConsoleVariables store, so it needs
+// the same display-free bring-up.
+TestResult Test_MMRandoOptions(void) {
+    auto ctx = CreateHarnessStyleContext();
+    if (!ctx) {
+        printf("[TEST] FAIL: could not create Ship::Context singleton\n");
+        return TEST_FAIL;
+    }
+    if (OoT_InitSharedContextSubsystems() != 0) {
+        printf("[TEST] FAIL: shared bring-up reported failure\n");
+        return TEST_FAIL;
+    }
+
+    return MM_RandoOptions_RunHeadless() == 0 ? TEST_PASS : TEST_FAIL;
+}
+
+// Paired MM PROFILE lock (#499 steps 2-4). Drives the real resolver over a
+// zeroed MM SaveContext — no fill, no region graph, no window — which is the
+// whole point of extracting it out of OnFileCreate.
+TestResult Test_MMPairedProfile(void) {
+    auto ctx = CreateHarnessStyleContext();
+    if (!ctx) {
+        printf("[TEST] FAIL: could not create Ship::Context singleton\n");
+        return TEST_FAIL;
+    }
+    if (OoT_InitSharedContextSubsystems() != 0) {
+        printf("[TEST] FAIL: shared bring-up reported failure\n");
+        return TEST_FAIL;
+    }
+
+    return MM_PairedProfile_RunHeadless() == 0 ? TEST_PASS : TEST_FAIL;
+}
+
 TestResult Test_RoundtripIntegrity(void) {
     printf("[TEST] roundtrip-integrity: OoT SaveContext byte-integrity across roundtrip (issue #262)\n");
     int failures = TestRoundtripIntegrity_Run();
@@ -1418,6 +1484,16 @@ const TestDescriptor gTests[] = {
      Test_ComboSpoilerView},
     {"combo-spoiler-window", "Common-owned spoiler window registers de-collided; inert under every active game (#496)",
      Test_ComboSpoilerWindow},
+    // MM randomizer options surface (#497 step 4, #499). Three locks, split by
+    // what they can see: the table needs MM's headers, the profile needs MM's
+    // SaveContext, the window needs a Gui.
+    {"mm-rando-options", "Every MM rando option has a row, a label, a bound cvar, and honest gating (#497)",
+     Test_MMRandoOptions},
+    {"mm-paired-profile", "The paired MM profile honours explicit choices and publishes a moving digest (#499)",
+     Test_MMPairedProfile},
+    {"combo-mm-options-window",
+     "Common-owned MM options pane registers de-collided; inert under every active game (#497)",
+     Test_ComboMMOptionsWindow},
     // Netplay 1a (ADR 0005, #460): the sourced-grant model, transport-free.
     {"grant-idempotency", "Retransmit delivers once; a second gift of the same item delivers twice (ADR 0005)",
      Test_GrantIdempotency},

--- a/src/common/tests/test_combo_mm_options_window.c
+++ b/src/common/tests/test_combo_mm_options_window.c
@@ -1,0 +1,180 @@
+/**
+ * @file test_combo_mm_options_window.c
+ * @brief ROM-free lock for the MM randomizer options WINDOW (#497 step 4).
+ *
+ * The table has its own lock, MM-side (games/mm/2s2h/mm_rando_options_test.cpp),
+ * because that is the only place both option tables are in scope. This one
+ * covers the window that renders it, in the shape of test_combo_spoiler_window.c:
+ *
+ * 1. REGISTRATION + IDEMPOTENCE + NAME DE-COLLISION. The pane lands on a bare
+ *    Ship::Gui under kComboMMOptionsWindowName, a second registration is a
+ *    no-op, and stand-ins already holding a SoH tracker name, an MM tracker
+ *    name and the sibling combo spoiler's name are undisturbed.
+ *    Gui::AddGuiWindow rejects duplicates SILENTLY from the caller's side, so a
+ *    collision would present only as a window that never appears.
+ *
+ * 2. GAME-AGNOSTICISM — the hard tripwire. ADR 0008 rule 5's claim is that a
+ *    common-owned window reads gComboCtx and never gSaveContext, which is what
+ *    lets it draw under GAME_OOT, GAME_MM and GAME_NONE alike. This harness has
+ *    NO ImGui context, so any Draw() that reaches ImGui::Begin aborts the test
+ *    process. Draw()/Update() are called under all three GameIds with the
+ *    visibility CVar CLEARED, in both paired and unpaired worlds.
+ *
+ *    That matters more here than for the spoiler: this pane deliberately READS
+ *    the active game (to draw the "Majora's Mask - suspended" state, ADR 0004
+ *    §6), and reading the active game is one step away from reading that game's
+ *    save. The tripwire is what keeps the distinction enforced rather than
+ *    merely intended.
+ *
+ * 3. THE PRODUCTION ENTRY POINT IS HEADLESS-SAFE and populates the model.
+ *    Combo_MMOptionsWindow_Init() must return cleanly with no window on the
+ *    shared context AND must still have published MM's descriptor table — the
+ *    table registration is deliberately NOT gated on the Gui existing, because
+ *    a test or a headless run has every reason to read the options and none to
+ *    draw them.
+ *
+ * Deliberately absent: any assertion about appearance. Whether the grouping
+ * reads well, whether the disabled rows' reasons are legible beside their
+ * widgets, and whether the three standing warnings land are operator
+ * verification; no headless test can stand in for them.
+ *
+ * Linkage note: #included into test_runner.cpp at FILE SCOPE (compiled as C++)
+ * — it drives the C++-linkage ComboGui::RegisterComboMmOptionsWindow.
+ *
+ * Entry point is a RunHeadless bridge, not a TestResult body, for the same
+ * reason the spoiler window's is: constructing a Ship::GuiWindow reads
+ * ConsoleVariables off the Ship::Context singleton, so it needs the display-free
+ * shared bring-up that lives (static) in test_runner.cpp.
+ */
+
+#include "../ComboMmOptionsWindow.h"
+#include "../ComboSpoilerWindow.h"
+#include "../combo_mm_options_view.h"
+#include "../context.h"
+#include "../foreign_items.h"
+#include "../test_runner.h"
+
+#include <cstdio>
+#include <cstring>
+#include <memory>
+
+#include <ship/window/gui/Gui.h>
+#include <ship/window/gui/GuiWindow.h>
+#include <libultraship/bridge/consolevariablebridge.h>
+
+#define CMOW_ASSERT(cond)                                                                                              \
+    do {                                                                                                               \
+        if (!(cond)) {                                                                                                 \
+            printf("[TEST] FAIL: %s:%d: %s\n", __FILE__, __LINE__, #cond);                                             \
+            return TEST_FAIL;                                                                                          \
+        }                                                                                                              \
+    } while (0)
+
+namespace {
+
+// Inert stand-in, matching test_combo_spoiler_window.c's: empty cvar (no
+// ConsoleVariables traffic in the ctor) and no-op overrides.
+class MMOptionsStandinWindow final : public Ship::GuiWindow {
+  public:
+    using GuiWindow::GuiWindow;
+
+    void InitElement() override {
+    }
+    void DrawElement() override {
+    }
+    void UpdateElement() override {
+    }
+};
+
+const char* const kMMOptionsNeighbourNames[] = {
+    "Check Tracker",    // SoH-owned
+    "MM Check Tracker", // MM-owned
+};
+
+} // namespace
+
+extern "C" int Combo_MMOptionsWindow_RunHeadless(void) {
+    printf("[TEST] combo-mm-options-window: the common-owned MM options pane registers de-collided, publishes its "
+           "table headlessly, and is inert under every active game (#497, ADR 0008)\n");
+
+    // Production entry point must be headless-safe: with no window on the
+    // shared context it returns without touching a Gui — while still having
+    // published MM's descriptor table.
+    Combo_MMOptionsWindow_Init();
+    CMOW_ASSERT(Combo_MMOptionCount() > 0);
+    CMOW_ASSERT(Combo_MMOptionAt(0) != NULL);
+    CMOW_ASSERT(Combo_MMOptionAt(Combo_MMOptionCount()) == NULL);
+
+    auto gui = std::make_shared<Ship::Gui>();
+
+    std::shared_ptr<Ship::GuiWindow> neighbours[2];
+    for (int i = 0; i < 2; i++) {
+        neighbours[i] = std::make_shared<MMOptionsStandinWindow>("", kMMOptionsNeighbourNames[i]);
+        gui->AddGuiWindow(neighbours[i]);
+    }
+
+    // The sibling common-owned window: both live in the same unprefixed name
+    // space, so a collision between the two is the one this file is uniquely
+    // placed to catch.
+    ComboGui::RegisterComboSpoilerWindow(gui);
+    auto spoiler = gui->GetGuiWindow(ComboGui::kComboSpoilerWindowName);
+    CMOW_ASSERT(spoiler != nullptr);
+
+    // Keep the pane shut for every Draw() below. The live-CVar early-out is the
+    // only thing between Draw() and ImGui::Begin in a process with no ImGui
+    // context, which is what makes the tripwire survivable.
+    CVarClear(ComboGui::kComboMMOptionsVisibilityCVar);
+
+    ComboGui::RegisterComboMmOptionsWindow(gui);
+    auto window = gui->GetGuiWindow(ComboGui::kComboMMOptionsWindowName);
+    CMOW_ASSERT(window != nullptr);
+    CMOW_ASSERT(window != spoiler);
+
+    // Idempotence: a second registration must not replace the instance.
+    ComboGui::RegisterComboMmOptionsWindow(gui);
+    CMOW_ASSERT(gui->GetGuiWindow(ComboGui::kComboMMOptionsWindowName) == window);
+
+    // De-collision: neither game's window names were disturbed, the sibling
+    // combo window still resolves to itself, and the pane took none of them.
+    for (int i = 0; i < 2; i++) {
+        CMOW_ASSERT(gui->GetGuiWindow(kMMOptionsNeighbourNames[i]) == neighbours[i]);
+        CMOW_ASSERT(gui->GetGuiWindow(kMMOptionsNeighbourNames[i]) != window);
+    }
+    CMOW_ASSERT(gui->GetGuiWindow(ComboGui::kComboSpoilerWindowName) == spoiler);
+
+    // The two common-owned windows must not share a visibility CVar either —
+    // that would make one un-openable without the other.
+    CMOW_ASSERT(strcmp(ComboGui::kComboMMOptionsVisibilityCVar, ComboGui::kComboSpoilerVisibilityCVar) != 0);
+
+    // ---- Game-agnosticism tripwire ---------------------------------------
+    const GameId prevGame = Context_GetCurrentGame();
+    const GameId allGames[] = { GAME_OOT, GAME_MM, GAME_NONE };
+
+    for (int paired = 0; paired <= 1; paired++) {
+        ComboContext_Init();
+        if (paired) {
+            gComboCtx.sourceIsRando = true;
+            gComboCtx.sharedRandoSeed = 0xC0FFEE97u;
+            gComboCtx.sharedRandoSettingsHash = 0x5EED0497u;
+            gComboCtx.mmProfileDigest = 0x4D4D0001u;
+        }
+
+        for (GameId game : allGames) {
+            Context_SetCurrentGame(game);
+            // Surviving these IS the assertion: an ungated path reaches
+            // ImGui::Begin with no ImGui context and aborts the process.
+            window->Draw();
+            window->Update();
+        }
+    }
+
+    Context_SetCurrentGame(prevGame);
+
+    // Leave global state clean for any subsequent test.
+    CVarClear(ComboGui::kComboMMOptionsVisibilityCVar);
+    ComboContext_Init();
+
+    printf("[TEST] PASS: the MM options pane registers de-collided and idempotently beside both games' windows and "
+           "the combo spoiler, and its draw path is inert under GAME_OOT/GAME_MM/GAME_NONE\n");
+    return TEST_PASS;
+}

--- a/src/common/tests/test_cvar_classification.c
+++ b/src/common/tests/test_cvar_classification.c
@@ -135,6 +135,54 @@ bool CvarClassTreeContainsExactKey(const std::vector<std::string>& tree, const c
     return false;
 }
 
+/// One scanned file, with the repo-relative path kept. The slurp above throws
+/// paths away because every question it asks is "does the tree contain X"; the
+/// menu-index reader allowlist asks "WHICH file contains X", so it needs them.
+struct CvarClassSourceFile {
+    std::string relPath; // forward slashes, relative to `root`
+    std::string text;
+};
+
+std::vector<CvarClassSourceFile> CvarClassSlurpTreeWithPaths(const std::filesystem::path& root, bool& ok) {
+    std::vector<CvarClassSourceFile> files;
+    std::error_code ec;
+
+    if (!std::filesystem::exists(root, ec) || ec) {
+        ok = false;
+        return files;
+    }
+    ok = true;
+
+    for (std::filesystem::recursive_directory_iterator it(root, std::filesystem::directory_options::skip_permission_denied, ec),
+         end;
+         it != end; it.increment(ec)) {
+        if (ec) {
+            ec.clear();
+            continue;
+        }
+        if (!it->is_regular_file(ec) || ec) {
+            ec.clear();
+            continue;
+        }
+        if (!CvarClassIsSourceFile(it->path())) {
+            continue;
+        }
+        std::ifstream file(it->path(), std::ios::binary);
+        if (!file.is_open()) {
+            continue;
+        }
+        CvarClassSourceFile entry;
+        entry.relPath = std::filesystem::relative(it->path(), root, ec).generic_string();
+        if (ec) {
+            ec.clear();
+            entry.relPath = it->path().generic_string();
+        }
+        entry.text.assign((std::istreambuf_iterator<char>(file)), std::istreambuf_iterator<char>());
+        files.push_back(std::move(entry));
+    }
+    return files;
+}
+
 } // namespace
 #endif // RSBS_SOURCE_DIR
 
@@ -318,6 +366,87 @@ TestResult Test_CVarClassification(void) {
                    "[TEST]       question; converging this family needs an explicit decision first.\n",
                    RSBS::kParkedCasingPrefixMM);
             return TEST_FAIL;
+        }
+
+        // (3d-2) #451's REAL arming condition, mechanized (#497 step 2).
+        //
+        // ADR 0004 discharges #451 by deciding there is only one menu shell —
+        // but that discharge is a prose proviso ("provided MM's menu is never
+        // revived as a second shell") with nothing enforcing it, and #446's
+        // closure removed the technical deterrent that used to make reviving
+        // BenMenu obviously dangerous.
+        //
+        // Note carefully what is asserted, because the obvious wording is RED
+        // at head and would be "fixed" by weakening it. #497's lock text asks
+        // that EVERY reader of a menu-index key be on a not-linked allowlist —
+        // but OoT's live SohMenu reads all four by design, so that assertion
+        // fails on correct code. The hazard is TWO SHELLS indexing one key, and
+        // the second shell can only be MM's. So the invariant is scoped to
+        // MM-side readers: inside games/mm, only the two known-elided BenGui
+        // TUs may name these keys. A new MM reader entering the tree is exactly
+        // the arming condition, and it fails here rather than in a player's
+        // navigation state.
+        {
+            bool mmPathsOk = false;
+            const std::vector<CvarClassSourceFile> mmFiles =
+                CvarClassSlurpTreeWithPaths(sourceRoot / "games" / "mm", mmPathsOk);
+            CVARCLASS_CHECK(mmPathsOk && !mmFiles.empty(),
+                            "could not re-scan games/mm with paths for the menu-index reader allowlist");
+
+            // The two TUs measured to be in NO CMake target: BenMenu.cpp is
+            // excluded wholesale by games/mm/CMakeLists.txt's BenGui filter,
+            // and BenGui/Menu.cpp survives only inside the elided
+            // 2ship_rando_ui archive.
+            static const char* const kAllowedMMMenuIndexReaders[] = {
+                "2s2h/BenGui/BenMenu.cpp",
+                "2s2h/BenGui/Menu.cpp",
+            };
+
+            for (std::size_t k = 0; k < RSBS::kMenuIndexKeyCount; k++) {
+                const std::string needle = std::string("\"") + RSBS::kMenuIndexKeys[k];
+                for (const CvarClassSourceFile& f : mmFiles) {
+                    if (f.text.find(needle) == std::string::npos) {
+                        continue;
+                    }
+                    bool allowed = false;
+                    for (const char* ok : kAllowedMMMenuIndexReaders) {
+                        if (f.relPath == ok) {
+                            allowed = true;
+                            break;
+                        }
+                    }
+                    if (!allowed) {
+                        printf("[TEST] FAIL: games/mm/%s reads the menu-index key \"%s\".\n"
+                               "[TEST]       That key indexes a MENU. ADR 0004 discharges #451 by deciding there is\n"
+                               "[TEST]       exactly one shell (OoT's SohMenu, extended); a second, MM-side shell\n"
+                               "[TEST]       indexing the same key is #451's arming condition, and one game's\n"
+                               "[TEST]       persisted section then selects an unrelated entry in the other.\n"
+                               "[TEST]       If this file genuinely is not in the link, add it to\n"
+                               "[TEST]       kAllowedMMMenuIndexReaders here WITH the CMake evidence. If it IS in\n"
+                               "[TEST]       the link, #451 is now armed — say so on #451 rather than widening\n"
+                               "[TEST]       this allowlist.\n",
+                               f.relPath.c_str(), RSBS::kMenuIndexKeys[k]);
+                        return TEST_FAIL;
+                    }
+                }
+            }
+
+            // Non-vacuity: the allowlist must actually be exercised. If MM ever
+            // stops reading these keys entirely, the loop above passes without
+            // examining anything and the lock silently retires.
+            bool sawAnyReader = false;
+            for (std::size_t k = 0; k < RSBS::kMenuIndexKeyCount && !sawAnyReader; k++) {
+                const std::string needle = std::string("\"") + RSBS::kMenuIndexKeys[k];
+                for (const CvarClassSourceFile& f : mmFiles) {
+                    if (f.text.find(needle) != std::string::npos) {
+                        sawAnyReader = true;
+                        break;
+                    }
+                }
+            }
+            CVARCLASS_CHECK(sawAnyReader, "no MM file reads any menu-index key — the allowlist check just passed "
+                                          "vacuously; if MM's menu TUs were deleted, retire this block and #451 "
+                                          "with them rather than leaving a check that examines nothing");
         }
 
         // (3e) The deliberate cheat sharing survives. Both documents warn


### PR DESCRIPTION
> **Stacked PR.** Based on Lane 6. Merge order: 3 → 5 → 1 → 2 → 6 → **4**. This will be rebased onto `main` once the lanes below it land, so its diff reduces to just this lane.

Nothing in the shipped link ever wrote a `gRando.Options.*` CVar, so the paired MM world generated on whatever `Rando::StaticData::Options` defaults happened to be — every shuffle and every hint off — with no way for a player to say otherwise (#499). The one live menu in the binary is OoT's `SohMenu` and all of its headers are OoT-only; MM's `BenMenu` shell is in no CMake target and MM's own rando pane is elided into `2ship_rando_ui`, which cannot be linked without dragging `BenMenu` — #451's arming condition. This lane adds a common-owned `Ship::Gui` window that hosts MM's full option set, extracts the paired profile into one callable so it can be locked without running a fill, and carves the profile digest into `ComboContext` so the paired world's identity covers both halves.

Scope note: the operator chose **Option B — the full 47-option pane**, not ADR 0004 §4.1's minimum (a read-only "Paired" summary plus a logic-mode picker). Every currently-dormant option is present, named, and drawn disabled with its reason, rather than absent. §4.1 is recorded as the 3.0 position and superseded by a new §4.1a.

## What changed

**The options surface (new)**
- `games/mm/2s2h/Rando/OptionsUiSingleExe.cpp` — MM-side descriptor table for all 47 `RandoOptionId`s: human labels, value enums, the 5-group taxonomy (MM's own 9 sidebars, less the 4 that carry no `RO_*` option), and a per-row liveness class. `cvar`, `name` and `defaultValue` are copied from each `StaticData::Options` row rather than restated, so a widget cannot bind to a key MM does not read. Registration is a call (`MM_RandoOptionsUi_Register`) rather than a file-scope registrar, because the table derives from a namespace-scope `std::map` in another TU and static init order across TUs is unspecified.
- `src/common/combo_mm_options_view.h` / `.c` — the common half of the seam: flat descriptor array, registry, and clamped get/set over the option CVars. No MM header crosses into common code (ADR 0009 decision 3). Includes `Combo_CVarIsExplicitInt`, which probes existence by reading a key twice with two different defaults — `CVarExists` is declared in `libultraship/bridge/consolevariablebridge.h` and defined nowhere in the pinned submodule, so calling it does not link.
- `src/common/ComboMmOptionsWindow.h` / `.cpp` — the window. Three presentation states per ADR 0004 §6 (live; editable-but-not-active when MM is suspended; disabled-by-capability with a reason), plus three pane-wide standing warnings that belong to the pipeline rather than to any row: arrival-time snapshot, silent vanilla revert on a dead-end fill, and the dormant end-of-cycle save hooks.
- `rsbs/src/main.cpp` — `Combo_MMOptionsWindow_Init()` at the same seam as the spoiler window. The host is common-owned rather than a `SohMenu` pane for a timing reason: the paired profile is snapshotted when MM's arrival dispatches `OnSaveInit` and an existing MM save is never regenerated, so the chooser must be reachable while OoT is the running game.
- `CMake/SingleExecutable.cmake` — new sources/headers and three CTest registrations.

**The paired profile**
- `games/mm/2s2h/Rando/Foreign.h` / `.cpp` — `Rando::Foreign::ResolvePairedProfile(bool paired)`: the option copy, the skulltula correction, the paired `RO_LOGIC` default and the digest, in one callable with a documented ordering contract (call before `MixPairedFinalSeed()`).
- `games/mm/2s2h/Rando/MiscBehavior/OnFileCreate.cpp` — three inline blocks replaced by that call under `RSBS_SINGLE_EXECUTABLE`; the non-single-exe path keeps the original loop verbatim. The `RO_LOGIC` pin becomes a default rather than a law: it now turns on whether the key was explicitly authored, so it no longer overrides a player who picked Glitchless.
- `src/common/context.h` — `uint32_t mmProfileDigest` at `.redsave` offset 788, carved from the front of `reserved[]` (216 → 212) with the literal-offset assert its neighbours carry. `sharedRandoSettingsHash` fingerprints OoT's settings only, so without this two peers can agree on seed *and* hash and still generate different MM halves. Computed from the same option string `MixPairedFinalSeed()` hashes.
- `games/mm/2s2h/Rando/StaticData/Options.cpp` — adds the missing `RO_ACCESS_MAJORA_REMAINS` row (47 ids, 46 rows). Adding rather than deleting the enumerator, because `RANDO_SAVE_OPTIONS` is indexed by that number in every MM rando save already written.

**ADR acceptance and classification (touches Lane 1's ADR area — intentional)**
- `docs/adr/0004-menu-information-architecture.md` — Proposed → Accepted; new §4.1a records the full-set/common-window supersession; §2d rules `gDeveloperTools.DebugSaveFileMode` **(P)**; all five open maintainer calls resolved from the tree (Cheats stays an Enhancements sidebar, ISG stays two keys, neither Group B pair converges, `TimeSavers` wins the casing).
- `docs/adr/0003-settings-namespace.md` — Proposed → Accepted; §4.1's `DebugSaveFileMode` row struck as wrong (MM's `RegisterDebugMode()` *writes* `DEBUG_SAVE_INFO_NONE` into the shared cell whenever debug mode is off, so the key is never left unwritten); §5.0 states the `TimeSavers` casing decision.
- `docs/adr/0009-combo-settings-and-reverse-pool.md` — claim 3 settled: 4 B, carved, offset recorded. This is the one row this lane edits inside Lane 1's document; the diff is expected.
- `src/common/cvar_shared_keys.h` — `kDisputedClassificationKeys` rewritten with the evidence and given the count `static_assert` every other table here has. The key stays disputed until MM's write is retired.

**Locks (all ROM-free, `redship` label)**
- `games/mm/2s2h/mm_rando_options_test.cpp` + `src/common/test_runner.cpp` — `MMRandoOptions` (table coverage and honesty, driven MM-side where both tables are in scope; verified non-vacuous by reverting the 47th `Options` row, which fails with `FAIL(23)` naming the id) and `MMPairedProfile` (drives the real resolver over a zeroed MM `SaveContext` with no fill, deliberately avoiding the vacuous "set a CVar, generate, observe it" shape).
- `src/common/tests/test_combo_mm_options_window.c` — `ComboMMOptionsWindow`: registration, idempotence, name de-collision, and `Draw()`/`Update()` under all three `GameId`s in paired and unpaired worlds with **no ImGui context**, so any path reaching `ImGui::Begin` aborts. This pane deliberately reads the active game to draw the suspended state, which is one step from reading that game's save.
- `src/common/tests/test_cvar_classification.c` — mechanizes #497 step 2, but scoped to MM-side readers rather than as worded: only the two measured-elided BenGui TUs may name a `kMenuIndexKeys` entry inside `games/mm`. The literal wording ("every reader must be on a not-linked allowlist") is red at head on correct code, because OoT's live `SohMenu` reads all four by design. A non-vacuity assertion sits beside it.

## Why

Capability gating is load-bearing rather than cautious. `Logic/GeneratePools.cpp` skips whole check classes when their option is off, so enabling an option whose hook has no MM dispatch point widens the pool, lets the fill place real items on those checks, and then never arms the hook that would award them — strictly worse than leaving it off. Crate, barrel and grass drops are the pure form (their identify-the-check helpers have no call site outside the undispatched hook). Gossip-stone hints and trials access are worse than inert: their VB legs fire and the text legs that would complete them are dead. #438's table is stale in one direction and this lane follows the tree — `OnSceneInit` *is* dispatched, so dungeon access is fully live.

No raised profile ships. Every `RO_SHUFFLE_*` and `RO_HINTS_*` row keeps its `RO_GENERIC_OFF` default, so dead-end rates are unchanged for anyone who does not touch the pane.

## Testing

- The stacked tip passes `ctest -L "^redship$"` locally, including the three new tests (`MMRandoOptions`, `MMPairedProfile`, `ComboMMOptionsWindow`) and the extended `CVarClassification`.
- Hosted CI covers the compile and ROM-free tiers only. The gameplay tier (`int-*`) is **not** covered here — it needs a self-hosted ROM runner that is not configured.
- The pane's appearance — grouping, readability of the disabled rows, whether the standing warnings land — is operator verification. No headless test asserts on pixels.

Closes #499

Refs #497 (steps 1, 2, 4 and 7 land here; step 3's `SohMenu` capability-gating infrastructure and step 6's tier-4 Combo section are not in this lane)
Refs #438
Refs #451
Refs #454

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!--- section:artifacts:start -->
### Build Artifacts
  - [rsbs-windows.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/8576941315.zip)
  - [rsbs-linux.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/8576327531.zip)
<!--- section:artifacts:end -->