### PR TITLE
Give the MM options pane and cross-game spoiler a menu entry (#509 interim)

### DIFF
--- a/games/oot/soh/SohGui/SohMenuRandomizer.cpp
+++ b/games/oot/soh/SohGui/SohMenuRandomizer.cpp
@@ -789,6 +789,46 @@ void SohMenu::AddMenuRandomizer() {
         .WindowName("Check Tracker Settings")
         .HideInSearch(true)
         .Options(WindowButtonOptions().Tooltip("Enables the separate Check Tracker Settings Window."));
+
+    // Cross-Game (RedShipBlueShip #509). Interim host for the two common-owned
+    // combo windows (ADR 0008). Both were registered on the shared Gui at
+    // startup (rsbs/src/main.cpp Combo_MMOptionsWindow_Init / Combo_SpoilerWindow_Init)
+    // but nothing wrote their visibility CVars, so the only way to open them was
+    // the console (set gCombo.Windows.MMOptions 1). These rows are the writer.
+    //
+    // WINDOW_BUTTON reads .CVar only for the open/close label and calls the
+    // window's own ToggleVisibility (UIWidgets.cpp:198), so .CVar MUST equal the
+    // window's ctor visibility CVar and .WindowName its registered name. String
+    // literals match the tracker rows above (they hardcode the same way); the
+    // authoritative constants are ComboGui::kComboMMOptions*/kComboSpoiler* in
+    // src/common/ComboMmOptionsWindow.h / ComboSpoilerWindow.h.
+    //
+    // This is the interim, NOT #497 step 3 (the SohMenu capability-gating
+    // manifest). Both windows read only gComboCtx/CVars, never either game's
+    // gSaveContext (ADR 0008 rule 5), so they are safe under every GameId and the
+    // rows are ungated.
+    path.sidebarName = "Cross-Game";
+    AddSidebarEntry("Randomizer", path.sidebarName, 1);
+
+    AddWidget(path, "Cross-Game", WIDGET_SEPARATOR_TEXT);
+    // Seed configuration — always reachable, like the trackers.
+    AddWidget(path, "Toggle MM Randomizer Options", WIDGET_WINDOW_BUTTON)
+        .CVar("gCombo.Windows.MMOptions")
+        .RaceDisable(false)
+        .WindowName("Majora's Mask Randomizer Options")
+        .HideInSearch(true)
+        .Options(WindowButtonOptions()
+                     .Tooltip("Toggles the Majora's Mask randomizer options pane (the paired MM world's settings).")
+                     .EmbedWindow(false));
+    // Spoiler — reveals paired-seed placements, so race-disabled like a spoiler tool.
+    AddWidget(path, "Toggle Cross-Game Spoiler", WIDGET_WINDOW_BUTTON)
+        .CVar("gCombo.Windows.Spoiler")
+        .RaceDisable(true)
+        .WindowName("Cross-Game Spoiler")
+        .HideInSearch(true)
+        .Options(WindowButtonOptions()
+                     .Tooltip("Toggles the cross-game spoiler (which MM check hosts which OoT item, and vice versa).")
+                     .EmbedWindow(false));
 }
 
 } // namespace SohGui


### PR DESCRIPTION
Fixes #509 — the MM options pane (#508) and cross-game spoiler (#496) were registered on the shared Gui but had no way to open them. This is the interim menu entry the issue recommends; it's what you hit as *"no additional options showing for MM"*.

## The fix

The scan corrected an assumption worth recording: `src/common/ComboMenuBar.cpp` is **dead code** (0 `redship.map` hits) — the live menu is OoT's `SohMenu`. So the entries go in `games/oot/soh/SohGui/SohMenuRandomizer.cpp`, as a new **Randomizer → Cross-Game** sidebar with two `WIDGET_WINDOW_BUTTON` rows, mirroring the existing tracker rows exactly.

`WindowButton` (`UIWidgets.cpp:184`) reads its `.CVar` only to pick the open/close icon and calls the window's own `ToggleVisibility()` — which toggles the CVar the window was constructed with. So `.CVar` is set to each window's ctor visibility CVar (`gCombo.Windows.MMOptions` / `gCombo.Windows.Spoiler`) and `.WindowName` to its registered name, as string literals the same way the tracker rows hardcode theirs.

## Two calls I made (both reversible)

- **RaceDisable** — options pane `false` (seed config, always reachable, like the trackers); spoiler `true` (it reveals paired-seed placements, so it hides in race mode like a spoiler tool). Flag if you'd rather the spoiler stay reachable in race mode.
- **Placement** — both under **Randomizer → Cross-Game**. A top-level Combo section is #497 step 6 (more work); this is the interim.

## Scope

This is **not** #497 step 3 (the SohMenu capability-gating manifest). The "no unreachable window" CI lock the issue suggested is **deferred** — the scoped design for it had a real defect (a value-vs-name grep mismatch), and a correct version is its own change. The windows read only `gComboCtx`/CVars, never either game's `gSaveContext` (ADR 0008 rule 5), so the rows are otherwise ungated.

## Testing

Menu draw is a Gui interaction with no ROM-free assertion, so **whether the toggle appears and opens the window is operator-verified**. Local `ctest` green on `redship` (60) and `rando` (13) confirms the binary still boots and builds the menu without regression. After this lands you should no longer need `set gCombo.Windows.MMOptions 1`.

Refs #509, #497

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!--- section:artifacts:start -->
### Build Artifacts
  - [rsbs-windows.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/8603285065.zip)
  - [rsbs-linux.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/8603059495.zip)
<!--- section:artifacts:end -->