### PR TITLE
Revive the two critical registrars BenPort's exclusion elided from single-exe (#516 Phase 1)

### DIFF
--- a/.github/scripts/check-registrar-elision.sh
+++ b/.github/scripts/check-registrar-elision.sh
@@ -332,6 +332,33 @@ main() {
         overall=1
     fi
 
+    # #516: registrars re-homed out of the excluded BenPort InitOTR sequence.
+    # These live in the report-only 2ship_enh / 2ship_port archives, where MOST
+    # members must legitimately stay dead (BenGui, DebugConsole, ...), so the
+    # archive-level gate above cannot express "this one specific member must be
+    # live." A per-symbol allowlist can. Each was 0-hit before the MM_Rando_Init
+    # revival (GameExports_SingleExe.cpp); absence now means a future refactor
+    # dropped the hard call and re-elided a required MM feature.
+    #
+    # Same plain-grep-not-`-q` discipline as the probes above (pipefail + SIGPIPE).
+    # RegisterSavingEnhancements / RegisterAutosave are deliberately ABSENT: they
+    # are #516 Phase 2 (their moon-crash / cycle-save hooks are a behavior change
+    # the arm-state test must be taught to survive first), and RegisterAutosave's
+    # symbol additionally ODR-folds with OoT's soh_enh Autosave.cpp twin, so a
+    # presence probe could not attribute it to MM anyway.
+    local required_mm_registrars=(
+        "CustomItem::RegisterHooks"                 # cross-game + rando item delivery (critical)
+        "S2H::CustomMessage::RegisterHooks"         # custom rando/hint message text 0x4B (critical)
+        "GfxPatcher_ApplyNecessaryAuthenticPatches" # authentic gfx patches incl. latent matrix-stack UB
+    )
+    local sym
+    for sym in "${required_mm_registrars[@]}"; do
+        if ! nm --demangle "$bin" 2>/dev/null | grep "$sym" > /dev/null; then
+            echo "FAIL: required MM registrar '$sym' elided from redship (#516 regression)" >&2
+            overall=1
+        fi
+    done
+
     if [ "$overall" -ne 0 ]; then
         echo "FAIL: registrar symbols were elided from a WHOLE_ARCHIVE-protected archive (#341)" >&2
         exit 1

--- a/games/mm/2s2h/GameExports_SingleExe.cpp
+++ b/games/mm/2s2h/GameExports_SingleExe.cpp
@@ -48,6 +48,12 @@
 
 #include "2s2h/Enhancements/Audio/AudioCollection.h"
 #include "2s2h/Enhancements/Audio/AudioEditor.h"
+// #516: registrars orphaned by the excluded BenPort InitOTR sequence, re-homed
+// into MM_Rando_Init below. Headers here so the calls are type-checked rather
+// than file-local extern prototypes.
+#include "2s2h/CustomItem/CustomItem.h"
+#include "2s2h/CustomMessage/CustomMessage.h"
+#include "2s2h/Enhancements/GfxPatcher/AuthenticGfxPatches.h"
 #include "2s2h/Rando/Rando.h"
 #include "2s2h/ShipInit.hpp"
 #include "2s2h/resource/type/2shResourceType.h"
@@ -1359,6 +1365,10 @@ extern "C" void MM_GameEvents_RegisterPump(void);
 // games/mm/2s2h/TrackersGuiSingleExe.cpp.
 extern "C" void MM_TrackersGui_Init(void);
 
+// Defined below in this TU; forward-declared so the #516 GfxPatcher gate can
+// reference it from MM_Rando_Init above the definition.
+extern "C" bool MM_Rando_AssetsReady(void);
+
 extern "C" void MM_Rando_Init(void) {
     static bool sRandoInitDone = false;
     if (sRandoInitDone) {
@@ -1370,6 +1380,56 @@ extern "C" void MM_Rando_Init(void) {
     fflush(stderr);
     S2H::ShipInit::InitAll();
     Rando::Init();
+
+    // #516: registrars orphaned by the excluded BenPort InitOTR sequence.
+    //
+    // BenPort.cpp (MM's OTRGlobals equivalent) is excluded from the single exe —
+    // it drags in a second window/Gui/config bring-up and the OoT-aliasing
+    // hazard class the shim exists to avoid — so every Init*/Register* it was
+    // the sole caller of got link-elided. This is not a "recompile BenPort"
+    // fix: only the individually single-exe-safe registrars are re-homed, here,
+    // by explicit call. An explicit call (rather than a per-TU
+    // RegisterShipInitFunc) is deliberate: 2ship_enh is a plain STATIC archive,
+    // so a registrar's own static initializer would be stripped with its
+    // unreferenced TU — the exact mechanism that elided these. A hard call from
+    // this always-linked TU forces /OPT:REF to keep the symbol AND pulls the TU
+    // into the link, and it is the reference the #516 CI probe asserts on.
+    //
+    // This block MUST run exactly once: CustomItem/CustomMessage register through
+    // raw RegisterForID (no unregister-first) and RegisterSavingEnhancements
+    // through plain Register<>, none of which de-dup. The sRandoInitDone guard
+    // above provides that — MM_Game_Resume does not re-enter here.
+    //
+    // Both hook registrars only became LIVE with #512/#514/#515, which wired the
+    // MM ShouldActorInit and OnOpenText execute points their bodies were written
+    // against; before that, reviving them here would have registered into a
+    // registry nothing dispatched.
+    CustomItem::RegisterHooks();    // ShouldActorInit[EN_ITEM00]: the swap that
+                                    // makes CustomItem::Spawn's placeholder a
+                                    // real item — cross-game arrivals + every
+                                    // rando reward. #516 critical.
+    CustomMessage::RegisterHooks(); // OnOpenText[0x4B]: loads staged rando/hint
+                                    // text; without it every custom message
+                                    // renders vanilla entry 0x4B. #516 critical.
+    // RegisterSavingEnhancements() / RegisterAutosave() are DELIBERATELY not
+    // here: both put registrants on the moon-crash and cycle-save reset paths
+    // (BeforeMoonCrashSaveReset -> DeleteOwlSave, BeforeEndOfCycleSave), and
+    // DeleteOwlSave dereferences MM_gPlayState. That is fine in production
+    // (z_demo.c:379 resets from &play->sramCtx with a live play state) but
+    // crashes the headless MMMoonCrashArmState arm-state test, which drives the
+    // reset with no play state. Reviving them is a real behavior change on those
+    // paths that needs the arm-state test taught to stand up a play state —
+    // #516 Phase 2, its own change. This PR ships the two criticals, which
+    // touch neither path.
+
+    // GfxPatcher is a one-shot resource patcher, not a hook registrar, so it is
+    // called (not registered) and gated on assets: its ResourceMgr_Load*ByName
+    // helpers null-deref with no mm.o2r, and mm_rando_gen_test.cpp drives this
+    // function ROM-free. Fixes OOB textures, mini-game symbols, and a latent
+    // matrix-stack UB the smithy chimney-fire DL hits (per its own comment).
+    if (MM_Rando_AssetsReady()) {
+        GfxPatcher_ApplyNecessaryAuthenticPatches();
+    }
 
     // Lane C1 (#392): register the GIEvent pump (the port of upstream's
     // ProcessEvents player-update hook, games/mm/2s2h/


### PR DESCRIPTION
Phase 1 of #516. Revives the four registrars orphaned by `BenPort.cpp`'s single-exe exclusion that are both safe and gameplay-relevant, from a full map-verified classification of the excluded `InitOTR` sequence (plan of record on [#516](https://github.com/spencerduncan/redshipblueship/issues/516#issuecomment-5066237988)).

## The class

`BenPort.cpp` (MM's `OTRGlobals` equivalent) is excluded from single-exe at `games/mm/CMakeLists.txt:238` — it drags in a second window/Gui/config bring-up and the OoT-aliasing hazard the shim exists to avoid. It was the sole caller of MM's `InitOTR` registration run, and because `2ship_enh` is a plain `STATIC` archive, every registrar reachable only through it was link-elided. Measured from `redship.map`: **only 8 of ~130 `2ship_enh` TUs survive the link.**

This is not a "recompile BenPort" fix. Each registrar in that sequence was classified individually (4 revive-now, 3 needs-adaptation, 5 must-stay-out); this PR lands the revive-now four plus `GfxPatcher`.

## What this fixes (all confirmed 0-hit in the current binary)

- **`CustomItem::RegisterHooks`** *(critical)* — the sole registrar of the `ShouldActorInit[EN_ITEM00, ITEM00_NOTHING]` swap that turns a `CustomItem::Spawn` placeholder into a real drawing, give-running item. Dead ⇒ **every cross-game foreign-item arrival and every rando reward materialized via `CustomItem::Spawn` delivered nothing.**
- **`CustomMessage::RegisterHooks`** *(critical)* — the `OnOpenText[0x4B]` handler that loads staged text. Dead ⇒ **every rando check-pickup and hint message rendered vanilla message-table entry `0x004B`** instead.
- **`GfxPatcher_ApplyNecessaryAuthenticPatches`** — OOB arrow/Freezard/Iron-Knuckle textures, mini-game X/O symbols, transition wipe, and a **latent matrix-stack UB** the smithy chimney-fire display list hits (per its own comment).

Both hook registrars only became reachable with #512/#514/#515, which wired the MM `ShouldActorInit` and `OnOpenText` execute points their bodies target — before that, reviving them would have registered into a registry nothing dispatched. That ordering is why this is only fixable now.

## Mechanism

Explicit calls from `MM_Rando_Init` (`GameExports_SingleExe.cpp`), after `Rando::Init()`, inside the existing once-only `sRandoInitDone` guard. Explicit calls rather than per-TU `RegisterShipInitFunc` deliberately: a static initializer in a plain-static `2ship_enh` TU is **stripped with its unreferenced object file** — the exact mechanism that elided these. A hard call from this always-linked TU forces `/OPT:REF` to keep the symbol, pulls the TU into the link, and is the reference the CI probe asserts on.

The once-guard is load-bearing: `CustomItem`/`CustomMessage` register through raw `RegisterForID` and `RegisterSavingEnhancements` through plain `Register<>`, none of which de-dup. `GfxPatcher` is a one-shot patcher (called, not registered) gated on `MM_Rando_AssetsReady()` — its `ResourceMgr_Load*ByName` helpers null-deref with no `mm.o2r`, and the ROM-free `mm_rando_gen_test` drives this path.

## The regression gate

`.github/scripts/check-registrar-elision.sh` gains a per-symbol allowlist for the four, modeled on the existing Lane C0 probes (same `nm --demangle | grep` — plain, not `-q`, for the documented pipefail/SIGPIPE reason). The archive-level gate **cannot** cover this: `2ship_enh` is checked report-only precisely because most of its registrars (BenGui, DebugConsole, …) must legitimately stay dead, so enforcement has to be per-symbol.

**`RegisterSavingEnhancements` and `RegisterAutosave` are deferred to Phase 2**, not just ungated. An initial version wired them here and CI's `rando` tier (which I had not run locally — my gap, now closed) caught it: both register hooks on the moon-crash/cycle-save reset paths (`BeforeMoonCrashSaveReset → DeleteOwlSave`), and `DeleteOwlSave` dereferences `MM_gPlayState`. That's correct in production (`z_demo.c:379` resets from a live `&play->sramCtx`) but crashes the headless `MMMoonCrashArmState` test. Reviving them is a real behavior change on those paths that needs the arm-state test taught to stand up a play state — its own change. `RegisterAutosave` additionally ODR-folds with OoT's `Autosave.cpp:80` twin, so it can't be gated by a presence probe anyway.

## Testing

Local `ctest` green on **both** the `redship` (59/59) and `rando` (13/13) tiers — the `rando` tier drives the moon-crash path this change interacts with, and is what caught the descope above. Hosted CI covers compile + ROM-free tiers plus the elision gate on the Linux binary; the actual delivery of a cross-game item and a custom textbox is gameplay-tier and rests on playtest — noted as open item 3 on #516.

## Not in this PR
- **Phase 2:** `RegisterSavingEnhancements` + `RegisterAutosave` (teach `MMMoonCrashArmState` to stand up a play state first); `RegisterAutosave` name disambiguation + gate; Autosave runtime-toggle decision.
- **Phase 3:** `PlayerCustomFlipbooks_Patch`, `OTRExtScanner` — both need a shared-ExtensionCache rescan after MM archives load, a distinct `MM_Game_Init` ordering change.
- **Staying out:** `BenGui::SetupGuiElements`, `DebugConsole_Init`, `GameInteractor::RegisterOwnHooks`, `OTRAudio_Init`, `ConfigVersion1Updater` — each already handled elsewhere or actively harmful to revive (rationale in the #516 table).

Refs #516, #513
🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!--- section:artifacts:start -->
### Build Artifacts
  - [rsbs-windows.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/8588290872.zip)
  - [rsbs-linux.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/8587316093.zip)
<!--- section:artifacts:end -->