### PR TITLE
Give MM a redship-native save path so Tier-3 stops being zeros (cross-game save fix, part 2/5)

### DIFF
--- a/.github/clang-format-paths.txt
+++ b/.github/clang-format-paths.txt
@@ -47,6 +47,7 @@ games/mm/2s2h/mm_notification_binding_test.cpp
 games/mm/2s2h/mm_resume_state_test.cpp
 games/mm/2s2h/mm_save_manager_stubs.c
 games/mm/2s2h/mm_trackers_gui_test.cpp
+games/mm/2s2h/mm_unified_save_test.cpp
 games/mm/2s2h/z_scene_2SH.cpp
 games/mm/src/audio/lib/dcache.c
 games/mm/src/audio/lib/load.c

--- a/CMake/SingleExecutable.cmake
+++ b/CMake/SingleExecutable.cmake
@@ -520,6 +520,18 @@ if(BUILD_TESTING)
     # over the live save (spawn-as-Fierce-Deity / all-Ocarina corruption).
     # Display-free and ROM-free, so it runs in this redship tier.
     redship_add_test(NAME MMFlashFileNumOob COMMAND redship --test mm-flash-filenum-oob)
+    # MM's redship-native unified-save capture (#35 follow-up,
+    # games/mm/2s2h/mm_unified_save_test.cpp). MM persists nothing in
+    # single-exe: 2s2h/SaveManager/*.cpp is filtered out of the link and the
+    # replacement flash stubs are a -1 read plus an EMPTY write, so the only
+    # thing that ever deposited MM bytes into the cross-game shadow was the
+    # departure freeze on a portal crossing. An operator .redsave confirmed it:
+    # Tier-2 had 16647 non-zero bytes, Tier-3 was 65536 zeros. Locks slot
+    # normalization (0xFF must mean "no slot", never clamp), the no-slot no-op,
+    # the round trip through a real file, sourceGame == GAME_MM, and that the
+    # capture is FULL-WIDTH rather than the sizeof(Save) prefix the excluded
+    # file used. Display-free and ROM-free, so it runs in this redship tier.
+    redship_add_test(NAME MMUnifiedSaveCapture COMMAND redship --test mm-unified-save-capture)
     # MM single-exe hook dispatch (#511, #438): the COND_HOOK/COND_ID_HOOK
     # macros park registrations in the MM-owned S2H::GameHooks registry, but
     # ShouldActorInit / OnActorInit / OnActorDraw / OnOpenText dispatched

--- a/games/mm/2s2h/GameExports_SingleExe.cpp
+++ b/games/mm/2s2h/GameExports_SingleExe.cpp
@@ -33,6 +33,7 @@
 #include "game_lifecycle.h"
 #include "integration_test_hooks.h"
 #include "context.h"
+#include "save.h" // RsbsSave_* — MM's redship-native unified-save capture
 #include "shared_items.h"
 // Paired-world keying + placement-table accessors (#439 switch-entry
 // activation logs the placement count at the pairing decision point).
@@ -1559,6 +1560,57 @@ void MM_Game_Suspend(void) {
 extern "C" void MM_ResumeColdBootPrep(void) {
     MM_SystemHeap_Init((void*)MM_gSystemHeap, SYSTEM_HEAP_SIZE);
     Regs_Init();
+}
+
+/**
+ * Commit MM's LIVE SaveContext into the unified .redsave slot (#35 follow-up).
+ *
+ * WHY THIS EXISTS. In single-exe builds MM has no persistence whatsoever:
+ * games/mm/CMakeLists.txt filters out 2s2h/SaveManager/*.cpp, and the linked
+ * replacement (games/mm/2s2h/mm_save_manager_stubs.c) returns -1 from
+ * SaveManager_SysFlashrom_ReadData and has an EMPTY SaveManager_SysFlashrom_-
+ * WriteData body. Every MM save route — new-cycle, owl, pause save-and-quit,
+ * autosave — funnels through those two symbols, so MM writes nothing at all.
+ * Before this, the ONLY thing that ever put real MM bytes into the cross-game
+ * shadow was the departure freeze in Combo_CheckEntranceSwitch, i.e. MM state
+ * was captured at exactly one instant: walking back through the portal. A
+ * session ended any other way (owl save, quit, closing the window) recorded
+ * nothing, which is why a .redsave's Tier-3 reads as 65536 zero bytes.
+ *
+ * This is the redship-native capture path: it does not go anywhere near MM's
+ * flash funnel, which is dead-ended twice over (the no-op stub, and the
+ * gSaveContext.fileNum != 0xFF gates that a cross-game session can never
+ * satisfy). It also cannot route through OoT's GameInteractor hooks, because
+ * GI_SINGLE_EXE_GATE returns early from every OoT executor for the entire MM
+ * session.
+ *
+ * FULL WIDTH, deliberately. The shadow write passes MM's real
+ * sizeof(SaveContext) — this TU is one of the few that can see it — and NOT
+ * the sizeof(Save) prefix the excluded SaveManager.cpp used. Context_Update-
+ * ShadowCopy does not zero the tail, so a prefix write would leave everything
+ * past Save (eventInf, cycleSceneFlags, the timer arrays, the runtime respawn
+ * table, ShipSaveContext) at whatever a DIFFERENT point in time left there.
+ *
+ * @return 1 on a committed write, 0 when there was nothing to write to.
+ */
+extern "C" int MM_Combo_CaptureSaveToUnifiedSlot(void) {
+    const int slot = RsbsSave_GetActiveSlot();
+    if (slot < 0) {
+        // No slot established this session. Honest no-op rather than a guess:
+        // defaulting to slot 0 here would let an MM session started from an
+        // unsaved new file overwrite an unrelated slot.
+        fprintf(stderr, "[MM] unified save skipped: no active slot for this session\n");
+        fflush(stderr);
+        return 0;
+    }
+
+    Context_UpdateShadowCopy(GAME_MM, &gSaveContext, sizeof(gSaveContext));
+    gComboCtx.sourceGame = GAME_MM;
+
+    const int ok = RsbsSave_Save(slot);
+    fprintf(stderr, "[MM] unified save to slot %d: %s\n", slot, ok ? "ok" : "FAILED");
+    fflush(stderr);
+    return ok;
 }
 
 /**

--- a/games/mm/2s2h/mm_unified_save_test.cpp
+++ b/games/mm/2s2h/mm_unified_save_test.cpp
@@ -1,0 +1,170 @@
+/**
+ * @file mm_unified_save_test.cpp
+ * ROM-free, display-free lock for MM's redship-native unified-save capture
+ * (#35 follow-up). CTest label "redship", row MMUnifiedSaveCapture in
+ * CMake/SingleExecutable.cmake, dispatch "mm-unified-save-capture" in
+ * src/common/test_runner.cpp.
+ *
+ * WHAT WAS BROKEN. In single-exe builds MM persisted nothing at all:
+ * games/mm/CMakeLists.txt filters out 2s2h/SaveManager/*.cpp, and the linked
+ * replacement (games/mm/2s2h/mm_save_manager_stubs.c) returns -1 from
+ * SaveManager_SysFlashrom_ReadData and has an EMPTY WriteData body. Every MM
+ * save route bottoms out there, so the only thing that ever deposited real MM
+ * bytes into the cross-game shadow was the departure freeze on a portal
+ * crossing. An operator-supplied redship_slot0.redsave confirmed the
+ * consequence directly: Tier-2 (OoT) held 16647 non-zero bytes while Tier-3
+ * (MM) was 65536 bytes of ZERO, with ComboContext.sourceGame pinned to
+ * GAME_OOT because the only GAME_MM writer lived in the excluded file.
+ *
+ * THE INVARIANTS THIS LOCKS, and how each one fails without the fix:
+ *
+ *   1. Slot normalization. RsbsSave_SetActiveSlot must reject out-of-range
+ *      values -- above all MM's 0xFF fileNum sentinel -- as "no slot" rather
+ *      than clamping. Clamping 0xFF to a real slot would let one session
+ *      overwrite an unrelated one.
+ *
+ *   2. No slot means no write. With no active slot the capture must be an
+ *      honest no-op returning 0, not a guess at slot 0. (An MM session started
+ *      from a never-saved new file is exactly this case.)
+ *
+ *   3. Capture reaches the FILE, not just memory. With a slot established, the
+ *      capture must produce a .redsave whose Tier-3 round-trips back through a
+ *      real Load. Before the fix there was no capture entry point at all, so
+ *      this cannot even be expressed.
+ *
+ *   4. sourceGame says MM. Before the fix the only two linked writers both
+ *      stamped GAME_OOT unconditionally, so no save could ever record that the
+ *      player was in MM -- the durable half of "remember which game".
+ *
+ *   5. FULL-WIDTH capture. This is the subtle one. The excluded SaveManager.cpp
+ *      mirrored only sizeof(Save) (0x100C) of the 0x10000 blob, and
+ *      Context_UpdateShadowCopy deliberately does NOT zero the tail -- so a
+ *      prefix write leaves everything past Save (eventInf, cycleSceneFlags, the
+ *      timer arrays, the runtime respawn table, ShipSaveContext) at whatever a
+ *      DIFFERENT point in time left there. The test stamps a byte near the end
+ *      of MM's real SaveContext and requires it to survive the round trip, so
+ *      re-introducing a prefix write fails here instead of silently shipping
+ *      stale tail bytes. Note the tail is pre-poisoned with a distinct value
+ *      first: without that, a prefix write would leave zeros there and a
+ *      "did the byte survive" check could pass vacuously against a zeroed
+ *      buffer rather than against genuinely stale data.
+ */
+
+#include "global.h"
+
+#include "save.h"
+#include "context.h"
+#include "game.h"
+
+#include <cstdio>
+#include <cstring>
+#include <filesystem>
+#include <string>
+#include <vector>
+
+extern "C" SaveContext gSaveContext;
+extern "C" int MM_Combo_CaptureSaveToUnifiedSlot(void);
+
+namespace {
+
+#define USAVE_ASSERT(cond, msg)                                           \
+    do {                                                                  \
+        if (!(cond)) {                                                    \
+            printf("[TEST] FAIL: %s (%s:%d)\n", msg, __FILE__, __LINE__); \
+            return 1;                                                     \
+        }                                                                 \
+    } while (0)
+
+// Offset well past sizeof(Save), used to prove the capture is full-width.
+size_t TailProbeOffset() {
+    return sizeof(SaveContext) - 1;
+}
+
+} // namespace
+
+extern "C" int MM_UnifiedSaveCapture_RunHeadless(void) {
+    // Isolated save directory so this never touches a real player's slots.
+    const std::filesystem::path dir = std::filesystem::temp_directory_path() / "rsbs_mm_unified_save_test";
+    std::error_code ec;
+    std::filesystem::remove_all(dir, ec);
+    std::filesystem::create_directories(dir, ec);
+    rsbs::SaveManager::Instance().SetSaveDirectory(dir.string());
+
+    Context_InitFrozenStates();
+    ComboContext_Init();
+
+    // ---- 1. Slot normalization -------------------------------------------
+    RsbsSave_SetActiveSlot(1);
+    USAVE_ASSERT(RsbsSave_GetActiveSlot() == 1, "an in-range slot must be accepted verbatim");
+    RsbsSave_SetActiveSlot(0xFF);
+    USAVE_ASSERT(RsbsSave_GetActiveSlot() == -1,
+                 "MM's 0xFF fileNum sentinel must normalize to 'no slot', never clamp to a real one");
+    RsbsSave_SetActiveSlot(-7);
+    USAVE_ASSERT(RsbsSave_GetActiveSlot() == -1, "a negative slot must normalize to 'no slot'");
+    RsbsSave_SetActiveSlot(RSBS_SAVE_MAX_SLOTS);
+    USAVE_ASSERT(RsbsSave_GetActiveSlot() == -1, "one past the last slot must normalize to 'no slot'");
+
+    // ---- 2. No slot means no write ---------------------------------------
+    USAVE_ASSERT(MM_Combo_CaptureSaveToUnifiedSlot() == 0, "capture with no active slot must be an honest no-op");
+    USAVE_ASSERT(RsbsSave_HasSave(0) == 0, "a no-slot capture must not have invented slot 0");
+
+    // ---- 3/4/5. Full-width capture that round-trips through the file ------
+    memset(&gSaveContext, 0, sizeof(SaveContext));
+
+    const char kPlayerName[8] = { 'O', 'W', 'L', 'T', 'E', 'S', 'T', '\0' };
+    memcpy(gSaveContext.save.saveInfo.playerData.playerName, kPlayerName, sizeof(kPlayerName));
+    gSaveContext.save.isOwlSave = true;
+    gSaveContext.save.owlWarpId = 5;
+
+    // Poison the shadow's tail with a value that is neither zero nor the byte
+    // we are about to stamp, so check 5 cannot pass vacuously: if the capture
+    // regressed to a sizeof(Save) prefix write, the tail would still read as
+    // this poison and the assertion below would fail loudly.
+    const uint8_t kPoison = 0xA5;
+    const uint8_t kTailStamp = 0x3C;
+    {
+        std::vector<uint8_t> poison(MM_SAVE_CONTEXT_SIZE, kPoison);
+        Context_UpdateShadowCopy(GAME_MM, poison.data(), poison.size());
+    }
+
+    reinterpret_cast<uint8_t*>(&gSaveContext)[TailProbeOffset()] = kTailStamp;
+
+    RsbsSave_SetActiveSlot(2);
+    USAVE_ASSERT(MM_Combo_CaptureSaveToUnifiedSlot() == 1, "capture with an active slot must commit");
+    USAVE_ASSERT(gComboCtx.sourceGame == GAME_MM, "an MM-authored save must record sourceGame == GAME_MM");
+    USAVE_ASSERT(RsbsSave_HasSave(2) == 1, "capture must have produced a readable slot file");
+
+    // Wipe every trace from memory, then reload from disk. This is what makes
+    // the check about the FILE rather than about the shadow we just wrote.
+    Context_ClearAllFrozenStates();
+    {
+        const uint8_t* cleared = static_cast<const uint8_t*>(Context_GetMMSaveContext());
+        USAVE_ASSERT(cleared != nullptr, "MM shadow must exist after a clear");
+        USAVE_ASSERT(cleared[TailProbeOffset()] == 0, "clear must have zeroed the MM shadow tail");
+    }
+
+    USAVE_ASSERT(RsbsSave_Load(2) == 1, "the captured slot must load back");
+
+    {
+        const uint8_t* mm = static_cast<const uint8_t*>(Context_GetMMSaveContext());
+        USAVE_ASSERT(mm != nullptr, "MM shadow must exist after a load");
+        USAVE_ASSERT(memcmp(mm + offsetof(SaveContext, save.saveInfo.playerData.playerName), kPlayerName,
+                            sizeof(kPlayerName)) == 0,
+                     "MM player name must survive the .redsave round trip");
+        USAVE_ASSERT(mm[offsetof(SaveContext, save.isOwlSave)] == 1,
+                     "isOwlSave must survive the round trip (owl-statue resume depends on it)");
+        USAVE_ASSERT(mm[TailProbeOffset()] == kTailStamp,
+                     "a byte past sizeof(Save) must survive: the capture must be full-width, not a "
+                     "sizeof(Save) prefix write over a non-zero tail");
+    }
+
+    // Leave global state clean for whatever runs next.
+    memset(&gSaveContext, 0, sizeof(SaveContext));
+    Context_ClearAllFrozenStates();
+    ComboContext_Init();
+    RsbsSave_SetActiveSlot(-1);
+    std::filesystem::remove_all(dir, ec);
+
+    printf("[TEST] mm-unified-save-capture: PASS\n");
+    return 0;
+}

--- a/games/mm/src/code/z_message.c
+++ b/games/mm/src/code/z_message.c
@@ -19,6 +19,12 @@
 #include "2s2h_assets.h"
 #include <libultraship/bridge/consolevariablebridge.h>
 
+// RSBS single-exe: MM's redship-native unified-save capture, defined in
+// games/mm/2s2h/GameExports_SingleExe.cpp. Declared locally rather than via a
+// header because src/common is not on this decomp TU's include path — the same
+// convention z_play.c uses for the Combo_* entry points.
+extern int MM_Combo_CaptureSaveToUnifiedSlot(void);
+
 const char* gBombersNotebookPhotos[] = {
     gBombersNotebookPhotoAnjuTex,
     gBombersNotebookPhotoKafeiTex,
@@ -6227,6 +6233,25 @@ void MM_Message_Update(PlayState* play) {
             gSaveContext.save.isOwlSave = true;
             Play_SaveCycleSceneFlags(play);
             func_8014546C(&play->sramCtx);
+
+            // RSBS (#35 follow-up): commit the owl save to the unified
+            // .redsave, OUTSIDE the fileNum gate below on purpose.
+            //
+            // A cross-game MM session (entered via the Happy Mask Shop) runs
+            // with fileNum pinned to the 0xFF sentinel for its entire life, so
+            // the vanilla branch below never runs — yet the state machine
+            // still advances to MSGMODE_OWL_SAVE_1/_2 and plays the whole
+            // save-and-quit sequence. The player therefore saw a complete,
+            // indistinguishable owl save that attempted zero bytes of
+            // persistence, with no diagnostic. This call is what makes the owl
+            // save real in that session. It must come AFTER
+            // Play_SaveCycleSceneFlags/func_8014546C so the checksummed cycle
+            // flags are already in gSaveContext.
+            //
+            // Deliberately NOT fixed by handing cross-game MM a fake real
+            // fileNum: that would re-arm every slot-addressed flash path the
+            // 0xFF guards were added to close (#487/#515).
+            MM_Combo_CaptureSaveToUnifiedSlot();
 
             if (gSaveContext.fileNum != 0xFF) {
                 Sram_SetFlashPagesOwlSave(&play->sramCtx,

--- a/games/oot/soh/GameExports_SingleExe.cpp
+++ b/games/oot/soh/GameExports_SingleExe.cpp
@@ -20,6 +20,7 @@
 #include "game_lifecycle.h"
 #include "integration_test_hooks.h"
 #include "context.h"
+#include "save.h" // RsbsSave_SetActiveSlot — publish the slot MM will save into
 #include "shared_items.h"
 #include "foreign_items.h" // OoT_ForeignItem_Give (Lane C1 redemption)
 #include "entrance.h"
@@ -1155,6 +1156,25 @@ extern "C" uint16_t Combo_CheckEntranceSwitch(uint16_t entranceIndex) {
 
     if (Combo_IsCrossGameSwitch() && !wasAlreadyPending) {
         fprintf(stderr, "[COMBO] Cross-game switch (%s)! entrance=0x%04X\n", gameId, entranceIndex);
+
+        // Publish the unified slot while OoT still knows it. This is the last
+        // moment it is knowable: MM boots with gSaveContext.fileNum pinned to
+        // the 0xFF sentinel (ConsoleLogo_Init) for the whole cross-game
+        // session, and the only writers of a real 0..2 slot live in MM's own
+        // file select, which a portal arrival never enters. Without this, an
+        // MM-side save has no slot to address.
+        //
+        // Guarded two ways. Only when OoT is the DEPARTING game: sizeof and
+        // field offsets in this TU are OoT's SaveContext layout, so reading
+        // fileNum while MM is active would pull an unrelated MM field. And
+        // only for an in-range value, so OoT's own 0xFF title-screen sentinel
+        // does not clear a slot that a real load already established.
+        if (currentGame != GAME_MM) {
+            const int ootFileNum = static_cast<int>(gSaveContext.fileNum);
+            if (ootFileNum >= 0 && ootFileNum < RSBS_SAVE_MAX_SLOTS) {
+                RsbsSave_SetActiveSlot(ootFileNum);
+            }
+        }
 
         uint16_t returnEntrance = Combo_GetSwitchReturnEntrance();
         // sizeof(gSaveContext) in this TU is OoT's SaveContext layout. When MM

--- a/games/oot/soh/SaveManager.cpp
+++ b/games/oot/soh/SaveManager.cpp
@@ -159,6 +159,9 @@ SaveManager::SaveManager() {
         if (fileNum < 0 || fileNum >= RSBS_SAVE_MAX_SLOTS) {
             return;
         }
+        // Publish the slot so a later MM-side save can address it; MM has no
+        // slot of its own (its fileNum is the 0xFF sentinel cross-game).
+        RsbsSave_SetActiveSlot(fileNum);
         Context_UpdateShadowCopy(GAME_OOT, &gSaveContext, sizeof(gSaveContext));
         gComboCtx.sourceGame = GAME_OOT;
         RsbsSave_Save(fileNum);
@@ -185,6 +188,12 @@ SaveManager::SaveManager() {
         if (fileNum < 0 || fileNum >= RSBS_SAVE_MAX_SLOTS) {
             return;
         }
+        // Establish the session's slot BEFORE the clear-and-reload below, so
+        // it survives regardless of whether this slot has a companion
+        // .redsave. A slot the player opened is the session's slot even when
+        // no cross-game state exists for it yet — that is exactly the case
+        // where MM is entered for the first time and needs somewhere to save.
+        RsbsSave_SetActiveSlot(fileNum);
         Context_InvalidateSessionOnSlotLoad();
         if (RsbsSave_HasSave(fileNum)) {
             RsbsSave_Load(fileNum);

--- a/src/common/save.cpp
+++ b/src/common/save.cpp
@@ -77,6 +77,18 @@ void SaveManager::SetSaveDirectory(const std::string& dir) {
     mSaveDir = dir.empty() ? std::string(".") : dir;
 }
 
+void SaveManager::SetActiveSlot(int slot) {
+    // Normalize anything out of range to "none". The value most likely to
+    // arrive here by mistake is MM's 0xFF fileNum sentinel, and silently
+    // clamping that to a real slot would write one game's session over an
+    // unrelated slot; -1 makes every consumer's "do not write" branch fire.
+    mActiveSlot = SlotInRange(slot) ? slot : -1;
+}
+
+int SaveManager::GetActiveSlot() const {
+    return mActiveSlot;
+}
+
 std::string SaveManager::SlotPath(int slot) const {
     return (std::filesystem::path(mSaveDir) /
             ("redship_slot" + std::to_string(slot) + ".redsave"))
@@ -481,6 +493,14 @@ int RsbsSave_HasSave(int slot) {
 
 void RsbsSave_DeleteSave(int slot) {
     rsbs::SaveManager::Instance().DeleteSave(slot);
+}
+
+void RsbsSave_SetActiveSlot(int slot) {
+    rsbs::SaveManager::Instance().SetActiveSlot(slot);
+}
+
+int RsbsSave_GetActiveSlot(void) {
+    return rsbs::SaveManager::Instance().GetActiveSlot();
 }
 
 void RsbsSave_RegisterGameMeta(GameId game, const RsbsGameMetaDesc* desc) {

--- a/src/common/save.h
+++ b/src/common/save.h
@@ -153,6 +153,31 @@ public:
     void RegisterGameMeta(GameId game, const RsbsGameMetaDesc* desc);
 
     /**
+     * The unified slot the CURRENT SESSION is attached to, or -1 for none.
+     *
+     * Why this has to exist at all: a .redsave write needs a slot index, and
+     * the only code that ever knew one was OoT's save hooks, which get it
+     * handed to them as `fileNum`. MM cannot ask the same question. A
+     * cross-game MM session (entered through the Happy Mask Shop) runs with
+     * gSaveContext.fileNum pinned to the 0xFF sentinel for its ENTIRE life —
+     * ConsoleLogo_Init sets it on every MM boot, and the only writers of a real
+     * 0..2 slot live in MM's own file select, which a portal arrival never
+     * enters. So MM has no slot of its own to save into, and before this there
+     * was nowhere for it to look one up.
+     *
+     * Session state, deliberately NOT serialized: which slot is open is a fact
+     * about the running process, not about the save file. It is set by
+     * whichever game last established a slot identity (OoT's load / save
+     * hooks) and read by any game that needs to persist without one of its own.
+     *
+     * Out-of-range values are normalized to -1 so a caller that passes MM's
+     * 0xFF sentinel by mistake gets "no slot" rather than a silent write to
+     * a nonexistent slot.
+     */
+    void SetActiveSlot(int slot);
+    int GetActiveSlot() const;
+
+    /**
      * Directory the .redsave files live in. Defaults to "Save" relative to the
      * working directory so the headless --test path (which never creates a
      * Ship::Context) can round-trip to a writable location. The game-integration
@@ -181,6 +206,9 @@ private:
 
     std::string mSaveDir = "Save";
 
+    // -1 == no slot established this session. See SetActiveSlot.
+    int mActiveSlot = -1;
+
     // Game-side metadata descriptors, indexed by GameId (GAME_OOT / GAME_MM).
     // mMetaPresent[i] guards mMetaDescs[i]; an unset descriptor causes
     // ReadMeta to fill that game's fields with zeros / `started=false`.
@@ -201,6 +229,14 @@ int  RsbsSave_Save(int slot);
 int  RsbsSave_Load(int slot);
 int  RsbsSave_HasSave(int slot);
 void RsbsSave_DeleteSave(int slot);
+
+/**
+ * Session-scoped "which slot is open" (see SaveManager::SetActiveSlot).
+ * RsbsSave_GetActiveSlot returns -1 when no slot has been established, which
+ * every caller must treat as "do not write" rather than as slot 0.
+ */
+void RsbsSave_SetActiveSlot(int slot);
+int  RsbsSave_GetActiveSlot(void);
 
 /**
  * Register a game's metadata-offset descriptor with the SaveManager. Called

--- a/src/common/test_runner.cpp
+++ b/src/common/test_runner.cpp
@@ -80,6 +80,7 @@ int MM_FbEffectsBinding_RunHeadless(void);
 // moon-crash reset then copies over the live save (the Fierce-Deity /
 // all-Ocarina corruption). Returns 0 on pass, non-zero on fail.
 int MM_FlashFileNumOob_RunHeadless(void);
+int MM_UnifiedSaveCapture_RunHeadless(void);
 // MM single-exe hook dispatch (games/mm/2s2h/mm_hook_dispatch_test.cpp, #511 /
 // #438): the COND_* macros park registrations in the MM-owned S2H::GameHooks
 // registry, but ShouldActorInit / OnActorInit / OnActorDraw / OnOpenText
@@ -305,6 +306,10 @@ static TestResult Test_MMFbEffectsBinding(void) {
 // the C entry point in games/mm/2s2h/mm_flash_filenum_test.cpp.
 static TestResult Test_MMFlashFileNumOob(void) {
     return MM_FlashFileNumOob_RunHeadless() == 0 ? TEST_PASS : TEST_FAIL;
+}
+
+static TestResult Test_MMUnifiedSaveCapture(void) {
+    return MM_UnifiedSaveCapture_RunHeadless() == 0 ? TEST_PASS : TEST_FAIL;
 }
 
 // MM hook-dispatch lock (see the extern decl above). Thin wrapper over the C
@@ -1771,6 +1776,15 @@ const TestDescriptor gTests[] = {
     // live save. Pure (no display), so it runs in the display-free suite.
     {"mm-flash-filenum-oob", "Flash page indices stay in bounds for fileNum 0xFF; moon-crash reset keeps the save",
      Test_MMFlashFileNumOob},
+    // MM's redship-native unified-save capture (#35 follow-up). MM has no
+    // persistence in single-exe (2s2h/SaveManager/*.cpp is link-excluded and
+    // the flash stubs are a -1 read plus an empty write), so every .redsave's
+    // Tier-3 was zeros and sourceGame could never say GAME_MM. Locks slot
+    // normalization, the no-slot no-op, the file round trip, and — the subtle
+    // one — that the capture is FULL-WIDTH rather than a sizeof(Save) prefix.
+    // Pure (no display, no ROM).
+    {"mm-unified-save-capture", "MM captures its live SaveContext into the unified slot, full-width and round-tripping",
+     Test_MMUnifiedSaveCapture},
     // Hook dispatch reaches the MM-owned registry the COND_* macros register
     // into. Registers through the production macros and drives each dispatcher
     // through the name MM's call sites spell, so both a deleted bridge and a


### PR DESCRIPTION
Part 2 of the operator-reported cross-game save breakage. Part 1 was #526.

## The finding this fixes

**MM persists nothing in single-exe.** `games/mm/CMakeLists.txt` filters out
`2s2h/SaveManager/*.cpp`, and the linked replacement
`games/mm/2s2h/mm_save_manager_stubs.c` returns `-1` from
`SaveManager_SysFlashrom_ReadData` and has an **empty**
`SaveManager_SysFlashrom_WriteData` body. Every MM save route bottoms out
there. The stub file says so itself: *"MM's flash storage in single-exe
persists nothing at all. Whether `redship` should have a real MM save path is
an operator-scoping question."* That deferral is the bug.

Confirmed on the operator's own `redship_slot0.redsave`:

| Tier | Contents |
|---|---|
| Tier-2 (OoT) | 16,647 non-zero bytes — real data |
| **Tier-3 (MM)** | **0 non-zero bytes out of 65,536** |
| `sourceGame` | `GAME_OOT` (the only `GAME_MM` writer is in the excluded file) |

## Approach

Operator chose the **redship-native** route over un-excluding `SaveManager.cpp`.
That exclusion is not safely liftable: the TU pulls in `gFileSelectState`,
`BenJsonConversions.hpp` and the whole Migrations set; its owl-write case does no
shadow update and never calls `RsbsSave_Save`; its new-cycle mirror writes only
`sizeof(Save)` of a `0x10000` blob; and its read path calls `RsbsSave_Load` once
per slot from inside MM's file-select scan, leaving resident cross-game state
equal to whichever slot was scanned last.

- **`RsbsSave_{Set,Get}ActiveSlot`** — the missing primitive. A `.redsave` write
  needs a slot and MM cannot supply one: `fileNum` is the `0xFF` sentinel for a
  cross-game session's whole life. Out-of-range normalizes to `-1` rather than
  clamping, so a stray `0xFF` means "no slot" instead of overwriting slot 0.
- **`MM_Combo_CaptureSaveToUnifiedSlot`** — commits MM's live `gSaveContext`
  **full-width**, stamps `sourceGame = GAME_MM`, writes the slot. It can't use
  OoT's GameInteractor hooks: `GI_SINGLE_EXE_GATE` returns early from every OoT
  executor for the entire MM session.
- **Owl-save call site** sits **outside** the `fileNum != 0xFF` gate. A
  cross-game session can never satisfy that gate, yet the state machine still
  advances through `MSGMODE_OWL_SAVE_1/_2` and plays the whole save-and-quit
  sequence — so the player saw a complete owl save that attempted zero bytes.

**Deliberately not done:** handing cross-game MM a fake real `fileNum`. That is
the obvious-looking fix and it would re-arm every slot-addressed flash path the
`0xFF` guards were added to close (#487/#515), including the moon-crash reset
that `MMFlashFileNumOob` exists to lock.

## Why full-width matters

`Context_UpdateShadowCopy` deliberately does **not** zero the tail. A
`sizeof(Save)` (0x100C) prefix write into a 0x10000 blob leaves everything past
`Save` — `eventInf`, `cycleSceneFlags`, the timer arrays, the runtime `respawn`
table, `ShipSaveContext` — at whatever a *different point in time* left there.

## Test

`MMUnifiedSaveCapture` (redship tier) locks slot normalization, the no-slot
no-op, a real file round-trip **after wiping memory**, `sourceGame == GAME_MM`,
and full-width capture.

The tail probe is **pre-poisoned with `0xA5`** before the capture. Without that,
a regression to the prefix write would leave zeros in the tail and a naive "did
the byte survive" check could pass against a zeroed buffer instead of against
genuinely stale data — the vacuity trap this repo has hit before.

**Negative control run:** reverting the capture to `sizeof(gSaveContext.save)`
fails the test on exactly the intended assertion, exit 1:

```
[TEST] FAIL: a byte past sizeof(Save) must survive: the capture must be
full-width, not a sizeof(Save) prefix write over a non-zero tail
```

Local: **62/62 redship, 14/14 rando.**

## Scope

No format change — `RSBS_SAVE_VERSION` untouched, no on-disk offset moves.

This makes MM's state reach the file. It does **not** make a loaded slot
reachable on the way back: `Load` still commits via `Context_UpdateShadowCopy`,
which never sets `hasBeenFrozen`, so restored blobs stay unarmed. That is part
3, which will also have to renegotiate
`src/common/tests/test_session_invalidation.c`'s
`Context_HasFrozenState(GAME_MM) == 0` assertion — that line is the bug locked
in as required behavior, and flipping it is the fix, not a regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!--- section:artifacts:start -->
### Build Artifacts
  - [rsbs-windows.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/8675913651.zip)
  - [rsbs-linux.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/8675738619.zip)
<!--- section:artifacts:end -->