### PR TITLE
Arm the MM half of a loaded .redsave so it is reachable (cross-game save fix, part 3/5)

### DIFF
--- a/src/common/context.cpp
+++ b/src/common/context.cpp
@@ -165,6 +165,49 @@ public:
         std::memcpy(state.saveContext.data(), saveContextData, size);
     }
 
+    // Arm the shadow bytes that are ALREADY resident as a frozen blob, without
+    // recopying them. This is the missing inverse of the freeze machinery: a
+    // .redsave Load commits through UpdateShadowCopy, which deliberately does
+    // not set hasBeenFrozen, and every consumer that can move a blob into a
+    // live gSaveContext gates on that flag (RestoreState above,
+    // Combo_ConsumeFrozenState, MM_Game_Resume). Before this there was no way
+    // to arm an existing shadow at all, so a faithfully loaded save sat in
+    // memory byte-exact and structurally unreachable.
+    //
+    // REFUSES an all-zero blob, and that refusal is load-bearing rather than
+    // defensive: a slot saved before the player ever entered MM has an all-zero
+    // Tier-3, and arming that would restore a zeroed SaveContext over the
+    // bootstrap file MM's title chain authors — strictly worse than the cold
+    // boot it would replace. "No bytes" and "bytes that happen to be zero" are
+    // indistinguishable here by construction, so zero means absent.
+    //
+    // Does NOT invent a returnEntrance beyond what the caller supplies; where a
+    // resumed game actually spawns is that game's own spawn policy, not a
+    // property of the blob's arming.
+    bool ArmShadowAsFrozen(GameId game, uint16_t returnEntrance) {
+        if (!mInitialized) Initialize();
+
+        FrozenGameState& state = GetState(game);
+        if (state.saveContext.empty()) {
+            return false;
+        }
+
+        bool anyNonZero = false;
+        for (uint8_t b : state.saveContext) {
+            if (b != 0) {
+                anyNonZero = true;
+                break;
+            }
+        }
+        if (!anyNonZero) {
+            return false;
+        }
+
+        state.returnEntrance = returnEntrance;
+        state.hasBeenFrozen = true;
+        return true;
+    }
+
 private:
     FrozenGameState& GetState(GameId game) {
         if (game == GAME_OOT) {
@@ -399,6 +442,13 @@ const void* Context_GetMMSaveContext(void) {
 
 void Context_UpdateShadowCopy(GameId game, const void* saveContext, size_t size) {
     gFrozenStates.UpdateShadowCopy(game, saveContext, size);
+}
+
+int Context_ArmShadowAsFrozen(GameId game, uint16_t returnEntrance) {
+    if (game != GAME_OOT && game != GAME_MM) {
+        return 0;
+    }
+    return gFrozenStates.ArmShadowAsFrozen(game, returnEntrance) ? 1 : 0;
 }
 
 // ============================================================================

--- a/src/common/context.h
+++ b/src/common/context.h
@@ -98,6 +98,32 @@ const void* Context_GetMMSaveContext(void);
  */
 void Context_UpdateShadowCopy(GameId game, const void* saveContext, size_t size);
 
+/**
+ * Arm the ALREADY-RESIDENT shadow bytes for @p game as a frozen blob, so the
+ * restore path will hand them to that game's live SaveContext.
+ *
+ * This is the missing inverse of the freeze machinery. Shadow copy and frozen
+ * blob are the same storage; the only thing separating them is hasBeenFrozen,
+ * which FreezeState alone used to set. A .redsave Load commits through
+ * Context_UpdateShadowCopy, which does not set it, and EVERY consumer that can
+ * move a blob into a live gSaveContext gates on it (Context_RestoreState,
+ * Combo_ConsumeFrozenState, MM_Game_Resume). So a faithfully loaded save sat in
+ * memory byte-exact and structurally unreachable, which is the read-side half
+ * of the operator's "MM will be reset after game restart".
+ *
+ * REFUSES an all-zero blob, returning 0. That refusal is load-bearing: a slot
+ * saved before the player ever entered MM has an all-zero Tier-3, and arming it
+ * would restore a zeroed SaveContext over the bootstrap file MM's title chain
+ * authors — strictly worse than the cold boot it replaces. "No bytes" and
+ * "bytes that are all zero" are indistinguishable here, so zero means absent.
+ *
+ * @param returnEntrance recorded verbatim; this call does not invent one. Where
+ *        a resumed game actually spawns is that game's own spawn policy (MM's
+ *        owl / new-cycle rules), not a property of arming.
+ * @return 1 if the blob was armed, 0 if it was empty or the game is invalid.
+ */
+int Context_ArmShadowAsFrozen(GameId game, uint16_t returnEntrance);
+
 // ============================================================================
 // Combo context
 // ============================================================================
@@ -688,9 +714,18 @@ typedef enum {
  * The seed stamp is governed by @p seedPolicy; see ComboSeedStampPolicy.
  *
  * Deliberately does NOT touch gCurrentGame (which game is running right now is
- * still true) and does NOT arm a frozen blob from anything. Arming is the
- * exclusive job of a real freeze, which keeps the "a plain .redsave load
- * applies on the next switch only" semantics from #419/#420 intact.
+ * still true) and does NOT arm a frozen blob from anything.
+ *
+ * NOTE (corrected): this used to claim arming was "the exclusive job of a real
+ * freeze, which keeps the 'a plain .redsave load applies on the next switch
+ * only' semantics from #419/#420 intact". That contract was never implementable
+ * as written — the next cross-game switch freezes the DEPARTING game
+ * (Combo_CheckEntranceSwitch resolves its gameId from Context_GetCurrentGame),
+ * so it never arms the ARRIVING side, and a loaded blob was therefore not
+ * applied on the next switch or on any other occasion. Arming a loaded slot is
+ * now an explicit, separate step: Context_ArmShadowAsFrozen. What this function
+ * still guarantees is narrower and true: invalidation itself never arms
+ * anything.
  */
 void Context_InvalidateSessionState(ComboSeedStampPolicy seedPolicy);
 
@@ -749,9 +784,11 @@ void Context_InvalidateSessionOnNewGame(int isRandoFile);
  * belonged to the slot. Clearing first makes "no .redsave" mean "no cross-game
  * state", which is the truth.
  *
- * Does NOT arm a frozen blob — the caller's RsbsSave_Load repopulates gComboCtx
- * and both shadows, and arming stays the exclusive job of a real freeze so the
- * #419/#420 "applies on next switch only" plain-load semantics survive.
+ * Does NOT arm a frozen blob itself — this is the CLEAR half. The caller's
+ * RsbsSave_Load repopulates gComboCtx and both shadows and performs its own
+ * explicit arming step (Context_ArmShadowAsFrozen) for a tier that actually
+ * carries data. Ordering matters and is already correct at the call site: the
+ * clear runs BEFORE the load, so it never wipes the bytes just read.
  */
 void Context_InvalidateSessionOnSlotLoad(void);
 

--- a/src/common/save.cpp
+++ b/src/common/save.cpp
@@ -309,12 +309,35 @@ bool SaveManager::Load(int slot) {
         return false;
     }
 
-    // All checks passed — commit. gComboCtx and both shadows are updated; the
-    // active game's live SaveContext is re-hydrated from its shadow by the
-    // existing freeze/restore path on the next cross-game switch.
+    // All checks passed — commit. gComboCtx and both shadows are updated.
     std::memcpy(&gComboCtx, &combo, sizeof(ComboContext));
     Context_UpdateShadowCopy(GAME_OOT, ootBlob.data(), kOoTSize);
     Context_UpdateShadowCopy(GAME_MM, mmBlob.data(), kMMSize);
+
+    // ARM the MM half so it is actually reachable.
+    //
+    // UpdateShadowCopy writes bytes without setting hasBeenFrozen, and every
+    // consumer that can move a blob into a live gSaveContext gates on that flag
+    // — so before this, a faithfully loaded MM save sat in memory byte-exact
+    // and structurally unreachable, then got overwritten by the bootstrap file
+    // the next crossing produced. That is the read-side half of "MM will be
+    // reset after game restart".
+    //
+    // MM ONLY, deliberately. OoT's own file{N+1}.sav is the authority for OoT
+    // state and is applied by Sram_OpenSave on the normal load path; arming
+    // Tier-2 as well would race a second, staler copy of OoT's world against
+    // it. MM has no such per-game file in single-exe — the unified slot is its
+    // only persistence — so Tier-3 is the one that needs delivering.
+    //
+    // Arming is refused for an all-zero tier (see Context_ArmShadowAsFrozen),
+    // which is exactly a slot saved before the player ever entered MM: that
+    // must keep cold-booting MM's own bootstrap rather than restoring a zeroed
+    // SaveContext over it. Entrance 0 is a placeholder, not a spawn decision —
+    // where a resumed MM session actually lands is MM's own owl / new-cycle
+    // policy.
+    const int armed = Context_ArmShadowAsFrozen(GAME_MM, 0);
+    std::fprintf(stderr, "[RsbsSave] slot %d loaded; MM half %s\n", slot,
+                 armed ? "armed for restore" : "empty (MM will cold-boot)");
     return true;
 }
 

--- a/src/common/tests/test_session_invalidation.c
+++ b/src/common/tests/test_session_invalidation.c
@@ -366,11 +366,47 @@ TestResult Test_SessionInvalidation(void) {
             SESSION_ASSERT(mmShadow[0] == kSessionAByte);
             SESSION_ASSERT(mmShadow[MM_SAVE_CONTEXT_SIZE - 1] == kSessionAByte);
         }
-        // A plain load must NOT arm a frozen blob. Restores stay the exclusive
-        // job of a real freeze, which is what keeps the #419/#420 "applies on
-        // the next switch only" plain-load semantics intact.
-        SESSION_ASSERT(Context_HasFrozenState(GAME_MM) == 0);
+        // A load ARMS the MM half so it is actually reachable (#35 follow-up).
+        //
+        // RENEGOTIATED, deliberately. This assertion used to require the
+        // OPPOSITE — Context_HasFrozenState(GAME_MM) == 0 — citing #419/#420's
+        // "a plain .redsave load applies on the next switch only". That
+        // contract was never implementable as written: the next cross-game
+        // switch freezes the DEPARTING game (Combo_CheckEntranceSwitch resolves
+        // its gameId from Context_GetCurrentGame), so it never armed the
+        // ARRIVING side, and the loaded MM half was applied on the next switch
+        // or on any other occasion. The old assertion was the operator's "MM
+        // will be reset after game restart" written down as required behavior.
+        SESSION_ASSERT(Context_HasFrozenState(GAME_MM) == 1);
+        // OoT stays unarmed on purpose: OoT's own file{N+1}.sav is the
+        // authority for OoT state and Sram_OpenSave applies it on the normal
+        // load path. Arming Tier-2 too would race a second, staler copy of
+        // OoT's world against it.
         SESSION_ASSERT(Context_HasFrozenState(GAME_OOT) == 0);
+
+        // ...and the complement, which is what stops the arming from being a
+        // blanket "always arm": a slot whose MM half is all zeros must NOT arm.
+        // That is precisely a slot saved before the player ever entered MM, and
+        // arming it would restore a zeroed SaveContext over the bootstrap file
+        // MM's title chain authors — strictly worse than the cold boot it
+        // replaces. Without this case the empty-tier branch is untested and a
+        // regression to unconditional arming would pass.
+        {
+            Context_InvalidateSessionOnSlotLoad();
+            SeedSessionA(0x1111u, 0x2222u);
+            std::vector<uint8_t> mmEmpty(MM_SAVE_CONTEXT_SIZE, 0);
+            Context_UpdateShadowCopy(GAME_MM, mmEmpty.data(), mmEmpty.size());
+            SESSION_ASSERT(mgr.Save(0));
+
+            Context_InvalidateSessionOnSlotLoad();
+            SESSION_ASSERT(mgr.Load(0));
+            SESSION_ASSERT(Context_HasFrozenState(GAME_MM) == 0);
+
+            // Restore slot 1 as the resident session so the cases below see the
+            // state they expect.
+            Context_InvalidateSessionOnSlotLoad();
+            SESSION_ASSERT(mgr.Load(1));
+        }
 
         // ---- 8. A slot with NO .redsave inherits nothing ------------------
         // The .redsave is per-OoT-slot but these globals are process


### PR DESCRIPTION
Part 3 of the operator-reported cross-game save breakage. Parts 1–2 were #526
and #527.

## The gap

`Load` committed both blobs through `Context_UpdateShadowCopy`, which writes
bytes and **never sets `hasBeenFrozen`**. That flag is the only thing separating
a shadow copy from a frozen blob — they are literally the same storage — and
every consumer that can move a blob into a live `gSaveContext` gates on it:

- `FrozenStateManager::RestoreState`
- `Combo_ConsumeFrozenState`
- `MM_Game_Resume`

No function in the tree could arm an existing shadow. So a faithfully loaded MM
save sat in memory byte-exact and structurally unreachable, then got overwritten
by the bootstrap file the next crossing produced. That's the read-side half of
*"MM will be reset after game restart"*.

## Changes

`Context_ArmShadowAsFrozen(game, returnEntrance)`, called from `Load`.

**MM only, deliberately.** OoT's own `file{N+1}.sav` is the authority for OoT
state and `Sram_OpenSave` applies it on the normal load path — arming Tier-2 as
well would race a second, staler copy of OoT's world against it. MM has no
per-game file in single-exe, so Tier-3 is the half that needs delivering.

**Refuses an all-zero blob.** Load-bearing, not defensive: a slot saved before
the player ever entered MM has an all-zero Tier-3, and arming it would restore a
zeroed `SaveContext` over the bootstrap file MM's title chain authors — strictly
worse than the cold boot it replaces. "No bytes" and "bytes that are all zero"
are indistinguishable here, so zero means absent.

## Contract correction

`context.h` documented the opposite as intentional — arming was *"the exclusive
job of a real freeze"*, preserving #419/#420's *"a plain .redsave load applies
on the next switch only"*.

**That was never implementable as written.** The next cross-game switch freezes
the **departing** game (`Combo_CheckEntranceSwitch` resolves its `gameId` from
`Context_GetCurrentGame`), so it never armed the **arriving** side. A loaded
blob was not applied on the next switch, or on any other occasion. Both header
comments are corrected rather than left contradicting the code.

## The test that had to be renegotiated

`src/common/tests/test_session_invalidation.c` case 7 asserted
`Context_HasFrozenState(GAME_MM) == 0` immediately after a successful `Load`,
citing #419/#420 as authority. **That assertion was the operator's bug written
down as required behavior.** It is flipped here deliberately — this is the fix,
not a regression.

Its complement is added at the same time, so the arming is not a blanket
"always arm": a slot whose MM half is all zeros must **not** arm.

**Negative control:** making the arming unconditional fails the new empty-tier
assertion, exit 1:

```
FAIL: src/common/tests/test_session_invalidation.c:403:
      Context_HasFrozenState(GAME_MM) == 0
```

Local: **62/62 redship, 14/14 rando.** No format change — `RSBS_SAVE_VERSION`
untouched, no on-disk offset moves.

## Scope

Still does **not** route a load *into* MM: boot hardcodes `GAME_OOT` and
`FileChoose_LoadGame` unconditionally enters `OoT_Play_Init`. That's part 4,
along with MM's own owl / new-cycle spawn policy, which currently has exactly
one caller (MM's file select) that a cross-game path never reaches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!--- section:artifacts:start -->
### Build Artifacts
  - [rsbs-windows.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/8677052673.zip)
  - [rsbs-linux.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/8676895326.zip)
<!--- section:artifacts:end -->