### PR TITLE
Reverse foreign pool: MM items in OoT checks, presented as native pickups (#510)

### DIFF
--- a/.github/scripts/check-registrar-elision.sh
+++ b/.github/scripts/check-registrar-elision.sh
@@ -38,11 +38,17 @@
 # report-only numbers for 2ship_enh/2ship_rando_ui trustworthy.
 #
 # One residual edge case, noted rather than solved: if two archives that are
-# BOTH required happen to share a basename (currently just Miscellaneous.cpp,
+# BOTH required happen to share a basename (Miscellaneous.cpp and — since #510
+# gave MM's copy a file-scope pool registrar — ForeignItemsSingleExe.cpp, both
 # soh_rando/2ship_rando) and exactly one physical copy is ever dropped, the
 # fixed-order attribution may credit the wrong one of the two — but the
 # overall gate still fails either way, since the shortfall has to land on
 # one of them. It cannot silently vanish the way the old bug did.
+#
+# For ForeignItemsSingleExe.cpp specifically there is a second, sharper net that
+# does not depend on symbol attribution at all: the ForeignPoolMM ctest row asks
+# the running binary whether MM's pool actually registered. A dropped initializer
+# is a red test, not a subtle count.
 #
 # Usage: check-registrar-elision.sh [build-dir]   (default: build-cmake)
 #

--- a/CMake/SingleExecutable.cmake
+++ b/CMake/SingleExecutable.cmake
@@ -374,6 +374,13 @@ if(BUILD_TESTING)
     # crossing, order preservation, origin filtering, and that a NULL PlayState
     # defers the give instead of dereferencing it.
     redship_add_test(NAME ForeignAwardMM COMMAND redship --test foreign-award-mm)
+    # #510: the reverse direction's SOURCE pool (kForeignPoolMMV1). Display-free
+    # — the table is a static in the WHOLE_ARCHIVE'd 2ship_rando and its
+    # registrar runs before main() — so this row doubles as the runtime proof
+    # that the registrar survived the link. A dropped file-scope initializer is
+    # silent at compile and link time and would leave OoT unable to place
+    # anything (#516's dead-registrar class).
+    redship_add_test(NAME ForeignPoolMM COMMAND redship --test foreign-pool-mm)
     redship_add_test(NAME ComboSpoilerView COMMAND redship --test combo-spoiler-view)
     redship_add_test(NAME ComboSpoilerWindow COMMAND redship --test combo-spoiler-window)
     # MM randomizer options (#497 step 4, #499). Display-free: the option table
@@ -620,6 +627,18 @@ if(BUILD_TESTING)
         LABEL rando
         TIMEOUT 180
         ENVIRONMENT "SDL_AUDIODRIVER=dummy;RSBS_DISABLE_OTR_INIT=1;RSBS_DIAG_CVARS=gRandoSettings.ShuffleSongs=3")
+
+    # #510: the reverse foreign pool over a REAL OoT fill. In the `rando` tier
+    # rather than the display-free one for a correctness reason, not a
+    # convenience one: OoT's host predicate reads GetPlacedRandomizerGet(), a
+    # FILL RESULT, so with no fill every location is RG_NONE, the predicate
+    # accepts nothing, and a "only chests are hosts" assertion passes with a
+    # count of zero. The row asserts a NON-ZERO eligible-host count and prints
+    # it, so host supply is visible before it becomes a shortfall.
+    redship_add_test(NAME ForeignPlacementOoT COMMAND redship --test foreign-placement-oot
+        LABEL rando
+        TIMEOUT 300
+        ENVIRONMENT "SDL_AUDIODRIVER=dummy;RSBS_DISABLE_OTR_INIT=1")
 
     # Lane C0 (#392): MM's 2ship_rando is un-elided and actually generates —
     # region graph populated via ShipInit registrars, OnFileCreate runs

--- a/games/mm/2s2h/Rando/ActorBehavior/EnBox.cpp
+++ b/games/mm/2s2h/Rando/ActorBehavior/EnBox.cpp
@@ -75,8 +75,12 @@ void EnBox_RandoPostLimbDraw(PlayState* play, s32 limbIndex, Gfx** dList, Vec3s*
     // RITYPE_MAJOR rather than a bespoke texture set: the ornate corner/lock
     // already means "worth opening", which a pinned progression item is, and
     // inventing a foreign-specific chest texture is the per-item asset tier
-    // #494 puts out of scope. The particle aura below is what makes it
-    // unambiguous — no other chest in the game sparkles.
+    // #494 puts out of scope.
+    //
+    // #510 removed the particle aura that used to accompany this. The aura was
+    // a deliberate "this one is from the other game" tell, and the cross-game
+    // item class is now presented as ordinary treasure — a foreign chest is an
+    // ornate chest, exactly like any other chest holding something good.
     if (Rando::Foreign::IsForeignCheck((RandoCheckId)ENBOX_RC)) {
         randoItemType = RITYPE_MAJOR;
     }
@@ -154,15 +158,6 @@ void EnBox_RandoPostLimbDraw(PlayState* play, s32 limbIndex, Gfx** dList, Vec3s*
 void EnBox_RandoDraw(Actor* actor, PlayState* play) {
     s32 pad;
     EnBox* enBox = (EnBox*)actor;
-
-#ifdef RSBS_SINGLE_EXECUTABLE
-    // The other half of the foreign-chest marker (see EnBox_RandoPostLimbDraw).
-    // Emitted here, once per frame, rather than in the post-limb callback,
-    // which runs per limb and would spawn the effect several times a frame.
-    if (Rando::Foreign::IsForeignCheck((RandoCheckId)ENBOX_RC)) {
-        Rando::DrawForeignCheckAura(actor);
-    }
-#endif
 
     OPEN_DISPS(play->state.gfxCtx);
 

--- a/games/mm/2s2h/Rando/DrawItem.cpp
+++ b/games/mm/2s2h/Rando/DrawItem.cpp
@@ -705,47 +705,13 @@ void Rando::DrawItem(RandoItemId randoItemId, Actor* actor) {
 
 #ifdef RSBS_SINGLE_EXECUTABLE
 
-// ============================================================================
-// Cross-game marker (Lane 6, #494 slice 6)
-// ============================================================================
-//
-// THE BUG THIS CLOSES IS A CORRECTNESS BUG, NOT POLISH. Before this, no draw
-// path consulted Rando::Foreign::IsForeignCheck, so a check hosting a foreign
-// item sat in the MM world DISGUISED AS THE JUNK ITEM THE FILL LEFT THERE (the
-// placement table overrides the save's item only inside CheckQueue's give, and
-// only after the player has already committed to collecting it). A cross-game
-// progression item was therefore indistinguishable in the world from a green
-// rupee. That is true identically at 4 pool items and at 32.
-//
-// WHY AN AURA AND NOT THE ORIGIN GAME'S MODEL. Both o2r archives ARE
-// co-mounted — one flat ArchiveManager, additive, never unmounted
-// (rsbs/src/main.cpp EnsureGameArchivesLoaded; MM's LoadMMArchives adds to
-// OoT's manager) — so cross-game asset resolution is NOT ruled out and this
-// lane's "stop and report" condition does not fire. But the origin game's
-// archive only mounts once that game has been entered in this process, and a
-// real per-item 3D model is the one presentation tier that scales per pool
-// entry, which #494 puts explicitly out of scope. So the marker is generic:
-// one signal that means "this belongs to the other game", identical for every
-// foreign item.
-//
-// It is additive rather than a replacement model because the host geometry is
-// already carrying information. A chest states its item CLASS through its
-// corner/lock texture set, and a foreign host is upgraded to the ornate/major
-// set there (EnBox.cpp) — swapping the whole model would throw that away. The
-// aura is what makes it unambiguous rather than merely "a good chest": the
-// kirakira effect is otherwise reserved for a handful of model-less items, so
-// nothing else in the world sparkles at rest.
-//
-// The operator verifies the appearance; CI locks the RESOLUTION SURFACE (every
-// pool entry resolves to a non-null display descriptor), not the pixels.
-void Rando::DrawForeignCheckAura(Actor* actor) {
-    // Actor-gated: DrawSparkles spawns at the actor's world position and
-    // returns immediately without one (a cutscene / get-item draw passes no
-    // actor, and there the textbox already names the item and its origin).
-    if (actor != NULL) {
-        DrawSparkles(RI_NONE, actor);
-    }
-}
+// #510 removed Rando::DrawForeignCheckAura from here. It existed to mark a
+// cross-game item as cross-game — a kirakira aura on the hosting chest and on
+// the held item, plus a matching "it belongs to Ocarina of Time" textbox. The
+// cross-game class is now presented as ORDINARY treasure in whichever game the
+// player finds it, so a tell that says "this one is different" is exactly the
+// thing that had to go. DrawSparkles stays: it is still the native model-less
+// form for RI_NONE and the magic/swim/time items.
 
 // ROM-free harness guard (#392): with no mm.o2r registered,
 // ResourceMgr_LoadGfxByName null-derefs on a missing asset. The real boot

--- a/games/mm/2s2h/Rando/Foreign.cpp
+++ b/games/mm/2s2h/Rando/Foreign.cpp
@@ -361,6 +361,15 @@ const char* ForeignNameForCheck(RandoCheckId randoCheckId) {
     return Combo_GetForeignItemName(*item);
 }
 
+const char* ForeignArticleForCheck(RandoCheckId randoCheckId) {
+    const SharedItem* item = PlacementFor(randoCheckId);
+    if (item == nullptr) {
+        return "";
+    }
+    const char* article = Combo_GetForeignItemArticle(*item);
+    return article != nullptr ? article : "";
+}
+
 bool RecordForeignPickup(RandoCheckId randoCheckId) {
     const SharedItem* item = PlacementFor(randoCheckId);
     if (item == nullptr) {

--- a/games/mm/2s2h/Rando/Foreign.h
+++ b/games/mm/2s2h/Rando/Foreign.h
@@ -77,6 +77,16 @@ bool IsForeignCheck(RandoCheckId randoCheckId);
 /** Display name for the foreign item hosted by this check, or nullptr. */
 const char* ForeignNameForCheck(RandoCheckId randoCheckId);
 
+/** The article MM's pickup textbox prepends to that name ("the ", "a ", "an ",
+ *  or "" — it carries its own trailing space). Empty string if the check hosts
+ *  nothing, so callers can concatenate unconditionally.
+ *
+ *  #510: a cross-game item is presented as an ORDINARY MM pickup, and MM builds
+ *  every native pickup sentence as article + name. The article has to come from
+ *  the pooled descriptor because MM cannot look up OoT's item table — that is
+ *  the ADR 0002 boundary this whole surface exists to hold. */
+const char* ForeignArticleForCheck(RandoCheckId randoCheckId);
+
 /** Give-path core: record the check's foreign item into the shared structure
  *  (durable immediately; de-duped by the A1 producer). Returns true if a
  *  foreign item was recorded. The CheckQueue lambda calls this and layers the

--- a/games/mm/2s2h/Rando/ForeignItemsSingleExe.cpp
+++ b/games/mm/2s2h/Rando/ForeignItemsSingleExe.cpp
@@ -6,10 +6,10 @@
  * the ONE MM translation unit where the cross-game item class may name real
  * RI_* enumerators, because everything leaves it as an origin-tagged SharedItem
  * (or a display string) and a raw RI_* therefore never crosses a game boundary
- * (ADR 0002, the #356 bug class). Lane 1 extends this same TU with
- * kForeignPoolMMV1 — the reverse-direction SOURCE pool — plus its
- * Combo_RegisterForeignItemPool file-scope registrar; this file deliberately
- * stops at the give so that boundary stays obvious.
+ * (ADR 0002, the #356 bug class). It holds BOTH halves of MM's side of the
+ * cross-game item class: the redemption give (below) and — since #510 —
+ * kForeignPoolMMV1, the reverse-direction SOURCE pool that OoT's placement pass
+ * draws from, with its Combo_RegisterForeignItemPool file-scope registrar.
  *
  * Lives in 2s2h/Rando/, glob-collected into `2ship_rando`, which links
  * WHOLE_ARCHIVE — so this TU survives the link with no CMake edit.
@@ -98,6 +98,275 @@ extern "C" {
 // own linkage and pulls in <stdbool.h>/<stdint.h> (matching Foreign.cpp).
 #include "foreign_items.h"
 #include "shared_items.h" // RSBS_SHARED_ITEM_CAP (via context.h)
+
+// ============================================================================
+// kForeignPoolMMV1 — the reverse-direction SOURCE pool (#510)
+// ============================================================================
+//
+// The MM items OoT's placement pass (OoT_PlaceForeignItems) may host in an OoT
+// check. The OoT twin of this table is kForeignPoolV1 in
+// soh/Enhancements/randomizer/ForeignItemsSingleExe.cpp; both are defined in
+// the one TU where their own enum is in scope and leave only as origin-tagged
+// SharedItems (ADR 0002).
+//
+// SCOPE: this is deliberately a BROAD pool, not a pinned handful.
+// RSBS_FOREIGN_PLACEMENT_CAP (8) caps PLACEMENTS PER SEED, not candidates — the
+// placement pass draws a random subset — so a wide pool buys seed-to-seed
+// variety at zero runtime cost. There is intentionally no
+// static_assert(count <= CAP) here; the OoT pool has one only because it
+// predates the reverse direction and happens to be smaller than the cap.
+//
+// ---------------------------------------------------------------------------
+// THE MEMBERSHIP RULE (and why each exclusion is a rule, not a taste)
+// ---------------------------------------------------------------------------
+// An MM item is a v1 candidate iff ALL of:
+//
+//  (1) It is a real item — not a sentinel. RI_UNKNOWN (enumerator 0, i.e. a
+//      zero-initialised slot), RI_NONE ("literally nothing") and RI_JUNK are
+//      excluded; MM_ForeignItem_Give's IsGiveableItemId refuses the first two
+//      outright (the #488 sentinel trap).
+//
+//  (2) Its randoItemType is not RITYPE_JUNK. The junk class is what a foreign
+//      HOST check degrades to when the placement table is absent — the OoT host
+//      physically holds an OoT junk item — so crossing MM junk would be a
+//      strictly worse duplicate of what is already there, and would burn one of
+//      at most 8 slots on a green rupee. Excluded with it: RI_GOLD_DUST_REFILL,
+//      which is typed RITYPE_LESSER but is semantically a bottle refill.
+//
+//  (3) Its give in Rando::GiveItem is UNCONDITIONALLY effectful — it changes MM
+//      save state whatever options the paired MM world was generated under.
+//      This is the load-bearing one, and it is what excludes the enemy/boss
+//      SOULS, the OCARINA BUTTONS, RI_ABILITY_SWIM, and the RI_TIME_* /
+//      RI_TIME_PROGRESSIVE clock items: each of those gives is a bare
+//      rando-inf/week-event flag whose only meaning comes from a specific MM
+//      shuffle setting, and OoT's placement pass runs at OoT generation time —
+//      possibly before the paired MM world exists at all — so it CANNOT read
+//      MM's option profile to find out. A settings-gated entry would be a
+//      crossing the player is promised in OoT ("it will be awarded there!") and
+//      then silently never receives in Termina, which is worse than no crossing.
+//      (Souls are also ~55 rows; admitting them would make a uniform draw of 8
+//      mostly souls and crowd out everything else. That is the secondary reason,
+//      not the reason.)
+//
+//  (4) Its give fires no GLOBAL WORLD EVENT. This excludes RI_TRIFORCE_PIECE and
+//      RI_TRIFORCE_PIECE_PREVIOUS: Rando::GiveItem increments
+//      foundTriforcePieces and, on reaching RO_TRIFORCE_PIECES_REQUIRED,
+//      recursively gives RI_SOUL_BOSS_MAJORA, fires
+//      GameInteractor_ExecuteOnGameCompletion() and QUEUES A FORCED SCENE
+//      TRANSITION (GiveItem.cpp:109-125). Detonating game completion from the
+//      foreign-redemption flush — the first gameplay frame after an arrival — is
+//      exactly what a cross-game seam must not do. The piece count is also a
+//      per-world goal quantity that extra crossings would silently inflate.
+//
+//  (5) It is a reward, not a punishment: RI_TRAP is excluded. The OoT-side
+//      pickup text promises an award in Termina; delivering MM's trap machinery
+//      instead would make that text a lie.
+//
+// Everything else is IN — every mask, every song, every bottle, both shields,
+// the sword and magic and wallet and quiver and bomb-bag upgrades, the
+// progressives (which resolve against the LIVE MM save, so they are the single
+// best-behaved cross-game gift, and the OoT pool sets the precedent with
+// RG_PROGRESSIVE_HOOKSHOT / RG_PROGRESSIVE_STRENGTH), the boss remains, the
+// deeds and letters and other sidequest items, the owl statues, the Tingle maps,
+// and the dungeon keys/maps/compasses/stray fairies.
+//
+// One property makes that breadth safe rather than reckless: a crossing is
+// ADDITIVE. The MM world's own fill is untouched — nothing is removed from it to
+// pay for a foreign placement (the OoT host keeps its own junk item too) — so no
+// crossing can make MM unwinnable. Extra keys, extra fairies and extra remains
+// can only ever trivialize, never block.
+//
+// NULL-play safety is NOT a membership criterion, deliberately. MM's give is
+// deferred to the first frame with a live MM_gPlayState (see the file header),
+// which is item-agnostic and O(1) in pool size — the #502 design note says in as
+// many words that an allowlist audited against today's pool would expire the
+// moment somebody added a row. This pool is that row, 134 times over, and it
+// relies on the deferral instead of re-auditing it.
+//
+// Display names are MM's own (Rando::StaticData::Items) verbatim. They are a
+// PERSISTENCE KEY, not decoration: Combo_GetForeignItemByNameFor is the
+// spoiler-LOAD inverse, so renaming an entry breaks spoiler round-trips for
+// already-generated worlds. "Bomb Bag" is deliberately identical to the OoT
+// pool's row of the same name — that collision is real, is the reason the
+// lookups are keyed on (originGame, name), and is asserted in
+// test_foreign_items.c rather than dodged.
+static const ComboForeignItemDef kForeignPoolMMV1[] = {
+    // --- Progressive upgrades: resolve against the live MM save at give time.
+    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_PROGRESSIVE_SWORD }, "Progressive Sword", "a " },
+    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_PROGRESSIVE_BOW }, "Progressive Bow", "a " },
+    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_PROGRESSIVE_BOMB_BAG }, "Progressive Bomb Bag", "a " },
+    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_PROGRESSIVE_MAGIC }, "Progressive Magic", "" },
+    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_PROGRESSIVE_WALLET }, "Progressive Wallet", "a " },
+    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_PROGRESSIVE_LULLABY }, "Progressive Goron Lullaby", "" },
+
+    // --- Core equipment, abilities and capacity upgrades.
+    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_BOW }, "Bow", "a " },
+    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_HOOKSHOT }, "Hookshot", "the " },
+    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_LENS }, "Lens of Truth", "the " },
+    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_ARROW_FIRE }, "Fire Arrows", "" },
+    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_ARROW_ICE }, "Ice Arrows", "" },
+    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_ARROW_LIGHT }, "Light Arrows", "" },
+    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_BOMB_BAG_20 }, "Bomb Bag", "a " },
+    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_BOMB_BAG_30 }, "Big Bomb Bag", "a " },
+    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_BOMB_BAG_40 }, "Biggest Bomb Bag", "the " },
+    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_QUIVER_40 }, "Large Quiver", "the " },
+    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_QUIVER_50 }, "Largest Quiver", "the " },
+    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_WALLET_ADULT }, "Adult's Wallet", "the " },
+    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_WALLET_GIANT }, "Giant's Wallet", "the " },
+    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_POWDER_KEG }, "Powder Keg", "a " },
+    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_PICTOGRAPH_BOX }, "Pictograph Box", "a " },
+    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_MAGIC_BEAN }, "Magic Bean", "a " },
+    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_BOMBERS_NOTEBOOK }, "Bomber's Notebook", "the " },
+    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_SHIELD_HERO }, "Hero's Shield", "the " },
+    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_SHIELD_MIRROR }, "Mirror Shield", "the " },
+    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_SWORD_KOKIRI }, "Kokiri Sword", "the " },
+    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_SWORD_RAZOR }, "Razor Sword", "the " },
+    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_SWORD_GILDED }, "Gilded Sword", "the " },
+    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_GREAT_FAIRY_SWORD }, "Great Fairy's Sword", "the " },
+    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_GREAT_SPIN_ATTACK }, "Great Spin Attack", "the " },
+    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_SINGLE_MAGIC }, "Power of Magic", "the " },
+    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_DOUBLE_MAGIC }, "Magic Upgrade", "a " },
+    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_DOUBLE_DEFENSE }, "Double Defense", "" },
+
+    // --- Bottles (the bottle itself, not its refills).
+    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_BOTTLE_EMPTY }, "Empty Bottle", "an " },
+    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_BOTTLE_MILK }, "Bottle of Milk", "a " },
+    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_BOTTLE_RED_POTION }, "Bottle with Red Potion", "a " },
+    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_BOTTLE_GOLD_DUST }, "Bottle With Gold Dust", "a " },
+    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_BOTTLE_CHATEAU_ROMANI }, "Bottle of Chateau Romani", "a " },
+
+    // --- Masks. All 24, transformation masks included.
+    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_MASK_DEKU }, "Deku Mask", "the " },
+    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_MASK_GORON }, "Goron Mask", "the " },
+    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_MASK_ZORA }, "Zora Mask", "the " },
+    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_MASK_FIERCE_DEITY }, "Fierce Deity Mask", "the " },
+    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_MASK_ALL_NIGHT }, "All-Night Mask", "the " },
+    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_MASK_BLAST }, "Blast Mask", "the " },
+    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_MASK_BREMEN }, "Bremen Mask", "the " },
+    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_MASK_BUNNY }, "Bunny Hood", "the " },
+    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_MASK_CAPTAIN }, "Captain's Hat", "the " },
+    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_MASK_CIRCUS_LEADER }, "Circus Leader's Mask", "the " },
+    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_MASK_COUPLE }, "Couples Mask", "the " },
+    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_MASK_DON_GERO }, "Don Gero Mask", "the " },
+    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_MASK_GARO }, "Garo's Mask", "" },
+    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_MASK_GIANT }, "Giant's Mask", "the " },
+    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_MASK_GIBDO }, "Gibdo Mask", "the " },
+    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_MASK_GREAT_FAIRY }, "Great Fairy Mask", "the " },
+    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_MASK_KAFEIS_MASK }, "Kafei's Mask", "" },
+    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_MASK_KAMARO }, "Kamaro's Mask", "" },
+    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_MASK_KEATON }, "Keaton Mask", "the " },
+    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_MASK_POSTMAN }, "Postman's Hat", "the " },
+    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_MASK_ROMANI }, "Romani's Mask", "" },
+    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_MASK_SCENTS }, "Mask of Scents", "the " },
+    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_MASK_STONE }, "Stone Mask", "the " },
+    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_MASK_TRUTH }, "Mask of Truth", "the " },
+
+    // --- Songs.
+    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_SONG_SONATA }, "Sonata of Awakening", "the " },
+    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_SONG_LULLABY }, "Goron Lullaby", "the " },
+    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_SONG_LULLABY_INTRO }, "Goron Lullaby Intro", "the " },
+    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_SONG_NOVA }, "New Wave Bossa Nova", "the " },
+    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_SONG_ELEGY }, "Elegy of Emptiness", "the " },
+    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_SONG_OATH }, "Oath to Order", "the " },
+    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_SONG_SOARING }, "Song of Soaring", "the " },
+    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_SONG_HEALING }, "Song of Healing", "the " },
+    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_SONG_EPONA }, "Epona's Song", "" },
+    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_SONG_SUN }, "Sun's Song", "the " },
+    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_SONG_TIME }, "Song of Time", "the " },
+    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_SONG_STORMS }, "Song of Storms", "the " },
+
+    // --- Quest and sidequest items.
+    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_OCARINA }, "Ocarina of Time", "the " },
+    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_MOONS_TEAR }, "Moon's Tear", "the " },
+    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_DEED_LAND }, "Land Title Deed", "the " },
+    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_DEED_SWAMP }, "Swamp Title Deed", "the " },
+    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_DEED_MOUNTAIN }, "Mountain Title Deed", "the " },
+    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_DEED_OCEAN }, "Ocean Title Deed", "the " },
+    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_ROOM_KEY }, "Room Key", "the " },
+    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_LETTER_TO_KAFEI }, "Letter to Kafei", "the " },
+    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_LETTER_TO_MAMA }, "Letter to Mama", "the " },
+    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_PENDANT_OF_MEMORIES }, "Pendant of Memories", "the " },
+    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_MUSHROOM }, "Magic Mushroom", "a " },
+    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_FROG_BLUE }, "Blue Frog", "a " },
+    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_FROG_CYAN }, "Cyan Frog", "a " },
+    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_FROG_PINK }, "Pink Frog", "a " },
+    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_FROG_WHITE }, "White Frog", "a " },
+
+    // --- Boss remains.
+    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_REMAINS_ODOLWA }, "Odolwa's Remains", "" },
+    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_REMAINS_GOHT }, "Goht's Remains", "" },
+    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_REMAINS_GYORG }, "Gyorg's Remains", "" },
+    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_REMAINS_TWINMOLD }, "Twinmold's Remains", "" },
+
+    // --- Health.
+    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_HEART_CONTAINER }, "Heart Container", "a " },
+    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_HEART_PIECE }, "Heart Piece", "a " },
+
+    // --- Skulltula tokens.
+    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_GS_TOKEN_SWAMP }, "Swamp Gold Skulltula Token", "a " },
+    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_GS_TOKEN_OCEAN }, "Ocean Gold Skulltula Token", "an " },
+
+    // --- Owl statues (Sram_ActivateOwl: always a real warp unlock).
+    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_OWL_CLOCK_TOWN_SOUTH }, "Clock Town Owl Statue", "the " },
+    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_OWL_MILK_ROAD }, "Milk Road Owl Statue", "the " },
+    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_OWL_SOUTHERN_SWAMP }, "Southern Swamp Owl Statue", "the " },
+    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_OWL_WOODFALL }, "Woodfall Owl Statue", "the " },
+    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_OWL_MOUNTAIN_VILLAGE }, "Mountain Village Owl Statue", "the " },
+    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_OWL_SNOWHEAD }, "Snowhead Owl Statue", "the " },
+    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_OWL_GREAT_BAY_COAST }, "Great Bay Coast Owl Statue", "the " },
+    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_OWL_ZORA_CAPE }, "Zora Cape Owl Statue", "the " },
+    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_OWL_IKANA_CANYON }, "Ikana Canyon Owl Statue", "the " },
+    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_OWL_STONE_TOWER }, "Stone Tower Owl Statue", "the " },
+
+    // --- Tingle maps.
+    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_TINGLE_MAP_CLOCK_TOWN }, "Tingle's Clock Town Map", "" },
+    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_TINGLE_MAP_WOODFALL }, "Tingle's Woodfall Map", "" },
+    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_TINGLE_MAP_SNOWHEAD }, "Tingle's Snowhead Map", "" },
+    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_TINGLE_MAP_ROMANI_RANCH }, "Tingle's Romani Ranch Map", "" },
+    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_TINGLE_MAP_GREAT_BAY }, "Tingle's Great Bay Map", "" },
+    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_TINGLE_MAP_STONE_TOWER }, "Tingle's Stone Tower Map", "" },
+
+    // --- Dungeon items. Additive, so an extra key can only ever trivialize.
+    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_WOODFALL_BOSS_KEY }, "Woodfall Boss Key", "the " },
+    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_WOODFALL_SMALL_KEY }, "Woodfall Small Key", "a " },
+    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_WOODFALL_MAP }, "Woodfall Map", "the " },
+    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_WOODFALL_COMPASS }, "Woodfall Compass", "the " },
+    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_SNOWHEAD_BOSS_KEY }, "Snowhead Boss Key", "the " },
+    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_SNOWHEAD_SMALL_KEY }, "Snowhead Small Key", "a " },
+    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_SNOWHEAD_MAP }, "Snowhead Map", "the " },
+    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_SNOWHEAD_COMPASS }, "Snowhead Compass", "the " },
+    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_GREAT_BAY_BOSS_KEY }, "Great Bay Boss Key", "the " },
+    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_GREAT_BAY_SMALL_KEY }, "Great Bay Small Key", "a " },
+    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_GREAT_BAY_MAP }, "Great Bay Map", "the " },
+    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_GREAT_BAY_COMPASS }, "Great Bay Compass", "the " },
+    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_STONE_TOWER_BOSS_KEY }, "Stone Tower Boss Key", "the " },
+    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_STONE_TOWER_SMALL_KEY }, "Stone Tower Small Key", "a " },
+    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_STONE_TOWER_MAP }, "Stone Tower Map", "the " },
+    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_STONE_TOWER_COMPASS }, "Stone Tower Compass", "the " },
+
+    // --- Stray fairies.
+    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_CLOCK_TOWN_STRAY_FAIRY }, "Clock Town Stray Fairy", "a " },
+    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_WOODFALL_STRAY_FAIRY }, "Woodfall Stray Fairy", "a " },
+    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_SNOWHEAD_STRAY_FAIRY }, "Snowhead Stray Fairy", "a " },
+    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_GREAT_BAY_STRAY_FAIRY }, "Great Bay Stray Fairy", "a " },
+    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_STONE_TOWER_STRAY_FAIRY }, "Stone Tower Stray Fairy", "a " },
+};
+
+static constexpr int kForeignPoolMMCount = sizeof(kForeignPoolMMV1) / sizeof(kForeignPoolMMV1[0]);
+
+// Publish into src/common's origin-indexed registry (ADR 0009 decision 3), the
+// same way the OoT pool does. File-scope initializer, so it runs before main()
+// and before any gameplay or test code can ask for the pool; this TU lives in
+// 2ship_rando, which links WHOLE_ARCHIVE, so it is never dropped as unreferenced
+// (the Mode-B elision class — see .github/scripts/check-registrar-elision.sh).
+namespace {
+struct ForeignPoolMMV1Registrar {
+    ForeignPoolMMV1Registrar() {
+        Combo_RegisterForeignItemPool((uint8_t)GAME_MM, kForeignPoolMMV1, kForeignPoolMMCount);
+    }
+};
+const ForeignPoolMMV1Registrar gForeignPoolMMV1Registrar;
+} // namespace
 
 namespace {
 
@@ -242,6 +511,23 @@ extern "C" int MM_ForeignItem_TestItemIdMax(void) {
  *  moves. */
 extern "C" int MM_ForeignItem_TestIsGiveableId(uint16_t riId) {
     return IsGiveableItemId(riId) ? 1 : 0;
+}
+
+/** Is `riId` declared RITYPE_JUNK in MM's item table? (#510)
+ *
+ *  The observable for kForeignPoolMMV1's membership rule (2) — "no junk-class
+ *  item may be a cross-game SOURCE, because junk is what a foreign HOST degrades
+ *  to". Reported from MM's real table rather than re-derived in the test, so a
+ *  row whose type changes upstream moves the lock with it instead of leaving it
+ *  asserting a stale copy.
+ *
+ *  @return 1 if junk-class, 0 if a real non-junk item, -1 if the id names no row. */
+extern "C" int MM_ForeignItem_TestIsJunkClassId(uint16_t riId) {
+    const auto it = Rando::StaticData::Items.find((RandoItemId)riId);
+    if (it == Rando::StaticData::Items.end()) {
+        return -1;
+    }
+    return (it->second.randoItemType == RITYPE_JUNK) ? 1 : 0;
 }
 
 #endif // RSBS_SINGLE_EXECUTABLE

--- a/games/mm/2s2h/Rando/MiscBehavior/CheckQueue.cpp
+++ b/games/mm/2s2h/Rando/MiscBehavior/CheckQueue.cpp
@@ -59,14 +59,31 @@ void Rando::MiscBehavior::CheckQueue() {
 #ifdef RSBS_SINGLE_EXECUTABLE
             // Lane C1 (#392): a check hosting a FOREIGN item (an OoT item in
             // this MM world — gComboCtx.foreignPlacements) hands the item to
-            // the shared structure instead of MM's give path, presented as a
-            // generic "foreign treasure" (textbox + gold-rupee model — the
-            // receiving game has no assets for the item, per the MVP's
-            // generic-presentation contract). The MM save table still holds
-            // its junk-class MM item at this check; the placement table
-            // overrides it here.
+            // the shared structure instead of MM's give path.
+            //
+            // PRESENTED AS AN ORDINARY MM PICKUP (#510). It used to announce
+            // itself — a giant-rupee stand-in model, a cross-game aura, and a
+            // textbox explaining the item belonged to Ocarina of Time and would
+            // be awarded there. All three are gone. A foreign item now reads
+            // exactly like any other check: "You found the Fairy Bow!".
+            //
+            // NO STAND-IN MODEL. We cannot draw OoT's real model — oot.o2r and
+            // mm.o2r share one flat ArchiveManager namespace with 151 documented
+            // object collisions (docs/resource-namespace-audit.md), 41 of them in
+            // exactly the object_gi_* class this would need, and oot.o2r is not
+            // even mounted until OoT has been entered (rsbs/src/main.cpp's
+            // EnsureGameArchivesLoaded). So instead of substituting a DIFFERENT
+            // item's model, we use MM's own model-LESS pickup form: RI_NONE
+            // draws no model and falls through to DrawSparkles, which is the
+            // identical presentation MM already gives Magic Upgrades, the Swim
+            // ability and Progressive Time (DrawItem.cpp). Showing nothing is
+            // native; showing a rupee that is not a rupee was the placeholder.
             if (Rando::Foreign::IsForeignCheck(randoCheckId)) {
                 MM_GameEvents_Queue().emplace_back(GIEventGiveItem{
+                    // Always cutscene: a foreign item is progression by
+                    // construction (the pool excludes junk), and this is the
+                    // only surface that names it, so it must not be swallowed by
+                    // the player's skip-junk-cutscene tier.
                     .showGetItemCutscene = true,
                     .param = (int16_t)randoCheckId,
                     .giveItem =
@@ -80,12 +97,16 @@ void Rando::MiscBehavior::CheckQueue() {
                             // consumer awards it on the next arrival there.
                             Rando::Foreign::RecordForeignPickup(checkId);
 
+                            // Same sentence shape as the native branch below:
+                            // "You found " + article + name + "!". The article
+                            // rides the pooled descriptor because MM cannot read
+                            // OoT's item table (ADR 0002).
                             CustomMessage::Entry entry = {
                                 .textboxType = 2,
-                                .icon = Rando::StaticData::GetIconForZMessage(RI_RUPEE_HUGE),
-                                .msg = std::string("You found the ") +
-                                       (foreignName != nullptr ? foreignName : "Foreign Treasure") +
-                                       "!\nIt belongs to Ocarina of Time -\nit will be awarded there!",
+                                .icon = Rando::StaticData::GetIconForZMessage(RI_NONE),
+                                .msg = std::string("You found ") +
+                                       Rando::Foreign::ForeignArticleForCheck(checkId) +
+                                       (foreignName != nullptr ? foreignName : "a foreign item") + "!",
                             };
                             if (CUSTOM_ITEM_FLAGS & CustomItem::GIVE_ITEM_CUTSCENE) {
                                 CustomMessage::SetActiveCustomMessage(entry.msg, entry);
@@ -99,22 +120,16 @@ void Rando::MiscBehavior::CheckQueue() {
                             queued = false;
                             // Post-give, CUSTOM_ITEM_PARAM carries an RI for
                             // the draw path (matching the normal branch).
-                            CUSTOM_ITEM_PARAM = RI_RUPEE_HUGE;
+                            CUSTOM_ITEM_PARAM = RI_NONE;
                         },
                     .drawItem =
                         [](Actor* actor, PlayState* play) {
+                            // Byte-for-byte the native branch's draw, with the
+                            // model-less item. No actor argument: passing it
+                            // adds hilites the native path does not, which would
+                            // itself be a cross-game tell.
                             MM_Matrix_Scale(30.0f, 30.0f, 30.0f, MTXMODE_APPLY);
-                            // #494 slice 6: the same cross-game marker the
-                            // world draws for a foreign host, so the item does
-                            // not change identity between "seen in the chest"
-                            // and "held over Link's head". Unconditional rather
-                            // than via a check-keyed dispatch: this lambda only
-                            // ever runs for a foreign check, and
-                            // CUSTOM_ITEM_PARAM has already been rewritten from
-                            // the RC to an RI by the give above, so there is no
-                            // check id left here to ask about.
-                            Rando::DrawItem(RI_RUPEE_HUGE, actor);
-                            Rando::DrawForeignCheckAura(actor);
+                            Rando::DrawItem(RI_NONE);
                         } });
                 return;
             }

--- a/games/mm/2s2h/Rando/Rando.h
+++ b/games/mm/2s2h/Rando/Rando.h
@@ -14,14 +14,6 @@ namespace Rando {
 
 void Init();
 void DrawItem(RandoItemId randoItemId, Actor* actor = nullptr);
-#ifdef RSBS_SINGLE_EXECUTABLE
-// Lane 6 (#494 slice 6): the particle aura that marks a check as holding a
-// cross-game item, so a player can SEE that before collecting it. An aura
-// rather than a replacement model because the host class already conveys item
-// class through its own geometry (a chest's ornate corner/lock set) and should
-// keep doing so. Defined in DrawItem.cpp; no-op without an actor.
-void DrawForeignCheckAura(Actor* actor);
-#endif
 void GiveItem(RandoItemId randoItemId);
 void RemoveItem(RandoItemId randoItemId);
 RandoItemId CurrentJunkItem();

--- a/games/oot/soh/Enhancements/randomizer/3drando/menu.cpp
+++ b/games/oot/soh/Enhancements/randomizer/3drando/menu.cpp
@@ -549,6 +549,30 @@ extern "C" int Rando_HeadlessSeedDeterminismDigest(const char* seedStr, const ch
     }
     const uint32_t placementHash = SohUtils::Hash(blob);
 
+    // #510: fold the REVERSE foreign placements (MM items hosted in OoT checks,
+    // written by OoT_PlaceForeignItems during the generation above) into the same
+    // digest. Without this the two-process diff would happily agree on a world
+    // whose cross-game half was drawn differently each run — the placement pass
+    // seeds a local xorshift32 from the paired identity precisely so it cannot,
+    // and this is what holds it to that. Canonical, fixed-slot order, and stable
+    // when the carve is empty (an unpaired world digests as all-zero slots rather
+    // than as absent, so a pairing that stops firing shows up as a mismatch).
+    std::string foreignBlob;
+    size_t foreignCount = 0;
+    for (int i = 0; i < (int)RSBS_FOREIGN_PLACEMENT_CAP; i++) {
+        const ComboForeignPlacement& fp = gComboCtx.foreignPlacementsOoT[i];
+        if (fp.item.originGame != (uint8_t)GAME_NONE) {
+            foreignCount++;
+        }
+        foreignBlob += std::to_string(fp.mmCheckId);
+        foreignBlob += ':';
+        foreignBlob += std::to_string((int)fp.item.originGame);
+        foreignBlob += ':';
+        foreignBlob += std::to_string(fp.item.id);
+        foreignBlob += ';';
+    }
+    const uint32_t foreignHash = SohUtils::Hash(foreignBlob);
+
     FILE* out = stdout;
     bool closeOut = false;
     if (outPath && outPath[0] != '\0') {
@@ -564,14 +588,19 @@ extern "C" int Rando_HeadlessSeedDeterminismDigest(const char* seedStr, const ch
             "settingsHash=%08X\n"
             "sourceIsRando=%d\n"
             "placementHash=%08X\n"
-            "placedCount=%zu\n",
+            "placedCount=%zu\n"
+            "foreignOoTHash=%08X\n"
+            "foreignOoTCount=%zu\n",
             gComboCtx.sharedRandoSeed, gComboCtx.sharedRandoSettingsHash, gComboCtx.sourceIsRando ? 1 : 0,
-            placementHash, placedCount);
+            placementHash, placedCount, foreignHash, foreignCount);
     if (closeOut) {
         fclose(out);
     }
-    fprintf(stderr, "[rando-determinism] digest: seed=%08X settingsHash=%08X placementHash=%08X placed=%zu\n",
-            gComboCtx.sharedRandoSeed, gComboCtx.sharedRandoSettingsHash, placementHash, placedCount);
+    fprintf(stderr,
+            "[rando-determinism] digest: seed=%08X settingsHash=%08X placementHash=%08X placed=%zu "
+            "foreignOoTHash=%08X foreignOoT=%zu\n",
+            gComboCtx.sharedRandoSeed, gComboCtx.sharedRandoSettingsHash, placementHash, placedCount, foreignHash,
+            foreignCount);
     return 0;
 }
 

--- a/games/oot/soh/Enhancements/randomizer/3drando/playthrough.cpp
+++ b/games/oot/soh/Enhancements/randomizer/3drando/playthrough.cpp
@@ -15,6 +15,9 @@
 #include "../option.h"
 #include "soh/Enhancements/debugger/performanceTimer.h"
 #include "context.h" // src/common — gComboCtx, Lane B unified-seed carrier (ADR 0002)
+#ifdef RSBS_SINGLE_EXECUTABLE
+#include "foreign_items.h" // src/common — OoT_PlaceForeignItems (#510)
+#endif
 
 namespace Playthrough {
 
@@ -116,6 +119,27 @@ int Playthrough_Init(uint32_t seed, std::set<RandomizerCheck> excludedLocations,
     gComboCtx.sourceIsRando = true;
     gComboCtx.sharedRandoSeed = seed;
     gComboCtx.sharedRandoSettingsHash = rsbsSettingsHash;
+
+#ifdef RSBS_SINGLE_EXECUTABLE
+    // #510, the reverse foreign pool: hand a few MM items to OoT checks now that
+    // this world's paired identity is stamped just above (the placement stream is
+    // derived from it, so the order is load-bearing — not stylistic).
+    //
+    // The #ifdef is required, not defensive: OoT_PlaceForeignItems exists only in
+    // the single-exe build, while Playthrough_Init is ordinary OoT code that also
+    // compiles for a standalone SoH.
+    //
+    // Propagated through the return code rather than an exception. Nothing in
+    // this chain catches — Rando_HeadlessSeedTest is extern "C" — so a throw here
+    // would std::terminate the headless CI rows and the live generate alike.
+    // A PARTIAL placement is not a failure and returns >= 0; only "the pairing is
+    // on but could not be honoured at all" is negative (see foreign_items.h).
+    const int foreignPlaced = OoT_PlaceForeignItems();
+    if (foreignPlaced < 0) {
+        SPDLOG_ERROR("Cross-game foreign placement failed ({}); aborting generation", foreignPlaced);
+        return foreignPlaced;
+    }
+#endif
 
     return 1;
 }

--- a/games/oot/soh/Enhancements/randomizer/ForeignItemsSingleExe.cpp
+++ b/games/oot/soh/Enhancements/randomizer/ForeignItemsSingleExe.cpp
@@ -23,10 +23,21 @@
  *
  * Lives in soh/Enhancements/randomizer/ (soh_rando) which links WHOLE_ARCHIVE,
  * so these definitions always survive the link.
+ *
+ * #510 added the REVERSE direction's producer half at the bottom of this file:
+ * OoT_Foreign_IsEligibleHost (which OoT check may host an MM item) and
+ * OoT_PlaceForeignItems (the generation-time placement pass Playthrough_Init
+ * calls). Those are the twin of MM's Rando::Foreign, and they consume MM's
+ * kForeignPoolMMV1 through the same origin-indexed registry — so this file still
+ * never sees an RI_*, only origin-tagged SharedItems.
  */
 #ifdef RSBS_SINGLE_EXECUTABLE
 
+#include <algorithm>
+#include <cstddef>
 #include <cstdio>
+#include <string>
+#include <vector>
 
 #include "soh/OTRGlobals.h"
 #include "soh/Enhancements/randomizer/randomizerTypes.h"
@@ -55,11 +66,13 @@ void GiveLinkRupees(int numOfRupees);
 // ADR's static_asserts reject raw-integer conversion; explicit members carry
 // the tag). Values must fit the struct's uint8_t/uint16_t members — a
 // constant-expression enumerator that fits is not a narrowing conversion.
+// The article column matches OoT's own item table (Item::GetArticle), so MM's
+// pickup textbox reads exactly like an MM one: "You found the Fairy Bow!".
 static const ComboForeignItemDef kForeignPoolV1[] = {
-    { { (uint8_t)GAME_OOT, 0, (uint16_t)RG_PROGRESSIVE_HOOKSHOT }, "Progressive Hookshot" },
-    { { (uint8_t)GAME_OOT, 0, (uint16_t)RG_FAIRY_BOW }, "Fairy Bow" },
-    { { (uint8_t)GAME_OOT, 0, (uint16_t)RG_BOMB_BAG }, "Bomb Bag" },
-    { { (uint8_t)GAME_OOT, 0, (uint16_t)RG_PROGRESSIVE_STRENGTH }, "Progressive Strength Upgrade" },
+    { { (uint8_t)GAME_OOT, 0, (uint16_t)RG_PROGRESSIVE_HOOKSHOT }, "Progressive Hookshot", "a " },
+    { { (uint8_t)GAME_OOT, 0, (uint16_t)RG_FAIRY_BOW }, "Fairy Bow", "the " },
+    { { (uint8_t)GAME_OOT, 0, (uint16_t)RG_BOMB_BAG }, "Bomb Bag", "a " },
+    { { (uint8_t)GAME_OOT, 0, (uint16_t)RG_PROGRESSIVE_STRENGTH }, "Progressive Strength Upgrade", "a " },
 };
 
 static constexpr int kForeignPoolCount = sizeof(kForeignPoolV1) / sizeof(kForeignPoolV1[0]);
@@ -124,6 +137,219 @@ extern "C" int OoT_ForeignItem_Give(uint16_t rgId) {
 
     fprintf(stderr, "[OoT] foreign give: unhandled modIndex %d for RG id=%u\n", (int)entry.modIndex, (unsigned)rgId);
     return 0;
+}
+
+// ============================================================================
+// REVERSE DIRECTION (#510): host eligibility + the OoT placement pass
+// ============================================================================
+//
+// The mirror of Rando::Foreign::IsEligibleHost / PlaceForeignItems on the MM
+// side (games/mm/2s2h/Rando/Foreign.cpp), for the other direction: MM items
+// (kForeignPoolMMV1) hosted in OoT checks, recorded in
+// gComboCtx.foreignPlacementsOoT and delivered in Termina by MM_AwardSharedItem.
+//
+// THE ASYMMETRY THAT MATTERS: **OoT has no RCTYPE_CHEST.** MM classifies a chest
+// with a dedicated check type, so its predicate keys on
+// `randoCheckType == RCTYPE_CHEST`. OoT's chests are RCTYPE_STANDARD and are
+// identified by the ACTOR they are built from — Location::Chest stores
+// ACTOR_EN_BOX (location_list.cpp passes it for every chest row) — so the
+// equivalent test here is on GetActorID(), not on the check type. Keying this
+// on a nonexistent RCTYPE_CHEST would silently accept nothing.
+//
+// TWO OBJECTS, TWO ACCESSORS. The static class of a check and the item the fill
+// actually placed there live in different tables and are reached differently:
+//   - Rando::StaticData::GetLocation(rc)          -> Rando::Location*    (static)
+//   - Rando::Context::GetInstance()->GetItemLocation(rc) -> Rando::ItemLocation* (fill)
+// Reading both off one pointer does not compile; they are separate types.
+//
+// WHY JUNK-CLASS. Same invariant MM's predicate enforces: a foreign host must
+// physically hold a legal junk item of its OWN game, because that is what the
+// check degrades to if the placement table is ever absent (a pre-#493 .redsave
+// zero-extends to an empty table). Nothing crashes, nothing aliases — the player
+// just gets the blue rupee that was really in the chest.
+static bool OoT_Foreign_IsEligibleHostImpl(RandomizerCheck rc) {
+    if (rc <= RC_UNKNOWN_CHECK || rc >= RC_MAX) {
+        return false;
+    }
+
+    Rando::Location* loc = Rando::StaticData::GetLocation(rc);
+    // A gap in the table is default-constructed and keeps RC_UNKNOWN_CHECK, so
+    // an id that does not name a real row fails this identity test.
+    if (loc == nullptr || loc->GetRandomizerCheck() != rc) {
+        return false;
+    }
+
+    // Tier A, and the only tier: an actual treasure chest.
+    if (loc->GetActorID() != ACTOR_EN_BOX) {
+        return false;
+    }
+
+    // Commerce is excluded EXPLICITLY even though no shop/scrub/merchant row is
+    // ACTOR_EN_BOX today. Their give-and-price flow and their spoiler shape both
+    // differ from the ordinary collect path this presentation targets, so the
+    // exclusion must survive any future widening of the actor test (the same
+    // reasoning MM's IsAllowedHostClass states for RCTYPE_SHOP).
+    const RandomizerCheckType checkType = loc->GetRCType();
+    if (checkType == RCTYPE_SHOP || checkType == RCTYPE_SCRUB || checkType == RCTYPE_MERCHANT ||
+        checkType == RCTYPE_CHEST_GAME) {
+        return false;
+    }
+    if (loc->IsShop()) {
+        return false;
+    }
+
+    // The fill-side half. RG_NONE is "the fill placed nothing here" (an
+    // unshuffled or unreached location) — the OoT analogue of MM's `.shuffled`
+    // test, and the reason a ROM-free run with no fill accepts nothing.
+    auto ctx = Rando::Context::GetInstance();
+    if (ctx == nullptr) {
+        return false;
+    }
+    Rando::ItemLocation* itemLoc = ctx->GetItemLocation(rc);
+    if (itemLoc == nullptr) {
+        return false;
+    }
+    const RandomizerGet placedItem = itemLoc->GetPlacedRandomizerGet();
+    if (placedItem == RG_NONE) {
+        return false;
+    }
+
+    return Rando::StaticData::RetrieveItem(placedItem).GetCategory() == ITEM_CATEGORY_JUNK;
+}
+
+// Local, self-contained PRNG for placement selection — deliberately NOT drawn
+// from Random_Init's stream. The fill consumes that stream, so taking numbers
+// out of it here would shift every subsequent draw and change the OoT world
+// itself as a side effect of the cross-game feature being on. Same reasoning,
+// same xorshift32, as Rando::Foreign's sSelectState.
+static uint32_t sOoTSelectState;
+
+static uint32_t OoT_Foreign_SelectNext() {
+    uint32_t x = sOoTSelectState;
+    x ^= x << 13;
+    x ^= x >> 17;
+    x ^= x << 5;
+    sOoTSelectState = (x != 0) ? x : 0xB5297A4Du;
+    return sOoTSelectState;
+}
+
+/**
+ * Place MM items into eligible OoT checks. Called once from Playthrough_Init,
+ * AFTER the gComboCtx pairing stamp (the identity this derives from must be live).
+ *
+ * @return the number of placements made (>= 0), or NEGATIVE if the pairing is
+ *         active but the pass could not honour it at all — see the note below.
+ *
+ * ERROR SIGNALLING — RETURN CODE, NEVER AN EXCEPTION. OoT's generation chain has
+ * no try/catch anywhere: Rando_HeadlessSeedTest (extern "C") -> GenerateRandomizer
+ * -> Playthrough_Init. A throw would cross that extern "C" boundary uncaught and
+ * std::terminate the process, killing the headless SeedDeterminism/MMRandoGen CI
+ * rows and the live GUI generate alike. GenerateRandomizer already speaks return
+ * codes (`if (ret < 0) return false`), so shortfall rides that convention.
+ *
+ * A PARTIAL placement is NOT a shortfall and must not fail generation: the pool
+ * is ~134 entries against a cap of 8, so placing fewer than the pool is the
+ * normal, intended outcome. Only two states are errors, and both mean the
+ * cross-game half of a PAIRED world would be silently absent:
+ *   -1  the MM pool is not registered at all (the Mode-B elision class — if
+ *       2ship_rando's pool TU is ever dropped from the link this turns a silent
+ *       feature loss into a loud generation failure)
+ *   -2  no eligible host exists in the finished fill. OoT has ~100 chest rows and
+ *       junk is plentiful, so zero is not a reachable fill outcome; it means the
+ *       predicate and the table have drifted apart.
+ */
+extern "C" int OoT_PlaceForeignItems(void) {
+    // A re-generated world must not inherit the previous one's placements.
+    Combo_ClearForeignPlacementsOoT();
+
+    if (!Combo_ForeignPairingActive()) {
+        return 0; // solo OoT rando: nothing to pair with, and that is normal
+    }
+
+    const ComboForeignItemDef* pool = nullptr;
+    const int poolCount = Combo_GetForeignItemPoolFor((uint8_t)GAME_MM, &pool);
+    if (poolCount <= 0 || pool == nullptr) {
+        fprintf(stderr, "[OoT] foreign placement: pairing is active but MM's source pool is empty — "
+                        "2ship_rando's pool TU was elided (#510)\n");
+        return -1;
+    }
+
+    auto ctx = Rando::Context::GetInstance();
+    if (ctx == nullptr) {
+        fprintf(stderr, "[OoT] foreign placement: no Rando::Context\n");
+        return -1;
+    }
+
+    // Candidates in ascending RandomizerCheck order. Walking the enum range
+    // rather than ctx->allLocations keeps the order fixed by construction — it
+    // cannot be perturbed by pool-bookkeeping changes — which is what the
+    // SeedDeterminism digest needs. Same shape as the digest's own walk.
+    std::vector<RandomizerCheck> candidates;
+    for (int i = 1; i < RC_MAX; i++) {
+        const RandomizerCheck rc = (RandomizerCheck)i;
+        if (OoT_Foreign_IsEligibleHostImpl(rc)) {
+            candidates.push_back(rc);
+        }
+    }
+
+    fprintf(stderr, "[OoT] foreign placement: %d MM pool items over %zu eligible host checks\n", poolCount,
+            candidates.size());
+
+    if (candidates.empty()) {
+        fprintf(stderr, "[OoT] foreign placement: no eligible OoT host check in this fill (#510)\n");
+        return -2;
+    }
+
+    // Deterministic from the paired-world identity alone: same seed + same
+    // settings profile => same placements. gComboCtx.sharedRandoSettingsHash is
+    // live by now (Playthrough_Init stamps it immediately before calling us), and
+    // the ":foreign-oot-v1" suffix keeps this stream disjoint from MM's
+    // ":foreign-v1" one so the two directions can never shadow each other.
+    sOoTSelectState = SohUtils::Hash(std::to_string(ctx->GetSeed()) + ":" +
+                                     std::to_string(gComboCtx.sharedRandoSettingsHash) + ":foreign-oot-v1");
+    if (sOoTSelectState == 0) {
+        sOoTSelectState = 0xB5297A4Du;
+    }
+
+    // BOTH sides are drawn without replacement. Drawing the ITEM matters as much
+    // as drawing the host: the pool is far larger than the cap, so walking it in
+    // order (as the forward pass does, where pool <= cap made that equivalent)
+    // would place the same first 8 entries in every seed and make the other ~126
+    // dead weight.
+    std::vector<int> poolIndices;
+    poolIndices.reserve((size_t)poolCount);
+    for (int i = 0; i < poolCount; i++) {
+        poolIndices.push_back(i);
+    }
+
+    const int wanted = std::min({ poolCount, (int)RSBS_FOREIGN_PLACEMENT_CAP, (int)candidates.size() });
+
+    int placed = 0;
+    for (int i = 0; i < wanted; i++) {
+        const size_t poolPick = (size_t)(OoT_Foreign_SelectNext() % (uint32_t)poolIndices.size());
+        const int poolEntry = poolIndices[poolPick];
+        poolIndices.erase(poolIndices.begin() + (std::ptrdiff_t)poolPick);
+
+        const size_t hostPick = (size_t)(OoT_Foreign_SelectNext() % (uint32_t)candidates.size());
+        const RandomizerCheck hostCheck = candidates[hostPick];
+        candidates.erase(candidates.begin() + (std::ptrdiff_t)hostPick);
+
+        if (Combo_SetForeignPlacementOoT((uint16_t)hostCheck, pool[poolEntry].item) >= 0) {
+            placed++;
+            fprintf(stderr, "[OoT] foreign placement: '%s' hosted at OoT check %s\n", pool[poolEntry].name,
+                    Rando::StaticData::GetLocation(hostCheck)->GetName().c_str());
+        }
+    }
+
+    return placed;
+}
+
+// ROM-free test bridge (redship tier; src/common/tests/test_foreign_items.c).
+// The SAME predicate the candidate loop above calls — exposed rather than
+// paraphrased in the test for the reason MM_Rando_Foreign_IsEligibleHost is: a
+// lock that restates the rule stops testing it the moment the rule moves.
+extern "C" int OoT_Foreign_IsEligibleHost(uint16_t rc) {
+    return OoT_Foreign_IsEligibleHostImpl((RandomizerCheck)rc) ? 1 : 0;
 }
 
 #endif // RSBS_SINGLE_EXECUTABLE

--- a/games/oot/soh/Enhancements/randomizer/hook_handlers.cpp
+++ b/games/oot/soh/Enhancements/randomizer/hook_handlers.cpp
@@ -16,6 +16,14 @@
 #include "soh/ObjectExtension/ObjectExtension.h"
 #include "soh/Enhancements/randomizer/randomizer.h"
 
+#ifdef RSBS_SINGLE_EXECUTABLE
+// src/common. OUTSIDE the extern "C" block below: these headers manage their own
+// linkage and pull in context.h, whose <type_traits> include must not be wrapped
+// in C linkage (see context.h's header comment).
+#include "foreign_items.h" // Combo_GetForeignPlacementForOoTCheck, Combo_GetForeignItemName (#510)
+#include "shared_items.h"  // Combo_RecordSharedItem (#510)
+#endif
+
 extern "C" {
 #include "macros.h"
 #include "functions.h"
@@ -360,6 +368,65 @@ void RandomizerOnPlayerUpdateForRCQueueHandler() {
 
     RandomizerCheck rc = randomizerQueuedChecks.front();
     auto loc = Rando::Context::GetInstance()->GetItemLocation(rc);
+
+#ifdef RSBS_SINGLE_EXECUTABLE
+    // #510 — the reverse direction's PRODUCER. This OoT check hosts an MM item
+    // (gComboCtx.foreignPlacementsOoT, written by OoT_PlaceForeignItems at
+    // generation). Hand it to the shared structure instead of OoT's give path;
+    // MM's already-wired consumer (MM_AwardSharedItem -> MM_ForeignItem_Give)
+    // awards it on the next arrival in Termina. The OoT item table still holds a
+    // junk item at this check — the placement table overrides it here, exactly as
+    // MM's CheckQueue foreign branch overrides its own table.
+    //
+    // Deliberately BEFORE the local getItemEntry resolution and the collectible
+    // drop: a foreign host must not also give its local item.
+    const SharedItem* foreignItem = Combo_GetForeignPlacementForOoTCheck((uint16_t)rc);
+    if (foreignItem != nullptr && !loc->HasObtained()) {
+        // Durable immediately (Combo_RecordSharedItem writes the serialized
+        // array, so an OoT save+quit before the next switch cannot lose the
+        // pickup), and de-duped by content so a re-fired queue cannot double it.
+        Combo_RecordSharedItem(GAME_MM, foreignItem->id);
+
+        // Presented as an ORDINARY OoT pickup (#510): "You found the Bunny
+        // Hood" — no mention of Termina, no "will be awarded there", no
+        // stand-in model. The item is not given locally (it belongs to MM's
+        // id-space), so nothing is dropped or held overhead; the toast is the
+        // whole presentation.
+        //
+        // A toast rather than a blue textbox is a SCOPE choice, not a technical
+        // one: OoT's item-get pipeline couples "show this item" to "grant this
+        // item", and there is no display-without-grant path, so routing a
+        // foreign item through it would also give it to OoT. Notification::Emit
+        // is the surface the OoT ARRIVAL half already uses for this exact item
+        // class (#494/#507, OoT_AwardSharedItem), it takes an arbitrary string,
+        // and it cannot interfere with the item-get queue. A fully native
+        // textbox is a follow-up that needs that display-only path first.
+        const char* foreignName = Combo_GetForeignItemName(*foreignItem);
+        const char* foreignArticle = Combo_GetForeignItemArticle(*foreignItem);
+        Notification::Emit({
+            .prefix = "You found",
+            .message = std::string(foreignArticle != nullptr ? foreignArticle : "") +
+                       (foreignName != nullptr ? foreignName : "a foreign item"),
+        });
+
+        // RCSHOW_COLLECTED is what HasObtained() reads (status == RCSHOW_COLLECTED
+        // || RCSHOW_SAVED), so this alone marks it obtained — there is no separate
+        // setter. Persisting the tracker section matters for correctness, not just
+        // display: an un-persisted collect would re-fire the check after a
+        // save/load and, once the first crossing had been REDEEMED, content
+        // de-dup would no longer suppress the second record.
+        loc->SetCheckStatus(RCSHOW_COLLECTED);
+        CheckTracker::SpoilAreaFromCheck(rc);
+        CheckTracker::RecalculateAllAreaTotals();
+        CheckTracker::RecalculateAvailableChecks();
+        SaveManager::Instance->SaveSection(gSaveContext.fileNum, SECTION_ID_TRACKER_DATA, true);
+
+        SPDLOG_INFO("Foreign (MM) item recorded from RC {}", static_cast<uint32_t>(rc));
+        randomizerQueuedChecks.pop();
+        return;
+    }
+#endif
+
     RandomizerGet vanillaRandomizerGet = Rando::StaticData::GetLocation(rc)->GetVanillaItem();
     GetItemID vanillaItem = (GetItemID)Rando::StaticData::RetrieveItem(vanillaRandomizerGet).GetItemID();
     GetItemEntry getItemEntry =

--- a/games/oot/soh/GameExports_SingleExe.cpp
+++ b/games/oot/soh/GameExports_SingleExe.cpp
@@ -1054,19 +1054,22 @@ static void OoT_AwardSharedItem(const SharedItem* item, void* ctx) {
     //
     // No .itemIcon: resolving one needs a per-item icon-name accessor that
     // src/common does not have yet (the Combo_GetForeignItemIconName tier of
-    // #494, which lands with Lane 1's pool surface). Emitting text-only is an
-    // existing idiom, not a degradation — the MOD_RANDOMIZER branch in
-    // hook_handlers.cpp omits the icon too — and it is the honest option: a
-    // wrong icon is worse than no icon for an item whose whole point is that it
-    // came from the other game.
+    // #494). Emitting text-only is an existing idiom, not a degradation — the
+    // MOD_RANDOMIZER branch in hook_handlers.cpp omits the icon too.
     //
-    // Name comes from the pinned pool via the origin-tagged SharedItem, so this
-    // never fabricates an id-space crossing. It returns NULL when the item's
-    // origin pool is not linked into this build, hence the fallback.
+    // WORDING (#510): "You got the Fairy Bow", not "Received from Termina: …".
+    // The arrival IS the moment the player receives it in OoT, so the native
+    // sentence is the correct one; naming the other game was the cross-game
+    // tell the operator asked to remove. Name and article both come from the
+    // pinned pool via the origin-tagged SharedItem, so this never fabricates an
+    // id-space crossing; both return NULL when that origin's pool is not linked
+    // into this build, hence the fallbacks.
     const char* foreignName = Combo_GetForeignItemName(*item);
+    const char* foreignArticle = Combo_GetForeignItemArticle(*item);
     Notification::Emit({
-        .prefix = "Received from Termina:",
-        .message = foreignName != nullptr ? foreignName : "a foreign item",
+        .prefix = "You got",
+        .message = std::string(foreignArticle != nullptr ? foreignArticle : "") +
+                   (foreignName != nullptr ? foreignName : "a foreign item"),
     });
 }
 

--- a/src/common/foreign_items.c
+++ b/src/common/foreign_items.c
@@ -93,6 +93,20 @@ const char* Combo_GetForeignItemName(SharedItem item) {
     return NULL;
 }
 
+const char* Combo_GetForeignItemArticle(SharedItem item) {
+    // Same origin-keyed walk as the name lookup — deliberately a separate entry
+    // point rather than a second out-param, so the spoiler surfaces (which want
+    // the bare name) are not forced to think about articles at all.
+    const ComboForeignItemDef* pool = NULL;
+    const int poolCount = Combo_GetForeignItemPoolFor(item.originGame, &pool);
+    for (int i = 0; i < poolCount; i++) {
+        if (pool[i].item.originGame == item.originGame && pool[i].item.id == item.id) {
+            return pool[i].article;
+        }
+    }
+    return NULL;
+}
+
 bool Combo_GetForeignItemByNameFor(uint8_t originGame, const char* name, SharedItem* outItem) {
     // The spoiler-LOAD inverse. Reused (not re-derived) so reconstruction shares
     // one source of truth with generation, and so a raw RG_*/RI_* is never

--- a/src/common/foreign_items.h
+++ b/src/common/foreign_items.h
@@ -45,9 +45,24 @@ extern "C" {
  * spoiler stays meaningful without OoT's enum in scope).
  */
 typedef struct {
-    SharedItem item;  // originGame == GAME_OOT, flags == 0, id == the RG_* value
-    const char* name; // e.g. "Progressive Hookshot"
+    SharedItem item;     // originGame == GAME_OOT, flags == 0, id == the RG_* value
+    const char* name;    // e.g. "Progressive Hookshot"
+    const char* article; // "the ", "a ", "an " or "" — see below
 } ComboForeignItemDef;
+
+// WHY THE ARTICLE IS PART OF THE DESCRIPTOR (#510). A cross-game item is
+// presented as an ORDINARY pickup of whichever game the player found it in —
+// "You found the Bomb Bag!", never "it belongs to the other game". Both games
+// build that sentence by prepending a per-item article (MM:
+// Rando::StaticData::Items[].article; OoT: Item::GetArticle()), but the HOST
+// game cannot look up the FOREIGN game's item table — that is the whole ADR 0002
+// boundary. So the article has to travel with the pooled descriptor, exactly as
+// the display name already does. Without it the presentation has to hardcode
+// "the ", which is wrong for a third of the pool ("a Bottle of Milk", "an Empty
+// Bottle") and instantly reads as machine-generated.
+//
+// Includes its own trailing space when non-empty, so callers concatenate
+// article + name with no separator logic.
 
 // ============================================================================
 // The pinned pools, indexed by ORIGIN game (ADR 0009 decision 3)
@@ -116,6 +131,17 @@ int Combo_GetForeignItemPool(const ComboForeignItemDef** outPool);
  * purpose: a redeemed entry keeps its name.
  */
 const char* Combo_GetForeignItemName(SharedItem item);
+
+/**
+ * The article that belongs in front of Combo_GetForeignItemName's result, or
+ * NULL if (originGame, id) is not in that origin's pinned pool. Carries its own
+ * trailing space when non-empty, so `article + name` needs no separator.
+ *
+ * Split from the name rather than baked into it because the two are consumed
+ * separately: a spoiler line wants the bare name, a pickup textbox wants the
+ * full "the Bomb Bag" phrase. See the note on ComboForeignItemDef.article.
+ */
+const char* Combo_GetForeignItemArticle(SharedItem item);
 
 /**
  * The inverse of Combo_GetForeignItemName, keyed on (originGame, name). Used by
@@ -227,6 +253,52 @@ void Combo_ClearForeignPlacementsOoT(void);
  *         the redemption bit is set by the caller's consumer either way).
  */
 int OoT_ForeignItem_Give(uint16_t rgId);
+
+// ============================================================================
+// Reverse-direction PRODUCER: OoT's generation-time placement pass (#510)
+// ============================================================================
+//
+// Both are defined in games/oot/soh/Enhancements/randomizer/
+// ForeignItemsSingleExe.cpp and exist ONLY under RSBS_SINGLE_EXECUTABLE — the
+// whole cross-game item class is single-exe-only. Playthrough_Init is an
+// ordinary (non-single-exe) function, so its call site MUST be wrapped in
+// `#ifdef RSBS_SINGLE_EXECUTABLE` or a plain OoT build fails to link.
+
+/**
+ * Place MM-origin items (kForeignPoolMMV1) into eligible OoT checks, recording
+ * them in gComboCtx.foreignPlacementsOoT. Called once per generation from
+ * Playthrough_Init, AFTER the gComboCtx pairing stamp — the placement is derived
+ * from that identity, so it must be live first.
+ *
+ * Selection is deterministic (a local xorshift32 seeded from seed + settings
+ * digest, never from the fill's own RNG stream) and draws BOTH the pool entry
+ * and the host without replacement, because the MM pool is far larger than
+ * RSBS_FOREIGN_PLACEMENT_CAP.
+ *
+ * @return the number of placements made (>= 0; 0 when no pairing is active,
+ *         which is the normal solo-rando case), or NEGATIVE when the pairing IS
+ *         active but could not be honoured at all: -1 no MM pool registered,
+ *         -2 no eligible host in the finished fill. Callers propagate the
+ *         negative through Playthrough_Init's existing return-code convention.
+ *         It never throws — the generation chain crosses an extern "C" boundary
+ *         with no try/catch, where an exception is a std::terminate.
+ */
+int OoT_PlaceForeignItems(void);
+
+/**
+ * May OoT check `rc` host a foreign item? The real selection predicate
+ * OoT_PlaceForeignItems' candidate loop uses, exposed for the CI lock so the
+ * test drives selection rather than a paraphrase of it.
+ *
+ * True only for a genuine treasure chest (Location::GetActorID() == ACTOR_EN_BOX
+ * — OoT has no RCTYPE_CHEST; chests are RCTYPE_STANDARD) that is not commerce
+ * and whose FILL placed a junk-category item there. The junk requirement is the
+ * degrade invariant: if the placement table is ever absent, the check quietly
+ * yields the ordinary item it really holds.
+ *
+ * @return 1 if eligible, 0 otherwise.
+ */
+int OoT_Foreign_IsEligibleHost(uint16_t rc);
 
 #ifdef __cplusplus
 }

--- a/src/common/test_runner.cpp
+++ b/src/common/test_runner.cpp
@@ -630,6 +630,174 @@ TestResult Test_RandoDeterminism(void) {
     return mmRc == 0 ? TEST_PASS : TEST_FAIL;
 }
 
+// ============================================================================
+// #510: the REVERSE foreign pool, end to end through a real OoT generation.
+//
+// WHY THIS ROW IS IN THE `rando` TIER AND NOT THE DISPLAY-FREE ONE. OoT's host
+// predicate reads GetPlacedRandomizerGet() — a FILL RESULT. In a ROM-free run
+// with no fill every location is RG_NONE, so the predicate accepts nothing and a
+// naive "only chests are accepted" assertion passes with an accepted count of
+// ZERO: green, and testing nothing. That is the same vacuity trap #491 recorded
+// for MM's deferred COND_HOOK unregister. The defence is structural — run a real
+// generation first — plus an explicit assertion that the accepted count is
+// NON-ZERO, and printing it so a supply regression is visible in CI logs before
+// it becomes a shortfall.
+//
+// Bridges: OoT_Foreign_IsEligibleHost is the real predicate the placement pass
+// uses; MM_ConsumeSharedItems -> MM_AwardSharedItem -> MM_ForeignItem_Give is
+// MM's real, already-merged (#507) award chain.
+// ============================================================================
+extern "C" {
+int OoT_Foreign_IsEligibleHost(uint16_t rc);
+void MM_ConsumeSharedItems(void);
+int MM_ForeignItem_TestPendingCount(void);
+uint16_t MM_ForeignItem_TestPendingAt(int index);
+void MM_ForeignItem_TestResetPending(void);
+}
+
+TestResult Test_ForeignPlacementOoT(void) {
+    printf("[TEST] foreign-placement-oot: a real OoT generation hosts MM items, deterministically, and MM's award "
+           "chain accepts them (#510)\n");
+
+    auto shipCtx = CreateHarnessStyleContext();
+    if (!shipCtx) {
+        printf("[TEST] FAIL: could not create Ship::Context singleton\n");
+        return TEST_FAIL;
+    }
+
+    static char arg0[] = "redship";
+    static char* fakeArgv[] = { arg0, nullptr };
+    InitOTRForMMFirstBoot(1, fakeArgv);
+
+    // A REAL fill. Everything below depends on this having run — without it the
+    // predicate is vacuous and the placement table is empty.
+    const char* kSeed = "RSBSFOREIGN1";
+    int rc = Rando_HeadlessSeedTest(kSeed);
+    if (rc != 0) {
+        printf("[TEST] FAIL: seed generation rc=%d\n", rc);
+        return TEST_FAIL;
+    }
+
+    // The producer's gate: generation stamps the pairing identity, so by now the
+    // reverse placement pass has run inside Playthrough_Init.
+    if (!Combo_ForeignPairingActive()) {
+        printf("[TEST] FAIL: generation did not stamp the pairing identity\n");
+        return TEST_FAIL;
+    }
+
+    // ------------------------------------------------------------------
+    // Host supply: NON-ZERO, and printed.
+    // ------------------------------------------------------------------
+    int eligibleHosts = 0;
+    for (int id = 1; id < 4200; id++) { // RC_MAX is ~4134; the predicate rejects out-of-range itself
+        if (OoT_Foreign_IsEligibleHost((uint16_t)id)) {
+            eligibleHosts++;
+        }
+    }
+    printf("[TEST] foreign-placement-oot: %d eligible OoT host checks after a real fill\n", eligibleHosts);
+    if (eligibleHosts <= 0) {
+        printf("[TEST] FAIL: no eligible OoT host check — the predicate accepts nothing (vacuity)\n");
+        return TEST_FAIL;
+    }
+
+    // ------------------------------------------------------------------
+    // Placements: made, MM-tagged, named, and hosted on eligible checks.
+    // ------------------------------------------------------------------
+    const int placedCount = Combo_CountForeignPlacementsOoT();
+    printf("[TEST] foreign-placement-oot: %d MM items hosted in OoT checks (cap %d)\n", placedCount,
+           (int)RSBS_FOREIGN_PLACEMENT_CAP);
+    if (placedCount <= 0) {
+        printf("[TEST] FAIL: generation placed no MM items despite an active pairing\n");
+        return TEST_FAIL;
+    }
+    if (placedCount > (int)RSBS_FOREIGN_PLACEMENT_CAP) {
+        printf("[TEST] FAIL: placement count %d exceeds the carve\n", placedCount);
+        return TEST_FAIL;
+    }
+
+    for (int slot = 0; slot < (int)RSBS_FOREIGN_PLACEMENT_CAP; slot++) {
+        const ComboForeignPlacement& p = gComboCtx.foreignPlacementsOoT[slot];
+        if (p.item.originGame == (uint8_t)GAME_NONE) {
+            continue; // unset slot
+        }
+        if (p.item.originGame != (uint8_t)GAME_MM) {
+            printf("[TEST] FAIL: OoT-hosted placement in slot %d is not MM-tagged (%u)\n", slot,
+                   (unsigned)p.item.originGame);
+            return TEST_FAIL;
+        }
+        // Resolvable through the pool: the spoiler and both presentation surfaces
+        // read the name through exactly this call.
+        if (Combo_GetForeignItemName(p.item) == nullptr) {
+            printf("[TEST] FAIL: hosted MM item id=%u resolves to no pool entry\n", (unsigned)p.item.id);
+            return TEST_FAIL;
+        }
+        // The host must still satisfy the predicate that selected it — it keeps
+        // its own junk item, which is the degrade invariant (#488): with the
+        // placement table absent the check just yields the junk it really holds.
+        if (!OoT_Foreign_IsEligibleHost(p.mmCheckId)) {
+            printf("[TEST] FAIL: OoT check %u hosts an MM item but is not an eligible host\n",
+                   (unsigned)p.mmCheckId);
+            return TEST_FAIL;
+        }
+    }
+
+    // ------------------------------------------------------------------
+    // MM's REAL award chain accepts a really-placed item, exactly once.
+    // ------------------------------------------------------------------
+    // The in-game pickup seam (hook_handlers.cpp) needs a live PlayState and is
+    // gameplay-tier, so this drives the half CI can honestly reach: record the
+    // crossing the way the seam does, then run MM's real consumer. With no
+    // PlayState the give DEFERS into MM's pending queue (#502) rather than
+    // dereferencing — so the queue is the observable that the id survived the
+    // whole path in MM's id-space.
+    const SharedItem firstPlaced = gComboCtx.foreignPlacementsOoT[0].item;
+    Combo_ClearSharedItemOutbox();
+    MM_ForeignItem_TestResetPending();
+    if (Combo_RecordSharedItem(GAME_MM, firstPlaced.id) < 0) {
+        printf("[TEST] FAIL: could not record the crossing\n");
+        return TEST_FAIL;
+    }
+    MM_ConsumeSharedItems();
+    if (MM_ForeignItem_TestPendingCount() != 1 || MM_ForeignItem_TestPendingAt(0) != firstPlaced.id) {
+        printf("[TEST] FAIL: MM's award chain did not accept the placed item (pending=%d)\n",
+               MM_ForeignItem_TestPendingCount());
+        return TEST_FAIL;
+    }
+    // Single-use: a second arrival awards nothing more.
+    MM_ForeignItem_TestResetPending();
+    MM_ConsumeSharedItems();
+    if (MM_ForeignItem_TestPendingCount() != 0) {
+        printf("[TEST] FAIL: crossing awarded twice\n");
+        return TEST_FAIL;
+    }
+    MM_ForeignItem_TestResetPending();
+
+    // ------------------------------------------------------------------
+    // DETERMINISM: the same seed reproduces the same placements exactly.
+    // ------------------------------------------------------------------
+    // The selection stream is a LOCAL xorshift32 seeded from the paired identity,
+    // deliberately not drawn from the fill's RNG. If it ever started borrowing
+    // Random_Init's stream — or iterating an unordered container — this is what
+    // goes red, and it is the same property the SeedDeterminism digest folds.
+    ComboForeignPlacement firstRun[RSBS_FOREIGN_PLACEMENT_CAP];
+    memcpy(firstRun, gComboCtx.foreignPlacementsOoT, sizeof(firstRun));
+
+    rc = Rando_HeadlessSeedTest(kSeed);
+    if (rc != 0) {
+        printf("[TEST] FAIL: second seed generation rc=%d\n", rc);
+        return TEST_FAIL;
+    }
+    if (memcmp(firstRun, gComboCtx.foreignPlacementsOoT, sizeof(firstRun)) != 0) {
+        printf("[TEST] FAIL: same seed produced different foreign placements (nondeterministic)\n");
+        return TEST_FAIL;
+    }
+
+    Combo_ClearSharedItemOutbox();
+    printf("[TEST] PASS: %d MM items hosted over %d eligible OoT checks, deterministic, MM awards each once\n",
+           placedCount, eligibleHosts);
+    return TEST_PASS;
+}
+
 // Lane C0 reachability lock (#392): MM's 2ship_rando is un-elided and
 // actually generates — ShipInit registrars populated the Logic/Regions
 // graph, OnFileCreate runs GeneratePools + a logic apply headlessly, and the
@@ -1450,6 +1618,11 @@ const TestDescriptor gTests[] = {
     // Lane C0: MM's randomizer is reachable and generates headlessly. Needs a
     // display like rando-gen, so `--test all` skips it (below).
     {"mm-rando-gen", "MM rando generation runs headlessly + writes tagged spoiler (Lane C0)", Test_MMRandoGen},
+    // #510: the reverse pool end to end over a REAL fill. In this tier, not the
+    // display-free one, because OoT's host predicate reads a fill result — with
+    // no fill it accepts nothing and the lock would pass vacuously.
+    {"foreign-placement-oot", "Real OoT fill hosts MM items deterministically; MM's award chain accepts them (#510)",
+     Test_ForeignPlacementOoT},
     // #439: the paired world must activate on the SWITCH-ENTRY path (the only
     // flow a player actually takes), not just the direct OnSaveInit chain.
     // Same display requirement as mm-rando-gen, so `--test all` skips it.
@@ -1504,6 +1677,11 @@ const TestDescriptor gTests[] = {
     // fprintf; this one drives the real one and the real give behind it.
     {"foreign-award-mm", "MM's real award reaches the real give: once per crossing, deferred safely (#502)",
      Test_ForeignAwardMM},
+    // #510: the reverse direction's SOURCE pool. Display-free — the table is a
+    // static in the WHOLE_ARCHIVE'd 2ship_rando and its registrar runs before
+    // main() — so this also proves that registrar survived the link.
+    {"foreign-pool-mm", "MM's cross-game source pool: registered, well-formed, giveable, non-junk (#510)",
+     Test_ForeignPoolMM},
     {"combo-spoiler-view", "In-game spoiler view model: named crossings, collected state, unpaired != empty (#496)",
      Test_ComboSpoilerView},
     {"combo-spoiler-window", "Common-owned spoiler window registers de-collided; inert under every active game (#496)",
@@ -1692,7 +1870,8 @@ int TestRunner_Run(const char* testName) {
                 strcmp(gTests[i].name, "mm-pair-switch-entry") == 0 ||
                 strcmp(gTests[i].name, "mm-reload-arm-state") == 0 ||
                 strcmp(gTests[i].name, "mm-moon-crash-arm-state") == 0 ||
-                strcmp(gTests[i].name, "mm-owl-save-arm-state") == 0) {
+                strcmp(gTests[i].name, "mm-owl-save-arm-state") == 0 ||
+                strcmp(gTests[i].name, "foreign-placement-oot") == 0) {
                 printf("\n--- Skipping: %s (needs display; runs as a rando-label CTest) ---\n", gTests[i].name);
                 continue;
             }

--- a/src/common/tests/test_foreign_items.c
+++ b/src/common/tests/test_foreign_items.c
@@ -60,6 +60,21 @@ int MM_Rando_Foreign_TestCheckClass(uint16_t randoCheckId, int* outIsChestType, 
 void MM_Rando_Foreign_TestStampCheck(uint16_t randoCheckId, int shuffled, int skipped, uint16_t itemId);
 void MM_Rando_Foreign_TestStampAllChecks(int shuffled, int skipped, uint16_t itemId);
 void MM_Rando_Foreign_TestItemSentinels(uint16_t* outJunk, uint16_t* outNone, uint16_t* outUnknown);
+
+// #510 reverse-pool bridges (games/mm/2s2h/Rando/ForeignItemsSingleExe.cpp).
+// The first is the REAL id predicate MM_ForeignItem_Give gates on; the second
+// reports an item's class straight out of MM's own table. Both are read from MM
+// rather than re-derived here, so a pool row whose classification changes
+// upstream moves this lock with it instead of leaving it asserting a stale copy.
+int MM_ForeignItem_TestIsGiveableId(uint16_t riId);
+int MM_ForeignItem_TestIsJunkClassId(uint16_t riId);
+
+// #510 OoT-side host predicate (games/oot/soh/Enhancements/randomizer/
+// ForeignItemsSingleExe.cpp) — the SAME function OoT_PlaceForeignItems' candidate
+// loop calls. Its fill-side half reads GetPlacedRandomizerGet(), so it accepts
+// nothing until a real generation has run: see Test_ForeignPlacementOoT, which
+// lives in the display-requiring `rando` tier for exactly that reason.
+int OoT_Foreign_IsEligibleHost(uint16_t rc);
 }
 
 #define FI_ASSERT(cond)                                                                                                \
@@ -144,6 +159,13 @@ TestResult Test_ForeignItemGive(void) {
         FI_ASSERT(pool[i].item.flags == 0);
         FI_ASSERT(pool[i].name != NULL && pool[i].name[0] != '\0');
         FI_ASSERT(Combo_GetForeignItemName(pool[i].item) == pool[i].name);
+        // #510: MM's pickup textbox reads "You found " + article + name, and MM
+        // cannot look up OoT's item table for the article — so it rides here.
+        FI_ASSERT(pool[i].article != NULL);
+        FI_ASSERT(Combo_GetForeignItemArticle(pool[i].item) == pool[i].article);
+        if (pool[i].article[0] != '\0') {
+            FI_ASSERT(pool[i].article[strlen(pool[i].article) - 1] == ' ');
+        }
     }
     // (originGame, name) uniqueness WITHIN a pool. Two entries sharing a name
     // in one id-space would make that origin's inverse ambiguous, which no
@@ -160,7 +182,17 @@ TestResult Test_ForeignItemGive(void) {
         SharedItem back;
         FI_ASSERT(Combo_GetForeignItemByNameFor((uint8_t)GAME_OOT, pool[i].name, &back));
         FI_ASSERT(back.originGame == pool[i].item.originGame && back.id == pool[i].item.id);
-        FI_ASSERT(!Combo_GetForeignItemByNameFor((uint8_t)GAME_MM, pool[i].name, NULL));
+        // NOT "the name must not exist in MM's pool": since #510 a real MM pool
+        // is registered and "Bomb Bag" is a genuine row in BOTH id-spaces, so
+        // that assertion would be false-by-design. The invariant that actually
+        // matters is that the two id-spaces never bleed: if the name resolves
+        // under GAME_MM at all, it comes back MM-tagged and is a DIFFERENT item
+        // from the OoT row of the same name.
+        SharedItem mmSide;
+        if (Combo_GetForeignItemByNameFor((uint8_t)GAME_MM, pool[i].name, &mmSide)) {
+            FI_ASSERT(mmSide.originGame == (uint8_t)GAME_MM);
+            FI_ASSERT(mmSide.originGame != back.originGame);
+        }
         FI_ASSERT(!Combo_GetForeignItemByNameFor((uint8_t)GAME_NONE, pool[i].name, NULL));
     }
 
@@ -180,20 +212,33 @@ TestResult Test_ForeignItemGive(void) {
     // renaming an item away from its real name — would degrade the spoiler to
     // work around a lookup bug. We assert the collision is HANDLED instead.
     //
-    // A synthetic MM pool stands in until the real one lands (Lane 6 creates
-    // 2s2h/Rando/ForeignItemsSingleExe.cpp; Lane 1 fills kForeignPoolMMV1 into
-    // it). When it does, switch this block to the real pool and drop the
-    // registry restore below.
+    // Driven against the REAL MM pool since #510 (kForeignPoolMMV1). The
+    // synthetic stand-in that used to live here — and its
+    // Combo_RegisterForeignItemPool / un-register pair — is GONE, deliberately:
+    // registering over the real pool clobbers process-global state, and the
+    // un-register left GAME_MM with NO pool for every later row in
+    // `--test all`. The collision is real now, so it is tested for real.
     {
-        static const ComboForeignItemDef kSyntheticMMPool[] = {
-            { { (uint8_t)GAME_MM, 0, 0x0037 }, "Bomb Bag" },   // deliberately collides with the OoT pool
-            { { (uint8_t)GAME_MM, 0, 0x0041 }, "Hero's Bow" },
-        };
-        FI_ASSERT(Combo_GetForeignItemPoolFor((uint8_t)GAME_MM, NULL) == 0); // nothing registered yet
-        Combo_RegisterForeignItemPool((uint8_t)GAME_MM, kSyntheticMMPool, 2);
-
         const ComboForeignItemDef* mmPool = NULL;
-        FI_ASSERT(Combo_GetForeignItemPoolFor((uint8_t)GAME_MM, &mmPool) == 2 && mmPool == kSyntheticMMPool);
+        const int mmPoolCount = Combo_GetForeignItemPoolFor((uint8_t)GAME_MM, &mmPool);
+        FI_ASSERT(mmPoolCount >= 1 && mmPool != NULL); // MM's file-scope registrar ran
+
+        // The collision this whole surface exists for must ACTUALLY be present in
+        // the two real pools, or everything below passes for want of a conflict.
+        int ootBombBagIdx = -1;
+        for (int k = 0; k < poolCount; k++) {
+            if (strcmp(pool[k].name, "Bomb Bag") == 0) {
+                ootBombBagIdx = k;
+            }
+        }
+        int mmBombBagIdx = -1;
+        for (int k = 0; k < mmPoolCount; k++) {
+            if (strcmp(mmPool[k].name, "Bomb Bag") == 0) {
+                mmBombBagIdx = k;
+            }
+        }
+        FI_ASSERT(ootBombBagIdx >= 0); // OoT's RG_BOMB_BAG row
+        FI_ASSERT(mmBombBagIdx >= 0);  // MM's RI_BOMB_BAG_20 row
 
         // The colliding bare name resolves to a DIFFERENT item under each
         // origin — never to the same one, and never to nothing.
@@ -202,21 +247,12 @@ TestResult Test_ForeignItemGive(void) {
         FI_ASSERT(Combo_GetForeignItemByNameFor((uint8_t)GAME_MM, "Bomb Bag", &fromMM));
         FI_ASSERT(fromOoT.originGame == (uint8_t)GAME_OOT);
         FI_ASSERT(fromMM.originGame == (uint8_t)GAME_MM);
-        FI_ASSERT(fromMM.id == 0x0037);
-        // Pin the OoT side to the REAL pool row rather than asserting the two
+        // Pin BOTH sides to their real pool rows rather than asserting the two
         // results merely differ. Comparing (id, origin) pairs would be
-        // tautological here — the two origins are already asserted distinct
-        // just above — and would still pass if the OoT lookup returned the
-        // wrong OoT item.
-        int ootBombBagIdx = -1;
-        for (int k = 0; k < poolCount; k++) {
-            if (strcmp(pool[k].name, "Bomb Bag") == 0) {
-                ootBombBagIdx = k;
-            }
-        }
-        FI_ASSERT(ootBombBagIdx >= 0); // the collision this block exists for must actually be present
+        // tautological — the origins are already asserted distinct just above —
+        // and would still pass if a lookup returned the wrong row of its own pool.
         FI_ASSERT(fromOoT.id == pool[ootBombBagIdx].item.id);
-        FI_ASSERT(fromOoT.id != fromMM.id); // the two id-spaces really did yield different items
+        FI_ASSERT(fromMM.id == mmPool[mmBombBagIdx].item.id);
 
         // The legacy bare-name entry point keeps its exact previous meaning:
         // the OoT pool. Call sites that predate the origin dimension must not
@@ -225,31 +261,25 @@ TestResult Test_ForeignItemGive(void) {
         FI_ASSERT(Combo_GetForeignItemByName("Bomb Bag", &legacy));
         FI_ASSERT(legacy.originGame == (uint8_t)GAME_OOT && legacy.id == fromOoT.id);
 
-        // Forward direction dispatches on the item's own tag: two items with
-        // the SAME id in different id-spaces must not resolve to one name.
-        SharedItem mmBow;
-        mmBow.originGame = (uint8_t)GAME_MM;
-        mmBow.flags = 0;
-        mmBow.id = 0x0041;
-        FI_ASSERT(Combo_GetForeignItemName(mmBow) != NULL);
-        FI_ASSERT(strcmp(Combo_GetForeignItemName(mmBow), "Hero's Bow") == 0);
-        SharedItem ootSameId = mmBow;
+        // Forward direction dispatches on the item's own tag: two items with the
+        // SAME raw id in different id-spaces must not resolve to one name.
+        const ComboForeignItemDef& mmProbe = mmPool[0];
+        FI_ASSERT(Combo_GetForeignItemName(mmProbe.item) != NULL);
+        FI_ASSERT(strcmp(Combo_GetForeignItemName(mmProbe.item), mmProbe.name) == 0);
+        SharedItem ootSameId = mmProbe.item;
         ootSameId.originGame = (uint8_t)GAME_OOT;
         // Same raw id, OoT id-space: must not borrow MM's name. (It may be a
         // real OoT pool entry with its OWN name, or nothing; either is correct,
         // borrowing MM's is not.)
         const char* ootName = Combo_GetForeignItemName(ootSameId);
-        FI_ASSERT(ootName == NULL || strcmp(ootName, "Hero's Bow") != 0);
+        FI_ASSERT(ootName == NULL || strcmp(ootName, mmProbe.name) != 0);
 
         // An untagged item resolves to no pool and therefore to no name.
         SharedItem untaggedName;
         untaggedName.originGame = (uint8_t)GAME_NONE;
         untaggedName.flags = 0;
-        untaggedName.id = 0x0037;
+        untaggedName.id = mmProbe.item.id;
         FI_ASSERT(Combo_GetForeignItemName(untaggedName) == NULL);
-
-        Combo_RegisterForeignItemPool((uint8_t)GAME_MM, NULL, 0); // restore process-global state
-        FI_ASSERT(Combo_GetForeignItemPoolFor((uint8_t)GAME_MM, NULL) == 0);
     }
 
     // ------------------------------------------------------------------
@@ -717,5 +747,92 @@ TestResult Test_ForeignHostEligibility(void) {
     FI_ASSERT(MM_Rando_Foreign_IsEligibleHost(chest) == 0);
 
     printf("[TEST] PASS: only chest-class hosts with a live, non-skipped, legal-junk slot can host a foreign item\n");
+    return TEST_PASS;
+}
+
+// ============================================================================
+// #510: the reverse direction's SOURCE pool (kForeignPoolMMV1).
+//
+// The MM twin of the pool-sanity block inside Test_ForeignItemGive, plus the
+// two membership rules that pool is authored under. Display-free: the table is a
+// static in the WHOLE_ARCHIVE'd 2ship_rando and its registrar runs before main(),
+// so this needs no fill, no save and no window.
+//
+// This row is also the runtime proof that MM's registrar SURVIVED THE LINK. The
+// dead-registrar class (#516) is silent at compile and link time — a dropped
+// file-scope initializer just leaves the pool empty — and an empty pool would
+// make OoT_PlaceForeignItems return -1 and fail every paired generation.
+// ============================================================================
+TestResult Test_ForeignPoolMM(void) {
+    printf("[TEST] foreign-pool-mm: MM's cross-game source pool is registered, well-formed and non-junk (#510)\n");
+
+    const ComboForeignItemDef* pool = NULL;
+    const int poolCount = Combo_GetForeignItemPoolFor((uint8_t)GAME_MM, &pool);
+    printf("[TEST] foreign-pool-mm: %d MM source items registered (placement cap is %d per seed)\n", poolCount,
+           (int)RSBS_FOREIGN_PLACEMENT_CAP);
+    FI_ASSERT(pool != NULL);
+    // Deliberately NOT `poolCount <= RSBS_FOREIGN_PLACEMENT_CAP` (the shape the
+    // OoT pool's static_assert uses). The cap bounds PLACEMENTS PER SEED, not
+    // candidates; this pool is intentionally far larger so the per-seed draw
+    // varies. A pool clamped to the cap would be the bug, not the guarantee.
+    FI_ASSERT(poolCount >= 1);
+
+    for (int i = 0; i < poolCount; i++) {
+        FI_ASSERT(pool[i].item.originGame == (uint8_t)GAME_MM);
+        FI_ASSERT(pool[i].item.id != 0); // RI_UNKNOWN is enumerator 0
+        FI_ASSERT(pool[i].item.flags == 0);
+        FI_ASSERT(pool[i].name != NULL && pool[i].name[0] != '\0');
+        FI_ASSERT(Combo_GetForeignItemName(pool[i].item) == pool[i].name);
+
+        // #510 presentation: OoT builds the pickup line as article + name, and
+        // it cannot read MM's item table to get the article — so every row must
+        // carry one. NULL would print "You found Bomb Bag"; the empty string is
+        // legal and correct for the several MM items that take no article
+        // ("Garo's Mask", "Epona's Song").
+        FI_ASSERT(pool[i].article != NULL);
+        FI_ASSERT(Combo_GetForeignItemArticle(pool[i].item) == pool[i].article);
+        // A non-empty article carries its own trailing space, so callers
+        // concatenate with no separator logic. Catches "the" for "the ".
+        if (pool[i].article[0] != '\0') {
+            FI_ASSERT(pool[i].article[strlen(pool[i].article) - 1] == ' ');
+        }
+
+        // Membership rule (1): every entry must be an id MM's own give ACCEPTS.
+        // Driven through the real predicate MM_ForeignItem_Give gates on, not a
+        // copy of it — an entry it refuses is an item the player is promised in
+        // OoT ("it will be awarded there!") and then never receives in Termina.
+        FI_ASSERT(MM_ForeignItem_TestIsGiveableId(pool[i].item.id) == 1);
+
+        // Membership rule (2): no junk-class item may be a cross-game SOURCE.
+        // Junk is what a foreign HOST degrades to, so crossing it would spend one
+        // of at most RSBS_FOREIGN_PLACEMENT_CAP slots on a strictly worse
+        // duplicate of what the host already physically holds. -1 would mean the
+        // id names no row in MM's table at all.
+        FI_ASSERT(MM_ForeignItem_TestIsJunkClassId(pool[i].item.id) == 0);
+    }
+
+    // (originGame, name) uniqueness WITHIN the pool, and id uniqueness with it. A
+    // duplicate name makes this origin's spoiler-load inverse ambiguous, which no
+    // amount of origin dispatch can repair — it is the same defect the (origin,
+    // name) key exists to prevent, arriving from inside one pool instead of
+    // between two.
+    for (int i = 0; i < poolCount; i++) {
+        for (int j = i + 1; j < poolCount; j++) {
+            FI_ASSERT(strcmp(pool[i].name, pool[j].name) != 0);
+            FI_ASSERT(pool[i].item.id != pool[j].item.id);
+        }
+    }
+
+    // Round-trip through the origin-keyed inverse — the spoiler-LOAD path, which
+    // rebuilds a placement table from untrusted text on disk and must never have
+    // to fabricate an RI_*.
+    for (int i = 0; i < poolCount; i++) {
+        SharedItem back;
+        FI_ASSERT(Combo_GetForeignItemByNameFor((uint8_t)GAME_MM, pool[i].name, &back));
+        FI_ASSERT(back.originGame == (uint8_t)GAME_MM && back.id == pool[i].item.id);
+        FI_ASSERT(!Combo_GetForeignItemByNameFor((uint8_t)GAME_NONE, pool[i].name, NULL));
+    }
+
+    printf("[TEST] PASS: MM source pool registered, well-formed, giveable, non-junk, name-invertible\n");
     return TEST_PASS;
 }


### PR DESCRIPTION
Closes #510.

Builds the **OoT producer** half of the cross-game item class — the thing that actually puts an MM item into an OoT world. The reverse GIVE and the `foreignPlacementsOoT` carve already landed (#493 / #507), so `MM_AwardSharedItem` was sitting there wired to a table nothing ever wrote.

Then, per operator direction mid-review, it also removes every "this item is from the other game" tell.

## What's here

**MM source pool** — `kForeignPoolMMV1`, 134 entries, in the one MM TU allowed to name raw `RI_*` (ADR 0002). Rule-defined rather than hand-picked, and every exclusion is a rule rather than taste:

| Excluded | Because |
|---|---|
| sentinels (`RI_UNKNOWN`/`RI_NONE`/`RI_JUNK`) | not items; the #488 sentinel trap |
| the junk class | junk is what a foreign **host** degrades to — crossing it is a strictly worse duplicate of what the host already holds, burning one of ≤8 slots |
| souls, ocarina buttons, swim, clock items | give is a bare flag that only means anything under a specific MM shuffle setting — and OoT's placement pass runs at OoT generation time, possibly before the paired MM world exists, so it **cannot** read MM's option profile. A settings-gated entry is an item the player is promised and never receives |
| Triforce pieces | the give fires `GameInteractor_ExecuteOnGameCompletion()` **and queues a forced scene transition**, out of the redemption flush |
| `RI_TRAP` | a curse, not a gift |

`RSBS_FOREIGN_PLACEMENT_CAP` caps **placements per seed**, not candidates, so the pool is deliberately *not* `static_assert`'d small.

**Host predicate** — `OoT_Foreign_IsEligibleHost`. The asymmetry that matters: **OoT has no `RCTYPE_CHEST`.** MM classifies chests with a dedicated check type; OoT's chests are `RCTYPE_STANDARD` identified by `ACTOR_EN_BOX` on the `Location`. So the predicate keys on `GetActorID()`, and separately on the `ItemLocation`'s placed item being junk-category — two different objects from two different accessors.

**Placement pass** — `OoT_PlaceForeignItems`, called from `Playthrough_Init` after the pairing stamp. Draws **both** the pool entry and the host without replacement from a local xorshift32 seeded off the paired identity, never from the fill's own RNG (which would move the OoT world as a side effect of the feature being on). Drawing the *item* matters as much as the host: with 134 candidates against a cap of 8, walking the pool in order would ship the same first 8 items every seed.

Shortfall is signalled by a **negative return, never a throw**. The generation chain has no `try`/`catch` and crosses an `extern "C"` boundary (`Rando_HeadlessSeedTest`), where an exception is a `std::terminate` that kills headless CI and the live generate alike. A *partial* placement is not a shortfall and returns `>= 0`.

**Pickup recorder** in `hook_handlers.cpp` — a hosting check records the crossing and does not give its local item.

## Presented as an ordinary pickup

A foreign item used to announce itself three ways: a giant-rupee stand-in model, a particle aura on the chest, and a textbox explaining the item belonged to the other game. All three are gone.

```
MM   "You found the Fairy Bow!"     was  "…It belongs to Ocarina of Time -
                                          it will be awarded there!"
OoT  "You found the Bunny Hood"     was  "- it belongs to Termina and will
                                          be awarded there!"
OoT  "You got the Fairy Bow"        was  "Received from Termina: …"
```

**On the model.** We cannot draw the other game's real one, and the blocker is specific: `oot.o2r` and `mm.o2r` share **one flat `ArchiveManager` namespace with 151 documented object collisions** (`docs/resource-namespace-audit.md`) — 41 of them in exactly the `object_gi_*` class this would need — and the other game's archive isn't even mounted until that game has been entered (`EnsureGameArchivesLoaded`). A by-path lookup is ambiguous precisely where it matters.

So MM uses **its own model-less pickup form** (`RI_NONE` → `DrawSparkles`), the identical presentation it already gives Magic Upgrades, the Swim ability and Progressive Time. Showing nothing is native; showing a rupee that is not a rupee was the placeholder. `Rando::DrawForeignCheckAura` is deleted along with both call sites.

`ComboForeignItemDef` gains an `article`, because both games build a pickup line as article + name and neither can read the other's item table. MM's 134 articles are generated from MM's own `StaticData::Items` and verified name-for-name.

## Tests

- **`foreign-pool-mm`** (redship tier) — pool registered and well-formed; every id passes MM's *real* give predicate; no entry is junk-class; articles present and space-terminated; names round-trip through the spoiler-load inverse. Doubles as the runtime proof the registrar survived the link, which a compile and a link are both silent about (#516).
- **`foreign-placement-oot`** (rando tier, deliberately **not** redship) — the OoT predicate reads a *fill result*, so in a ROM-free run every location is `RG_NONE`, the predicate accepts nothing, and a "only chests are hosts" assertion would pass with an accepted count of **zero**. Same vacuity trap as #491. This row runs a real generation first, then asserts a **non-zero** host count (and prints it), that placements are MM-tagged and land on eligible hosts, that MM's real award chain accepts one exactly once, and that the same seed reproduces the same placements.
- The pre-existing **synthetic `GAME_MM` pool is removed** from `test_foreign_items.c`. It asserted "nothing registered yet" — now false — and its register/un-register pair would have clobbered the real pool for every later row in `--test all`. The "Bomb Bag" cross-pool collision is now driven against both *real* pools.
- Reverse placements are folded into the **SeedDeterminism** digest, so a nondeterministic pool surfaces as a two-process digest mismatch.

## Verification

Local: **redship 61/61**, **rando 14/14** (both tiers, per the standing rule that the rando tier is the tripwire for newly-firing generation paths). New symbols confirmed 0 → present in `build-cmake/redship.map`: `kForeignPoolMMV1`, `ForeignPoolMMV1Registrar`, `OoT_PlaceForeignItems`, `OoT_Foreign_IsEligibleHost`.

**End-to-end delivery is gameplay-tier and rests on playtest.** CI reaches the placement, the record, and MM's award queue; it cannot reach a live-`PlayState` give. The textbox and model changes are likewise operator-verified — CI locks the resolution surface, not pixels.

## Not in this PR

Shared rupees and shared hearts (operator-required) are **designed but deliberately deferred**, along with the pool shrink they justify. They carve `gComboCtx.reserved[]`, write both games' live `gSaveContext`, add hooks on both sides of the switch boundary, and interact with MM's cycle reset and the live #487 owl-save flash-readback class — the highest-risk area in this repo by its own history. Bundling that with a presentation refactor makes a red CI un-bisectable, and the shrink is only *correct* once the sharing exists (removing wallet/heart rows without it is a strict regression). Filed as a follow-up with the full design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!--- section:artifacts:start -->
### Build Artifacts
  - [rsbs-windows.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/8673517871.zip)
  - [rsbs-linux.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/8673124641.zip)
<!--- section:artifacts:end -->