### PR TITLE
Persist MM's pause save-and-quit; drop a slot's .redsave on erase (cross-game save fix, part 4a/5)

### DIFF
--- a/games/mm/src/overlays/kaleido_scope/ovl_kaleido_scope/z_kaleido_scope_NES.c
+++ b/games/mm/src/overlays/kaleido_scope/ovl_kaleido_scope/z_kaleido_scope_NES.c
@@ -16,6 +16,12 @@
 #include "interface/icon_item_vtx_static/icon_item_vtx_static.h"
 #include "BenPort.h"
 #include <libultraship/bridge/gfxdebuggerbridge.h>
+
+// RSBS single-exe: MM's redship-native unified-save capture, defined in
+// games/mm/2s2h/GameExports_SingleExe.cpp. Declared locally because src/common
+// is not on this decomp TU's include path — the convention z_play.c and
+// z_message.c already use for the Combo_* entry points.
+extern int MM_Combo_CaptureSaveToUnifiedSlot(void);
 #include "archives/item_name_static/item_name_static.h"
 #include "archives/map_name_static/map_name_static.h"
 #include "2s2h/Enhancements/FrameInterpolation/FrameInterpolation.h"
@@ -3585,6 +3591,28 @@ void MM_KaleidoScope_Update(PlayState* play) {
                             Play_SaveCycleSceneFlags(play);
                             gSaveContext.save.saveInfo.playerData.savedSceneId = play->sceneId;
                             func_8014546C(sramCtx);
+
+                            // RSBS (#35 follow-up): persist the pause save-and-quit to the
+                            // unified .redsave, OUTSIDE the fileNum gate immediately below,
+                            // for the same reason as the owl-statue capture in z_message.c.
+                            //
+                            // A cross-game MM session runs at the 0xFF fileNum sentinel for
+                            // its whole life, so the else-branch below never runs and this
+                            // leg wrote ZERO bytes -- "save and exit in MM" persisted
+                            // nothing at all. Placed after Play_SaveCycleSceneFlags /
+                            // savedSceneId / func_8014546C so the checksummed cycle flags
+                            // and scene are already in gSaveContext.
+                            //
+                            // NOTE the asymmetry this leg has and the owl statue does not:
+                            // when the PauseSave enhancement is on, isOwlSave and
+                            // pauseSaveEntrance are set ABOVE (before the gate), while the
+                            // pair that clears them again lives in the else-branch and so
+                            // never runs cross-game. Capturing here is what makes that
+                            // state meaningful -- MM's spawn policy prefers
+                            // pauseSaveEntrance over owlWarpId, which is the correct
+                            // reading of a pause save.
+                            MM_Combo_CaptureSaveToUnifiedSlot();
+
                             if (!gSaveContext.flashSaveAvailable ||
                                 gSaveContext.fileNum ==
                                     255) { // 2S2H [Enhancement] Don't let them save if they are in debug save

--- a/games/oot/soh/SaveManager.cpp
+++ b/games/oot/soh/SaveManager.cpp
@@ -200,6 +200,22 @@ SaveManager::SaveManager() {
         }
     });
 
+    GameInteractor::Instance->RegisterGameHook<GameInteractor::OnDeleteFile>([](int32_t fileNum) {
+        // Keep the unified slot in lock-step with OoT's own file. Erasing
+        // file{N+1}.sav and starting a new game in slot N must NOT inherit the
+        // erased file's cross-game half.
+        //
+        // This was inert while nothing consumed the .redsave's recorded game —
+        // a stale slot file just sat there. It stops being inert the moment a
+        // load routes on that record: the new file would carry the old one's
+        // MM world and its sourceGame, and a fresh OoT save would be resumed
+        // into a stranger's MM session.
+        if (fileNum < 0 || fileNum >= RSBS_SAVE_MAX_SLOTS) {
+            return;
+        }
+        RsbsSave_DeleteSave(fileNum);
+    });
+
     GameInteractor::Instance->RegisterGameHook<GameInteractor::OnExitGame>([](int32_t fileNum) {
         // Snapshot on quit so unsaved cross-game flags (shared items, last
         // game) survive across a process exit even if the user never went


### PR DESCRIPTION
Part 4a of the cross-game save work. Parts 1–3 were #526, #527, #528.

Both gaps here were surfaced by adversarial review of the resume-routing design
(two independent designs, each judged against the code). Both are prerequisites
for that routing, and **the first is a correctness gap in #527, not new scope**.

## 1. Pause save-and-quit persisted nothing

#527 wired `MM_Combo_CaptureSaveToUnifiedSlot` into the **owl-statue leg only**.
The pause menu's save-and-quit runs `Play_SaveCycleSceneFlags`, records
`savedSceneId`, calls `func_8014546C` — then hits
`!flashSaveAvailable || fileNum == 255` and jumps to `PAUSE_SAVEPROMPT_STATE_5`
with **no write at all**.

A cross-game MM session is pinned at the `0xFF` sentinel for its entire life, so
that leg wrote zero bytes. The operator's request was literally *"if they save
and exit in MM"* — #527 did not cover it.

**A correction to my own earlier reasoning.** I had held that
`pauseSaveEntrance` could never be populated in a cross-game session. That is
wrong: with the PauseSave enhancement on, `isOwlSave` and `pauseSaveEntrance`
are both set **before** the gate, while the pair that clears them again lives in
the `else` branch that never runs cross-game. Capturing here is what makes that
state meaningful rather than stale — MM's spawn policy prefers
`pauseSaveEntrance` over `owlWarpId`, which is the correct reading of a pause
save.

## 2. Erasing an OoT file left its .redsave behind

`OnDeleteFile` is defined in `GameInteractor_HookTable.h` and dispatched
directly via `ExecuteHooks` (bypassing `GI_SINGLE_EXE_GATE`, so it genuinely
fires) — but nothing was registered against it.

Harmless while nothing consumed the recorded game. It stops being harmless the
moment a load routes on that record: erasing `file{N+1}.sav` and starting a new
game in slot N would carry the erased file's MM world **and** its `sourceGame`,
so a fresh OoT file would resume into a stranger's MM session. Pulled forward
rather than deferred precisely because the next commit is what makes it
reachable.

## Verification

Local: **62/62 redship, 14/14 rando.** No format change — `RSBS_SAVE_VERSION`
untouched, no on-disk offset moves.

## Next (4b, the routing itself)

Design is complete and judged sound. The seam is verified: `OoT_RunFrame`
returns from *inside* the gamestate loop and `Combo_CheckHotSwap` is tested at
`graph.c:586` **before** the loop is re-entered, so arming a pending switch at
the file-select confirm discards the queued `Play_Init` transition without
touching `SET_NEXT_GAMESTATE`. `gComboCtx.sourceGame` and the armed Tier-3 are
both committed before that point.

Hardening the review demanded, going into 4b:
- gate on `Combo_HasFrozenState("mm")` **and** `sourceGame` — a stale record
  alone would drop the player into "Dawn of the First Day" on a blank file
- make the `mm.o2r` archive pre-flight **mandatory**; a refused switch re-runs
  `OoT_SystemHeap_Init` over a live `FileChooseContext` (a confirmed AV class)
- a game-**tagged** resume primitive; today's `Combo_SetStartupEntrance` tags
  `GAME_NONE`, a wildcard both title chains accept
- factor MM's owl/new-cycle policy out of `MM_Sram_OpenSave`'s flash I/O, keeping
  the single-use `VB_DELETE_OWL_SAVE` consume on the correct side of the split

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!--- section:artifacts:start -->
### Build Artifacts
  - [rsbs-windows.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/8716915939.zip)
  - [rsbs-linux.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/8716667203.zip)
<!--- section:artifacts:end -->