### PR TITLE
Seed an unset lastTimeLog instead of injecting a Unix epoch into filePlaytime (#513)

### DIFF
--- a/.github/clang-format-paths.txt
+++ b/.github/clang-format-paths.txt
@@ -40,6 +40,7 @@ games/mm/2s2h/mm_culling_test.cpp
 games/mm/2s2h/mm_fb_effects_test.cpp
 games/mm/2s2h/mm_flash_filenum_test.cpp
 games/mm/2s2h/mm_hook_dispatch_test.cpp
+games/mm/2s2h/mm_playtime_seed_test.cpp
 games/mm/2s2h/mm_framebuffer_effects.c
 games/mm/2s2h/mm_gi_shim_test.cpp
 games/mm/2s2h/mm_notification_binding_test.cpp

--- a/CMake/SingleExecutable.cmake
+++ b/CMake/SingleExecutable.cmake
@@ -523,6 +523,13 @@ if(BUILD_TESTING)
     # randomized while their models and dialog stayed vanilla. Display-free and
     # ROM-free, so it runs in this redship tier.
     redship_add_test(NAME MMHookDispatch COMMAND redship --test mm-hook-dispatch)
+    # filePlaytime epoch injection (#513): SavingEnhancements_AdvancePlaytime is
+    # called from plain C (z_sram_NES.c, z_kaleido_scope_NES.c) regardless of
+    # hook wiring, and accrued now - lastTimeLog with lastTimeLog unseeded (0) --
+    # the OnSaveLoad seeder was elided (#516) and the value is re-zeroed on
+    # new-file paths -- writing a ~56-year Unix epoch into the PERSISTED
+    # filePlaytime. Display-free and ROM-free, so it runs in this redship tier.
+    redship_add_test(NAME MMPlaytimeSeed COMMAND redship --test mm-playtime-seed)
     # MM tracker registration surface (#392): the four MM tracker windows must
     # register on the shared Gui under "MM "-prefixed names (SoH owns the
     # unprefixed ones; Gui::AddGuiWindow rejects duplicates) and their

--- a/games/mm/2s2h/Enhancements/Saving/SavingEnhancements.cpp
+++ b/games/mm/2s2h/Enhancements/Saving/SavingEnhancements.cpp
@@ -107,7 +107,18 @@ extern "C" bool SavingEnhancements_CanSave() {
 extern "C" void SavingEnhancements_AdvancePlaytime() {
     if (gSaveContext.save.shipSaveInfo.fileCompletedAt == 0) {
         uint64_t timestamp = GetUnixTimestamp();
-        gSaveContext.save.shipSaveInfo.filePlaytime += timestamp - gSaveContext.shipSaveContext.lastTimeLog;
+        // lastTimeLog == 0 means "no prior observation this session": either the
+        // OnSaveLoad seeder in RegisterSavingEnhancements has not run (in the
+        // single exe it was elided entirely — #516 Phase 2 revives it), or a
+        // new-file / continue path zeroed it (z_sram_NES.c). filePlaytime is a
+        // PERSISTED field (z64save.h ShipSaveInfo) while lastTimeLog is not
+        // (ShipSaveContext), so accruing `timestamp - 0` here writes a whole
+        // Unix epoch (~1.7e9 s, ~56 years) to disk. Treat the zero as the seed
+        // and accrue from the next tick instead — correct whether or not the
+        // seeder ran, and it survives the z_sram_NES.c re-zeroing (#513).
+        if (gSaveContext.shipSaveContext.lastTimeLog != 0) {
+            gSaveContext.save.shipSaveInfo.filePlaytime += timestamp - gSaveContext.shipSaveContext.lastTimeLog;
+        }
         gSaveContext.shipSaveContext.lastTimeLog = timestamp;
     }
 }
@@ -218,7 +229,8 @@ void skipEntranceCutsceneOnLoad(s16 fileNum) {
     // Register hook to skip entrance cutscenes - may skip multiple if they chain
     skipEntranceCutsceneHookId = REGISTER_VB_SHOULD(VB_START_CUTSCENE, {
         // Only skip normal cutscenes
-        if (gSaveContext.gameMode == GAMEMODE_NORMAL && MM_gPlayState != nullptr && MM_gPlayState->sceneId != SCENE_SPOT00) {
+        if (gSaveContext.gameMode == GAMEMODE_NORMAL && MM_gPlayState != nullptr &&
+            MM_gPlayState->sceneId != SCENE_SPOT00) {
             *should = false;
         }
     });

--- a/games/mm/2s2h/mm_playtime_seed_test.cpp
+++ b/games/mm/2s2h/mm_playtime_seed_test.cpp
@@ -1,0 +1,103 @@
+/**
+ * @file mm_playtime_seed_test.cpp
+ * ROM-free, display-free lock for the filePlaytime epoch-injection bug (#513).
+ * CTest label "redship", row MMPlaytimeSeed in CMake/SingleExecutable.cmake,
+ * dispatch "mm-playtime-seed" in src/common/test_runner.cpp.
+ *
+ * What was broken: SavingEnhancements_AdvancePlaytime accrues
+ *   filePlaytime += now - lastTimeLog
+ * where filePlaytime is a PERSISTED field (z64save.h ShipSaveInfo) and
+ * lastTimeLog is runtime-only (ShipSaveContext, "not persisted"). lastTimeLog
+ * is seeded only by RegisterSavingEnhancements' OnSaveLoad hook, which the
+ * single exe elided entirely (#516; revival is Phase 2), and it is re-zeroed on
+ * new-file / continue paths (z_sram_NES.c:1033/1265). So AdvancePlaytime — which
+ * is called from plain C (z_sram_NES.c:2212, z_kaleido_scope_NES.c:3583)
+ * regardless of any hook wiring — ran with lastTimeLog == 0 and wrote
+ * `now - 0`, a whole Unix epoch (~1.7e9 s, ~56 years), into the saved playtime.
+ *
+ * The fix treats lastTimeLog == 0 as the seed: set it, accrue nothing this tick.
+ * Robust whether or not the seeder runs, and it survives the re-zeroing.
+ *
+ * Three checks, none needing a display or ROM:
+ *   1. The bug. fileCompletedAt == 0, lastTimeLog == 0, filePlaytime == 0. One
+ *      AdvancePlaytime must leave filePlaytime near zero (the seed tick accrues
+ *      nothing) and lastTimeLog non-zero. Pre-fix this wrote ~1.7e9; the check
+ *      fails if filePlaytime exceeds a generous sane bound.
+ *   2. Accrual still works. lastTimeLog == 1 (non-zero, ancient), so the guard
+ *      must NOT suppress it — filePlaytime must grow. Proves the fix narrows the
+ *      zero case only, rather than disabling playtime accrual outright.
+ *   3. The completed-file gate is intact. fileCompletedAt != 0 must block all
+ *      accrual, leaving a pre-stamped filePlaytime untouched.
+ */
+
+#include "global.h"
+
+#include <cstdio>
+#include <cstring>
+
+namespace {
+
+#define PLAYTIME_ASSERT(cond, code, msg)                                                \
+    do {                                                                                \
+        if (!(cond)) {                                                                  \
+            printf("[TEST] FAIL(%d): %s (%s:%d)\n", (code), (msg), __FILE__, __LINE__); \
+            return (code);                                                              \
+        }                                                                               \
+    } while (0)
+
+// A filePlaytime above this is unreachable by honest accrual in a unit test and
+// is the epoch-injection signature. ~1.7e9 s (the bug) is orders of magnitude
+// past it; a real few-second test delta is far below it.
+constexpr uint64_t kSaneMaxSeconds = 100000000ULL; // ~3.2 years
+
+} // namespace
+
+extern "C" void SavingEnhancements_AdvancePlaytime(void);
+
+extern "C" int MM_PlaytimeSeed_RunHeadless(void) {
+    // ---------------------------------------------------------------- 1
+    // The bug: no prior observation. Seed, do not accrue the epoch.
+    memset(&gSaveContext, 0, sizeof(gSaveContext));
+    gSaveContext.save.shipSaveInfo.fileCompletedAt = 0;
+    gSaveContext.save.shipSaveInfo.filePlaytime = 0;
+    gSaveContext.shipSaveContext.lastTimeLog = 0;
+
+    SavingEnhancements_AdvancePlaytime();
+
+    PLAYTIME_ASSERT(gSaveContext.save.shipSaveInfo.filePlaytime < kSaneMaxSeconds, 1,
+                    "AdvancePlaytime injected an epoch into filePlaytime from lastTimeLog == 0");
+    PLAYTIME_ASSERT(gSaveContext.shipSaveContext.lastTimeLog != 0, 1,
+                    "AdvancePlaytime did not seed lastTimeLog, so the next tick would inject the epoch too");
+
+    // ---------------------------------------------------------------- 2
+    // Accrual still works when lastTimeLog is a real prior observation. Using 1
+    // (an ancient non-zero) makes the accrued delta the current epoch, so the
+    // assertion is just "it grew" — the point is the guard did NOT suppress it.
+    memset(&gSaveContext, 0, sizeof(gSaveContext));
+    gSaveContext.save.shipSaveInfo.fileCompletedAt = 0;
+    gSaveContext.save.shipSaveInfo.filePlaytime = 0;
+    gSaveContext.shipSaveContext.lastTimeLog = 1;
+
+    SavingEnhancements_AdvancePlaytime();
+
+    PLAYTIME_ASSERT(gSaveContext.save.shipSaveInfo.filePlaytime > 0, 2,
+                    "AdvancePlaytime stopped accruing entirely — the zero-guard is too broad");
+
+    // ---------------------------------------------------------------- 3
+    // Completed file: the gate must block all accrual and preserve the value.
+    memset(&gSaveContext, 0, sizeof(gSaveContext));
+    gSaveContext.save.shipSaveInfo.fileCompletedAt = 0x1234;
+    gSaveContext.save.shipSaveInfo.filePlaytime = 42;
+    gSaveContext.shipSaveContext.lastTimeLog = 0;
+
+    SavingEnhancements_AdvancePlaytime();
+
+    PLAYTIME_ASSERT(gSaveContext.save.shipSaveInfo.filePlaytime == 42, 3,
+                    "AdvancePlaytime accrued past the fileCompletedAt gate");
+
+    // Leave gSaveContext clean for whatever runs next.
+    memset(&gSaveContext, 0, sizeof(gSaveContext));
+
+    printf("[TEST] mm-playtime-seed: PASS\n");
+    return 0;
+}

--- a/src/common/test_runner.cpp
+++ b/src/common/test_runner.cpp
@@ -87,6 +87,11 @@ int MM_FlashFileNumOob_RunHeadless(void);
 // mm_stubs.c no-ops -- so 21 TUs' chest-model rewrites and 24 TUs' rando text
 // overrides were registered and never run. Returns 0 on pass, non-zero on fail.
 int MM_HookDispatch_RunHeadless(void);
+// MM playtime seed (games/mm/2s2h/mm_playtime_seed_test.cpp, #513): with
+// lastTimeLog unseeded (0), SavingEnhancements_AdvancePlaytime accrued now-0 --
+// a full Unix epoch -- into the persisted filePlaytime. The fix treats the zero
+// as the seed. Returns 0 on pass, non-zero on fail.
+int MM_PlaytimeSeed_RunHeadless(void);
 // MM tracker registration surface (games/mm/2s2h/mm_trackers_gui_test.cpp,
 // #392): the four MM tracker windows must register on a Gui under
 // "MM "-prefixed names (SoH owns the unprefixed ones and Gui::AddGuiWindow
@@ -306,6 +311,12 @@ static TestResult Test_MMFlashFileNumOob(void) {
 // entry point in games/mm/2s2h/mm_hook_dispatch_test.cpp.
 static TestResult Test_MMHookDispatch(void) {
     return MM_HookDispatch_RunHeadless() == 0 ? TEST_PASS : TEST_FAIL;
+}
+
+// MM playtime-seed lock (see the extern decl above). Thin wrapper over the C
+// entry point in games/mm/2s2h/mm_playtime_seed_test.cpp.
+static TestResult Test_MMPlaytimeSeed(void) {
+    return MM_PlaytimeSeed_RunHeadless() == 0 ? TEST_PASS : TEST_FAIL;
 }
 
 // ============================================================================
@@ -1588,6 +1599,11 @@ const TestDescriptor gTests[] = {
     // dropped rebind #define fail here. Pure (no display, no ROM).
     {"mm-hook-dispatch", "ShouldActorInit/OnActorInit/OnActorDraw/OnOpenText dispatch reaches S2H::GameHooks (#511)",
      Test_MMHookDispatch},
+    // filePlaytime epoch injection: AdvancePlaytime accrued now-lastTimeLog with
+    // lastTimeLog unseeded (0), writing a full Unix epoch into the persisted
+    // playtime. Pure (no display), so it runs in the display-free suite.
+    {"mm-playtime-seed", "AdvancePlaytime seeds an unset lastTimeLog instead of injecting an epoch (#513)",
+     Test_MMPlaytimeSeed},
     {"mm-trackers-gui", "MM tracker windows register de-collided on the shared Gui + gate on the active game (#392)",
      Test_MMTrackersGui},
     // The two MM resume-contract tests below mutate process-global state


### PR DESCRIPTION
Fixes #513 — MM's first pause/owl save injects a full Unix epoch (~56 years) into the persisted `filePlaytime`. A point-of-use fix that is correct independent of the elided registrar (#516) it originally stemmed from.

## Root cause

`SavingEnhancements_AdvancePlaytime` (`SavingEnhancements.cpp:107`) accrues:

```c
filePlaytime += now - lastTimeLog;
lastTimeLog = now;
```

`filePlaytime` is a **persisted** field (`z64save.h` `ShipSaveInfo`); `lastTimeLog` is **runtime-only** (`ShipSaveContext`, documented "not persisted"). `lastTimeLog` is seeded only by `RegisterSavingEnhancements`' `OnSaveLoad` hook — which the single exe elided entirely (#516; revival is Phase 2) — and is re-zeroed on new-file / continue paths (`z_sram_NES.c:1033/1265`).

But `AdvancePlaytime` is called from **plain C** (`z_sram_NES.c:2212`, `z_kaleido_scope_NES.c:3583`), independent of any hook wiring. So it runs with `lastTimeLog == 0` and writes `now - 0` — a whole Unix epoch (~1.7e9 s) — to disk.

Confirmed from the linked binary in #513: `SavingEnhancements_AdvancePlaytime` is present in `redship.map`, its `RegisterSavingEnhancements` seeder is absent (0 hits). The adder ships; its baseline seeder does not.

## Fix

Treat `lastTimeLog == 0` as the seed: set it, accrue nothing that tick.

```c
if (gSaveContext.shipSaveContext.lastTimeLog != 0) {
    filePlaytime += now - lastTimeLog;
}
lastTimeLog = now;
```

This is deliberately at the point of use, not dependent on the seeder:
- Correct whether or not #516 Phase 2 revives the `OnSaveLoad` seeder.
- Survives the `z_sram_NES.c` re-zeroing, which would otherwise re-arm the bug mid-session even after the seeder lands.
- Costs at most one interval's accrual (file-load → first save point), negligible against injecting 56 years.

## Testing

New ROM-free row **`MMPlaytimeSeed`**, three checks:
1. **The bug** — `lastTimeLog == 0` ⇒ `filePlaytime` stays near zero (pre-fix: ~1.7e9), `lastTimeLog` seeded.
2. **Accrual still works** — `lastTimeLog == 1` (non-zero) ⇒ `filePlaytime` grows, proving the guard narrows only the zero case.
3. **The `fileCompletedAt` gate is intact** — a completed file blocks all accrual.

Falsified before trusting (see PR comment). Local `ctest` green on both `redship` and `rando` tiers.

## Scope note

This prevents **new** corruption. Repairing saves already written with the bad value (a load-time clamp of an absurd `filePlaytime`) is deferred: nothing in the current build reads `filePlaytime` (`DisplayOverlay.cpp:78` isn't reachable in single-exe yet), so the dormant value causes no active harm, and a clamp touches the deserialization path — better handled when MM's overlay surfaces land and there's a reader to validate against. Noted on #513.

Closes #513
Refs #516

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!--- section:artifacts:start -->
### Build Artifacts
  - [rsbs-windows.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/8600275861.zip)
  - [rsbs-linux.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/8599948334.zip)
<!--- section:artifacts:end -->