### PR TITLE
Wire OnGameCompletion dispatch, the last revived-registrar gap (#438)

### DIFF
--- a/games/mm/2s2h/GameExports_SingleExe.cpp
+++ b/games/mm/2s2h/GameExports_SingleExe.cpp
@@ -1923,6 +1923,21 @@ extern "C" void MM_GameHooks_ExecuteAfterEndOfCycleSave(void) {
 }
 
 /**
+ * OnGameCompletion dispatch (#438). The last revived-registrar gap: #520
+ * un-elided RegisterSavingEnhancements, whose COND_HOOK(OnGameCompletion)
+ * (SavingEnhancements.cpp) stamps shipSaveInfo.fileCompletedAt and freezes
+ * post-credits playtime — but the call sites (z_boss_07.c Majora's Wrath death,
+ * Rando/GiveItem.cpp final Triforce) reached the mm_stubs.c no-op, so the stamp
+ * never happened. 0-arg (DEFINE_HOOK(OnGameCompletion, ())), single Execute<>
+ * leg — no MM TU registers it by id/ptr/filter — matching the excluded
+ * GameInteractor.cpp twin. The hook body touches only gSaveContext + playtime,
+ * no MM_gPlayState, so it is headless-safe.
+ */
+extern "C" void MM_GameHooks_ExecuteOnGameCompletion(void) {
+    S2H::GameHooks::Execute<GameInteractor::OnGameCompletion>();
+}
+
+/**
  * MM-owned "Should" dispatch (#392 VB follow-up). MM call sites reach these
  * through the single-exe macro rebind at the bottom of MM's GameInteractor.h
  * (GameInteractor_Should -> MM_GameHooks_ExecuteVBShould, etc.), so MM VB ids

--- a/games/mm/2s2h/GameInteractor/GameInteractor.h
+++ b/games/mm/2s2h/GameInteractor/GameInteractor.h
@@ -690,6 +690,11 @@ void MM_GameHooks_ExecuteOnActorKill(Actor* actor);
 void MM_GameHooks_ExecuteOnActorDestroy(Actor* actor);
 #define GameInteractor_ExecuteOnActorKill MM_GameHooks_ExecuteOnActorKill
 #define GameInteractor_ExecuteOnActorDestroy MM_GameHooks_ExecuteOnActorDestroy
+
+// OnGameCompletion (#438). Its registrant (RegisterSavingEnhancements' fileCompletedAt
+// stamp) went live with #520; the call sites bound the mm_stubs.c no-op until this.
+void MM_GameHooks_ExecuteOnGameCompletion(void);
+#define GameInteractor_ExecuteOnGameCompletion MM_GameHooks_ExecuteOnGameCompletion
 #endif // RSBS_SINGLE_EXECUTABLE
 
 #ifdef __cplusplus

--- a/games/mm/2s2h/mm_hook_dispatch_test.cpp
+++ b/games/mm/2s2h/mm_hook_dispatch_test.cpp
@@ -120,6 +120,7 @@ int sAfterEndOfCycleSaveRuns = 0;
 int sOnActorKillRuns = 0;
 int sOnActorKillForIdRuns = 0;
 int sOnActorDestroyForIdRuns = 0;
+int sOnGameCompletionRuns = 0;
 
 // Distinct sentinel ids, so no check can be satisfied by another's registrant.
 constexpr s16 kActorIdInit = 0x0BAD;
@@ -139,6 +140,7 @@ void ResetAll() {
     S2H::GameHooks::ResetForTest<GameInteractor::AfterEndOfCycleSave>();
     S2H::GameHooks::ResetForTest<GameInteractor::OnActorKill>();
     S2H::GameHooks::ResetForTest<GameInteractor::OnActorDestroy>();
+    S2H::GameHooks::ResetForTest<GameInteractor::OnGameCompletion>();
 }
 
 } // namespace
@@ -363,6 +365,26 @@ extern "C" int MM_HookDispatch_RunHeadless(void) {
                     "OnActorDestroy registrant never ran -- element-keyed check ids are never freed");
         HOOK_ASSERT(sOnActorKillRuns == 2, 7, "the Destroy dispatcher also ran Kill registrants");
         HOOK_ASSERT(sOnActorKillForIdRuns == 1, 7, "the Destroy dispatcher also ran id-keyed Kill registrants");
+    }
+
+    // ---------------------------------------------------------------- 8
+    // OnGameCompletion (#438): RegisterSavingEnhancements' fileCompletedAt stamp
+    // went live with #520, but the call sites (z_boss_07.c, Rando/GiveItem.cpp)
+    // bound the mm_stubs.c no-op. 0-arg, single unkeyed leg. Unlike the others
+    // this symbol is MM-only and its stub was DELETED with the fix, so dropping
+    // the rebind or the dispatcher is a LINK error, not a silent pass — this
+    // runtime check additionally proves the dispatcher reaches the registry.
+    {
+        sOnGameCompletionRuns = 0;
+        S2H::GameHooks::Register<GameInteractor::OnGameCompletion>([]() { sOnGameCompletionRuns++; });
+
+        HOOK_ASSERT(sOnGameCompletionRuns == 0, 8, "OnGameCompletion ran at registration time");
+
+        // Spelled exactly as z_boss_07.c / Rando/GiveItem.cpp spell it.
+        GameInteractor_ExecuteOnGameCompletion();
+
+        HOOK_ASSERT(sOnGameCompletionRuns == 1, 8,
+                    "OnGameCompletion registrant never ran -- the game-completion stamp is dropped");
     }
 
     // NOTE ON WHAT COVERS THE REBIND. An earlier draft of this row compared

--- a/src/common/mm_stubs.c
+++ b/src/common/mm_stubs.c
@@ -158,7 +158,13 @@ void GameInteractor_ExecuteOnBossDefeated(int bossId) { (void)bossId; }
 void GameInteractor_ExecuteOnBottleContentsUpdate(int slotId) { (void)slotId; }
 void GameInteractor_ExecuteOnConsoleLogoUpdate(void) {}
 void GameInteractor_ExecuteOnFileSelectSaveLoad(void* state, int fileNum) { (void)state; (void)fileNum; }
-void GameInteractor_ExecuteOnGameCompletion(void) {}
+/* GameInteractor_ExecuteOnGameCompletion moved to real, header-checked dispatch
+ * in games/mm/2s2h/GameExports_SingleExe.cpp (#438), reached through the
+ * single-exe macro rebind at the bottom of MM's GameInteractor.h. Its registrant
+ * (RegisterSavingEnhancements' fileCompletedAt stamp) went live with #520, so a
+ * no-op here would silently drop the game-completion stamp again. Re-stubbing it
+ * would sever that dispatch. (MM-only symbol — OoT defines no twin, so deleting
+ * the stub cannot orphan an OoT caller.) */
 /* GameInteractor_ExecuteBeforeEndOfCycleSave / ExecuteAfterEndOfCycleSave moved
  * to real, header-checked dispatch in
  * games/mm/2s2h/GameExports_SingleExe.cpp (#514), reached through the


### PR DESCRIPTION
Wires `OnGameCompletion` dispatch — the single hook that gained a live registrant from #520 but still bound a `mm_stubs.c` no-op. Same 3-file pattern as #512/#514, verified by a re-scan of every revived registrar (the audit's full re-scan is on [#438](https://github.com/spencerduncan/redshipblueship/issues/438)).

## The gap

After #518/#520 un-elided `CustomItem`/`CustomMessage`/`GfxPatcher`/`RegisterSavingEnhancements`/`RegisterAutosave`, I checked every hook type those five register against the dispatched set. **Exactly one gap:** `RegisterSavingEnhancements` registers `COND_HOOK(OnGameCompletion, …)` (`SavingEnhancements.cpp:268`), but dispatch bound the no-op stub at `mm_stubs.c:161`. Every other hook they touch (`ShouldActorInit`, `OnOpenText`, `OnGameStateUpdate/DrawFinish`, the VB and save hooks) is already dispatched.

The audit originally listed this as "not fixable by dispatch alone — `RegisterSavingEnhancements` has no single-exe caller." #520 revived that caller, so it's now pure dispatch work.

## What it does

The hook stamps `shipSaveInfo.fileCompletedAt` and freezes post-credits playtime when the game is beaten. Its call sites — `z_boss_07.c:1777` (Majora's Wrath death) and `Rando/GiveItem.cpp:118` (final Triforce piece) — reached the stub, so the stamp never happened.

## Changes (the established pattern)

- **`GameExports_SingleExe.cpp`** — `MM_GameHooks_ExecuteOnGameCompletion` calling `S2H::GameHooks::Execute<OnGameCompletion>()`. Single 0-arg leg (`DEFINE_HOOK(OnGameCompletion, ())`, no id/ptr/filter registrants), matching the excluded `GameInteractor.cpp` twin.
- **`GameInteractor.h`** — declaration + `#define` rebind in the single-exe block.
- **`mm_stubs.c`** — delete the no-op, with the file's standard "re-stubbing would sever dispatch" comment. `OnGameCompletion` is MM-only (no OoT twin), so deleting it can't orphan an OoT caller — and it makes a future dispatch miss a *link* error, not a silent no-op.

## Headless-safety

The hook body touches only `gSaveContext` + `GetUnixTimestamp` + `SavingEnhancements_AdvancePlaytime` — no `MM_gPlayState` — so it doesn't reproduce the #516 Phase 1 headless crash and needs no play-state scaffolding. Both call sites are play-state paths that never run in a ROM-free test anyway.

## #513 interaction (resolved)

`AdvancePlaytime` reads `lastTimeLog` as its baseline; that baseline is seeded now (#520 revived the `OnSaveLoad` seeder) and guarded (#519), so the post-credits stamp banks correct playtime, and both `AdvancePlaytime` and the hook body gate on `fileCompletedAt == 0` so accrual stops after the stamp.

## Testing

`MMHookDispatch` gains check 8: registers a throwaway `OnGameCompletion` hook on `S2H::GameHooks`, drives the dispatcher through the upstream spelling, asserts it fired. Because the symbol is MM-only and the stub is deleted, dropping the rebind or dispatcher is a **link error** — check 8 additionally proves the dispatcher reaches the registry at runtime. Local `ctest` green on `redship` and `rando` tiers (falsification in PR comment).

Refs #438, #520, #513

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!--- section:artifacts:start -->
### Build Artifacts
  - [rsbs-linux.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/8604322975.zip)
  - [rsbs-windows.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/8604210349.zip)
<!--- section:artifacts:end -->