### PR TITLE
Wire the .redsave save directory and stop Save() failing silently (cross-game save fix, part 1/5)

### DIFF
--- a/rsbs/src/main.cpp
+++ b/rsbs/src/main.cpp
@@ -28,6 +28,7 @@
 #include "ComboSpoilerWindow.h"   // Combo_SpoilerWindow_Init (#496, ADR 0008)
 #include "ComboMmOptionsWindow.h" // Combo_MMOptionsWindow_Init (#497/#499, ADR 0004+0008)
 #include "entrance.h"
+#include "save.h" // rsbs::SaveManager — unified .redsave save-directory wiring
 #include "rsbs_version.h"
 #include "test_runner.h"
 #include "integration_test_hooks.h"
@@ -344,6 +345,27 @@ int main(int argc, char** argv) {
     }
     fprintf(stderr, "[RSBS] Ship::Context singleton created successfully at %p\n", (void*)shipContext.get());
     fflush(stderr);
+
+    // Point the unified .redsave at the SAME directory the games write their own
+    // per-game saves to. save.h documents this as the injection point where "the
+    // game-integration follow-up injects the real per-app save directory" — that
+    // follow-up never landed, so until now mSaveDir stayed at its bare relative
+    // default "Save", resolved against the process WORKING DIRECTORY.
+    //
+    // Both games use Ship::Context::GetPathRelativeToAppDirectory("Save") (see
+    // games/oot/soh/SaveManager.cpp GetFileName), so the two halves of a slot —
+    // file{N+1}.sav and redship_slot{N}.redsave — only landed together when the
+    // CWD happened to equal the app directory. Launch from a shortcut, a
+    // debugger, or a packaged bundle and they silently fork: the .redsave for a
+    // slot is written to, or looked for in, a different folder than the OoT save
+    // it annotates, and the load is skipped with only a stderr line no
+    // GUI-launched player ever sees.
+    //
+    // The "Save" default is deliberately left in place for the headless --test
+    // path, which never creates a Ship::Context and relies on a CWD-relative
+    // directory it can write to.
+    rsbs::SaveManager::Instance().SetSaveDirectory(
+        Ship::Context::GetPathRelativeToAppDirectory("Save"));
 
     // Claim crash handling BEFORE any game init runs (#388).
     //

--- a/src/common/save.cpp
+++ b/src/common/save.cpp
@@ -54,6 +54,18 @@ void SaveLogReject(bool verbose, const char* reason, unsigned long long got,
                  reason, got, expected);
 }
 
+// Save() used to fail SILENTLY at five separate points, and every production
+// caller discards the bool it returns (games/oot/soh/SaveManager.cpp's OnSaveFile
+// and OnExitGame hooks both ignore it). A save that does not happen is therefore
+// indistinguishable from one that does, right up until the player reloads and
+// finds a stale or empty slot — which is exactly the shape of the "saving is a
+// little broken" report this exists to make diagnosable. Load already names every
+// refusal; the write path now does too.
+bool SaveLogFail(int slot, const char* reason) {
+    std::fprintf(stderr, "[RsbsSave] slot %d NOT saved: %s\n", slot, reason);
+    return false;
+}
+
 }  // namespace
 
 SaveManager& SaveManager::Instance() {
@@ -87,7 +99,7 @@ uint32_t SaveManager::Crc32(const uint8_t* data, size_t len) {
 
 bool SaveManager::Save(int slot) {
     if (!SlotInRange(slot)) {
-        return false;
+        return SaveLogFail(slot, "slot index out of range");
     }
 
     // Serialization source = the context-layer shadow copies. Both must be
@@ -96,7 +108,7 @@ bool SaveManager::Save(int slot) {
     const void* ootShadow = Context_GetOoTSaveContext();
     const void* mmShadow = Context_GetMMSaveContext();
     if (ootShadow == nullptr || mmShadow == nullptr) {
-        return false;
+        return SaveLogFail(slot, "context shadows are absent (Context_InitFrozenStates has not run)");
     }
 
     // Assemble Tiers 1..3 contiguously so the CRC covers exactly the bytes we
@@ -137,6 +149,8 @@ bool SaveManager::Save(int slot) {
     {
         std::ofstream out(tmpPath, std::ios::binary | std::ios::trunc);
         if (!out) {
+            std::fprintf(stderr, "[RsbsSave] slot %d NOT saved: cannot open '%s' for writing\n",
+                         slot, tmpPath.c_str());
             return false;
         }
         out.write(reinterpret_cast<const char*>(&header), sizeof(header));
@@ -146,12 +160,14 @@ bool SaveManager::Save(int slot) {
         if (!out) {
             out.close();
             std::filesystem::remove(tmpPath, ec);
-            return false;
+            return SaveLogFail(slot, "write failed (disk full or permissions?); temp file discarded");
         }
     }
 
     std::filesystem::rename(tmpPath, finalPath, ec);
     if (ec) {
+        std::fprintf(stderr, "[RsbsSave] slot %d NOT saved: rename '%s' -> '%s' failed (%s)\n",
+                     slot, tmpPath.c_str(), finalPath.c_str(), ec.message().c_str());
         std::filesystem::remove(tmpPath, ec);
         return false;
     }


### PR DESCRIPTION
First slice of the operator-reported cross-game save breakage ("saving in OoT
doesn't save the MM data; owl saves don't work; saving needs to remember which
game the player was in").

## What this PR is not

It does **not** fix the reported symptoms. It removes two silent-failure modes
that sit underneath them, so the remaining work is diagnosable rather than
guessed at. The actual root cause is scoped and staged; see below.

## Changes

**`SetSaveDirectory` had zero production callers.** `save.h` documents it as the
seam where "the game-integration follow-up injects the real per-app save
directory" — that follow-up never landed, so `mSaveDir` stayed at its bare
relative default `"Save"`, resolved against the process **working directory**.
Both games write their own saves to
`Ship::Context::GetPathRelativeToAppDirectory("Save")`, so the two halves of a
slot (`file{N+1}.sav` and `redship_slot{N}.redsave`) only co-located when CWD
happened to equal the app directory. Launched from a shortcut, a debugger or a
packaged bundle they fork silently: `RsbsSave_HasSave` returns false and the
load is skipped with no user-visible signal.

Wired from `main.cpp` after `CreateUninitializedInstance`. The `"Save"` default
is kept for the headless `--test` path, which never creates a `Ship::Context`.

**`SaveManager::Save` failed silently at five points** and every production
caller discards its `bool` (both the `OnSaveFile` and `OnExitGame` hooks in
`games/oot/soh/SaveManager.cpp` ignore it). `Load` already names every refusal
via `SaveLogReject`; the write path now does too.

## Format impact

None. `RSBS_SAVE_VERSION` is untouched and no on-disk offset moves.

## Verification

`redship_common` and `rsbs` both compile clean. Note a **pre-existing,
unrelated** local failure: a bare `cmake -B build -S .` picks the Visual Studio
generator + Debug (an unexercised config — CI and the documented local loop both
use Ninja + Release), where `games/mm/2s2h/Rando/Logic/Regions/TerminaField.cpp`
blows the COFF section limit and needs `/bigobj`. Not touched by this PR, but
worth a follow-up since `docs/BUILDING.md` documents the VS generator.

## What actually causes the reported bug (staged follow-ups)

Confirmed by parsing the operator's own `redship_slot0.redsave`: Tier-2 (OoT)
holds 16,647 non-zero bytes, **Tier-3 (MM) is 65,536 bytes of zero**, and
`sourceGame` is pinned to `GAME_OOT`. MM's half was never written.

1. **MM has no persistence at all in single-exe.** `games/mm/CMakeLists.txt`
   filters out `2s2h/SaveManager/*.cpp`; the linked replacement
   `mm_save_manager_stubs.c` returns `-1` from flash read and has an **empty**
   flash write body. Every MM save route bottoms out there. This also explains
   MM's file select listing three empty slots.
2. **Owl saves are skipped before reaching even that.** `z_message.c` gates the
   write on `gSaveContext.fileNum != 0xFF`, but a cross-game session runs at the
   `0xFF` sentinel for its whole life — while the state machine advances to the
   save-and-quit exit anyway, so the player sees a complete save that never
   happened.
3. **The owl exit escapes the launcher.** `z_play.c` does
   `SET_NEXT_GAMESTATE(MM_TitleSetup_Init)` with no pending switch, so
   `ops->run()` never returns to `main.cpp`, and `TitleSetup_SetupTitleScreen`
   then calls `MM_Sram_InitNewSave()` — destroying the save just made.
4. **A `.redsave` load leaves both blobs unarmed.** `Load` commits via
   `Context_UpdateShadowCopy`, which never sets `hasBeenFrozen`; every consumer
   gates on it and no arming API exists. The documented contract ("applies on
   the next cross-game switch") is not implementable as written, because that
   switch freezes the *departing* game.
5. **Nothing reads `sourceGame`.** Boot hardcodes `GAME_OOT`;
   `FileChoose_LoadGame` unconditionally enters `OoT_Play_Init`.

Heads-up for the reviewer of part 3: `src/common/tests/test_session_invalidation.c`
asserts `Context_HasFrozenState(GAME_MM) == 0` immediately after a successful
`Load`, citing #419/#420. That assertion is the bug locked in as required
behavior and will be renegotiated in the same commit that fixes it — it is not
a regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!--- section:artifacts:start -->
### Build Artifacts
  - [rsbs-windows.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/8675269181.zip)
  - [rsbs-linux.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/8674825178.zip)
<!--- section:artifacts:end -->