### PR TITLE
Revive MM's save-enhancement registrars, held back from #516 Phase 1 (#516 Phase 2)

### DIFF
--- a/.github/scripts/check-registrar-elision.sh
+++ b/.github/scripts/check-registrar-elision.sh
@@ -341,14 +341,14 @@ main() {
     # dropped the hard call and re-elided a required MM feature.
     #
     # Same plain-grep-not-`-q` discipline as the probes above (pipefail + SIGPIPE).
-    # RegisterSavingEnhancements / RegisterAutosave are deliberately ABSENT: they
-    # are #516 Phase 2 (their moon-crash / cycle-save hooks are a behavior change
-    # the arm-state test must be taught to survive first), and RegisterAutosave's
-    # symbol additionally ODR-folds with OoT's soh_enh Autosave.cpp twin, so a
-    # presence probe could not attribute it to MM anyway.
+    # RegisterAutosave is deliberately ABSENT: its symbol ODR-folds with OoT's
+    # soh_enh Autosave.cpp twin (a static void RegisterAutosave()), so a presence
+    # probe cannot attribute a hit to MM's copy. RegisterSavingEnhancements has no
+    # such twin and is gated here (#516 Phase 2).
     local required_mm_registrars=(
         "CustomItem::RegisterHooks"                 # cross-game + rando item delivery (critical)
         "S2H::CustomMessage::RegisterHooks"         # custom rando/hint message text 0x4B (critical)
+        "RegisterSavingEnhancements"                # owl-save persistence, cycle-save playtime (#516 Phase 2)
         "GfxPatcher_ApplyNecessaryAuthenticPatches" # authentic gfx patches incl. latent matrix-stack UB
     )
     local sym

--- a/games/mm/2s2h/GameExports_SingleExe.cpp
+++ b/games/mm/2s2h/GameExports_SingleExe.cpp
@@ -53,6 +53,7 @@
 // than file-local extern prototypes.
 #include "2s2h/CustomItem/CustomItem.h"
 #include "2s2h/CustomMessage/CustomMessage.h"
+#include "2s2h/Enhancements/Saving/SavingEnhancements.h"
 #include "2s2h/Enhancements/GfxPatcher/AuthenticGfxPatches.h"
 #include "2s2h/Rando/Rando.h"
 #include "2s2h/ShipInit.hpp"
@@ -1411,16 +1412,24 @@ extern "C" void MM_Rando_Init(void) {
     CustomMessage::RegisterHooks(); // OnOpenText[0x4B]: loads staged rando/hint
                                     // text; without it every custom message
                                     // renders vanilla entry 0x4B. #516 critical.
-    // RegisterSavingEnhancements() / RegisterAutosave() are DELIBERATELY not
-    // here: both put registrants on the moon-crash and cycle-save reset paths
-    // (BeforeMoonCrashSaveReset -> DeleteOwlSave, BeforeEndOfCycleSave), and
-    // DeleteOwlSave dereferences MM_gPlayState. That is fine in production
-    // (z_demo.c:379 resets from &play->sramCtx with a live play state) but
-    // crashes the headless MMMoonCrashArmState arm-state test, which drives the
-    // reset with no play state. Reviving them is a real behavior change on those
-    // paths that needs the arm-state test taught to stand up a play state —
-    // #516 Phase 2, its own change. This PR ships the two criticals, which
-    // touch neither path.
+    // #516 Phase 2 — save mechanics. RegisterSavingEnhancements gives owl-save
+    // persistence, cycle-save playtime banking, grotto respawn restore and
+    // moon-crash owl cleanup; RegisterAutosave gives MM its periodic owl autosave
+    // and its on-screen icon.
+    //
+    // These were held back from Phase 1 because their DeleteOwlSave leg (on
+    // BeforeMoonCrashSaveReset / BeforeEndOfCycleSave) dereferences MM_gPlayState,
+    // which crashed the headless MMMoonCrashArmState test — the only test that
+    // drives a real reset path. That test now stands up a play state (as
+    // production always has: z_demo.c:379 resets from a live &play->sramCtx), so
+    // the leg runs faithfully rather than being avoided.
+    //
+    // The Autosave frame legs are headless-safe as-is and need no scaffolding:
+    // HandleAutoSave's interval guard and DrawAutosaveIcon's iconTimer==0 guard
+    // both return before touching MM_gPlayState, and OnGameStateUpdate/DrawFinish
+    // dispatch only from MM's real frame loop (game.c), never a headless test.
+    RegisterSavingEnhancements();
+    RegisterAutosave();
 
     // GfxPatcher is a one-shot resource patcher, not a hook registrar, so it is
     // called (not registered) and gated on assets: its ResourceMgr_Load*ByName

--- a/games/mm/2s2h/mm_rando_gen_test.cpp
+++ b/games/mm/2s2h/mm_rando_gen_test.cpp
@@ -30,7 +30,7 @@
 #include <libultraship/bridge/consolevariablebridge.h>
 #include <nlohmann/json.hpp>
 
-#include "2s2h/BenPort.h" // appShortName
+#include "2s2h/BenPort.h"                       // appShortName
 #include "2s2h/GameInteractor/GameInteractor.h" // S2H::GameHooks counters (single-exe tail)
 #include "2s2h/Rando/Rando.h"
 #include "2s2h/Rando/Foreign.h"
@@ -320,8 +320,7 @@ extern "C" int MM_Rando_HeadlessGenTest(void) {
         // an actual paired fill rather than the synthetic table the ROM-free
         // ForeignHostEligibility lock uses.
         const auto staticIt = Rando::StaticData::Checks.find(hostCheck);
-        if (staticIt == Rando::StaticData::Checks.end() ||
-            staticIt->second.randoCheckType != RCTYPE_CHEST ||
+        if (staticIt == Rando::StaticData::Checks.end() || staticIt->second.randoCheckType != RCTYPE_CHEST ||
             staticIt->second.flagType != FLAG_CYCL_SCENE_CHEST) {
             fprintf(stderr,
                     "[MM-RANDO-GEN] FAIL(12): hosting check %u is not a Tier A (chest/FLAG_CYCL_SCENE_CHEST) host — "
@@ -563,8 +562,8 @@ extern "C" int MM_Rando_HeadlessGenTest(void) {
             return 22;
         }
         const RandoItemId heldAfterReject = RANDO_SAVE_CHECKS[ineligible->randoCheckId].randoItemId;
-        if (Rando::StaticData::Items[heldAfterReject].randoItemType != RITYPE_JUNK ||
-            heldAfterReject == RI_UNKNOWN || heldAfterReject == RI_NONE) {
+        if (Rando::StaticData::Items[heldAfterReject].randoItemType != RITYPE_JUNK || heldAfterReject == RI_UNKNOWN ||
+            heldAfterReject == RI_NONE) {
             fprintf(stderr,
                     "[MM-RANDO-GEN] FAIL(22): rejected host %s left holding %d — must degrade to a legal junk item, "
                     "not a sentinel that arms .eligible and gives nothing\n",
@@ -655,8 +654,10 @@ extern "C" int MM_Rando_HeadlessGenTest(void) {
         fprintf(stderr, "[MM-RANDO-GEN] FAIL(25): un-overridden VB did not pass the caller's verdict through\n");
         return 25;
     }
-    fprintf(stderr, "[MM-RANDO-GEN] VB dispatch (rando save): give VBs suppressed (ForID + non-ID), "
-                    "pass-through intact (%zu VB hooks)\n", vbHooks);
+    fprintf(stderr,
+            "[MM-RANDO-GEN] VB dispatch (rando save): give VBs suppressed (ForID + non-ID), "
+            "pass-through intact (%zu VB hooks)\n",
+            vbHooks);
 
     // Vanilla direction: a non-rando file re-run through the REAL OnSaveLoad
     // chain must disarm the overrides (the COND_* macros re-evaluate IS_RANDO
@@ -961,14 +962,16 @@ extern "C" int MM_Rando_HeadlessPairSwitchEntry(void) {
     fprintf(stderr, "[MM-PAIR-SWITCH] switch-entry paired under master seed %u\n", usedMasterSeed);
 
     if (Combo_CountForeignPlacements() != poolCount) {
-        fprintf(stderr, "[MM-PAIR-SWITCH] FAIL(7): expected %d foreign placements after switch-entry pairing, found "
-                        "%d\n",
+        fprintf(stderr,
+                "[MM-PAIR-SWITCH] FAIL(7): expected %d foreign placements after switch-entry pairing, found "
+                "%d\n",
                 poolCount, Combo_CountForeignPlacements());
         return 7;
     }
     if (gSaveContext.save.entrance != kArrival) {
-        fprintf(stderr, "[MM-PAIR-SWITCH] FAIL(8): arrival entrance 0x%04X lost to generation's start state "
-                        "(save.entrance=0x%04X)\n",
+        fprintf(stderr,
+                "[MM-PAIR-SWITCH] FAIL(8): arrival entrance 0x%04X lost to generation's start state "
+                "(save.entrance=0x%04X)\n",
                 kArrival, gSaveContext.save.entrance);
         return 8;
     }
@@ -1038,8 +1041,9 @@ extern "C" int MM_Rando_HeadlessPairSwitchEntry(void) {
         return 12;
     }
     if (gSaveContext.save.saveInfo.playerData.rupees != 142 || gSaveContext.save.day != 3) {
-        fprintf(stderr, "[MM-PAIR-SWITCH] FAIL(13): return leg did not preserve the player's progress "
-                        "(rupees=%d day=%d)\n",
+        fprintf(stderr,
+                "[MM-PAIR-SWITCH] FAIL(13): return leg did not preserve the player's progress "
+                "(rupees=%d day=%d)\n",
                 gSaveContext.save.saveInfo.playerData.rupees, gSaveContext.save.day);
         return 13;
     }
@@ -1368,12 +1372,26 @@ extern "C" int MM_Rando_HeadlessMoonCrashArmState(void) {
     // Phase 2 — the REAL moon-crash reset. Flash holds no rando save for this
     // in-memory paired world (nothing was ever written), which is exactly the
     // production condition: the reload yields a zeroed/vanilla Save.
+    //
+    // Production (z_demo.c:379) resets from &play->sramCtx with a live play
+    // state, and #516 Phase 2 revived RegisterSavingEnhancements, whose
+    // BeforeMoonCrashSaveReset leg (DeleteOwlSave) dereferences MM_gPlayState.
+    // So stand up a play state and reset from ITS sramCtx, faithfully — rather
+    // than the free-standing SramContext this used before the leg existed. Only
+    // sramCtx is touched on this path; a zeroed PlayState with a real save buffer
+    // is sufficient and its 0x19258 bytes sit in BSS.
     // ----------------------------------------------------------------------
     static u8 sMoonCrashSaveBuf[SAVE_BUFFER_SIZE];
-    SramContext moonCrashSram = {};
-    moonCrashSram.saveBuf = sMoonCrashSaveBuf;
+    static PlayState sMoonCrashPlayState;
+    memset(&sMoonCrashPlayState, 0, sizeof(sMoonCrashPlayState));
+    sMoonCrashPlayState.sramCtx.saveBuf = sMoonCrashSaveBuf;
 
-    Sram_ResetSaveFromMoonCrash(&moonCrashSram);
+    PlayState* savedPlayState = MM_gPlayState;
+    MM_gPlayState = &sMoonCrashPlayState;
+
+    Sram_ResetSaveFromMoonCrash(&MM_gPlayState->sramCtx);
+
+    MM_gPlayState = savedPlayState;
 
     // ----------------------------------------------------------------------
     // Phase 3 — the world identity must survive, and the hooks must still be


### PR DESCRIPTION
#516 Phase 2. Revives the two save-mechanic registrars Phase 1 ([#518](https://github.com/spencerduncan/redshipblueship/pull/518)) deferred, now that the one test that blocked them can survive the behavior change.

## What this restores

`RegisterSavingEnhancements` and `RegisterAutosave` were elided with `BenPort.cpp`'s InitOTR sequence (the #516 class). Reviving them by explicit call from `MM_Rando_Init`'s once-guard gives MM back:

- **owl-save persistence** — `gEnhancements.Saving.PersistentOwlSaves` and the pause-save-entrance guard (owl saves were always deleted on continue)
- **cycle-save playtime banking** and **grotto respawn restore** on load
- **moon-crash owl cleanup**
- **periodic owl autosave** and its **on-screen icon** — MM had no autosave at all in single-exe (a crash/quit lost everything since the last manual owl statue)

## Why they were deferred, and what changed

The `DeleteOwlSave` leg (on `BeforeMoonCrashSaveReset` / `BeforeEndOfCycleSave`) dereferences `MM_gPlayState` via `func_80147314(&MM_gPlayState->sramCtx, …)`. Correct in production — `z_demo.c:379` resets from a live `&play->sramCtx` — but it crashed the headless `MMMoonCrashArmState` test, the **only** test that drives a real reset path (verified: nothing else calls `Sram_ResetSaveFromMoonCrash` / the end-of-cycle save).

That test now stands up a zeroed static `PlayState`, points `MM_gPlayState` at it with a real save buffer, and resets from **its** `sramCtx` — faithful to production, rather than the free-standing `SramContext` it used before this leg existed. The revived hook runs in the test instead of being avoided; the earlier crash-then-pass is itself proof it fires.

The Autosave frame legs need no scaffolding: `HandleAutoSave`'s interval guard and `DrawAutosaveIcon`'s `iconTimer==0` guard both return before touching `MM_gPlayState`, and `OnGameStateUpdate`/`OnGameStateDrawFinish` dispatch only from MM's real frame loop (`game.c`), never a headless test. `loadRespawnData` and the `OnSaveLoad` seeder are `gSaveContext`-only.

## Interaction with #513

`RegisterSavingEnhancements` also revives the `OnSaveLoad` seeder that sets `lastTimeLog` — the baseline whose absence caused #513's epoch injection. #513's point-of-use guard (merged, `65f8799e`) makes that correct either way; this PR makes the seeder itself present again, so the guard becomes the belt to its suspenders rather than the sole defense.

## Testing

- `RegisterSavingEnhancements` verified 0 → present in `redship.map`; now gated by `check-registrar-elision.sh` (no OoT twin).
- `RegisterAutosave` stays ungated — its symbol ODR-folds with OoT's static `Autosave.cpp` `RegisterAutosave`, so a presence probe can't attribute a hit to MM's copy. Name disambiguation is a remaining #516 task.
- Local `ctest` green on **both** `redship` (59/59) and `rando` (13/13) tiers — `MMMoonCrashArmState` among them with `DeleteOwlSave` live.
- The modified arm-state test remains non-vacuous: neutering the rando-preserve macro still fails it `FAIL(4)`.

Behavioral coverage (owl save survives continue, cycle save banks playtime, autosave fires) is gameplay-tier and rests on playtest — noted on #516.

Refs #516, #513

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!--- section:artifacts:start -->
### Build Artifacts
  - [rsbs-windows.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/8601218320.zip)
  - [rsbs-linux.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/8600905732.zip)
<!--- section:artifacts:end -->