### PR TITLE
Give MM's four tracker windows a menu entry too (#509 follow-up)

### DIFF
--- a/games/oot/soh/SohGui/SohMenuRandomizer.cpp
+++ b/games/oot/soh/SohGui/SohMenuRandomizer.cpp
@@ -829,6 +829,52 @@ void SohMenu::AddMenuRandomizer() {
         .Options(WindowButtonOptions()
                      .Tooltip("Toggles the cross-game spoiler (which MM check hosts which OoT item, and vice versa).")
                      .EmbedWindow(false));
+
+    // MM's four tracker windows had the same unreachability bug as the two
+    // windows above. #489 made them openable and correctly named (they register
+    // under "MM "-prefixed names, since SoH owns the unprefixed ones), but
+    // nothing in the live menu ever wrote their visibility CVars:
+    //   - MM's own menu, BenGui.cpp SetupGuiElements, is excluded from single-exe
+    //     (0 hits in redship.map) — that was their intended writer.
+    //   - The OoT tracker rows above cannot serve: CVAR_WINDOW expands to
+    //     "gOpenWindows.*" (CVAR_PREFIX_WINDOW, CMake/soh-cvars.cmake:8) while
+    //     MM's trackers read "gWindows.*". Different CVars entirely, by design —
+    //     the distinct namespaces are what avoid a store collision.
+    //   - ItemTrackerSettings.cpp does link and has its own Enable/Disable
+    //     button, but it is drawn INSIDE the settings window, which has no
+    //     writer either. Chicken-and-egg.
+    // So the only way to open them was the console. These rows are the writer.
+    //
+    // Names and CVars are the constants in games/mm/2s2h/TrackersGuiSingleExe.h
+    // (kCheckTracker*/kItemTracker*), spelled as literals to match the rows
+    // above. The windows are MMActiveGated, so they draw only while MM is the
+    // running game — the buttons are always usable, the window simply stays
+    // blank under OoT, which is the upstream behavior.
+    AddWidget(path, "Majora's Mask Trackers", WIDGET_SEPARATOR_TEXT);
+    AddWidget(path, "Toggle MM Item Tracker", WIDGET_WINDOW_BUTTON)
+        .CVar("gWindows.ItemTracker")
+        .RaceDisable(false)
+        .WindowName("MM Item Tracker")
+        .HideInSearch(true)
+        .Options(WindowButtonOptions().Tooltip("Toggles the Majora's Mask item tracker.").EmbedWindow(false));
+    AddWidget(path, "Popout MM Item Tracker Settings", WIDGET_WINDOW_BUTTON)
+        .CVar("gWindows.ItemTrackerSettings")
+        .RaceDisable(false)
+        .WindowName("MM Item Tracker Settings")
+        .HideInSearch(true)
+        .Options(WindowButtonOptions().Tooltip("Enables the Majora's Mask Item Tracker Settings window."));
+    AddWidget(path, "Toggle MM Check Tracker", WIDGET_WINDOW_BUTTON)
+        .CVar("gWindows.CheckTracker")
+        .RaceDisable(false)
+        .WindowName("MM Check Tracker")
+        .HideInSearch(true)
+        .Options(WindowButtonOptions().Tooltip("Toggles the Majora's Mask check tracker.").EmbedWindow(false));
+    AddWidget(path, "Popout MM Check Tracker Settings", WIDGET_WINDOW_BUTTON)
+        .CVar("gWindows.CheckTrackerSettings")
+        .RaceDisable(false)
+        .WindowName("MM Check Tracker Settings")
+        .HideInSearch(true)
+        .Options(WindowButtonOptions().Tooltip("Enables the Majora's Mask Check Tracker Settings window."));
 }
 
 } // namespace SohGui


### PR DESCRIPTION
Follow-up to #522. That PR gave the MM options pane and cross-game spoiler menu rows but **missed MM's four tracker windows**, which have the identical unreachability bug. The operator found it immediately — they're registered, correctly named, and openable only from the console.

## Why they had no writer

#489 fixed the trackers' *naming* problems (three of four couldn't be reopened after MM's first boot; check-tracker rows drew blank labels). It did not give them a writer for their visibility CVars. Three independent reasons none existed:

1. **MM's own menu is gone.** `BenGui.cpp` `SetupGuiElements` was the intended writer — **0 hits** in `redship.map`, excluded from single-exe.
2. **OoT's tracker rows can't substitute.** `CVAR_WINDOW()` expands to `gOpenWindows.*` (`CVAR_PREFIX_WINDOW`, `CMake/soh-cvars.cmake:8`); MM's trackers read `gWindows.*`. Different CVars **by design** — the split is what avoids a store collision, so this isn't a namespace to converge, it's a writer that has to exist.
3. **The one in-binary writer is itself unreachable.** `ItemTrackerSettings.cpp` does link and carries an Enable/Disable `WindowButton` for `gWindows.ItemTracker` — but it draws *inside* the settings window, which has no writer either. Chicken-and-egg.

## The fix

Four `WIDGET_WINDOW_BUTTON` rows under the same **Randomizer → Cross-Game** sidebar, using the constants from `games/mm/2s2h/TrackersGuiSingleExe.h` (`kCheckTracker*` / `kItemTracker*`), spelled as literals to match the neighbouring rows. `RaceDisable(false)` on all four, mirroring OoT's own tracker rows.

The windows are `MMActiveGated`, so they draw only while MM is the running game. The buttons stay usable under OoT and the window is simply blank — that's upstream behavior, not something these rows should hide.

## Testing

Local `ctest` green on `redship` (60) and `rando` (13). Menu draw is **operator-verified** — no ROM-free row asserts on menu contents, which is precisely why this slipped past #522. The "registered window with no writer" CI lock deferred from #509 would have caught it automatically; worth revisiting with a corrected design (its first draft had a value-vs-name grep mismatch).

Until this is in a build, the console still works:
```
set gWindows.ItemTracker 1
set gWindows.CheckTracker 1
```

Refs #509, #489

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!--- section:artifacts:start -->
### Build Artifacts
  - [rsbs-windows.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/8607275018.zip)
  - [rsbs-linux.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/8605854089.zip)
<!--- section:artifacts:end -->