### PR TITLE
Dispatch the cycle-save and actor-lifecycle hooks MM registers but never runs

### DIFF
--- a/games/mm/2s2h/GameExports_SingleExe.cpp
+++ b/games/mm/2s2h/GameExports_SingleExe.cpp
@@ -1734,12 +1734,123 @@ extern "C" void MM_GameHooks_ExecuteOnOpenText(u16* textId, bool* loadFromMessag
     S2H::GameHooks::ExecuteForID<GameInteractor::OnOpenText>(*textId, textId, loadFromMessageTable);
 }
 
+/**
+ * OnActorKill / OnActorDestroy dispatch (#515) — the actor-lifecycle pair the
+ * block above left behind.
+ *
+ * WHY THESE TWO OUTLIVED THE #511 AUDIT: neither name has an entry in
+ * src/common/mm_stubs.c. The other members of this class announced themselves
+ * as a no-op somebody had written down; these bound OoT's definitions in
+ * soh/Enhancements/game-interactor/GameInteractor_Hooks.cpp purely because the
+ * spelling matches, and OoT's first statement there is GI_SINGLE_EXE_GATE() —
+ * an unconditional return for the whole MM session. Silent bind, no stub to
+ * grep, no diagnostic. Both MM call sites (z_actor.c, MM_Actor_Kill and
+ * MM_Actor_Delete) were live and unguarded the entire time.
+ *
+ * WHAT THAT COST, and why this one can make a seed unwinnable: EnemyDrops.cpp
+ * registers the only code that pays out the 18 DROP_TYPE_KILL enemies, and
+ * ObjGrass.cpp's ACTOR_OBJ_GRASS_UNIT registrant is the SOLE writer of
+ * RandoCheckIds onto non-actor grass elements — every RC_*_GRASS_* check, 216
+ * in Termina Field alone and every other grass location from Romani Ranch to
+ * the cow grottos. Grass carrying a check looks and behaves exactly vanilla, so
+ * there is no on-screen tell: a seed that placed a required item behind one
+ * could not be finished, and nothing told the player why.
+ *
+ * ExecuteForID IS LOAD-BEARING, not defensive like the ForPtr legs. ObjGrass
+ * registers through COND_ID_HOOK(OnActorKill, ACTOR_OBJ_GRASS_UNIT, ...), so an
+ * Execute-only bridge compiles, links, fixes the enemy drops, reads correctly,
+ * and leaves every grass check exactly as dead as it was.
+ *
+ * THE PAIR LANDS TOGETHER, and the reason runs the opposite way to the usual
+ * before/after pairing argument: OnActorDestroy is harmless TODAY ONLY BECAUSE
+ * OnActorKill is dead. The grass registrant keys its ObjectExtension entries on
+ * element addresses INTERIOR to the ObjGrass actor allocation
+ * (&grassGroup->elements[j]), and ObjectExtension's key is the exact pointer —
+ * z_actor.c's own ObjectExtension_Free(actor) in MM_Actor_Delete erases only
+ * entries whose key is the actor base address, so it does not reach them.
+ * ObjGrass.cpp's ACTOR_OBJ_GRASS OnActorDestroy registrant is their only
+ * reaper. Wiring Kill alone would start creating hundreds of entries per scene
+ * with nothing to free them, keyed on arena addresses MM_ZeldaArena_Free then
+ * recycles — a later actor landing on a stale key reads a cross-scene
+ * RandoCheckId back out of GetObjectRandoCheckId. That is a worse bug than the
+ * one being fixed, which is why half of this change must never ship alone.
+ *
+ * Leg sets mirror the GameInteractor.cpp twins (:166-178) minus ForFilter, the
+ * standing deviation: the S2H registry has no filter surface. The ForPtr legs
+ * ride along for the same reason the #512 actor pair carries them — upstream
+ * has them and the ptr-keyed registry exists, while the one ptr registrant in
+ * the tree (ActorViewer.cpp, OnActorDestroy) sits in link-elided
+ * DeveloperTools. They cost an empty map lookup and stop the next ptr-keyed
+ * registrant from being silently dead the way these two were.
+ */
+extern "C" void MM_GameHooks_ExecuteOnActorKill(Actor* actor) {
+    S2H::GameHooks::Execute<GameInteractor::OnActorKill>(actor);
+    S2H::GameHooks::ExecuteForID<GameInteractor::OnActorKill>(actor->id, actor);
+    S2H::GameHooks::ExecuteForPtr<GameInteractor::OnActorKill>((uintptr_t)actor, actor);
+}
+
+extern "C" void MM_GameHooks_ExecuteOnActorDestroy(Actor* actor) {
+    S2H::GameHooks::Execute<GameInteractor::OnActorDestroy>(actor);
+    S2H::GameHooks::ExecuteForID<GameInteractor::OnActorDestroy>(actor->id, actor);
+    S2H::GameHooks::ExecuteForPtr<GameInteractor::OnActorDestroy>((uintptr_t)actor, actor);
+}
+
 extern "C" void MM_GameHooks_ExecuteOnFlagSet(FlagType flagType, u32 flag) {
     S2H::GameHooks::Execute<GameInteractor::OnFlagSet>(flagType, flag);
 }
 
 extern "C" void MM_GameHooks_ExecuteOnSceneFlagSet(s16 sceneId, FlagType flagType, u32 flag) {
     S2H::GameHooks::Execute<GameInteractor::OnSceneFlagSet>(sceneId, flagType, flag);
+}
+
+/**
+ * Before/AfterEndOfCycleSave dispatch (#514, the #438 table's worst entry).
+ *
+ * These two bracket Sram_SaveEndOfCycle (games/mm/src/code/z_sram_NES.c) — the
+ * vanilla three-day wipe that Song of Time and "Dawn of the New Day" run. Both
+ * call sites are live and unguarded; only the bodies were mm_stubs.c no-ops,
+ * so the wipe ran with no snapshot taken and no restore performed and
+ * Rando::MiscBehavior's cycle fix-ups (2s2h/Rando/MiscBehavior/OnCycleSave.cpp
+ * — dungeon keys, boss keys, stray fairies, skulltula tokens, frog flags, the
+ * three trade slots, and the per-check cycleObtained reset) never ran. The
+ * checks stay flagged obtained, so nothing the wipe took was re-collectable:
+ * silent, unrecoverable loss on a routine action, which is what makes this the
+ * P0 of the class rather than another dormant hook.
+ *
+ * The pair is dispatched TOGETHER and must stay that way. The restore work all
+ * hangs off After; Before's rando registrant is nothing but the memcpy into
+ * OnCycleSave.cpp's saveContextCopy that After reads. Wiring one half is not
+ * half a fix, it is a snapshot nobody consumes — the reasoning the retired
+ * mm_stubs.c comment recorded, honoured here by landing both.
+ *
+ * WHAT ELSE GOES LIVE WITH THE BEFORE HALF, since it is not only a snapshot:
+ * SavingEnhancements.cpp registers BeforeEndOfCycleSave unconditionally
+ * (SavingEnhancements_AdvancePlaytime + DeleteOwlSave), so a cycle save now
+ * banks playtime and clears the owl save. That is upstream 2S2H behaviour
+ * restored, and DeleteOwlSave already ran live on the moon-crash leg (#442) —
+ * it deletes a flash slot and clears isOwlSave rather than reading flash back
+ * over gSaveContext, so it is not the #487 flash-readback class.
+ *
+ * WHAT DOES NOT COME BACK: 2s2h/Enhancements/Cycle/EndOfCycle.cpp's six
+ * registrants (its own saveInfoCopy plus the DoNotReset{Rupees,Consumables,
+ * BottleContent,RazorSword,TimeSpeed} restores) are still absent from the
+ * binary — that TU is link-elided from the plain-archive 2ship_enh, verified
+ * against build-cmake/redship.map, which lists no EndOfCycle.cpp.obj. Nothing
+ * here changes that; those CVars stay inert until the TU links. The rando half
+ * is unaffected because 2ship_rando links WHOLE_ARCHIVE.
+ *
+ * Unkeyed leg only, matching the GameInteractor.cpp twins: both hook types are
+ * DEFINE_HOOK(..., ()) 0-arg, upstream's executors call plain ExecuteHooks<>,
+ * and no compiled MM TU registers either type by id or ptr. The ForFilter leg
+ * is absent for the usual reason — the S2H registry has no filter surface (see
+ * the OnSceneInit and Should blocks).
+ */
+extern "C" void MM_GameHooks_ExecuteBeforeEndOfCycleSave(void) {
+    S2H::GameHooks::Execute<GameInteractor::BeforeEndOfCycleSave>();
+}
+
+extern "C" void MM_GameHooks_ExecuteAfterEndOfCycleSave(void) {
+    S2H::GameHooks::Execute<GameInteractor::AfterEndOfCycleSave>();
 }
 
 /**

--- a/games/mm/2s2h/GameInteractor/GameInteractor.h
+++ b/games/mm/2s2h/GameInteractor/GameInteractor.h
@@ -640,6 +640,56 @@ void MM_GameHooks_ExecuteOnOpenText(u16* textId, bool* loadFromMessageTable);
 #define GameInteractor_ExecuteOnActorInit MM_GameHooks_ExecuteOnActorInit
 #define GameInteractor_ExecuteOnActorDraw MM_GameHooks_ExecuteOnActorDraw
 #define GameInteractor_ExecuteOnOpenText MM_GameHooks_ExecuteOnOpenText
+
+// The end-of-cycle pair (#514). Same rebind, but note what is different about
+// it: these two names are MM-ONLY — OoT has no end-of-cycle concept — so the
+// upstream names did not cross-bind to an active-game-gated OoT wrapper, they
+// resolved to a pair of src/common/mm_stubs.c no-ops that were left stubbed on
+// purpose until both halves could land at once. The damage was therefore not a
+// missing cosmetic override but the vanilla three-day wipe running unattended:
+// Sram_SaveEndOfCycle (games/mm/src/code/z_sram_NES.c, reached by Song of Time
+// and "Dawn of the New Day") stripped dungeon keys, boss keys, stray fairies,
+// skulltula tokens, frog flags and the trade slots while
+// Rando::MiscBehavior::AfterEndOfCycleSave — the code that puts them back and
+// clears cycleObtained — sat registered and unreachable. Checks stay flagged
+// obtained, so none of it comes back.
+//
+// Rebinding BOTH is load-bearing, not tidiness: the rando half of Before is a
+// pure snapshot into saveContextCopy and After is its only reader, so a
+// one-sided rebind buys a memcpy per cycle save and no restored progress. See
+// the bridge comment in GameExports_SingleExe.cpp for what else the Before
+// half wakes up and for the one registrant set that stays link-elided.
+void MM_GameHooks_ExecuteBeforeEndOfCycleSave(void);
+void MM_GameHooks_ExecuteAfterEndOfCycleSave(void);
+#define GameInteractor_ExecuteBeforeEndOfCycleSave MM_GameHooks_ExecuteBeforeEndOfCycleSave
+#define GameInteractor_ExecuteAfterEndOfCycleSave MM_GameHooks_ExecuteAfterEndOfCycleSave
+
+// The actor-lifecycle pair (#515). Third rebind block, and the one that was
+// hardest to SEE was missing: the end-of-cycle names above at least resolved to
+// a stub somebody had written down in src/common/mm_stubs.c, and the #438 block
+// was found by chasing a visible symptom. These two have no stub at all. MM's
+// z_actor.c call sites (MM_Actor_Kill, MM_Actor_Delete) simply bound OoT's
+// identically-spelled GameInteractor_ExecuteOnActorKill / ...OnActorDestroy,
+// which open with GI_SINGLE_EXE_GATE() and return immediately for the entire MM
+// session. Registered, linked, silently never run.
+//
+// The cost was the largest in the class. EnemyDrops.cpp's OnActorKill
+// registrant is the only thing that pays out the 18 DROP_TYPE_KILL enemies, and
+// ObjGrass.cpp's ACTOR_OBJ_GRASS_UNIT registrant is the only writer of
+// RandoCheckIds onto non-actor grass — roughly 230 checks that look and behave
+// exactly vanilla while holding items no seed could ever collect.
+//
+// BOTH NAMES, IN ONE CHANGE. OnActorDestroy carries ObjGrass.cpp's frees for the
+// element-keyed ObjectExtension entries the OnActorKill registrant creates, and
+// z_actor.c's own actor-keyed ObjectExtension_Free cannot reach those (their key
+// is an address inside the actor, not the actor). Rebinding Kill on its own
+// would trade an inert bug for a per-scene leak of stale check-id keys over
+// recycled arena addresses — see the bridge comment in GameExports_SingleExe.cpp
+// for the full failure mode.
+void MM_GameHooks_ExecuteOnActorKill(Actor* actor);
+void MM_GameHooks_ExecuteOnActorDestroy(Actor* actor);
+#define GameInteractor_ExecuteOnActorKill MM_GameHooks_ExecuteOnActorKill
+#define GameInteractor_ExecuteOnActorDestroy MM_GameHooks_ExecuteOnActorDestroy
 #endif // RSBS_SINGLE_EXECUTABLE
 
 #ifdef __cplusplus

--- a/games/mm/2s2h/Rando/OptionsUiSingleExe.cpp
+++ b/games/mm/2s2h/Rando/OptionsUiSingleExe.cpp
@@ -71,13 +71,30 @@
  * GameExports_SingleExe.cpp, called from z_play.c), so RO_ACCESS_DUNGEONS is
  * fully live. Re-measure before trusting either document.
  *
- * ONE HAZARD THAT IS NOT PER-ROW. `BeforeEndOfCycleSave` / `AfterEndOfCycleSave`
- * are registered unconditionally under IS_RANDO and are dormant, and their body
- * (Rando/MiscBehavior/OnCycleSave.cpp) is what carries dungeon items, keys,
- * stray fairies and trade slots across a cycle reset and clears the per-cycle
- * check flags. With it dead, a cycle reset degrades rando state for EVERY
- * option. That belongs in a pane-wide banner rather than 47 identical reason
- * strings; the window draws it as one.
+ * AND THE TABLE IS NOW STALE IN THAT SAME DIRECTION, left that way on purpose
+ * rather than guessed at. It was measured before #512 wired OnActorInit /
+ * OnActorDraw / OnOpenText, so `kReasonActorInitDrop` names a blocker that no
+ * longer exists — RO_SHUFFLE_CRATE_DROPS, RO_SHUFFLE_BARREL_DROPS and
+ * RO_SHUFFLE_GRASS_DROPS are still DORMANT against a hook that dispatches, and
+ * grass's other blocker (OnActorKill, the only writer of non-actor grass check
+ * ids) was cleared by #515. Promoting a row ENABLES it, which ADR 0004 calls
+ * the high-stakes direction, so those three want a deliberate re-measure of
+ * every leg rather than a flip riding on someone else's fix. Being stale
+ * towards DORMANT costs a disabled option; being wrong towards LIVE costs an
+ * unwinnable seed.
+ *
+ * THE HAZARD THAT WAS NOT PER-ROW, AND IS NOW GONE (#514). This table used to
+ * be read alongside a pane-wide banner: `BeforeEndOfCycleSave` /
+ * `AfterEndOfCycleSave` are registered unconditionally under IS_RANDO, were
+ * dormant, and their body (Rando/MiscBehavior/OnCycleSave.cpp) is what carries
+ * dungeon items, keys, stray fairies and trade slots across a cycle reset and
+ * clears the per-cycle check flags. With it dead a cycle reset degraded rando
+ * state for EVERY option, which is why it was one banner rather than 47
+ * identical reason strings. #514 gave both halves MM dispatch
+ * (MM_GameHooks_ExecuteBefore/AfterEndOfCycleSave), so the banner is retired
+ * and RO_SHUFFLE_GOLD_SKULLTULAS — whose PARTIAL reason named this gap and
+ * nothing else — is LIVE. Same standing instruction as the paragraph above:
+ * re-measure against the tree, do not trust this history.
  */
 #ifdef RSBS_SINGLE_EXECUTABLE
 
@@ -228,10 +245,12 @@ const OptionUi kOptionUi[] = {
     { RO_SHUFFLE_BOSS_REMAINS, COMBO_MM_GROUP_SHUFFLE, COMBO_MM_WIDGET_CHECKBOX,
       "Shuffle Boss Remains", "Shuffles the four Boss Remains into the item pool.",
       0, 0, nullptr, 0, COMBO_MM_LIVENESS_LIVE, "" },
+    // LIVE as of #514: the only leg this row was ever missing was the cycle-save
+    // restore (AfterEndOfCycleSave copies skullTokenCount back under exactly
+    // this option), and that now dispatches.
     { RO_SHUFFLE_GOLD_SKULLTULAS, COMBO_MM_GROUP_SHUFFLE, COMBO_MM_WIDGET_CHECKBOX,
       "Shuffle Gold Skulltula Tokens", "Adds the Spider House tokens to the check pool.",
-      0, 0, nullptr, 0,
-      COMBO_MM_LIVENESS_PARTIAL, "Token count is lost on a cycle reset: EndOfCycleSave dispatch missing (#438)" },
+      0, 0, nullptr, 0, COMBO_MM_LIVENESS_LIVE, "" },
     { RO_MINIMUM_SKULLTULA_TOKENS, COMBO_MM_GROUP_SHUFFLE, COMBO_MM_WIDGET_SLIDER,
       "Minimum Gold Skulltula Tokens",
       "Tokens needed for the Spider House reward. Forced to the vanilla value when tokens are not shuffled.",
@@ -283,10 +302,16 @@ const OptionUi kOptionUi[] = {
     { RO_SHUFFLE_ENEMY_SOULS, COMBO_MM_GROUP_ITEMS, COMBO_MM_WIDGET_CHECKBOX,
       "Enemy Souls", "Enemy Souls enter the item pool; an enemy is immune until its soul is found.",
       0, 0, nullptr, 0, COMBO_MM_LIVENESS_LIVE, "" },
+    // LIVE as of #515. The one leg this row was missing was the kill-drop path:
+    // EnemyDrops.cpp's unkeyed OnActorKill registrant, which covers the 18
+    // DROP_TYPE_KILL enemies, and which now dispatches
+    // (MM_GameHooks_ExecuteOnActorKill). Its other three legs were already live
+    // — VB_ENEMY_DROP_COLLECTIBLE for DROP_TYPE_NORMAL, and OnFlagSet /
+    // OnSceneFlagSet for the two cutscene deaths (Captain Keeta, Igos) — and the
+    // payout itself is a CustomItem::Spawn, not a hook, so nothing else gates it.
     { RO_SHUFFLE_ENEMY_DROPS, COMBO_MM_GROUP_ITEMS, COMBO_MM_WIDGET_CHECKBOX,
       "Enemy Drops", "Shuffles the first drop from a non-boss enemy.",
-      0, 0, nullptr, 0,
-      COMBO_MM_LIVENESS_PARTIAL, "Partly live: the kill-drop leg needs MM OnActorKill dispatch (#438)" },
+      0, 0, nullptr, 0, COMBO_MM_LIVENESS_LIVE, "" },
     { RO_SHUFFLE_OCARINA_BUTTONS, COMBO_MM_GROUP_ITEMS, COMBO_MM_WIDGET_CHECKBOX,
       "Shuffle Ocarina Buttons", "Ocarina buttons become items; a song is unplayable until its notes are found.",
       0, 0, nullptr, 0, COMBO_MM_LIVENESS_LIVE, "" },

--- a/games/mm/2s2h/mm_hook_dispatch_test.cpp
+++ b/games/mm/2s2h/mm_hook_dispatch_test.cpp
@@ -17,6 +17,19 @@
  * model and every rando text override stayed vanilla, because those ride
  * ShouldActorInit and OnOpenText.
  *
+ * #514 added check 6 for the same class's worst instance: Before/
+ * AfterEndOfCycleSave, the pair bracketing Sram_SaveEndOfCycle. There the
+ * dormancy was not cosmetic -- the vanilla three-day wipe ran with the rando
+ * restore dead, so a Song of Time reset took dungeon keys, stray fairies,
+ * tokens and trade slots for good.
+ *
+ * #515 added check 7 for the pair the audit almost missed entirely:
+ * OnActorKill / OnActorDestroy. They have NO mm_stubs.c entry, so there was
+ * nothing to notice -- the names simply bound OoT's gated wrappers. With
+ * OnActorKill dead the 18 DROP_TYPE_KILL enemies dropped vanilla collectibles
+ * and every grass check (~230, ObjGrass.cpp being their sole id writer) was
+ * uncollectable with no on-screen tell, so a seed could be unwinnable.
+ *
  * The invariant this locks: a hook registered on the MM-owned registry is
  * actually reached by the dispatcher MM's call sites resolve to. Each check
  * registers through the SAME macro production code uses, then drives the
@@ -32,7 +45,20 @@
  * call binds OoT's active-game-gated wrapper, which links fine and does
  * nothing. Verified red before green: reverting either the GameInteractor.h
  * rebind block or the GameExports_SingleExe.cpp bridges fails
- * FAIL(1)/FAIL(3)/FAIL(4)/FAIL(5).
+ * FAIL(1)/FAIL(3)/FAIL(4)/FAIL(5)/FAIL(7). Check 6 (#514) is stricter by
+ * accident of its symbols: its upstream names are MM-only and their mm_stubs.c
+ * no-ops were deleted with the fix, so reverting its rebind is a LINK error
+ * rather than a silent pass. It is also asserted as a pair on purpose -- wiring
+ * only the Before half is a snapshot nobody reads, indistinguishable from the
+ * bug in player-visible state, so FAIL(6) must be reachable from half a fix.
+ *
+ * Check 7 (#515) is the OPPOSITE extreme and the reason the "drive it through
+ * the upstream spelling" rule is not optional: OoT defines both of its names,
+ * so a dropped rebind links silently and does nothing. It asserts the unkeyed
+ * and id-keyed Kill legs SEPARATELY, because an Execute-only bridge is the
+ * plausible half-fix -- it revives the enemy drops and leaves every grass check
+ * dead -- and it asserts Destroy in the same block, because Destroy is what
+ * frees the entries Kill creates.
  *
  * WHAT THIS DOES NOT COVER -- READ BEFORE TRUSTING THE SUITE ON IT. The
  * z_actor.c half (two stale `#ifdef RSBS_SINGLE_EXECUTABLE` blocks that skipped
@@ -89,19 +115,30 @@ int sShouldActorInitRuns = 0;
 int sOnActorInitRuns = 0;
 int sOnOpenTextRuns = 0;
 int sOnActorDrawRuns = 0;
+int sBeforeEndOfCycleSaveRuns = 0;
+int sAfterEndOfCycleSaveRuns = 0;
+int sOnActorKillRuns = 0;
+int sOnActorKillForIdRuns = 0;
+int sOnActorDestroyForIdRuns = 0;
 
 // Distinct sentinel ids, so no check can be satisfied by another's registrant.
 constexpr s16 kActorIdInit = 0x0BAD;
 constexpr s16 kActorIdDraw = 0x0BAE;
+constexpr s16 kActorIdKill = 0x0BAF;
+constexpr s16 kActorIdDestroy = 0x0BB0;
 constexpr u16 kTextIdPlain = 0x0C0D;
 
-// ResetForTest is per-hook-type (templated on H), so the four types this row
-// touches are cleared explicitly rather than through one global reset.
+// ResetForTest is per-hook-type (templated on H), so the types this row touches
+// are cleared explicitly rather than through one global reset.
 void ResetAll() {
     S2H::GameHooks::ResetForTest<GameInteractor::ShouldActorInit>();
     S2H::GameHooks::ResetForTest<GameInteractor::OnActorInit>();
     S2H::GameHooks::ResetForTest<GameInteractor::OnActorDraw>();
     S2H::GameHooks::ResetForTest<GameInteractor::OnOpenText>();
+    S2H::GameHooks::ResetForTest<GameInteractor::BeforeEndOfCycleSave>();
+    S2H::GameHooks::ResetForTest<GameInteractor::AfterEndOfCycleSave>();
+    S2H::GameHooks::ResetForTest<GameInteractor::OnActorKill>();
+    S2H::GameHooks::ResetForTest<GameInteractor::OnActorDestroy>();
 }
 
 } // namespace
@@ -211,6 +248,123 @@ extern "C" int MM_HookDispatch_RunHeadless(void) {
         HOOK_ASSERT(sOnOpenTextRuns == 1, 5, "OnOpenText id-keyed leg fired for the wrong text id");
     }
 
+    // -------------------------------------------------------------------- 6
+    // Before/AfterEndOfCycleSave (#514): the pair that brackets
+    // Sram_SaveEndOfCycle. Registered by Rando::MiscBehavior under IS_RANDO and
+    // dispatched nowhere, so every Song of Time reset ran the vanilla three-day
+    // wipe with the rando restore dead and took dungeon keys, stray fairies,
+    // tokens and trade slots permanently -- the checks stay flagged obtained.
+    //
+    // Both are asserted in ONE block, deliberately: the failure this guards
+    // against is not "a bridge is missing" but "only one bridge is here". A
+    // Before-only wiring snapshots into OnCycleSave.cpp's saveContextCopy and
+    // nothing reads it, which is indistinguishable from the bug at the level of
+    // player-visible state, so the row must not be able to go green on half.
+    //
+    // These use the unkeyed leg because both hook types are 0-arg
+    // (DEFINE_HOOK(..., ())) and every production registrant is a plain
+    // COND_HOOK / Register, matching the bridges' single Execute<> leg.
+    {
+        sBeforeEndOfCycleSaveRuns = 0;
+        sAfterEndOfCycleSaveRuns = 0;
+        S2H::GameHooks::Register<GameInteractor::BeforeEndOfCycleSave>([]() { sBeforeEndOfCycleSaveRuns++; });
+        S2H::GameHooks::Register<GameInteractor::AfterEndOfCycleSave>([]() { sAfterEndOfCycleSaveRuns++; });
+
+        HOOK_ASSERT(sBeforeEndOfCycleSaveRuns == 0, 6, "BeforeEndOfCycleSave ran at registration time");
+        HOOK_ASSERT(sAfterEndOfCycleSaveRuns == 0, 6, "AfterEndOfCycleSave ran at registration time");
+
+        // Spelled exactly as z_sram_NES.c spells them, so the rebinds are under
+        // test. Unlike the checks above, dropping a rebind here does not bind a
+        // gated OoT wrapper -- these names are MM-only and their mm_stubs.c
+        // no-ops were deleted -- so a regression surfaces as a link error.
+        GameInteractor_ExecuteBeforeEndOfCycleSave();
+        HOOK_ASSERT(sBeforeEndOfCycleSaveRuns == 1, 6,
+                    "BeforeEndOfCycleSave registrant never ran -- the cycle snapshot is not taken");
+        HOOK_ASSERT(sAfterEndOfCycleSaveRuns == 0, 6, "the Before dispatcher also ran After registrants");
+
+        GameInteractor_ExecuteAfterEndOfCycleSave();
+        HOOK_ASSERT(sAfterEndOfCycleSaveRuns == 1, 6,
+                    "AfterEndOfCycleSave registrant never ran -- rando progress is not restored after the wipe");
+        HOOK_ASSERT(sBeforeEndOfCycleSaveRuns == 1, 6, "the After dispatcher also re-ran Before registrants");
+    }
+
+    // -------------------------------------------------------------------- 7
+    // OnActorKill + OnActorDestroy (#515): the actor-lifecycle pair. Dead in
+    // exactly the silent way -- no mm_stubs.c entry to notice, so both bound
+    // OoT's GI_SINGLE_EXE_GATE()'d wrappers. That cost the 18 DROP_TYPE_KILL
+    // enemy drops (EnemyDrops.cpp, unkeyed) and every grass check (ObjGrass.cpp,
+    // COND_ID_HOOK on ACTOR_OBJ_GRASS_UNIT -- the sole writer of grass
+    // RandoCheckIds, ~230 checks with no on-screen tell that they were dead).
+    //
+    // BOTH LEGS OF Kill ARE ASSERTED SEPARATELY, and that is the point of this
+    // check rather than a flourish: an Execute-only bridge revives the enemy
+    // drops and leaves every grass check as dead as before, which is the
+    // plausible half-fix here and would otherwise ship green.
+    //
+    // Destroy is in the SAME block for the pairing reason recorded on the
+    // bridge: it is what frees the element-keyed ObjectExtension entries the
+    // Kill registrant creates, so a Kill-only wiring is not a partial fix but a
+    // per-scene leak of stale check-id keys. The row must not pass on half.
+    {
+        sOnActorKillRuns = 0;
+        sOnActorKillForIdRuns = 0;
+        sOnActorDestroyForIdRuns = 0;
+
+        // The EnemyDrops.cpp shape (COND_HOOK -> unkeyed).
+        S2H::GameHooks::Register<GameInteractor::OnActorKill>([](Actor* actor) {
+            (void)actor;
+            sOnActorKillRuns++;
+        });
+        // The ObjGrass.cpp shape (COND_ID_HOOK -> id-keyed).
+        S2H::GameHooks::RegisterForID<GameInteractor::OnActorKill>(kActorIdKill, [](Actor* actor) {
+            (void)actor;
+            sOnActorKillForIdRuns++;
+        });
+        S2H::GameHooks::RegisterForID<GameInteractor::OnActorDestroy>(kActorIdDestroy, [](Actor* actor) {
+            (void)actor;
+            sOnActorDestroyForIdRuns++;
+        });
+
+        HOOK_ASSERT(sOnActorKillRuns == 0, 7, "OnActorKill ran at registration time");
+        HOOK_ASSERT(sOnActorKillForIdRuns == 0, 7, "OnActorKill (id-keyed) ran at registration time");
+        HOOK_ASSERT(sOnActorDestroyForIdRuns == 0, 7, "OnActorDestroy ran at registration time");
+
+        Actor killed;
+        memset(&killed, 0, sizeof(killed));
+        killed.id = kActorIdKill;
+
+        // Spelled exactly as z_actor.c's MM_Actor_Kill spells it.
+        GameInteractor_ExecuteOnActorKill(&killed);
+
+        HOOK_ASSERT(sOnActorKillRuns == 1, 7,
+                    "OnActorKill unkeyed registrant never ran -- enemy kill-drops stay vanilla");
+        HOOK_ASSERT(sOnActorKillForIdRuns == 1, 7,
+                    "OnActorKill id-keyed registrant never ran -- every grass check stays uncollectable");
+        HOOK_ASSERT(sOnActorDestroyForIdRuns == 0, 7, "the Kill dispatcher also ran Destroy registrants");
+
+        // Another actor id reaches the unkeyed leg but must NOT reach the
+        // id-keyed one -- the discrimination ObjGrass depends on.
+        Actor otherKilled;
+        memset(&otherKilled, 0, sizeof(otherKilled));
+        otherKilled.id = kActorIdKill + 1;
+        GameInteractor_ExecuteOnActorKill(&otherKilled);
+
+        HOOK_ASSERT(sOnActorKillRuns == 2, 7, "OnActorKill unkeyed leg skipped an actor of another id");
+        HOOK_ASSERT(sOnActorKillForIdRuns == 1, 7, "OnActorKill id-keyed leg fired for the wrong actor id");
+
+        Actor destroyed;
+        memset(&destroyed, 0, sizeof(destroyed));
+        destroyed.id = kActorIdDestroy;
+
+        // Spelled exactly as z_actor.c's MM_Actor_Delete spells it.
+        GameInteractor_ExecuteOnActorDestroy(&destroyed);
+
+        HOOK_ASSERT(sOnActorDestroyForIdRuns == 1, 7,
+                    "OnActorDestroy registrant never ran -- element-keyed check ids are never freed");
+        HOOK_ASSERT(sOnActorKillRuns == 2, 7, "the Destroy dispatcher also ran Kill registrants");
+        HOOK_ASSERT(sOnActorKillForIdRuns == 1, 7, "the Destroy dispatcher also ran id-keyed Kill registrants");
+    }
+
     // NOTE ON WHAT COVERS THE REBIND. An earlier draft of this row compared
     // &GameInteractor_ExecuteOnOpenText against &MM_GameHooks_ExecuteOnOpenText
     // to prove the #define was in place. That check is tautological: the rebind
@@ -221,7 +375,7 @@ extern "C" int MM_HookDispatch_RunHeadless(void) {
     // each drives the dispatcher through the UPSTREAM spelling and asserts a
     // hook registered on the MM-owned registry ran. Drop the #define and those
     // calls bind OoT's active-game-gated wrapper instead, which links fine,
-    // does nothing, and fails FAIL(1)/FAIL(3)/FAIL(4)/FAIL(5).
+    // does nothing, and fails FAIL(1)/FAIL(3)/FAIL(4)/FAIL(5)/FAIL(7).
 
     ResetAll();
 

--- a/src/common/ComboMmOptionsWindow.cpp
+++ b/src/common/ComboMmOptionsWindow.cpp
@@ -28,9 +28,13 @@ namespace {
  * Draw the pane-wide warnings.
  *
  * These are pane-wide because their causes are: they are properties of the
- * paired-generation pipeline and of MM's dormant cycle-save hooks, not of any
- * one option. Repeating them 47 times as per-row reason strings would bury the
- * per-row reasons that ARE specific.
+ * paired-generation pipeline, not of any one option. Repeating them 47 times as
+ * per-row reason strings would bury the per-row reasons that ARE specific.
+ *
+ * A third standing warning used to live here — the dormant cycle-save hooks —
+ * and was retired by #514, which gave Before/AfterEndOfCycleSave real dispatch.
+ * It is not replaced by a "now fixed" notice: the pane states current hazards,
+ * and a resolved one is simply absent.
  */
 void DrawStandingWarnings() {
     const ImVec4 warn(0.98f, 0.76f, 0.24f, 1.0f);
@@ -53,15 +57,6 @@ void DrawStandingWarnings() {
     ImGui::TextWrapped("Paired generation is attempt-free by design. If your settings make the fill dead-end, the MM "
                        "file becomes an ordinary vanilla file rather than reporting an error. Glitchless logic is the "
                        "setting most likely to do this.");
-    ImGui::Spacing();
-
-    // (3) The cycle-save hazard, which is rando-wide rather than per-option:
-    // Before/AfterEndOfCycleSave are registered unconditionally under IS_RANDO
-    // and dormant, and their body is what carries dungeon items, keys, stray
-    // fairies and trade slots across a cycle reset.
-    ImGui::TextColored(warn, "Cycle resets are not yet rando-aware.");
-    ImGui::TextWrapped("MM's end-of-cycle save hooks have no dispatch point in this build (#438), so playing the Song "
-                       "of Time can lose randomizer progress regardless of the options below.");
     ImGui::Separator();
 }
 

--- a/src/common/mm_stubs.c
+++ b/src/common/mm_stubs.c
@@ -159,17 +159,25 @@ void GameInteractor_ExecuteOnBottleContentsUpdate(int slotId) { (void)slotId; }
 void GameInteractor_ExecuteOnConsoleLogoUpdate(void) {}
 void GameInteractor_ExecuteOnFileSelectSaveLoad(void* state, int fileNum) { (void)state; (void)fileNum; }
 void GameInteractor_ExecuteOnGameCompletion(void) {}
-/* GameInteractor_ExecuteBeforeEndOfCycleSave / ExecuteAfterEndOfCycleSave stay
- * stubbed on purpose (#442 leaves this pair to #438, which already tracks it
- * alongside the rest of the registered-but-dormant hook table): they are a
- * matched before/after pair around Rando::MiscBehavior's cycle-save
- * fix-ups, and BeforeEndOfCycleSave now also has a real S2H::GameHooks
- * registrant from SavingEnhancements.cpp (RegisterSavingEnhancements). Wiring
- * only the Before half here would run its memcpy backup every cycle save
- * while AfterEndOfCycleSave's restore logic stays dead — harmless (the copy
- * goes unread) but a half-fix; #438 wires both together. */
-void GameInteractor_ExecuteBeforeEndOfCycleSave(void) {}
-void GameInteractor_ExecuteAfterEndOfCycleSave(void) {}
+/* GameInteractor_ExecuteBeforeEndOfCycleSave / ExecuteAfterEndOfCycleSave moved
+ * to real, header-checked dispatch in
+ * games/mm/2s2h/GameExports_SingleExe.cpp (#514), reached through the
+ * single-exe macro rebind at the bottom of MM's GameInteractor.h. #442 left
+ * this pair stubbed deliberately, to be wired as a pair rather than half-wired;
+ * #514 wires both, so that deferral is spent and the "stay stubbed on purpose"
+ * note it carried is gone with it.
+ *
+ * These two were the most expensive no-ops in this file. Both call sites in
+ * games/mm/src/code/z_sram_NES.c (Sram_SaveEndOfCycle, entered by Song of Time
+ * and "Dawn of the New Day") are live and unguarded, so the vanilla three-day
+ * wipe ran with no snapshot taken and no restore performed:
+ * Rando::MiscBehavior::AfterEndOfCycleSave — dungeon/boss keys, stray fairies,
+ * skulltula tokens, frog flags, the three trade slots, and the per-check
+ * cycleObtained reset — was registered and unreachable, and because the checks
+ * stay flagged obtained none of what the wipe took was re-collectable.
+ * Re-stubbing either name here silently restores that: routine play quietly
+ * eats randomizer progress with no diagnostic, and the loss only surfaces
+ * cycles later when a check refuses to re-offer an item the player had. */
 /* GameInteractor_ExecuteBeforeMoonCrashSaveReset moved to real, header-checked
  * dispatch in games/mm/2s2h/GameExports_SingleExe.cpp (#442): MM's real
  * z_sram_NES.c call site already pumps this at the moon-crash reset point;


### PR DESCRIPTION
Two more instances of the #511 class — hooks registered into `S2H::GameHooks` that nothing ever dispatches — found by auditing all 48 hook types after #512 fixed the first four. Both are gameplay-breaking today, not latent. Full audit on [#438](https://github.com/spencerduncan/redshipblueship/issues/438#issuecomment-5065101747).

## #514 — every Song of Time reset silently destroyed rando progress

`Before/AfterEndOfCycleSave` were `mm_stubs.c` no-ops while **both call sites ran live and unguarded** (`z_sram_NES.c:472` and `:712`). So the vanilla three-day wipe executed with no snapshot taken and no restore performed, and `Rando::MiscBehavior`'s cycle fix-ups (`OnCycleSave.cpp`) never ran.

Because the checks stay flagged `obtained`, nothing the wipe took was re-collectable: dungeon keys, boss keys, stray fairies, skulltula tokens, frog flags and the three trade slots, gone permanently, on a routine action, with no diagnostic.

**Both halves land together.** `Before` only fills the copy buffers; every registrant that reads them hangs off `After`. Wiring one half is not half a fix, it is a memcpy nobody reads — which is what the retired `mm_stubs.c` comment already warned.

## #515 — ~230 rando checks were uncollectable, seeds could be unwinnable

`OnActorKill` / `OnActorDestroy` had **no stub at all**, so the names silently bound OoT's `GI_SINGLE_EXE_GATE()`'d wrappers — an unconditional return for the whole MM session, with nothing to grep for. This is why the audit nearly missed them.

Cost: the 18 `DROP_TYPE_KILL` enemies paid out vanilla collectibles, and every grass check (~230, `ObjGrass.cpp` being their sole `RandoCheckId` writer) was uncollectable. Grass carrying a check looks and behaves exactly vanilla — no on-screen tell — so a seed placing a required item behind one could not be finished.

**`ExecuteForID` is load-bearing here, not defensive.** `ObjGrass.cpp:388` registers via `COND_ID_HOOK`, so an `Execute`-only bridge would compile, link, revive the enemy drops, read as correct, and leave every grass check exactly as dead.

**The pair lands together for the inverse of the usual reason:** `OnActorDestroy` is harmless *today only because* `OnActorKill` is dead. The grass registrant keys `ObjectExtension` entries on addresses interior to the `ObjGrass` allocation, which `z_actor.c`'s actor-base `ObjectExtension_Free` never reaches. Wiring Kill alone would strand hundreds of entries per scene on arena addresses `MM_ZeldaArena_Free` then recycles — a worse bug than the one being fixed.

## Options pane

Retires the now-false standing warning that cycle resets aren't rando-aware, and promotes the two rows whose only blocker was exactly these fixes (`RO_SHUFFLE_GOLD_SKULLTULAS`, `RO_SHUFFLE_ENEMY_DROPS`).

Three rows unblocked by #512 (`CRATE`/`BARREL`/`GRASS_DROPS`) are **deliberately left DORMANT** pending their own re-measure. Promoting a row enables it; being stale toward DORMANT costs a disabled option, being wrong toward LIVE costs an unwinnable seed.

## Testing

`MMHookDispatch` gains checks 6 and 7, and both were **falsified before being trusted**:

- neutering the cycle bridges → `FAIL(6): BeforeEndOfCycleSave registrant never ran`
- neutering the actor bridges → `FAIL(7): OnActorKill unkeyed registrant never ran`
- restoring both → green

Check 7 asserts the unkeyed and id-keyed Kill legs with **separate counters**, so the plausible `Execute`-only half-fix fails rather than passing on the enemy-drop half.

Local `ctest -L "^redship$"`: **59/59**. Hosted CI covers compile plus the ROM-free tiers; the gameplay tier (`int-*`) needs the self-hosted ROM runner and is not run.

**Not covered by automation:** as with #512, the behavior of these hooks in real play is unverified. The cycle-save restore in particular only demonstrates itself across an actual Song of Time. Operator playtest is the check.

Closes #514
Closes #515
Refs #438, #511

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!--- section:artifacts:start -->
### Build Artifacts
  - [rsbs-windows.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/8586479520.zip)
  - [rsbs-linux.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/8585888890.zip)
<!--- section:artifacts:end -->