### PR TITLE
Share rupees and hearts across both games, and shrink the pool they replace (#525)

### DIFF
--- a/CMake/SingleExecutable.cmake
+++ b/CMake/SingleExecutable.cmake
@@ -28,6 +28,12 @@ set(REDSHIP_COMMON_SOURCES
     # Cross-game shared-item producers/consumers over gComboCtx.sharedItemsTagged
     # (ADR 0002, Lane A1) — read/written by both games' suspend + consumption hooks
     ${CMAKE_SOURCE_DIR}/src/common/shared_items.c
+    # Shared cross-game RESOURCES over gComboCtx.sharedResources (#525) — one
+    # quantity spanning both games (rupees, wallet tier, hearts, current health,
+    # double defense), harvested at each game's suspend and applied at its
+    # startup entrance. Distinct from shared_items.c: that carries one-way
+    # single-use crossings, this carries a continuously shared value.
+    ${CMAKE_SOURCE_DIR}/src/common/shared_resources.c
     # Foreign-item placement table over gComboCtx.foreignPlacements (Lane C1,
     # #392) — written by MM's paired-world generation, read by MM's give path
     # and both spoiler surfaces; the pinned pool itself is OoT-side
@@ -381,6 +387,14 @@ if(BUILD_TESTING)
     # silent at compile and link time and would leave OoT unable to place
     # anything (#516's dead-registrar class).
     redship_add_test(NAME ForeignPoolMM COMMAND redship --test foreign-pool-mm)
+    # Shared cross-game resources (#525): rupees and hearts are ONE quantity
+    # spanning both games. Locks the delta-harvest watermark that survives MM's
+    # 500-rupee tier-3 wallet against OoT's 999 (a naive copy costs the player
+    # 300 rupees per round trip), the monotonic/consumable split, the
+    # first-harvest seed that stops a .redsave load from doubling the balance,
+    # and the canonical heart quantity with its 20-heart clamp. Display-free,
+    # ROM-free and save-free, so it runs in this redship tier.
+    redship_add_test(NAME SharedResources COMMAND redship --test shared-resources)
     redship_add_test(NAME ComboSpoilerView COMMAND redship --test combo-spoiler-view)
     redship_add_test(NAME ComboSpoilerWindow COMMAND redship --test combo-spoiler-window)
     # MM randomizer options (#497 step 4, #499). Display-free: the option table

--- a/docs/adr/0009-combo-settings-and-reverse-pool.md
+++ b/docs/adr/0009-combo-settings-and-reverse-pool.md
@@ -182,8 +182,8 @@ determinism digest.
 
 `reserved[]` begins at offset 740 and there are 20 further bytes of record slack
 (`sizeof(ComboContext)` 1004 vs. `RSBS_COMBO_CONTEXT_RECORD_SIZE` 1024), so
-Tier-1 growth capacity is **284 bytes**. Five work items are queued against it.
-Publishing the allocation once beats four sequential re-versions:
+Tier-1 growth capacity is **284 bytes**. Six work items are queued against it.
+Publishing the allocation once beats five sequential re-versions:
 
 | # | Claimant | Size | Status |
 |---|---|---|---|
@@ -191,10 +191,26 @@ Publishing the allocation once beats four sequential re-versions:
 | 2 | `comboSettingsHash` (#498 decision 1, Lane 1) | 4 B | reserved |
 | 3 | MM option-profile digest (#497 step 7 / #499 step 4, Lane 4) | 4 B | **carved by Lane 4; size CONFIRMED at 4 B** |
 | 4 | Netplay grant fields (#460, ADR 0005/0007) | 64 B | reserved |
-| 5 | Unallocated floor | 164 B | must not drop below 64 |
+| 5 | `sharedResources[8]` (#525, shared rupees + hearts) | 32 B | **carved by #525** |
+| 6 | Unallocated floor | 132 B | must not drop below 64 |
 
-Total reserved-against: 120 B of 284. After claims 1 and 3 land, `reserved[]` is
-212 bytes and 232 B of capacity remain.
+Total reserved-against: 152 B of 284. After claims 1, 3 and 5 land, `reserved[]`
+is 180 bytes and 200 B of capacity remain.
+
+**Claim 5, settled (#525, 2026-07-29).** Shared cross-game resources are eight
+kind-tagged 4-byte slots — `ComboSharedResource sharedResources[8]` at `.redsave`
+byte offset **792**, immediately after `mmProfileDigest`. v1 occupies five of the
+eight (rupees, wallet tier, health quarters, current health, double defense);
+shared magic and the ammo upgrades are the queued members of the same class and
+fit in the remaining three without another carve, which is why the claim is sized
+at the array rather than at today's five resources.
+
+The tag is load-bearing, not bookkeeping. This ADR's growth contract is "zero
+means unset", and **0 rupees is a legal player state** — so a bare `uint16_t
+sharedRupees` cannot distinguish a pre-#525 record from a broke player, and would
+either resurrect a stale balance or discard a real zero. Occupancy therefore
+rides `kind != RSBS_SHARED_RES_NONE`, exactly as `SharedItem`'s rides
+`originGame != GAME_NONE`. Do not "simplify" the slots back into scalars.
 
 **Claim 3, settled (Lane 4, 2026-07-23).** The digest is a single `uint32_t
 mmProfileDigest` at `.redsave` byte offset 788, computed by

--- a/games/mm/2s2h/GameExports_SingleExe.cpp
+++ b/games/mm/2s2h/GameExports_SingleExe.cpp
@@ -35,6 +35,7 @@
 #include "context.h"
 #include "save.h" // RsbsSave_* — MM's redship-native unified-save capture
 #include "shared_items.h"
+#include "shared_resources.h" // Shared cross-game rupees/hearts (#525)
 // Paired-world keying + placement-table accessors (#439 switch-entry
 // activation logs the placement count at the pairing decision point).
 #include "foreign_items.h"
@@ -1367,6 +1368,10 @@ extern "C" void MM_GameEvents_RegisterPump(void);
 // games/mm/2s2h/TrackersGuiSingleExe.cpp.
 extern "C" void MM_TrackersGui_Init(void);
 
+// Cycle-safe shared rupees (#525) — defined further down THIS TU, beside the
+// rest of the MM shared-resource half.
+extern "C" void MM_RegisterSharedResourceCycleHooks(void);
+
 // Defined below in this TU; forward-declared so the #516 GfxPatcher gate can
 // reference it from MM_Rando_Init above the definition.
 extern "C" bool MM_Rando_AssetsReady(void);
@@ -1454,6 +1459,18 @@ extern "C" void MM_Rando_Init(void) {
     // SetupGuiElements (excluded); the bypass surface lives in
     // 2s2h/TrackersGuiSingleExe.cpp. No-op when the harness has no window.
     MM_TrackersGui_Init();
+
+    // Shared cross-game resources (#525): keep the SHARED rupee pool alive
+    // across MM's three-day cycle. Registered from HERE, not from
+    // 2s2h/Enhancements/Cycle/EndOfCycle.cpp where the analogous
+    // DoNotResetRupees restore lives, because that TU is link-elided from the
+    // plain-archive 2ship_enh — its six registrants are absent from the binary
+    // (verified against redship.map; see the Before/AfterEndOfCycleSave
+    // dispatch comment below). Registering there would be the #516/#513
+    // elided-provider class exactly: code that reads correctly and never runs.
+    // This TU is always linked, and the sRandoInitDone guard above is what
+    // makes the registration once-only, as the block header requires.
+    MM_RegisterSharedResourceCycleHooks();
 }
 
 /**
@@ -1481,6 +1498,11 @@ void MM_Game_Run(void) {
     fflush(stderr);
 }
 
+// Shared cross-game resources (#525) — defined further down this TU beside the
+// apply half; forward-declared so Game_Suspend and the unified-save capture can
+// harvest before they hand MM's state over.
+extern "C" void MM_HarvestSharedResources(void);
+
 /**
  * Suspend MM for a game switch (issue #270).
  * Stops audio to prevent interference with OoT, keeps libultraship context and
@@ -1498,6 +1520,11 @@ void MM_Game_Suspend(void) {
     // calls suspend() on both switch paths, so this is the one point that never
     // drops a hotkey switch's writes.
     Combo_CommitStagedSharedItems();
+
+    // Shared cross-game resources (#525) — mirrors OoT_Game_Suspend. Fold MM's
+    // live rupees, wallet tier, hearts, current health and double defense into
+    // the shared pool while gSaveContext still belongs to MM.
+    MM_HarvestSharedResources();
 
     // Drain the SHARED audio thread before touching MM's audio state. In
     // single-exe builds MM's synth runs on OoT's OTRAudio_Thread (the
@@ -1603,6 +1630,12 @@ extern "C" int MM_Combo_CaptureSaveToUnifiedSlot(void) {
         fflush(stderr);
         return 0;
     }
+
+    // Shared cross-game resources (#525) BEFORE the shadow capture, so the pool
+    // and the MM blob stored beside it agree. Without it, money earned since the
+    // last switch lives in the MM save but not in the pool, and the post-load
+    // first-harvest seed reads that balance as already counted and drops it.
+    MM_HarvestSharedResources();
 
     Context_UpdateShadowCopy(GAME_MM, &gSaveContext, sizeof(gSaveContext));
     gComboCtx.sourceGame = GAME_MM;
@@ -2088,6 +2121,219 @@ static void MM_AwardSharedItem(const SharedItem* item, void* ctx) {
  */
 void MM_ConsumeSharedItems(void) {
     Combo_RedeemSharedItemsForGame(GAME_MM, MM_AwardSharedItem, nullptr);
+}
+
+// ============================================================================
+// Shared cross-game RESOURCES — MM side (#525)
+//
+// The OoT twin of this block is games/oot/soh/GameExports_SingleExe.cpp; the
+// merge rules both call into live in src/common/shared_resources.c, which has
+// no game headers. This half owns MM's field names and unit conversions.
+//
+// THE ASYMMETRY THAT MAKES THE WATERMARK NECESSARY LIVES HERE: MM's
+// gUpgradeCapacities row for UPG_WALLET is {99, 200, 500, 500} while OoT's is
+// {99, 200, 500, 999}. At tier 3 MM can hold 500 and OoT 999, so a shared pool
+// above 500 simply does not fit in MM's wallet. The pool keeps the true total;
+// apply materializes only what fits and records THAT as the watermark, so the
+// overflow rides out the MM visit instead of being harvested away.
+// ============================================================================
+
+// MM's own upgrade setter and the three tables CUR_UPG_VALUE / CUR_CAPACITY
+// expand to (games/mm/src/code/z_inventory.c, declared in variables.h).
+// Declared here rather than by including variables.h, for the same
+// narrow-header-surface reason as the OoT twin; the declarations match
+// variables.h exactly.
+extern "C" void MM_Inventory_ChangeUpgrade(s16 upgrade, u32 value);
+extern "C" u32 MM_gUpgradeMasks[8];
+extern "C" u8 MM_gUpgradeShifts[8];
+extern "C" u16 MM_gUpgradeCapacities[][4];
+
+// Heart pieces occupy the TOP NIBBLE of questItems in both games
+// (MM's QUEST_HEART_PIECE_COUNT is 0x1C; OoT writes 1 << (QUEST_HEART_PIECE+4)).
+#define MM_HEART_PIECE_SHIFT 28u
+#define MM_HEART_PIECE_MASK 0xF0000000u
+
+// Highest wallet tier this build defines (MM_gUpgradeCapacities UPG_WALLET row
+// has 4 entries). Bounds the pool value so a tier authored by a future build
+// cannot index off the end of MM's capacity table.
+#define MM_MAX_WALLET_TIER 3u
+
+static uint16_t MM_ReadHealthQuarters(void) {
+    const uint16_t pieces =
+        (uint16_t)((gSaveContext.save.saveInfo.inventory.questItems & MM_HEART_PIECE_MASK) >> MM_HEART_PIECE_SHIFT);
+    const s16 rawCapacity = gSaveContext.save.saveInfo.playerData.healthCapacity;
+    // MM converts 4 pieces into a container immediately inside Item_GiveImpl,
+    // where OoT defers to textbox close — so MM never produces the pieces==4
+    // state OoT can sit in. The canonical quantity (capacity + 4 per piece)
+    // dissolves that divergence rather than guarding it; the arithmetic has one
+    // definition, in src/common.
+    return Combo_MakeHealthQuarters(rawCapacity < 0 ? 0u : (uint16_t)rawCapacity, pieces);
+}
+
+/**
+ * HARVEST (#525), the twin of OoT_HarvestSharedResources.
+ *
+ * Called from MM_Game_Suspend and immediately before MM's `.redsave` writes.
+ * Idempotent in both merge disciplines.
+ */
+extern "C" void MM_HarvestSharedResources(void) {
+    // Settle rupeeAccumulator into the count first — MM drains it one per frame
+    // exactly as OoT does, so a pending accumulator would be harvested as
+    // nothing now and then credited again later.
+    const int32_t walletCap = (int32_t)CUR_CAPACITY(UPG_WALLET);
+    int32_t liveRupees = (int32_t)gSaveContext.save.saveInfo.playerData.rupees + (int32_t)gSaveContext.rupeeAccumulator;
+    if (liveRupees < 0) {
+        liveRupees = 0;
+    }
+    if (liveRupees > walletCap) {
+        liveRupees = walletCap;
+    }
+    gSaveContext.save.saveInfo.playerData.rupees = (s16)liveRupees;
+    gSaveContext.rupeeAccumulator = 0;
+
+    Combo_HarvestSharedResource(GAME_MM, RSBS_SHARED_RES_RUPEES, (uint16_t)liveRupees);
+    Combo_HarvestSharedResource(GAME_MM, RSBS_SHARED_RES_WALLET_TIER, (uint16_t)CUR_UPG_VALUE(UPG_WALLET));
+    Combo_HarvestSharedResource(GAME_MM, RSBS_SHARED_RES_HEALTH_QUARTERS, MM_ReadHealthQuarters());
+    Combo_HarvestSharedResource(
+        GAME_MM, RSBS_SHARED_RES_HEALTH_CURRENT,
+        gSaveContext.save.saveInfo.playerData.health < 0 ? 0u : (uint16_t)gSaveContext.save.saveInfo.playerData.health);
+    Combo_HarvestSharedResource(GAME_MM, RSBS_SHARED_RES_DOUBLE_DEFENSE,
+                                gSaveContext.save.saveInfo.playerData.doubleDefense ? 1u : 0u);
+}
+
+/**
+ * APPLY (#525), the twin of OoT_ApplySharedResources.
+ *
+ * Called from MM_Play_ConsumeStartupEntrance beside MM_ConsumeSharedItems, once
+ * per cross-game arrival into MM. Capacities are applied before the quantities
+ * they bound.
+ *
+ * Touches gSaveContext only — no MM_gPlayState — so it is safe at this point in
+ * the arrival, which runs BEFORE `MM_gPlayState = this` (z_play.c). That is the
+ * same constraint that forces MM's shared-ITEM give to defer to the first
+ * gameplay frame; a direct save-field write has no such dependency.
+ */
+extern "C" void MM_ApplySharedResources(void) {
+    // --- Wallet tier (monotonic). Raises MM's clamp before rupees land.
+    uint16_t walletTier = (uint16_t)CUR_UPG_VALUE(UPG_WALLET);
+    if (Combo_ApplySharedResource(GAME_MM, RSBS_SHARED_RES_WALLET_TIER, MM_MAX_WALLET_TIER, &walletTier)) {
+        MM_Inventory_ChangeUpgrade(UPG_WALLET, (u32)walletTier);
+    }
+
+    // --- Health capacity + pieces from the one canonical quantity, clamped at
+    // 20 hearts: neither game's give path clamps capacity, and a total summed
+    // across both games' pieces and containers passes 20 easily.
+    uint16_t quarters = MM_ReadHealthQuarters();
+    if (Combo_ApplySharedResource(GAME_MM, RSBS_SHARED_RES_HEALTH_QUARTERS,
+                                  (uint16_t)RSBS_SHARED_RES_MAX_HEALTH_QUARTERS, &quarters)) {
+        uint16_t capacity = 0;
+        uint16_t pieces = 0;
+        Combo_SplitHealthQuarters(quarters, &capacity, &pieces);
+        gSaveContext.save.saveInfo.playerData.healthCapacity = (s16)capacity;
+        gSaveContext.save.saveInfo.inventory.questItems =
+            (gSaveContext.save.saveInfo.inventory.questItems & ~MM_HEART_PIECE_MASK) |
+            ((uint32_t)pieces << MM_HEART_PIECE_SHIFT);
+    }
+
+    // --- Double defense (monotonic 0/1). MM spells the flag `doubleDefense`
+    // where OoT spells it `isDoubleDefenseAcquired`, and each game keeps its own
+    // inventory.defenseHearts counter that its life meter reads — so this
+    // shares the FACT and lets each side set its own pair. A byte copy across
+    // the two layouts would be wrong in both directions.
+    uint16_t doubleDefense = gSaveContext.save.saveInfo.playerData.doubleDefense ? 1u : 0u;
+    if (Combo_ApplySharedResource(GAME_MM, RSBS_SHARED_RES_DOUBLE_DEFENSE, 1u, &doubleDefense) && doubleDefense != 0) {
+        gSaveContext.save.saveInfo.playerData.doubleDefense = 1;
+        if (gSaveContext.save.saveInfo.inventory.defenseHearts < 20) {
+            gSaveContext.save.saveInfo.inventory.defenseHearts = 20;
+        }
+    }
+
+    // --- Rupees (consumable), clamped to the wallet capacity just applied.
+    uint16_t rupees =
+        gSaveContext.save.saveInfo.playerData.rupees < 0 ? 0u : (uint16_t)gSaveContext.save.saveInfo.playerData.rupees;
+    if (Combo_ApplySharedResource(GAME_MM, RSBS_SHARED_RES_RUPEES, (uint16_t)CUR_CAPACITY(UPG_WALLET), &rupees)) {
+        gSaveContext.save.saveInfo.playerData.rupees = (s16)rupees;
+    }
+    gSaveContext.rupeeAccumulator = 0;
+
+    // --- Current health (consumable): one bar across both games.
+    uint16_t health =
+        gSaveContext.save.saveInfo.playerData.health < 0 ? 0u : (uint16_t)gSaveContext.save.saveInfo.playerData.health;
+    if (Combo_ApplySharedResource(GAME_MM, RSBS_SHARED_RES_HEALTH_CURRENT,
+                                  (uint16_t)gSaveContext.save.saveInfo.playerData.healthCapacity, &health)) {
+        // Floored at one heart for the same reason as OoT's side: a departing
+        // game cannot normally hand over a dead bar, and spawning dead on an
+        // arrival lands in a death handler no arrival path has been tested
+        // through.
+        gSaveContext.save.saveInfo.playerData.health = (s16)(health < 0x10u ? 0x10u : health);
+    }
+}
+
+// ============================================================================
+// Cycle-safe shared rupees (#525)
+// ============================================================================
+//
+// MM's three-day cycle zeroes the wallet: Sram_SaveEndOfCycle
+// (games/mm/src/code/z_sram_NES.c) sets playerData.rupees = 0 and
+// rupeeAccumulator = 0, and both Song of Time and "Dawn of the New Day" run it.
+// With ONE shared pool spanning both games, leaving that unhandled means the
+// next delta harvest computes `0 - watermark` and the wipe drains the OoT
+// rupees too.
+//
+// OPERATOR CALL: the shared pool is CYCLE-SAFE. A Song of Time no longer costs
+// the player money that crossed over from OoT. This is a deliberate departure
+// from vanilla MM, taken because the alternative — strict one-game semantics —
+// lets an MM mechanic silently delete an OoT-side grind the player was not
+// thinking about when they played the song. Rupees SPENT in MM are still gone;
+// only the wipe is suppressed.
+//
+// This is the same seam 2S2H's own DoNotResetRupees enhancement uses, and the
+// restore is deliberately unconditional rather than CVar-gated: the shared pool
+// is not an optional enhancement, it is the resource model this build ships.
+//
+// The pair brackets the wipe — Before snapshots, After restores — and both are
+// genuinely dispatched in single-exe as of #514
+// (MM_GameHooks_ExecuteBefore/AfterEndOfCycleSave below, called from
+// z_sram_NES.c, locked by games/mm/2s2h/mm_hook_dispatch_test.cpp). That was
+// checked before this was written, not assumed: registering against a hook
+// nothing dispatches is a documented recurring failure here (#512/#517).
+//
+// No watermark bookkeeping is needed. Nothing harvests during a cycle save, and
+// the restore puts the count back where the watermark already expects it, so
+// the round trip is invisible to the delta arithmetic.
+//
+// CURRENT HEALTH deliberately has no equivalent hook. The cycle reset floors
+// health at 0x30, and under one-health-bar semantics that is a Song of Time
+// healing the single shared bar — which is what "as if OoT and MM were one
+// game" means. It reads as a heal, not a bug.
+
+static s16 sPreCycleRupees = 0;
+
+extern "C" void MM_RegisterSharedResourceCycleHooks(void) {
+    S2H::GameHooks::Register<GameInteractor::BeforeEndOfCycleSave>([]() {
+        // Snapshot the SETTLED balance: a pending accumulator is money the
+        // player has earned but not yet seen counted, and the wipe below drops
+        // it too. Clamped to the wallet so the restore cannot exceed what MM
+        // can hold.
+        const int32_t walletCap = (int32_t)CUR_CAPACITY(UPG_WALLET);
+        int32_t settled =
+            (int32_t)gSaveContext.save.saveInfo.playerData.rupees + (int32_t)gSaveContext.rupeeAccumulator;
+        if (settled < 0) {
+            settled = 0;
+        }
+        if (settled > walletCap) {
+            settled = walletCap;
+        }
+        sPreCycleRupees = (s16)settled;
+    });
+
+    S2H::GameHooks::Register<GameInteractor::AfterEndOfCycleSave>([]() {
+        gSaveContext.save.saveInfo.playerData.rupees = sPreCycleRupees;
+        gSaveContext.rupeeAccumulator = 0;
+        // The "you lost your rupees" notice would be a lie now, and it is the
+        // same flag 2S2H's DoNotResetRupees clears for the same reason.
+        CLEAR_EVENTINF(EVENTINF_THREEDAYRESET_LOST_RUPEES);
+    });
 }
 
 /**

--- a/games/mm/2s2h/Rando/ForeignItemsSingleExe.cpp
+++ b/games/mm/2s2h/Rando/ForeignItemsSingleExe.cpp
@@ -162,8 +162,29 @@ extern "C" {
 //      pickup text promises an award in Termina; delivering MM's trap machinery
 //      instead would make that text a lie.
 //
+//  (6) It is NOT a shared cross-game resource (#525). Rupees and hearts are one
+//      quantity spanning both games now — one wallet, one health bar, capacity
+//      AND current value (src/common/shared_resources.h) — so there is nothing
+//      left for a wallet or heart item to CROSS. Shipping one anyway would hand
+//      the player a second copy of a capacity they already have, or worse, a
+//      rupee award that the next harvest reconciles straight back out. Six rows
+//      left with the sharing that replaced them: RI_PROGRESSIVE_WALLET,
+//      RI_WALLET_ADULT, RI_WALLET_GIANT, RI_DOUBLE_DEFENSE, RI_HEART_CONTAINER
+//      and RI_HEART_PIECE.
+//
+//      Note RI_DOUBLE_DEFENSE was NOT in the "Health" block — it sat under core
+//      equipment, so a block delete misses it. The block-shaped grouping below
+//      is presentational; criterion 6 is not.
+//
+//      This criterion grows with the shared-resource set. Shared magic and the
+//      ammo upgrades are the queued members of that class, and when they land,
+//      RI_PROGRESSIVE_MAGIC / RI_SINGLE_MAGIC / RI_DOUBLE_MAGIC and the
+//      quiver/bomb-bag rows leave by this same rule — see the collision trap in
+//      #525's optional tier before deleting the bomb bags, since "Bomb Bag" is
+//      the only name shared with OoT's pool and a test depends on it.
+//
 // Everything else is IN — every mask, every song, every bottle, both shields,
-// the sword and magic and wallet and quiver and bomb-bag upgrades, the
+// the sword and magic and quiver and bomb-bag upgrades, the
 // progressives (which resolve against the LIVE MM save, so they are the single
 // best-behaved cross-game gift, and the OoT pool sets the precedent with
 // RG_PROGRESSIVE_HOOKSHOT / RG_PROGRESSIVE_STRENGTH), the boss remains, the
@@ -180,7 +201,7 @@ extern "C" {
 // deferred to the first frame with a live MM_gPlayState (see the file header),
 // which is item-agnostic and O(1) in pool size — the #502 design note says in as
 // many words that an allowlist audited against today's pool would expire the
-// moment somebody added a row. This pool is that row, 134 times over, and it
+// moment somebody added a row. This pool is that row, 128 times over, and it
 // relies on the deferral instead of re-auditing it.
 //
 // Display names are MM's own (Rando::StaticData::Items) verbatim. They are a
@@ -196,7 +217,6 @@ static const ComboForeignItemDef kForeignPoolMMV1[] = {
     { { (uint8_t)GAME_MM, 0, (uint16_t)RI_PROGRESSIVE_BOW }, "Progressive Bow", "a " },
     { { (uint8_t)GAME_MM, 0, (uint16_t)RI_PROGRESSIVE_BOMB_BAG }, "Progressive Bomb Bag", "a " },
     { { (uint8_t)GAME_MM, 0, (uint16_t)RI_PROGRESSIVE_MAGIC }, "Progressive Magic", "" },
-    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_PROGRESSIVE_WALLET }, "Progressive Wallet", "a " },
     { { (uint8_t)GAME_MM, 0, (uint16_t)RI_PROGRESSIVE_LULLABY }, "Progressive Goron Lullaby", "" },
 
     // --- Core equipment, abilities and capacity upgrades.
@@ -211,8 +231,6 @@ static const ComboForeignItemDef kForeignPoolMMV1[] = {
     { { (uint8_t)GAME_MM, 0, (uint16_t)RI_BOMB_BAG_40 }, "Biggest Bomb Bag", "the " },
     { { (uint8_t)GAME_MM, 0, (uint16_t)RI_QUIVER_40 }, "Large Quiver", "the " },
     { { (uint8_t)GAME_MM, 0, (uint16_t)RI_QUIVER_50 }, "Largest Quiver", "the " },
-    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_WALLET_ADULT }, "Adult's Wallet", "the " },
-    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_WALLET_GIANT }, "Giant's Wallet", "the " },
     { { (uint8_t)GAME_MM, 0, (uint16_t)RI_POWDER_KEG }, "Powder Keg", "a " },
     { { (uint8_t)GAME_MM, 0, (uint16_t)RI_PICTOGRAPH_BOX }, "Pictograph Box", "a " },
     { { (uint8_t)GAME_MM, 0, (uint16_t)RI_MAGIC_BEAN }, "Magic Bean", "a " },
@@ -226,7 +244,6 @@ static const ComboForeignItemDef kForeignPoolMMV1[] = {
     { { (uint8_t)GAME_MM, 0, (uint16_t)RI_GREAT_SPIN_ATTACK }, "Great Spin Attack", "the " },
     { { (uint8_t)GAME_MM, 0, (uint16_t)RI_SINGLE_MAGIC }, "Power of Magic", "the " },
     { { (uint8_t)GAME_MM, 0, (uint16_t)RI_DOUBLE_MAGIC }, "Magic Upgrade", "a " },
-    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_DOUBLE_DEFENSE }, "Double Defense", "" },
 
     // --- Bottles (the bottle itself, not its refills).
     { { (uint8_t)GAME_MM, 0, (uint16_t)RI_BOTTLE_EMPTY }, "Empty Bottle", "an " },
@@ -298,9 +315,8 @@ static const ComboForeignItemDef kForeignPoolMMV1[] = {
     { { (uint8_t)GAME_MM, 0, (uint16_t)RI_REMAINS_GYORG }, "Gyorg's Remains", "" },
     { { (uint8_t)GAME_MM, 0, (uint16_t)RI_REMAINS_TWINMOLD }, "Twinmold's Remains", "" },
 
-    // --- Health.
-    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_HEART_CONTAINER }, "Heart Container", "a " },
-    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_HEART_PIECE }, "Heart Piece", "a " },
+    // --- Health: EMPTY since #525. Heart containers, heart pieces and double
+    // defense are a SHARED RESOURCE now (criterion 6 below), not a crossing.
 
     // --- Skulltula tokens.
     { { (uint8_t)GAME_MM, 0, (uint16_t)RI_GS_TOKEN_SWAMP }, "Swamp Gold Skulltula Token", "a " },

--- a/games/mm/src/code/z_play.c
+++ b/games/mm/src/code/z_play.c
@@ -77,6 +77,12 @@ extern int Combo_ConsumeFrozenState(const char* gameId, void* saveContext, size_
 // SharedItem/GameId types.
 extern void MM_ConsumeSharedItems(void);
 
+// Cross-game shared-RESOURCE apply (#525). Reconciles MM's live rupees, wallet
+// tier, hearts, current health and double defense against the single shared
+// pool in gComboCtx. Declared rather than included so this TU stays free of the
+// src/common resource types.
+extern void MM_ApplySharedResources(void);
+
 // Paired-world activation on the switch-entry path (#439). Defined in
 // games/mm/2s2h/GameExports_SingleExe.cpp so this TU stays free of the Rando
 // C++ surface. Dispatches OnSaveInit (the generation entry point) when a live
@@ -2403,6 +2409,13 @@ void MM_Play_ConsumeStartupEntrance(void) {
     // (RSBS_SHARED_ITEM_REDEEMED). Presence-gated by this function's early
     // return, so it runs once per MM arrival and never on a plain boot/.redsave
     // load — un-redeemed items then wait for the next switch into MM.
+    //
+    // Shared cross-game RESOURCES (#525) go FIRST, before the item consumer,
+    // for the same reason as OoT's side: apply authors an absolute rupee count
+    // and heart capacity from the pool, so a shared item given before it would
+    // be overwritten. Applied first, a give layers on top and the next harvest
+    // picks it up as a delta.
+    MM_ApplySharedResources();
     MM_ConsumeSharedItems();
     Combo_ClearStartupEntrance();
 

--- a/games/oot/soh/Enhancements/randomizer/ForeignItemsSingleExe.cpp
+++ b/games/oot/soh/Enhancements/randomizer/ForeignItemsSingleExe.cpp
@@ -248,7 +248,7 @@ static uint32_t OoT_Foreign_SelectNext() {
  * codes (`if (ret < 0) return false`), so shortfall rides that convention.
  *
  * A PARTIAL placement is NOT a shortfall and must not fail generation: the pool
- * is ~134 entries against a cap of 8, so placing fewer than the pool is the
+ * is ~128 entries against a cap of 8, so placing fewer than the pool is the
  * normal, intended outcome. Only two states are errors, and both mean the
  * cross-game half of a PAIRED world would be silently absent:
  *   -1  the MM pool is not registered at all (the Mode-B elision class — if

--- a/games/oot/soh/GameExports_SingleExe.cpp
+++ b/games/oot/soh/GameExports_SingleExe.cpp
@@ -22,7 +22,8 @@
 #include "context.h"
 #include "save.h" // RsbsSave_SetActiveSlot — publish the slot MM will save into
 #include "shared_items.h"
-#include "foreign_items.h" // OoT_ForeignItem_Give (Lane C1 redemption)
+#include "shared_resources.h" // Shared cross-game rupees/hearts (#525)
+#include "foreign_items.h"    // OoT_ForeignItem_Give (Lane C1 redemption)
 #include "entrance.h"
 #include "soh/Enhancements/game-interactor/GameInteractor.h"
 #include "soh/Enhancements/game-interactor/GameInteractor_Hooks.h"
@@ -809,6 +810,10 @@ void OoT_Game_Run(void) {
     fflush(stderr);
 }
 
+// Shared cross-game resources (#525) — defined further down this TU, beside the
+// apply half; forward-declared so Game_Suspend can harvest.
+extern "C" void OoT_HarvestSharedResources(void);
+
 /**
  * Suspend OoT for a game switch (issue #160).
  * Stops audio to prevent interference with MM, keeps libultraship context alive.
@@ -827,6 +832,13 @@ void OoT_Game_Suspend(void) {
     // being shared; committing here just moves staged pickups into the durable
     // (serialized) store before the arriving game's consumer reads it.
     Combo_CommitStagedSharedItems();
+
+    // Shared cross-game resources (#525): fold OoT's live rupees, wallet tier,
+    // hearts, current health and double defense into the shared pool while
+    // gSaveContext still belongs to OoT. Same reason this sits at Game_Suspend
+    // rather than Combo_CheckEntranceSwitch — the F10 path bypasses the
+    // entrance hook, and both switch paths call suspend().
+    OoT_HarvestSharedResources();
 
     // Stop OoT audio playback to prevent interference with MM (issue #160).
     // OoT_Audio_PreNMI triggers the audio reset path which stops all sequences
@@ -1088,6 +1100,158 @@ static void OoT_AwardSharedItem(const SharedItem* item, void* ctx) {
  */
 extern "C" void OoT_ConsumeSharedItems(void) {
     Combo_RedeemSharedItemsForGame(GAME_OOT, OoT_AwardSharedItem, nullptr);
+}
+
+// ============================================================================
+// Shared cross-game RESOURCES — OoT side (#525)
+//
+// The merge rules live in src/common/shared_resources.c, which has no game
+// headers. This is the half that does: it reads and writes OoT's own
+// gSaveContext fields and converts them into the units the pool is defined in.
+// MM's twin is games/mm/2s2h/GameExports_SingleExe.cpp.
+// ============================================================================
+
+// OoT's own upgrade setter and the three tables CUR_UPG_VALUE / CUR_CAPACITY
+// expand to (games/oot/src/code/z_inventory.c, declared in variables.h).
+// Declared here rather than by including variables.h: this TU deliberately keeps
+// a narrow game-header surface — it already hand-declares gSaveContext for the
+// same reason — and pulling in the full variable set to reach three arrays would
+// widen it for no benefit. The declarations match variables.h exactly, so a
+// layout change breaks the link rather than reading garbage.
+extern "C" void OoT_Inventory_ChangeUpgrade(s16 upgrade, s16 value);
+extern "C" u32 OoT_gUpgradeMasks[8];
+extern "C" u8 OoT_gUpgradeShifts[8];
+extern "C" u16 OoT_gUpgradeCapacities[8][4];
+
+// Heart pieces live in the TOP NIBBLE of questItems in BOTH games (OoT writes
+// `1 << (QUEST_HEART_PIECE + 4)`, MM's QUEST_HEART_PIECE_COUNT is 0x1C), which
+// is what makes one canonical quantity possible at all.
+#define OOT_HEART_PIECE_SHIFT 28u
+#define OOT_HEART_PIECE_MASK 0xF0000000u
+
+// The highest wallet tier this build defines (OoT_gUpgradeCapacities row
+// UPG_WALLET is {99, 200, 500, 999}). Passed as the apply CAP so a pool value
+// authored by a future build with more tiers cannot index off the end of OoT's
+// capacity table.
+#define OOT_MAX_WALLET_TIER 3u
+
+static uint16_t OoT_ReadHealthQuarters(void) {
+    const uint16_t pieces =
+        (uint16_t)((gSaveContext.inventory.questItems & OOT_HEART_PIECE_MASK) >> OOT_HEART_PIECE_SHIFT);
+    const uint16_t capacity = gSaveContext.healthCapacity < 0 ? 0u : (uint16_t)gSaveContext.healthCapacity;
+    // The canonical quantity and its inverse both live in src/common so there
+    // is exactly one copy of the arithmetic; see Combo_MakeHealthQuarters for
+    // why hearts are one number rather than two shared fields.
+    return Combo_MakeHealthQuarters(capacity, pieces);
+}
+
+/**
+ * HARVEST (#525). Fold OoT's live resource values into the shared pool.
+ *
+ * Called from OoT_Game_Suspend — the one point on BOTH the entrance and the F10
+ * hot-swap path while gSaveContext still belongs to OoT — and immediately
+ * before every `.redsave` write, so a file written mid-session carries a pool
+ * that agrees with the OoT save stored beside it. Idempotent: a second call
+ * with unchanged values is a no-op in both merge disciplines.
+ */
+extern "C" void OoT_HarvestSharedResources(void) {
+    // SETTLE THE ACCUMULATOR FIRST. Both games write rupeeAccumulator, not the
+    // count, and drain it one per frame. A pending accumulator would otherwise
+    // ride the frozen blob and drain into OoT later — after an apply has
+    // already written an authoritative count — crediting the player twice. Fold
+    // it in and zero it so what we harvest is what OoT actually has.
+    const int32_t walletCap = (int32_t)CUR_CAPACITY(UPG_WALLET);
+    int32_t liveRupees = (int32_t)gSaveContext.rupees + (int32_t)gSaveContext.rupeeAccumulator;
+    if (liveRupees < 0) {
+        liveRupees = 0;
+    }
+    if (liveRupees > walletCap) {
+        liveRupees = walletCap;
+    }
+    gSaveContext.rupees = (s16)liveRupees;
+    gSaveContext.rupeeAccumulator = 0;
+
+    Combo_HarvestSharedResource(GAME_OOT, RSBS_SHARED_RES_RUPEES, (uint16_t)liveRupees);
+    Combo_HarvestSharedResource(GAME_OOT, RSBS_SHARED_RES_WALLET_TIER, (uint16_t)CUR_UPG_VALUE(UPG_WALLET));
+    Combo_HarvestSharedResource(GAME_OOT, RSBS_SHARED_RES_HEALTH_QUARTERS, OoT_ReadHealthQuarters());
+    Combo_HarvestSharedResource(GAME_OOT, RSBS_SHARED_RES_HEALTH_CURRENT,
+                                gSaveContext.health < 0 ? 0u : (uint16_t)gSaveContext.health);
+    Combo_HarvestSharedResource(GAME_OOT, RSBS_SHARED_RES_DOUBLE_DEFENSE,
+                                gSaveContext.isDoubleDefenseAcquired ? 1u : 0u);
+}
+
+/**
+ * APPLY (#525). Write the shared pool into OoT's live gSaveContext.
+ *
+ * Called from OoT_Play_Init's presence-gated startup-entrance branch beside
+ * OoT_ConsumeSharedItems — the first point after the boot chain's last
+ * gSaveContext wipe, and once per arrival into OoT. NOT Game_Resume: both
+ * restores are re-authored afterwards by Opening_Init.
+ *
+ * ORDER MATTERS. Wallet tier and health capacity are applied BEFORE the
+ * quantities they bound, because each quantity is clamped to the ceiling the
+ * arriving game can actually display — and that ceiling is what the two lines
+ * above may have just raised.
+ */
+extern "C" void OoT_ApplySharedResources(void) {
+    // --- Wallet tier (monotonic). Raises OoT's clamp before rupees land.
+    uint16_t walletTier = (uint16_t)CUR_UPG_VALUE(UPG_WALLET);
+    if (Combo_ApplySharedResource(GAME_OOT, RSBS_SHARED_RES_WALLET_TIER, OOT_MAX_WALLET_TIER, &walletTier)) {
+        OoT_Inventory_ChangeUpgrade(UPG_WALLET, (s16)walletTier);
+    }
+
+    // --- Health capacity + pieces, from the ONE canonical quantity.
+    uint16_t quarters = OoT_ReadHealthQuarters();
+    if (Combo_ApplySharedResource(GAME_OOT, RSBS_SHARED_RES_HEALTH_QUARTERS,
+                                  (uint16_t)RSBS_SHARED_RES_MAX_HEALTH_QUARTERS, &quarters)) {
+        // Split back: whole hearts to capacity, the remainder to the piece
+        // nibble. The 320 clamp inside the split is load-bearing — NEITHER
+        // game's give path clamps capacity, and a total accumulated across two
+        // pools of pieces and containers exceeds 20 hearts easily. The life
+        // meter past 20 is untested in both ports.
+        uint16_t capacity = 0;
+        uint16_t pieces = 0;
+        Combo_SplitHealthQuarters(quarters, &capacity, &pieces);
+        gSaveContext.healthCapacity = (s16)capacity;
+        gSaveContext.inventory.questItems =
+            (gSaveContext.inventory.questItems & ~OOT_HEART_PIECE_MASK) | ((uint32_t)pieces << OOT_HEART_PIECE_SHIFT);
+    }
+
+    // --- Double defense (monotonic 0/1). Deliberately NOT a byte copy: the
+    // flag is spelled isDoubleDefenseAcquired here and doubleDefense in MM, and
+    // each game carries its own separate inventory.defenseHearts counter that
+    // the life meter reads. Share the FACT, let each game set its own pair.
+    uint16_t doubleDefense = gSaveContext.isDoubleDefenseAcquired ? 1u : 0u;
+    if (Combo_ApplySharedResource(GAME_OOT, RSBS_SHARED_RES_DOUBLE_DEFENSE, 1u, &doubleDefense) && doubleDefense != 0) {
+        gSaveContext.isDoubleDefenseAcquired = 1;
+        if (gSaveContext.inventory.defenseHearts < 20) {
+            gSaveContext.inventory.defenseHearts = 20;
+        }
+    }
+
+    // --- Rupees (consumable), clamped to the wallet capacity just applied.
+    uint16_t rupees = gSaveContext.rupees < 0 ? 0u : (uint16_t)gSaveContext.rupees;
+    if (Combo_ApplySharedResource(GAME_OOT, RSBS_SHARED_RES_RUPEES, (uint16_t)CUR_CAPACITY(UPG_WALLET), &rupees)) {
+        gSaveContext.rupees = (s16)rupees;
+    }
+    // Whatever the restored blob had pending would drain on top of the count we
+    // just authored. Zero it: the harvest that produced this pool already
+    // folded OoT's accumulator in.
+    gSaveContext.rupeeAccumulator = 0;
+
+    // --- Current health (consumable). One bar across both games, per OoTMM:
+    // "current health is tracked as if OoT and MM were one game with a single
+    // health bar". Clamped to the capacity applied above.
+    uint16_t health = gSaveContext.health < 0 ? 0u : (uint16_t)gSaveContext.health;
+    if (Combo_ApplySharedResource(GAME_OOT, RSBS_SHARED_RES_HEALTH_CURRENT, (uint16_t)gSaveContext.healthCapacity,
+                                  &health)) {
+        // Floor at one heart. A departing game cannot normally hand over a dead
+        // bar (death resets health before any suspend can see it), so this only
+        // fires on a corrupt or hand-edited pool — and spawning dead on a
+        // cross-game arrival lands in a death handler no arrival path has ever
+        // been tested through.
+        gSaveContext.health = (s16)(health < 0x10u ? 0x10u : health);
+    }
 }
 
 static bool sLastF10State = false;

--- a/games/oot/soh/SaveManager.cpp
+++ b/games/oot/soh/SaveManager.cpp
@@ -38,6 +38,11 @@
 #include <mutex>
 
 extern "C" SaveContext gSaveContext;
+// Shared cross-game resources (#525), defined in soh/GameExports_SingleExe.cpp.
+// Declared here rather than included so this TU keeps its narrow src/common
+// surface; it is called immediately before each .redsave write below so the
+// pool never lags the OoT blob stored beside it.
+extern "C" void OoT_HarvestSharedResources(void);
 using namespace std::string_literals;
 
 void SaveManager::WriteSaveFile(const std::filesystem::path& savePath, const uintptr_t addr, void* dramAddr,
@@ -162,6 +167,12 @@ SaveManager::SaveManager() {
         // Publish the slot so a later MM-side save can address it; MM has no
         // slot of its own (its fileNum is the 0xFF sentinel cross-game).
         RsbsSave_SetActiveSlot(fileNum);
+        // Shared cross-game resources (#525) BEFORE the shadow capture, so the
+        // pool and the OoT blob stored beside it agree. Without this, money
+        // earned since the last switch is in the OoT save but not in the pool,
+        // and the post-load first-harvest seed reads the balance as already
+        // counted and drops it.
+        OoT_HarvestSharedResources();
         Context_UpdateShadowCopy(GAME_OOT, &gSaveContext, sizeof(gSaveContext));
         gComboCtx.sourceGame = GAME_OOT;
         RsbsSave_Save(fileNum);
@@ -207,6 +218,12 @@ SaveManager::SaveManager() {
         if (fileNum < 0 || fileNum >= RSBS_SAVE_MAX_SLOTS) {
             return;
         }
+        // Shared cross-game resources (#525) BEFORE the shadow capture, so the
+        // pool and the OoT blob stored beside it agree. Without this, money
+        // earned since the last switch is in the OoT save but not in the pool,
+        // and the post-load first-harvest seed reads the balance as already
+        // counted and drops it.
+        OoT_HarvestSharedResources();
         Context_UpdateShadowCopy(GAME_OOT, &gSaveContext, sizeof(gSaveContext));
         gComboCtx.sourceGame = GAME_OOT;
         RsbsSave_Save(fileNum);

--- a/games/oot/src/code/z_play.c
+++ b/games/oot/src/code/z_play.c
@@ -40,6 +40,12 @@ extern int Combo_ConsumeFrozenState(const char* gameId, void* saveContext, size_
 // TU stays free of the ADR SharedItem/GameId types.
 extern void OoT_ConsumeSharedItems(void);
 
+// Cross-game shared-RESOURCE apply (#525). Reconciles OoT's live rupees, wallet
+// tier, hearts, current health and double defense against the single shared
+// pool in gComboCtx. Same reason it is declared rather than included: this TU
+// stays free of the src/common resource types.
+extern void OoT_ApplySharedResources(void);
+
 // Cross-game combo support - entrance switch checking
 extern uint16_t Combo_CheckEntranceSwitch(uint16_t entranceIndex);
 extern bool Combo_IsCrossGameSwitch(void);
@@ -562,6 +568,15 @@ void OoT_Play_Init(GameState* thisx) {
                 // wait for the next switch into OoT (shared_items.h). Placed
                 // after the inventory-touching age/equip fixups above so a
                 // redeemed item lands in a settled gSaveContext.
+                //
+                // Shared cross-game RESOURCES (#525) go FIRST, before the item
+                // consumer. Both can touch the same fields, and the order is
+                // load-bearing: apply authors an absolute rupee count and heart
+                // capacity from the pool, so a shared item given BEFORE it
+                // would be silently overwritten. Applied first, an item's give
+                // layers on top and is picked up as a delta by the next
+                // harvest.
+                OoT_ApplySharedResources();
                 OoT_ConsumeSharedItems();
                 Combo_ClearStartupEntrance();
                 osSyncPrintf("[OoT] Cross-game switch: loading entrance 0x%04X\n", startupEntrance);

--- a/src/common/context.cpp
+++ b/src/common/context.cpp
@@ -11,6 +11,7 @@
 // staging outbox, which lives in shared_items.c. Included here (a .cpp) rather
 // than from context.h so the header keeps its no-dependency shape.
 #include "shared_items.h"
+#include "shared_resources.h"
 // Combo_HasStartupEntrance() — the discriminator that keeps the return-to-title
 // hook from eating a cross-game arrival's blob.
 #include "entrance.h"
@@ -333,6 +334,12 @@ void Context_InvalidateSessionState(ComboSeedStampPolicy seedPolicy) {
     // outbox is RAM-only and would otherwise drain into the NEXT session's
     // array at its first suspend.
     Combo_ClearSharedItemOutbox();
+
+    // Same reasoning for the shared-resource watermarks (#525): RAM-only, they
+    // describe how much of the dead session's pool was materialized in its live
+    // save. Carrying one into a fresh session would make the next harvest
+    // measure a delta against a balance that no longer exists.
+    Combo_ResetSharedResourceWatermarks();
 
     // Every remaining field of gComboCtx is session state, so the initializer
     // IS the invalidator — there is no per-field clear to drift out of sync

--- a/src/common/context.h
+++ b/src/common/context.h
@@ -234,6 +234,24 @@ int Context_ArmShadowAsFrozen(GameId game, uint16_t returnEntrance);
 #define RSBS_GRANT_SOURCE_CAP 8u
 
 /**
+ * Capacity of ComboContext.sharedResources (#525): how many distinct SHARED
+ * RESOURCES can be tracked at once. A shared resource is not an item that
+ * crosses once — it is ONE QUANTITY spanning both games, capacity and current
+ * value together ("current health is tracked as if OoT and MM were one game
+ * with a single health bar"). v1 occupies five of the eight slots (rupees,
+ * wallet tier, health quarters, current health, double defense); magic and the
+ * ammo upgrades are the queued members of the same class.
+ *
+ * DO NOT BUMP THIS CONSTANT to get more capacity, for the reason
+ * RSBS_GRANT_SOURCE_CAP spells out: the array is carved from the front of
+ * reserved[] and anything carved after it inherits its position, so a widen in
+ * place moves those fields off the offset every shipped .redsave stored them
+ * at. Carve a second block from the front of reserved[] and span both in every
+ * accessor instead. See ADR 0005 §1 for the identical hazard.
+ */
+#define RSBS_SHARED_RESOURCE_CAP 8u
+
+/**
  * One cross-game item, tagged with the game whose id-space `id` belongs to.
  *
  * Why a struct and not a packed integer (ADR 0002): OoT's RandomizerGet (RG_*)
@@ -319,6 +337,71 @@ RSBS_CTX_STATIC_ASSERT(sizeof(ComboGrantSourceCursor) == 8,
 RSBS_CTX_STATIC_ASSERT(offsetof(ComboGrantSourceCursor, sourceKey) == 0 &&
                            offsetof(ComboGrantSourceCursor, lastSeq) == 4,
                        "ComboGrantSourceCursor member offsets are .redsave format and must not move");
+
+/**
+ * Which shared resource a ComboSharedResource slot holds (#525). Zero is the
+ * EMPTY marker, never a real resource — occupancy rides this tag exactly as
+ * SharedItem's occupancy rides originGame != GAME_NONE.
+ *
+ * WHY THE TAG EXISTS AT ALL, rather than a bare `uint16_t sharedRupees` field.
+ * The growth contract for everything carved from reserved[] is "zero means
+ * unset" (see the reserved[] comment below), and 0 rupees is a perfectly legal
+ * player state. A bare scalar therefore cannot distinguish "this save predates
+ * shared resources" from "this player is broke" — and getting that wrong
+ * resurrects a stale balance on a legacy record, or discards a real zero. With
+ * the kind tag, a zero-extended legacy record reads as eight EMPTY slots, which
+ * is unambiguous and correct.
+ *
+ * These values are .redsave format. Append only; never renumber.
+ */
+enum {
+    RSBS_SHARED_RES_NONE = 0,             // empty slot (the growth contract's "unset")
+    RSBS_SHARED_RES_RUPEES = 1,           // CONSUMABLE: the single shared rupee pool
+    RSBS_SHARED_RES_WALLET_TIER = 2,      // MONOTONIC: wallet upgrade level (both games clamp against their own)
+    RSBS_SHARED_RES_HEALTH_QUARTERS = 3,  // MONOTONIC: capacity + pieces*4, the canonical heart quantity
+    RSBS_SHARED_RES_HEALTH_CURRENT = 4,   // CONSUMABLE: the single shared health bar, in 0x10-per-heart units
+    RSBS_SHARED_RES_DOUBLE_DEFENSE = 5,   // MONOTONIC: 0/1 flag; each game sets its OWN differently-named field pair
+};
+
+/**
+ * Merge discipline for a shared-resource slot. Set on the slot at first write
+ * and stable thereafter, so a reader can tell the two disciplines apart without
+ * a switch on `kind` — the byte is descriptive, `kind` is authoritative.
+ */
+#define RSBS_SHARED_RES_F_MONOTONIC 0x01u // max-merge both ways; decay is impossible by construction
+
+/**
+ * One shared cross-game resource (#525): a single quantity that spans both
+ * games, harvested from the departing game at suspend and applied to the
+ * arriving game at its startup entrance.
+ *
+ * TWO MERGE DISCIPLINES, and picking the wrong one is a correctness bug:
+ *
+ *   - MONOTONIC (wallet tier, health quarters, double defense) — a capacity
+ *     that only ever grows. Harvest is `shared = max(shared, live)`, apply is
+ *     `live = max(live, shared)`. Idempotent; decay impossible.
+ *   - CONSUMABLE (rupee count, current health) — a quantity the player spends.
+ *     Harvest takes a DELTA against a RAM-only watermark recorded at apply
+ *     time, never a raw copy. That watermark is mandatory, not an optimization:
+ *     MM's tier-3 wallet holds 500 and OoT's holds 999, so a naive
+ *     `shared = live` copy clamps an 800-rupee arrival to 500 and harvests 500
+ *     back, silently costing the player 300 rupees on EVERY round trip.
+ *
+ * Zero means unset for every member (growth contract): a slot is occupied iff
+ * kind != RSBS_SHARED_RES_NONE. There is deliberately no count field — a count
+ * would be a second source of truth a zero-extended legacy record contradicts.
+ */
+typedef struct {
+    uint8_t kind;   // RSBS_SHARED_RES_*; RSBS_SHARED_RES_NONE (0) = empty slot
+    uint8_t flags;  // RSBS_SHARED_RES_F_* bits; 0 = consumable (delta-harvested)
+    uint16_t value; // the shared quantity, in that resource's own units; 0 when empty
+} ComboSharedResource;
+
+RSBS_CTX_STATIC_ASSERT(sizeof(ComboSharedResource) == 4,
+                       "ComboSharedResource is serialized raw inside the .redsave Tier-1 record; its layout is format");
+RSBS_CTX_STATIC_ASSERT(offsetof(ComboSharedResource, kind) == 0 && offsetof(ComboSharedResource, flags) == 1 &&
+                           offsetof(ComboSharedResource, value) == 2,
+                       "ComboSharedResource member offsets are .redsave format and must not move");
 
 typedef struct {
     char magic[8];        // "OoT+MM<3"
@@ -449,6 +532,23 @@ typedef struct {
     // unchanged.
     uint32_t mmProfileDigest;
 
+    // #525: the shared cross-game RESOURCES — one quantity spanning both games,
+    // capacity and current value together, as opposed to sharedItemsTagged's
+    // one-way single-use crossings. Carved from the FRONT of the old
+    // reserved[212] under the growth contract: all-zero = every slot EMPTY,
+    // which is exactly what a zero-extended pre-#525 record must read as.
+    //
+    // The kind tag is what makes that work, and it is the whole reason this is
+    // an array of tagged slots rather than a handful of bare scalars: 0 rupees
+    // is a legal player state, so a bare `uint16_t sharedRupees` could not tell
+    // a legacy record from a broke player. See ComboSharedResource.
+    //
+    // Occupancy and merge discipline are the struct's business; shared_resources.c
+    // owns every read and write. Nothing here is a per-game mirror — there is
+    // ONE value, and each game's harvest/apply shim reconciles its own live
+    // gSaveContext against it at the switch boundary.
+    ComboSharedResource sharedResources[RSBS_SHARED_RESOURCE_CAP];
+
     // Headroom. Carve new fields from the FRONT of this array (as
     // sharedItemsTagged, sharedRandoSettingsHash, foreignPlacements, the
     // grant cursors, and the reverse placement table were) so the struct
@@ -459,12 +559,13 @@ typedef struct {
     // a freshly-initialized one — every field carved from here must keep
     // "zero means unset".
     //
-    // 264 - 48 (foreignPlacementsOoT) - 4 (mmProfileDigest). ADR 0009 publishes the remaining
+    // 264 - 48 (foreignPlacementsOoT) - 4 (mmProfileDigest) - 32 (sharedResources).
+    // ADR 0009 publishes the remaining
     // allocation across the other claimants and sets a 64-byte floor:
     // Test_SaveComboRecordFixed's scribble loop iterates sizeof(reserved), so
     // at zero it degenerates to zero iterations and passes vacuously, retiring
     // the only test that proves headroom round-trips at all.
-    uint8_t reserved[212];
+    uint8_t reserved[180];
 } ComboContext;
 
 /**
@@ -560,12 +661,24 @@ RSBS_CTX_STATIC_ASSERT(offsetof(ComboContext, mmProfileDigest) ==
                                RSBS_FOREIGN_PLACEMENT_CAP * sizeof(ComboForeignPlacement),
                        "mmProfileDigest must be carved from the FRONT of reserved[] (contiguous with "
                        "the reverse placement table); moving it changes .redsave format");
-RSBS_CTX_STATIC_ASSERT(offsetof(ComboContext, reserved) ==
+// The shared-resource slots are the next carve (#525, 32 bytes). Pinned to the
+// literal 792 for the same reason 672, 736, 740 and 788 are: anything carved
+// after it inherits its position, so a field growing in place ahead of it must
+// break the build rather than slide it.
+RSBS_CTX_STATIC_ASSERT(offsetof(ComboContext, sharedResources) == 792u,
+                       "sharedResources lives at .redsave byte offset 792; if this fires, a field "
+                       "before it grew in place - carve from reserved[] instead");
+RSBS_CTX_STATIC_ASSERT(offsetof(ComboContext, sharedResources) ==
                            offsetof(ComboContext, mmProfileDigest) + sizeof(uint32_t),
+                       "sharedResources must be carved from the FRONT of reserved[] (contiguous with "
+                       "the MM profile digest); moving it changes .redsave format");
+RSBS_CTX_STATIC_ASSERT(offsetof(ComboContext, reserved) ==
+                           offsetof(ComboContext, sharedResources) +
+                               RSBS_SHARED_RESOURCE_CAP * sizeof(ComboSharedResource),
                        "the tagged-item array, the settings digest, both foreign-placement tables, "
-                       "the grant cursors, the overflow count, the MM profile digest, and the "
-                       "remaining headroom must stay contiguous (no padding, no fields slipped "
-                       "between them)");
+                       "the grant cursors, the overflow count, the MM profile digest, the shared "
+                       "resource slots, and the remaining headroom must stay contiguous (no padding, "
+                       "no fields slipped between them)");
 // ADR 0009's floor. reserved[] is what Test_SaveComboRecordFixed scribbles to
 // prove Tier-1 headroom round-trips; at zero that loop runs zero times and the
 // test passes vacuously, so the carve budget stops here rather than there.
@@ -587,6 +700,10 @@ static_assert(!std::is_assignable<SharedItem&, GameId>::value,
 static_assert(!std::is_convertible<int, ComboForeignPlacement>::value &&
                   !std::is_assignable<ComboForeignPlacement&, int>::value,
               "a raw integer must never become a foreign placement — the item member carries the origin tag");
+static_assert(!std::is_convertible<int, ComboSharedResource>::value &&
+                  !std::is_assignable<ComboSharedResource&, int>::value,
+              "a raw integer must never become a shared resource — the kind tag is what separates "
+              "an unset slot from a legitimate zero");
 static_assert(std::is_trivially_copyable<ComboContext>::value,
               "gComboCtx is serialized with memcpy; ComboContext must stay trivially copyable");
 #endif

--- a/src/common/save.cpp
+++ b/src/common/save.cpp
@@ -10,6 +10,7 @@
 
 #include "context.h"
 #include "game.h"
+#include "shared_resources.h"
 
 #include <cstdio>
 #include <cstring>
@@ -311,6 +312,15 @@ bool SaveManager::Load(int slot) {
 
     // All checks passed — commit. gComboCtx and both shadows are updated.
     std::memcpy(&gComboCtx, &combo, sizeof(ComboContext));
+
+    // The shared-resource watermarks (#525) are RAM-only and describe the
+    // PREVIOUS session's live save; the pool we just loaded belongs to a
+    // different one. Dropping them is what arms the first-harvest seed: an
+    // occupied slot now seeds at the loaded game's live balance (delta zero)
+    // instead of contributing money this pool already counted, which is the
+    // difference between "rupees load correctly" and "rupees double on the
+    // first switch after a load". See shared_resources.h.
+    Combo_ResetSharedResourceWatermarks();
     Context_UpdateShadowCopy(GAME_OOT, ootBlob.data(), kOoTSize);
     Context_UpdateShadowCopy(GAME_MM, mmBlob.data(), kMMSize);
 

--- a/src/common/shared_resources.c
+++ b/src/common/shared_resources.c
@@ -1,0 +1,254 @@
+/**
+ * @file shared_resources.c
+ * @brief Shared cross-game resource merge core (#525).
+ *
+ * See shared_resources.h for the model, the two merge disciplines and why the
+ * watermark is mandatory rather than an optimization.
+ *
+ * This TU is intentionally free of game headers — it touches
+ * gComboCtx.sharedResources and a small RAM-only watermark table and nothing
+ * else — so it compiles into the shared redship_common library and both games'
+ * per-game shims call it directly with values they read out of their own
+ * gSaveContext. The unit conversions and field names stay on the game side,
+ * where the headers are; the merge rules stay here, where there is exactly one
+ * copy of them.
+ */
+
+#include "shared_resources.h"
+#include <stdio.h>
+#include <string.h>
+
+// ============================================================================
+// The RAM-only watermark table: how much of the shared pool is currently
+// MATERIALIZED in the live save, per resource.
+//
+// Indexed by KIND, not by slot: slot positions are found by scan and are not
+// promised to be stable, while a kind is a fixed enumerator. `owner` is the
+// game the watermark describes — GAME_NONE means "no game has been applied to
+// for this resource in this process", which is the first-harvest seed case the
+// header spells out.
+// ============================================================================
+
+typedef struct {
+    uint16_t value; // the live value at the last apply/harvest sync point
+    uint8_t owner;  // GameId the watermark belongs to; GAME_NONE = not live
+} SharedResWatermark;
+
+static SharedResWatermark sWatermarks[RSBS_SHARED_RES_KIND_COUNT];
+
+static bool IsRealGame(GameId game) {
+    return game == GAME_OOT || game == GAME_MM;
+}
+
+static bool IsRealKind(uint8_t kind) {
+    return kind != RSBS_SHARED_RES_NONE && kind < RSBS_SHARED_RES_KIND_COUNT;
+}
+
+/**
+ * Which discipline `kind` merges under. This switch is the ONE authoritative
+ * statement of the split — the RSBS_SHARED_RES_F_MONOTONIC flag byte stored on
+ * the slot is descriptive (so a reader or a save inspector can tell them apart
+ * without this table), never the thing decided on.
+ */
+static bool IsMonotonicKind(uint8_t kind) {
+    switch (kind) {
+        case RSBS_SHARED_RES_WALLET_TIER:
+        case RSBS_SHARED_RES_HEALTH_QUARTERS:
+        case RSBS_SHARED_RES_DOUBLE_DEFENSE:
+            return true;
+        default:
+            // RSBS_SHARED_RES_RUPEES, RSBS_SHARED_RES_HEALTH_CURRENT: the
+            // player spends these, so they are delta-harvested.
+            return false;
+    }
+}
+
+// Locate the occupied slot holding `kind`, or -1 when the resource has never
+// been shared. Slots are unordered; there is at most one per kind because
+// FindOrCreateSlot always looks first.
+static int FindSlot(uint8_t kind) {
+    for (int i = 0; i < (int)RSBS_SHARED_RESOURCE_CAP; i++) {
+        if (gComboCtx.sharedResources[i].kind == kind) {
+            return i;
+        }
+    }
+    return -1;
+}
+
+// Locate `kind`'s slot, claiming a free one (value 0) if it has none. Returns
+// -1 only when every slot is taken by some OTHER resource. Nothing is ever
+// evicted: unlike a shared ITEM, a shared resource has no "redeemed" state, so
+// there is no slot that is safe to reclaim — a full array means the resource
+// set outgrew RSBS_SHARED_RESOURCE_CAP, which is a carve-time bug, not a
+// runtime condition. The array is sized with room for the whole class.
+static int FindOrCreateSlot(uint8_t kind) {
+    int slot = FindSlot(kind);
+    if (slot >= 0) {
+        return slot;
+    }
+    for (int i = 0; i < (int)RSBS_SHARED_RESOURCE_CAP; i++) {
+        if (gComboCtx.sharedResources[i].kind == RSBS_SHARED_RES_NONE) {
+            gComboCtx.sharedResources[i].kind = kind;
+            gComboCtx.sharedResources[i].flags = IsMonotonicKind(kind) ? RSBS_SHARED_RES_F_MONOTONIC : 0u;
+            gComboCtx.sharedResources[i].value = 0u;
+            return i;
+        }
+    }
+    fprintf(stderr, "[combo] shared-resource slots full; dropping kind=%u (raise RSBS_SHARED_RESOURCE_CAP by carving a second block)\n",
+            (unsigned)kind);
+    return -1;
+}
+
+// ============================================================================
+// The canonical heart quantity. See the header for why hearts are ONE number.
+// ============================================================================
+
+uint16_t Combo_MakeHealthQuarters(uint16_t capacity, uint16_t pieces) {
+    uint32_t quarters = (uint32_t)capacity + (uint32_t)pieces * 4u;
+    if (quarters > RSBS_SHARED_RES_MAX_HEALTH_QUARTERS) {
+        quarters = RSBS_SHARED_RES_MAX_HEALTH_QUARTERS;
+    }
+    return (uint16_t)quarters;
+}
+
+void Combo_SplitHealthQuarters(uint16_t quarters, uint16_t* outCapacity, uint16_t* outPieces) {
+    if (quarters > RSBS_SHARED_RES_MAX_HEALTH_QUARTERS) {
+        quarters = (uint16_t)RSBS_SHARED_RES_MAX_HEALTH_QUARTERS;
+    }
+    if (outCapacity != NULL) {
+        *outCapacity = (uint16_t)((quarters / 16u) * 16u);
+    }
+    if (outPieces != NULL) {
+        *outPieces = (uint16_t)((quarters % 16u) / 4u);
+    }
+}
+
+void Combo_HarvestSharedResource(GameId game, uint8_t kind, uint16_t liveValue) {
+    if (!IsRealGame(game) || !IsRealKind(kind)) {
+        return;
+    }
+
+    // Read occupancy BEFORE any slot is created: "has this resource ever been
+    // shared" is the discriminator the first-harvest seed turns on, and
+    // FindOrCreateSlot would destroy the answer.
+    const bool everShared = (FindSlot(kind) >= 0);
+
+    if (IsMonotonicKind(kind)) {
+        if (!everShared && liveValue == 0) {
+            // Nothing to record. Deliberately does NOT create the slot: every
+            // game harvests its whole resource set at each suspend, and a
+            // player who has no wallet upgrade and no double defense yet would
+            // otherwise occupy slots with zeros that read as "shared" — making
+            // a fresh world indistinguishable from a played one, which is the
+            // growth contract's "zero means unset" rule turned inside out.
+            return;
+        }
+        const int slot = FindOrCreateSlot(kind);
+        if (slot < 0) {
+            return;
+        }
+        if (liveValue > gComboCtx.sharedResources[slot].value) {
+            gComboCtx.sharedResources[slot].value = liveValue;
+        }
+        return;
+    }
+
+    // CONSUMABLE: delta against the watermark, never a raw copy.
+    SharedResWatermark* wm = &sWatermarks[kind];
+    if (wm->owner != (uint8_t)game) {
+        // No live watermark for this game — either a cold boot or a .redsave
+        // load. Seed per the header's rule: an occupied slot means the pool was
+        // written by a harvest that already counted this balance (seed at live,
+        // delta zero), an empty slot means nothing was ever shared (seed at
+        // zero, so the whole balance enters the pool).
+        wm->value = everShared ? liveValue : 0u;
+        wm->owner = (uint8_t)game;
+    }
+
+    const int32_t delta = (int32_t)liveValue - (int32_t)wm->value;
+    wm->value = liveValue;
+    if (delta == 0) {
+        // Nothing changed. Deliberately does NOT create the slot: an untouched
+        // resource stays unshared, which keeps a zero-extended legacy record
+        // and a genuinely-never-used resource indistinguishable, as the growth
+        // contract requires.
+        return;
+    }
+
+    int slot = FindOrCreateSlot(kind);
+    if (slot < 0) {
+        return;
+    }
+    int32_t next = (int32_t)gComboCtx.sharedResources[slot].value + delta;
+    if (next < 0) {
+        next = 0;
+    }
+    if (next > 0xFFFF) {
+        next = 0xFFFF;
+    }
+    gComboCtx.sharedResources[slot].value = (uint16_t)next;
+}
+
+bool Combo_ApplySharedResource(GameId game, uint8_t kind, uint16_t cap, uint16_t* liveValue) {
+    if (!IsRealGame(game) || !IsRealKind(kind) || liveValue == NULL) {
+        return false;
+    }
+
+    const int slot = FindSlot(kind);
+    if (slot < 0) {
+        // Never shared: nothing to apply, and deliberately NO watermark write.
+        // Seeding lives in exactly one place — the harvest rule above — because
+        // two seeding rules is how the halves disagree. Leaving the watermark
+        // unset here means the next harvest applies that one rule and sees an
+        // empty slot, so the game's existing balance joins the pool as genuinely
+        // new money. That is the same answer a cold boot gets, which is what
+        // makes "which side went first" stop mattering.
+        return false;
+    }
+
+    const uint16_t shared = gComboCtx.sharedResources[slot].value;
+    const uint16_t applied = (shared > cap) ? cap : shared;
+
+    if (IsMonotonicKind(kind)) {
+        // Raise only. A capacity the arriving game already exceeds is its own
+        // business and its next harvest folds it back into the pool.
+        if (applied > *liveValue) {
+            *liveValue = applied;
+        }
+        return true;
+    }
+
+    // CONSUMABLE. Record what was ACTUALLY materialized, not what the pool
+    // holds: the difference is the money that does not fit in this game's
+    // wallet, and it must stay in the pool rather than be harvested away.
+    *liveValue = applied;
+    sWatermarks[kind].value = applied;
+    sWatermarks[kind].owner = (uint8_t)game;
+    return true;
+}
+
+bool Combo_GetSharedResource(uint8_t kind, uint16_t* outValue) {
+    if (!IsRealKind(kind) || outValue == NULL) {
+        return false;
+    }
+    const int slot = FindSlot(kind);
+    if (slot < 0) {
+        return false;
+    }
+    *outValue = gComboCtx.sharedResources[slot].value;
+    return true;
+}
+
+int Combo_CountSharedResources(void) {
+    int count = 0;
+    for (int i = 0; i < (int)RSBS_SHARED_RESOURCE_CAP; i++) {
+        if (gComboCtx.sharedResources[i].kind != RSBS_SHARED_RES_NONE) {
+            count++;
+        }
+    }
+    return count;
+}
+
+void Combo_ResetSharedResourceWatermarks(void) {
+    memset(sWatermarks, 0, sizeof(sWatermarks));
+}

--- a/src/common/shared_resources.h
+++ b/src/common/shared_resources.h
@@ -1,0 +1,225 @@
+/**
+ * @file shared_resources.h
+ * @brief Shared cross-game RESOURCES — one quantity spanning both games (#525).
+ *
+ * A shared resource is NOT a shared item. `shared_items.h` carries a one-way,
+ * single-use crossing: an item found in one game is awarded once in the other
+ * and the entry is retired. A shared RESOURCE is one continuous quantity that
+ * both games read and write for the whole run — capacity AND current value
+ * together. Copying OoTMM's user-facing behavior:
+ *
+ *   "Receiving a heart piece, heart container or double defense affects the
+ *    maximum health/defence of both games."
+ *   "Current health is tracked as if OoT and MM were one game with a single
+ *    health bar."
+ *
+ * v1 shares rupees and hearts. That is what justifies the matching pool shrink
+ * in `kForeignPoolMMV1` (#525): with one wallet and one health bar spanning
+ * both games, MM's wallet/heart/double-defense rows are no longer separate
+ * items to cross — they ARE the shared resource, so shipping them as foreign
+ * placements too would hand the player a second copy of a quantity they
+ * already have. Shared magic and the ammo upgrades are the queued members of
+ * the same class.
+ *
+ * ---------------------------------------------------------------------------
+ * THE TWO MERGE DISCIPLINES
+ * ---------------------------------------------------------------------------
+ * Picking the wrong one is a correctness bug, not a style choice.
+ *
+ *   MONOTONIC — wallet tier, health quarters, double defense. A capacity that
+ *   only ever grows. Harvest is `shared = max(shared, live)`, apply is
+ *   `live = max(live, shared)`. Idempotent in both directions; decay is
+ *   impossible by construction, so no bookkeeping is needed.
+ *
+ *   CONSUMABLE — rupee count, current health. A quantity the player spends.
+ *   Harvest takes a DELTA against a watermark recorded at apply time, never a
+ *   raw copy.
+ *
+ * THE WATERMARK IS MANDATORY. MM's tier-3 wallet holds 500 and OoT's holds 999
+ * (`gUpgradeCapacities`, both games). Under a naive `shared = live` harvest,
+ * arriving in MM with 800 shared rupees clamps the live count to 500, and the
+ * next suspend harvests that 500 straight back over the 800 — the player
+ * silently loses 300 rupees on EVERY round trip. With the watermark, apply
+ * records what it actually materialized (500) and harvest contributes only what
+ * changed since (0), so the 300 that never fit in MM's wallet stays in the pool
+ * and comes back intact in OoT.
+ *
+ * The watermark is RAM-only and per (kind, game): it describes how much of the
+ * shared pool is currently materialized in the LIVE save, which is a property
+ * of this process's session, not of the saved world.
+ *
+ * ---------------------------------------------------------------------------
+ * THE FIRST-HARVEST SEED, and why it is not an edge case
+ * ---------------------------------------------------------------------------
+ * Because the watermark is RAM-only, a game that has never been APPLIED to in
+ * this process has no watermark — and harvesting a delta against a default of
+ * zero would dump its entire live balance into the pool. Whether that is right
+ * depends on a distinction the slot array already records:
+ *
+ *   - Slot EMPTY (kind == RSBS_SHARED_RES_NONE): nothing has ever been shared.
+ *     A cold boot that earned 200 rupees genuinely has 200 to contribute, so
+ *     seed the watermark at 0 and let the whole balance enter the pool.
+ *   - Slot OCCUPIED: the pool was restored from a `.redsave`, which is only
+ *     ever written AFTER a harvest — so the live balance is money the pool has
+ *     already counted. Seed the watermark at the live value; the delta is zero
+ *     and the balance is not double-counted.
+ *
+ * Without that split, loading a `.redsave` and switching games doubles the
+ * player's rupees. The discriminator costs nothing because occupancy is already
+ * the kind tag (see ComboSharedResource — a bare `uint16_t` could not express
+ * it, since 0 rupees is a legal value).
+ *
+ * ---------------------------------------------------------------------------
+ * DIRECTION: HARVEST WRITES, APPLY READS
+ * ---------------------------------------------------------------------------
+ * Only harvest writes `gComboCtx.sharedResources`; apply only reads it (plus
+ * the RAM watermark). Keep it that way — it is what makes the wiring auditable:
+ * every pool mutation is at a suspend or a pre-save point, never mid-scene. An
+ * arriving game holding MORE than the pool is not lost, it is picked up by that
+ * game's own next harvest.
+ *
+ * WIRING (both games, see each GameExports_SingleExe.cpp):
+ *   - Harvest at `Game_Suspend`, beside `Combo_CommitStagedSharedItems()`, and
+ *     before every `.redsave` write. Game_Suspend is the only point on BOTH the
+ *     entrance and the F10 hot-swap path while the live `gSaveContext` still
+ *     belongs to the departing game.
+ *   - Apply at each game's presence-gated startup-entrance point in `z_play.c`,
+ *     beside the shared-item consumer — the first point after the boot chain's
+ *     last `gSaveContext` wipe. NOT `Game_Resume`: both restores are
+ *     re-authored afterwards by `Opening_Init` / `MM_Sram_InitNewSave`.
+ *
+ * THREADING: game thread only, exactly like shared_items.h.
+ */
+
+#ifndef RSBS_COMMON_SHARED_RESOURCES_H
+#define RSBS_COMMON_SHARED_RESOURCES_H
+
+#include "context.h" // ComboSharedResource, gComboCtx, GameId, RSBS_SHARED_RES_*
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * One past the highest defined RSBS_SHARED_RES_* kind. Sizes the RAM watermark
+ * table, which is indexed by KIND (stable) rather than by slot (slots are found
+ * by scan and a future compaction could move them).
+ */
+#define RSBS_SHARED_RES_KIND_COUNT 6u
+
+/**
+ * Canonical heart quantity ceiling, in health units (0x10 per heart, 4 per
+ * quarter — so a heart PIECE is worth 4 and `RSBS_SHARED_RES_HEALTH_QUARTERS`
+ * is `healthCapacity + pieces * 4`). 320 == 20 hearts.
+ *
+ * Clamping here is required, not defensive: NEITHER game's give path clamps
+ * health capacity, and a quantity accumulated across two pools of heart pieces
+ * and containers can exceed 20 hearts easily. The life meter past 20 hearts is
+ * untested in both ports.
+ */
+#define RSBS_SHARED_RES_MAX_HEALTH_QUARTERS 320u
+
+/**
+ * Build the canonical heart quantity from a game's two fields, clamped to
+ * RSBS_SHARED_RES_MAX_HEALTH_QUARTERS.
+ *
+ * `capacity` is the game's healthCapacity (0x10 per heart); `pieces` is the
+ * un-converted heart-piece count from the TOP NIBBLE of questItems — which is
+ * where BOTH games keep it (OoT writes `1 << (QUEST_HEART_PIECE + 4)`, MM's
+ * QUEST_HEART_PIECE_COUNT is 0x1C), and that agreement is what makes one shared
+ * quantity possible at all.
+ *
+ * Why one number instead of two shared fields: the games CONVERT at different
+ * times. MM turns 4 pieces into a container immediately inside Item_GiveImpl;
+ * OoT defers to textbox close, with a third site in rando. So OoT can sit at
+ * `pieces == 4` with capacity not yet bumped — a state MM never produces, and an
+ * F10 swap can land on exactly that frame. Folded into a single quantity the
+ * divergence dissolves: the threshold becomes arithmetic instead of a state
+ * machine, and neither game can hand the other a combination it cannot express.
+ */
+uint16_t Combo_MakeHealthQuarters(uint16_t capacity, uint16_t pieces);
+
+/**
+ * Split the canonical quantity back into a game's two fields — the exact
+ * inverse of Combo_MakeHealthQuarters for any input it can produce.
+ *
+ * Lives here rather than in each game's shim so the arithmetic has ONE
+ * definition; two copies of a normalize/denormalize pair is how the halves
+ * drift. Either out-pointer may be NULL.
+ */
+void Combo_SplitHealthQuarters(uint16_t quarters, uint16_t* outCapacity, uint16_t* outPieces);
+
+/**
+ * HARVEST. Fold `liveValue` — the departing game's live value for `kind` — into
+ * the shared pool, using that kind's merge discipline. Creates the slot on
+ * first use.
+ *
+ * The caller is responsible for handing over a SETTLED value. For rupees that
+ * means folding `rupeeAccumulator` into the count and zeroing it first: both
+ * games write the accumulator rather than the count and drain it one per frame,
+ * so a pending accumulator would otherwise be harvested as nothing here and
+ * then drain into the same game later — under-count now, double-count later.
+ *
+ * Idempotent for both disciplines: a second call with an unchanged `liveValue`
+ * is a no-op (monotonic re-maxes to the same number; consumable computes a zero
+ * delta because the first call advanced the watermark).
+ *
+ * No-op if `game` is not a real game or `kind` is not a real resource. If the
+ * slot array is full of other resources the harvest is dropped — the array is
+ * sized with headroom for the whole class, so this cannot happen with today's
+ * five resources.
+ */
+void Combo_HarvestSharedResource(GameId game, uint8_t kind, uint16_t liveValue);
+
+/**
+ * APPLY. Reconcile the arriving game's live value against the shared pool.
+ *
+ * @param game       the arriving game (owns the watermark that results)
+ * @param kind       RSBS_SHARED_RES_*
+ * @param cap        the ARRIVING GAME'S OWN ceiling for this resource — its
+ *                   wallet capacity, its health capacity, 1 for a flag. The
+ *                   games' ceilings genuinely differ (MM's tier-3 wallet is
+ *                   500, OoT's is 999); the pool holds the true total and this
+ *                   is what the arriving game can actually display.
+ * @param liveValue  in/out: the game's live value, overwritten on success
+ *
+ * @return true if a shared value existed and `*liveValue` was written; false if
+ *         the resource has never been shared, in which case `*liveValue` is
+ *         untouched and no watermark is recorded — the game's existing balance
+ *         then joins the pool at its next harvest, exactly as a cold boot's
+ *         would.
+ *
+ * MONOTONIC raises `*liveValue` to `min(shared, cap)` and never lowers it.
+ * CONSUMABLE sets `*liveValue` to `min(shared, cap)` and records exactly that
+ * as the watermark — the excess stays in the pool rather than being lost.
+ */
+bool Combo_ApplySharedResource(GameId game, uint8_t kind, uint16_t cap, uint16_t* liveValue);
+
+/**
+ * Read the shared pool's value for `kind` (trackers / tests / the cycle-safe
+ * rupee hook). Returns false and leaves `*outValue` untouched when the resource
+ * has never been shared.
+ */
+bool Combo_GetSharedResource(uint8_t kind, uint16_t* outValue);
+
+/**
+ * Number of occupied shared-resource slots (read-only; trackers / tests).
+ */
+int Combo_CountSharedResources(void);
+
+/**
+ * Drop every RAM-only watermark WITHOUT touching gComboCtx.sharedResources.
+ *
+ * This is the "a new session owns the live save now" reset, and it is exactly
+ * what makes the first-harvest seed above correct after a `.redsave` load:
+ * with no watermark, an occupied slot seeds at the live value (delta zero)
+ * instead of re-contributing money the pool already counted. Also used for test
+ * isolation.
+ */
+void Combo_ResetSharedResourceWatermarks(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // RSBS_COMMON_SHARED_RESOURCES_H

--- a/src/common/test_runner.cpp
+++ b/src/common/test_runner.cpp
@@ -201,6 +201,14 @@ extern "C" {
 // via shared_items.h.
 #include "tests/test_grant_sources.c"
 
+// Shared cross-game RESOURCE locks (#525): the delta-harvest watermark that
+// survives the 500-vs-999 wallet mismatch, the monotonic/consumable split, the
+// first-harvest seed that stops a .redsave load from doubling the player's
+// money, and the canonical heart quantity with its 20-heart clamp. FILE SCOPE
+// (compiled as C++) like the file above; every symbol it drives is C-linkage
+// via shared_resources.h.
+#include "tests/test_shared_resources.c"
+
 // Netplay grant-relay loopback locks (ADR 0007, #460). Guarded: with
 // RSBS_NETPLAY=OFF (the default) the relay sources are not in the build at all,
 // so the code under test does not exist. The `#include "tests/..."` text is
@@ -1687,6 +1695,10 @@ const TestDescriptor gTests[] = {
     // main() — so this also proves that registrar survived the link.
     {"foreign-pool-mm", "MM's cross-game source pool: registered, well-formed, giveable, non-junk (#510)",
      Test_ForeignPoolMM},
+    // #525: shared cross-game resources. Display-free, ROM-free and save-free —
+    // everything under test is gComboCtx plus a RAM watermark table.
+    {"shared-resources", "One quantity across both games: watermark, disciplines, seed, heart clamp (#525)",
+     Test_SharedResources},
     {"combo-spoiler-view", "In-game spoiler view model: named crossings, collected state, unpaired != empty (#496)",
      Test_ComboSpoilerView},
     {"combo-spoiler-window", "Common-owned spoiler window registers de-collided; inert under every active game (#496)",

--- a/src/common/tests/test_foreign_items.c
+++ b/src/common/tests/test_foreign_items.c
@@ -833,6 +833,48 @@ TestResult Test_ForeignPoolMM(void) {
         FI_ASSERT(!Combo_GetForeignItemByNameFor((uint8_t)GAME_NONE, pool[i].name, NULL));
     }
 
-    printf("[TEST] PASS: MM source pool registered, well-formed, giveable, non-junk, name-invertible\n");
+    // Membership rule (6), #525: no SHARED CROSS-GAME RESOURCE may be a
+    // crossing. Rupees and hearts are one quantity spanning both games now —
+    // one wallet, one health bar (src/common/shared_resources.h) — so a wallet
+    // or heart item has nothing left to carry across. Shipping one anyway would
+    // hand the player a second copy of a capacity they already have, or a rupee
+    // award the next harvest reconciles straight back out.
+    //
+    // Asserted as an EXCLUSION rather than an exact pool count on purpose: the
+    // count is not the invariant and would go stale the moment an unrelated row
+    // is added, whereas "these are not eligible to cross" is exactly what
+    // criterion 6 says.
+    //
+    // Keyed on the DISPLAY NAME, not the RI_* id, because this TU is src/common
+    // and has no MM headers in scope by design — the same reason the giveable /
+    // junk-class checks above go through MM-side bridge predicates. The name is
+    // not a weaker key here: it is the pool's own persistence key (the
+    // spoiler-LOAD inverse is keyed on (originGame, name)), so a row that
+    // answers to one of these names IS the row that must be gone.
+    //
+    // "Double Defense" is in this list because it lived under core equipment,
+    // NOT the health block — a block-shaped delete misses it, and it is the row
+    // a reviewer is most likely to miss too.
+    static const char* const kSharedResourceNames[] = {
+        "Progressive Wallet", "Adult's Wallet",  "Giant's Wallet",
+        "Double Defense",     "Heart Container", "Heart Piece",
+    };
+    for (size_t k = 0; k < sizeof(kSharedResourceNames) / sizeof(kSharedResourceNames[0]); k++) {
+        for (int i = 0; i < poolCount; i++) {
+            FI_ASSERT(strcmp(pool[i].name, kSharedResourceNames[k]) != 0);
+        }
+        // ...and the name-keyed inverse agrees, so a spoiler naming one of these
+        // cannot resurrect a crossing the shared-resource model replaced.
+        FI_ASSERT(!Combo_GetForeignItemByNameFor((uint8_t)GAME_MM, kSharedResourceNames[k], NULL));
+    }
+
+    // The shrink is real, not a rename: those six rows left and nothing took
+    // their place. Bounded rather than exact for the reason above — a future
+    // shared resource (magic, ammo) removes more, and unrelated work may add.
+    printf("[TEST] foreign-pool-mm: %d entries after the #525 shared-resource shrink\n", poolCount);
+    FI_ASSERT(poolCount <= 128);
+
+    printf("[TEST] PASS: MM source pool registered, well-formed, giveable, non-junk, name-invertible, "
+           "no shared resources\n");
     return TEST_PASS;
 }

--- a/src/common/tests/test_shared_resources.c
+++ b/src/common/tests/test_shared_resources.c
@@ -1,0 +1,337 @@
+/**
+ * @file test_shared_resources.c
+ * @brief ROM-free locks for shared cross-game resources (#525).
+ *
+ * A shared resource is ONE quantity spanning both games — capacity AND current
+ * value — as opposed to a shared ITEM's one-way single-use crossing. What is
+ * locked here is the arithmetic that makes that safe:
+ *
+ *  (1) THE WATERMARK, and the 500-vs-999 round trip it exists for. MM's tier-3
+ *      wallet holds 500 and OoT's holds 999. Under a naive `shared = live`
+ *      harvest, carrying 800 rupees into MM clamps the live count to 500 and
+ *      the next suspend writes that 500 back over the pool — 300 rupees gone,
+ *      silently, on EVERY round trip. This is the regression this file exists
+ *      to make impossible.
+ *
+ *  (2) THE TWO DISCIPLINES ARE DIFFERENT. Monotonic resources max-merge in both
+ *      directions and cannot decay; consumables delta-harvest and MUST decay
+ *      when the player spends. Applying one discipline to the other's resource
+ *      is a correctness bug either way round — a decaying wallet tier, or a
+ *      rupee count that can only ever grow.
+ *
+ *  (3) THE FIRST-HARVEST SEED, which is where a `.redsave` load would otherwise
+ *      DOUBLE the player's money. The watermark is RAM-only, so a freshly
+ *      loaded session has none; harvesting a delta against zero would
+ *      contribute the whole restored balance a second time. The empty/occupied
+ *      split is what tells "a cold boot genuinely earned this" apart from "the
+ *      pool already counted this".
+ *
+ *  (4) ZERO IS A LEGAL VALUE, and is distinguishable from unset. This is the
+ *      whole reason the slots are kind-tagged rather than bare u16s: the
+ *      .redsave growth contract says zero means unset, and a broke player has
+ *      0 rupees.
+ *
+ *  (5) THE HEART QUANTITY round-trips through its split, and clamps at 20
+ *      hearts. Neither game's give path clamps capacity.
+ *
+ * Display-free, ROM-free and save-free: everything under test is gComboCtx plus
+ * a RAM watermark table, so this runs in the plain `redship` tier.
+ *
+ * Linkage note: #included into test_runner.cpp at FILE SCOPE (compiled as C++,
+ * like test_grant_sources.c); every symbol it drives is C-linkage via
+ * shared_resources.h.
+ */
+
+#include "../context.h"
+#include "../shared_resources.h"
+#include "../test_runner.h"
+
+#include <cstdio>
+
+#define SR_ASSERT(cond)                                                                                                \
+    do {                                                                                                               \
+        if (!(cond)) {                                                                                                 \
+            printf("[TEST] FAIL: %s (line %d)\n", #cond, __LINE__);                                                    \
+            return TEST_FAIL;                                                                                          \
+        }                                                                                                              \
+    } while (0)
+
+// Both games' real tier-3 wallet capacities. Named rather than inlined because
+// the DIFFERENCE between them is the subject of half this file.
+#define SR_OOT_WALLET_CAP_T3 999u
+#define SR_MM_WALLET_CAP_T3 500u
+
+// Start from a world with no shared state at all: an empty pool AND no live
+// watermarks. This is a cold boot, and it is deliberately the same pair of calls
+// src/common/context.cpp makes when it invalidates a session.
+static void SR_FreshWorld(void) {
+    ComboContext_Init();
+    Combo_ResetSharedResourceWatermarks();
+}
+
+// Read a slot's value, or a sentinel that no test expects, so a "resource is
+// unset" bug shows up as a wrong number rather than a stale local.
+static uint16_t SR_Pool(uint8_t kind) {
+    uint16_t value = 0xBEEF;
+    if (!Combo_GetSharedResource(kind, &value)) {
+        return 0xBEEF;
+    }
+    return value;
+}
+
+TestResult Test_SharedResources(void) {
+    printf("[TEST] shared-resources: one quantity across both games — watermark, disciplines, seed, clamps (#525)\n");
+
+    // ------------------------------------------------------------------
+    // (4) Unset is not zero. A fresh world has NO shared rupees, which is a
+    // different fact from "the player has 0 rupees" — and the .redsave growth
+    // contract makes a zero-extended legacy record read exactly like a fresh
+    // world, so these two must stay distinguishable.
+    // ------------------------------------------------------------------
+    SR_FreshWorld();
+    uint16_t probe = 0;
+    SR_ASSERT(!Combo_GetSharedResource(RSBS_SHARED_RES_RUPEES, &probe));
+    SR_ASSERT(Combo_CountSharedResources() == 0);
+
+    // Harvesting a genuine zero from a world that never shared anything must
+    // NOT manufacture a slot: nothing has been shared, and saying otherwise
+    // would make a fresh world indistinguishable from a played one. This
+    // matters because both games harvest their WHOLE resource set at every
+    // suspend, so a player with no wallet upgrade and no double defense yet
+    // pushes zeros through here constantly.
+    Combo_HarvestSharedResource(GAME_OOT, RSBS_SHARED_RES_RUPEES, 0);
+    Combo_HarvestSharedResource(GAME_OOT, RSBS_SHARED_RES_WALLET_TIER, 0);
+    Combo_HarvestSharedResource(GAME_OOT, RSBS_SHARED_RES_DOUBLE_DEFENSE, 0);
+    SR_ASSERT(!Combo_GetSharedResource(RSBS_SHARED_RES_RUPEES, &probe));
+    SR_ASSERT(Combo_CountSharedResources() == 0);
+
+    // ------------------------------------------------------------------
+    // (1) THE ROUND TRIP. OoT earns 800 with a tier-3 wallet, crosses to MM
+    // (which cannot hold more than 500), sits there spending nothing, and comes
+    // home. The player must return with all 800.
+    // ------------------------------------------------------------------
+    SR_FreshWorld();
+
+    // OoT suspends holding 800. Empty slot + no watermark => the whole balance
+    // is genuinely new money and enters the pool.
+    Combo_HarvestSharedResource(GAME_OOT, RSBS_SHARED_RES_RUPEES, 800);
+    SR_ASSERT(SR_Pool(RSBS_SHARED_RES_RUPEES) == 800);
+
+    // Arrive in MM. Only 500 fits.
+    uint16_t mmLive = 0;
+    SR_ASSERT(Combo_ApplySharedResource(GAME_MM, RSBS_SHARED_RES_RUPEES, SR_MM_WALLET_CAP_T3, &mmLive));
+    SR_ASSERT(mmLive == 500);
+    // The 300 that did not fit stays in the pool rather than being lost at the
+    // clamp — the pool holds the true total, the game shows what it can.
+    SR_ASSERT(SR_Pool(RSBS_SHARED_RES_RUPEES) == 800);
+
+    // MM suspends having spent nothing. THIS is the line a naive
+    // `shared = live` harvest gets wrong: it would write 500 over the 800.
+    Combo_HarvestSharedResource(GAME_MM, RSBS_SHARED_RES_RUPEES, 500);
+    SR_ASSERT(SR_Pool(RSBS_SHARED_RES_RUPEES) == 800);
+
+    // Home again, with the full balance.
+    uint16_t ootLive = 0;
+    SR_ASSERT(Combo_ApplySharedResource(GAME_OOT, RSBS_SHARED_RES_RUPEES, SR_OOT_WALLET_CAP_T3, &ootLive));
+    SR_ASSERT(ootLive == 800);
+
+    // And it is stable under repetition — a second round trip must not shave
+    // another 300 off, which is how the naive bug actually presents.
+    Combo_HarvestSharedResource(GAME_OOT, RSBS_SHARED_RES_RUPEES, 800);
+    SR_ASSERT(Combo_ApplySharedResource(GAME_MM, RSBS_SHARED_RES_RUPEES, SR_MM_WALLET_CAP_T3, &mmLive));
+    Combo_HarvestSharedResource(GAME_MM, RSBS_SHARED_RES_RUPEES, 500);
+    SR_ASSERT(Combo_ApplySharedResource(GAME_OOT, RSBS_SHARED_RES_RUPEES, SR_OOT_WALLET_CAP_T3, &ootLive));
+    SR_ASSERT(ootLive == 800);
+    SR_ASSERT(SR_Pool(RSBS_SHARED_RES_RUPEES) == 800);
+
+    // ------------------------------------------------------------------
+    // (2a) A consumable MUST decay when the player actually spends. The
+    // watermark protects the clamp overflow, not the player's spending.
+    // ------------------------------------------------------------------
+    SR_FreshWorld();
+    Combo_HarvestSharedResource(GAME_OOT, RSBS_SHARED_RES_RUPEES, 800);
+    SR_ASSERT(Combo_ApplySharedResource(GAME_MM, RSBS_SHARED_RES_RUPEES, SR_MM_WALLET_CAP_T3, &mmLive));
+    SR_ASSERT(mmLive == 500);
+    // Spend 200 in Termina, then suspend.
+    Combo_HarvestSharedResource(GAME_MM, RSBS_SHARED_RES_RUPEES, 300);
+    SR_ASSERT(SR_Pool(RSBS_SHARED_RES_RUPEES) == 600);
+    SR_ASSERT(Combo_ApplySharedResource(GAME_OOT, RSBS_SHARED_RES_RUPEES, SR_OOT_WALLET_CAP_T3, &ootLive));
+    SR_ASSERT(ootLive == 600);
+
+    // Spending down to nothing leaves an OCCUPIED slot holding zero — the
+    // "legitimately broke" state, which the kind tag is what makes expressible.
+    Combo_HarvestSharedResource(GAME_OOT, RSBS_SHARED_RES_RUPEES, 0);
+    SR_ASSERT(Combo_GetSharedResource(RSBS_SHARED_RES_RUPEES, &probe));
+    SR_ASSERT(probe == 0);
+
+    // ------------------------------------------------------------------
+    // (2b) A monotonic resource cannot decay, in either direction.
+    // ------------------------------------------------------------------
+    SR_FreshWorld();
+    Combo_HarvestSharedResource(GAME_OOT, RSBS_SHARED_RES_WALLET_TIER, 3);
+    SR_ASSERT(SR_Pool(RSBS_SHARED_RES_WALLET_TIER) == 3);
+    // MM harvesting a LOWER tier must not downgrade the shared wallet.
+    Combo_HarvestSharedResource(GAME_MM, RSBS_SHARED_RES_WALLET_TIER, 1);
+    SR_ASSERT(SR_Pool(RSBS_SHARED_RES_WALLET_TIER) == 3);
+
+    // Apply raises the arriving game and never lowers it.
+    uint16_t tier = 1;
+    SR_ASSERT(Combo_ApplySharedResource(GAME_MM, RSBS_SHARED_RES_WALLET_TIER, 3, &tier));
+    SR_ASSERT(tier == 3);
+    uint16_t higher = 3;
+    Combo_HarvestSharedResource(GAME_MM, RSBS_SHARED_RES_WALLET_TIER, 2);
+    SR_ASSERT(Combo_ApplySharedResource(GAME_MM, RSBS_SHARED_RES_WALLET_TIER, 3, &higher));
+    SR_ASSERT(higher == 3);
+
+    // Double defense is the same discipline as a 0/1 flag, and once earned in
+    // either game it is earned in both.
+    SR_FreshWorld();
+    Combo_HarvestSharedResource(GAME_MM, RSBS_SHARED_RES_DOUBLE_DEFENSE, 1);
+    uint16_t dd = 0;
+    SR_ASSERT(Combo_ApplySharedResource(GAME_OOT, RSBS_SHARED_RES_DOUBLE_DEFENSE, 1, &dd));
+    SR_ASSERT(dd == 1);
+    Combo_HarvestSharedResource(GAME_OOT, RSBS_SHARED_RES_DOUBLE_DEFENSE, 0);
+    SR_ASSERT(SR_Pool(RSBS_SHARED_RES_DOUBLE_DEFENSE) == 1);
+
+    // ------------------------------------------------------------------
+    // (3) THE FIRST-HARVEST SEED — the .redsave double-count guard.
+    // ------------------------------------------------------------------
+    // Case (a): cold boot, nothing ever shared. The player earned 200 from
+    // scratch, so all 200 must enter the pool.
+    SR_FreshWorld();
+    Combo_HarvestSharedResource(GAME_OOT, RSBS_SHARED_RES_RUPEES, 200);
+    SR_ASSERT(SR_Pool(RSBS_SHARED_RES_RUPEES) == 200);
+
+    // Case (b): a .redsave load. The pool comes back holding 300 and OoT's own
+    // save comes back holding the same 300 — one balance, stored twice. Only
+    // the watermarks are dropped, exactly as rsbs::SaveManager::Load does.
+    SR_FreshWorld();
+    Combo_HarvestSharedResource(GAME_OOT, RSBS_SHARED_RES_RUPEES, 300);
+    SR_ASSERT(SR_Pool(RSBS_SHARED_RES_RUPEES) == 300);
+    Combo_ResetSharedResourceWatermarks(); // <- the load
+
+    // The first harvest after that load must contribute NOTHING. Getting this
+    // wrong doubles the player's money on the first switch after every load.
+    Combo_HarvestSharedResource(GAME_OOT, RSBS_SHARED_RES_RUPEES, 300);
+    SR_ASSERT(SR_Pool(RSBS_SHARED_RES_RUPEES) == 300);
+
+    // ...and money earned AFTER the load still counts. The seed must set a
+    // baseline, not disable harvesting.
+    Combo_HarvestSharedResource(GAME_OOT, RSBS_SHARED_RES_RUPEES, 450);
+    SR_ASSERT(SR_Pool(RSBS_SHARED_RES_RUPEES) == 450);
+
+    // ------------------------------------------------------------------
+    // Applying a resource nobody has ever shared reports "nothing to apply" and
+    // leaves the game's own value alone — and must NOT record a watermark, so
+    // that the balance the game already had still joins the pool at its next
+    // harvest. Seeding happens in one place (the harvest rule) so that which
+    // side moved first cannot change the answer.
+    // ------------------------------------------------------------------
+    SR_FreshWorld();
+    uint16_t untouched = 137;
+    SR_ASSERT(!Combo_ApplySharedResource(GAME_OOT, RSBS_SHARED_RES_RUPEES, SR_OOT_WALLET_CAP_T3, &untouched));
+    SR_ASSERT(untouched == 137);
+    Combo_HarvestSharedResource(GAME_OOT, RSBS_SHARED_RES_RUPEES, 137);
+    SR_ASSERT(SR_Pool(RSBS_SHARED_RES_RUPEES) == 137);
+
+    // ------------------------------------------------------------------
+    // (5) The canonical heart quantity: capacity + 4 per un-converted piece,
+    // round-tripping through its own split, clamped at 20 hearts.
+    // ------------------------------------------------------------------
+    uint16_t capacity = 0;
+    uint16_t pieces = 0;
+
+    // Three hearts, no pieces.
+    SR_ASSERT(Combo_MakeHealthQuarters(0x30, 0) == 0x30);
+    Combo_SplitHealthQuarters(0x30, &capacity, &pieces);
+    SR_ASSERT(capacity == 0x30 && pieces == 0);
+
+    // Three hearts and three pieces — the state OoT can sit in and MM cannot.
+    // It survives the round trip intact rather than being normalized away.
+    SR_ASSERT(Combo_MakeHealthQuarters(0x30, 3) == 0x3C);
+    Combo_SplitHealthQuarters(0x3C, &capacity, &pieces);
+    SR_ASSERT(capacity == 0x30 && pieces == 3);
+
+    // The FOURTH piece is a whole heart. This is the conversion the two games
+    // disagree about the timing of; as one number it is just arithmetic, and
+    // the split hands MM a state it can express.
+    SR_ASSERT(Combo_MakeHealthQuarters(0x30, 4) == 0x40);
+    Combo_SplitHealthQuarters(0x40, &capacity, &pieces);
+    SR_ASSERT(capacity == 0x40 && pieces == 0);
+
+    // The 20-heart clamp, from both directions. Neither game's give path
+    // clamps capacity, and the life meter past 20 hearts is untested in both.
+    SR_ASSERT(Combo_MakeHealthQuarters(0x140, 0) == RSBS_SHARED_RES_MAX_HEALTH_QUARTERS);
+    SR_ASSERT(Combo_MakeHealthQuarters(0x140, 3) == RSBS_SHARED_RES_MAX_HEALTH_QUARTERS);
+    SR_ASSERT(Combo_MakeHealthQuarters(0x200, 0) == RSBS_SHARED_RES_MAX_HEALTH_QUARTERS);
+    Combo_SplitHealthQuarters(0x400, &capacity, &pieces);
+    SR_ASSERT(capacity == RSBS_SHARED_RES_MAX_HEALTH_QUARTERS && pieces == 0);
+
+    // Health capacity merges monotonically and clamps on the way out too, so an
+    // over-20 pool can never reach a live save.
+    SR_FreshWorld();
+    Combo_HarvestSharedResource(GAME_OOT, RSBS_SHARED_RES_HEALTH_QUARTERS, 0x140);
+    Combo_HarvestSharedResource(GAME_MM, RSBS_SHARED_RES_HEALTH_QUARTERS, 0x30);
+    SR_ASSERT(SR_Pool(RSBS_SHARED_RES_HEALTH_QUARTERS) == 0x140);
+    uint16_t quarters = 0x30;
+    SR_ASSERT(Combo_ApplySharedResource(GAME_MM, RSBS_SHARED_RES_HEALTH_QUARTERS,
+                                        (uint16_t)RSBS_SHARED_RES_MAX_HEALTH_QUARTERS, &quarters));
+    SR_ASSERT(quarters == RSBS_SHARED_RES_MAX_HEALTH_QUARTERS);
+
+    // ------------------------------------------------------------------
+    // Current health is a CONSUMABLE, not a capacity: one bar across both
+    // games, per OoTMM. Damage taken in MM must still be there in OoT.
+    // ------------------------------------------------------------------
+    SR_FreshWorld();
+    Combo_HarvestSharedResource(GAME_OOT, RSBS_SHARED_RES_HEALTH_CURRENT, 0x50); // 5 hearts
+    uint16_t health = 0x30;
+    SR_ASSERT(Combo_ApplySharedResource(GAME_MM, RSBS_SHARED_RES_HEALTH_CURRENT, 0x100, &health));
+    SR_ASSERT(health == 0x50);
+    Combo_HarvestSharedResource(GAME_MM, RSBS_SHARED_RES_HEALTH_CURRENT, 0x20); // took 3 hearts of damage
+    SR_ASSERT(Combo_ApplySharedResource(GAME_OOT, RSBS_SHARED_RES_HEALTH_CURRENT, 0x100, &health));
+    SR_ASSERT(health == 0x20);
+
+    // ------------------------------------------------------------------
+    // Garbage in: a bogus game or kind must change nothing.
+    // ------------------------------------------------------------------
+    SR_FreshWorld();
+    Combo_HarvestSharedResource(GAME_NONE, RSBS_SHARED_RES_RUPEES, 500);
+    Combo_HarvestSharedResource(GAME_OOT, RSBS_SHARED_RES_NONE, 500);
+    Combo_HarvestSharedResource(GAME_OOT, (uint8_t)RSBS_SHARED_RES_KIND_COUNT, 500);
+    SR_ASSERT(Combo_CountSharedResources() == 0);
+    uint16_t sink = 42;
+    SR_ASSERT(!Combo_ApplySharedResource(GAME_NONE, RSBS_SHARED_RES_RUPEES, 999, &sink));
+    SR_ASSERT(!Combo_ApplySharedResource(GAME_OOT, RSBS_SHARED_RES_RUPEES, 999, NULL));
+    SR_ASSERT(sink == 42);
+
+    // ------------------------------------------------------------------
+    // All five v1 resources coexist: the slot array holds the whole set at
+    // once, with no kind overwriting another's slot.
+    // ------------------------------------------------------------------
+    SR_FreshWorld();
+    Combo_HarvestSharedResource(GAME_OOT, RSBS_SHARED_RES_RUPEES, 250);
+    Combo_HarvestSharedResource(GAME_OOT, RSBS_SHARED_RES_WALLET_TIER, 2);
+    Combo_HarvestSharedResource(GAME_OOT, RSBS_SHARED_RES_HEALTH_QUARTERS, 0x60);
+    Combo_HarvestSharedResource(GAME_OOT, RSBS_SHARED_RES_HEALTH_CURRENT, 0x40);
+    Combo_HarvestSharedResource(GAME_OOT, RSBS_SHARED_RES_DOUBLE_DEFENSE, 1);
+    SR_ASSERT(Combo_CountSharedResources() == 5);
+    SR_ASSERT(SR_Pool(RSBS_SHARED_RES_RUPEES) == 250);
+    SR_ASSERT(SR_Pool(RSBS_SHARED_RES_WALLET_TIER) == 2);
+    SR_ASSERT(SR_Pool(RSBS_SHARED_RES_HEALTH_QUARTERS) == 0x60);
+    SR_ASSERT(SR_Pool(RSBS_SHARED_RES_HEALTH_CURRENT) == 0x40);
+    SR_ASSERT(SR_Pool(RSBS_SHARED_RES_DOUBLE_DEFENSE) == 1);
+    // The set fits with headroom left for the queued members of the class
+    // (shared magic, the ammo upgrades) without another .redsave carve.
+    SR_ASSERT(Combo_CountSharedResources() < (int)RSBS_SHARED_RESOURCE_CAP);
+
+    // Session invalidation retires the pool AND the watermarks together — a
+    // watermark surviving into a fresh world would measure a delta against a
+    // balance that no longer exists.
+    SR_FreshWorld();
+    SR_ASSERT(Combo_CountSharedResources() == 0);
+    Combo_HarvestSharedResource(GAME_OOT, RSBS_SHARED_RES_RUPEES, 700);
+    SR_ASSERT(SR_Pool(RSBS_SHARED_RES_RUPEES) == 700);
+
+    printf("[TEST] PASS: watermark survives the 500/999 round trip, disciplines split, load cannot double-count\n");
+    return TEST_PASS;
+}


### PR DESCRIPTION
Closes #525.

Copies OoTMM's user-facing behavior: a shared resource is **one quantity spanning both games**, capacity *and* current value. v1 shares **rupees and hearts**, which is what justifies the matching pool shrink.

> "Receiving a heart piece, heart container or double defense affects the maximum health/defence of both games."
> "Current health is tracked as if OoT and MM were one game with a single health bar."

Per the issue's correction comment, **current health is shared** — the issue body's "share capacity, never current health" is the part that was wrong.

## Storage

Eight kind-tagged 4-byte slots carved from the front of `ComboContext.reserved[]` at `.redsave` byte offset **792**, pinned by a literal `offsetof` assert plus a contiguity assert. `reserved[212]` → `reserved[180]`. ADR 0009's budget table is amended in the same commit (claim 5). No `RSBS_SAVE_VERSION` bump — a zero-extended legacy record reads as eight empty slots, which is correct.

The kind tag is load-bearing, not bookkeeping: the growth contract is "zero means unset" and **0 rupees is a legal player state**, so a bare `uint16_t` could not tell a pre-#525 record from a broke player, and would either resurrect a stale balance or discard a real zero.

## Two merge disciplines

- **MONOTONIC** (wallet tier, health quarters, double defense) — max-merge both ways; decay impossible by construction.
- **CONSUMABLE** (rupee count, current health) — delta-harvest against a RAM-only watermark.

**The watermark is mandatory.** MM's tier-3 wallet holds 500, OoT's holds 999. Under a naive `shared = live` harvest, carrying 800 rupees into MM clamps the live count to 500 and the next suspend writes that 500 back over the pool — **300 rupees gone, silently, on every round trip.** Apply records what it actually materialized, so the overflow rides out the visit instead of being harvested away.

## One thing the issue's design didn't cover

Because the watermark is RAM-only, a freshly loaded session has none — and a delta against zero would contribute the whole restored balance a second time. **Loading a `.redsave` and switching games would have doubled the player's rupees.**

Closed with a seed rule that needs no new state, because the discriminator was already in the data:

- **slot empty** → nothing was ever shared; seed at 0, so a cold boot's earnings genuinely enter the pool.
- **slot occupied** → the pool was restored from a `.redsave`, which is only ever written *after* a harvest; seed at the live value, delta zero.

Seeding lives in exactly one place (the harvest rule), so which side moved first cannot change the answer.

## Hearts

Stored as **one canonical quantity** — `capacity + pieces*4`, clamped at 320 (20 hearts). That dissolves the OoT-defers / MM-converts-immediately mismatch instead of guarding it: OoT can sit at `pieces == 4` with capacity not yet bumped, a state MM never produces and an F10 swap can land on. Neither game's give path clamps capacity, and a total summed across both games passes 20 hearts easily. The `Make`/`Split` pair lives in `src/common` so the arithmetic has one definition rather than two that can drift.

Double defense is shared as a 0/1 **fact**, not a byte copy — the flag is spelled `isDoubleDefenseAcquired` in OoT and `doubleDefense` in MM, and each game carries its own `inventory.defenseHearts` counter that its life meter reads.

## Cycle-safe shared rupees (operator call)

MM's three-day cycle zeroes the wallet, which unhandled would let a Song of Time drain the OoT rupees too. The shared pool now survives the wipe via `Before`/`AfterEndOfCycleSave` — the seam 2S2H's own `DoNotResetRupees` uses. Rupees *spent* in MM are still gone; only the wipe is suppressed.

**Registered from `GameExports_SingleExe.cpp`, deliberately not from `Enhancements/Cycle/EndOfCycle.cpp`** where the analogous restore lives: that TU is link-elided from the plain-archive `2ship_enh` and its six registrants are absent from the binary. Registering there would have been the #516/#513 dead-registrar class exactly — code that reads correctly and never runs. The hook's dispatch was verified live (#514, `mm_hook_dispatch_test.cpp`) *before* this was written.

Current health deliberately has no equivalent hook: the cycle's health floor is a Song of Time healing the one shared bar, which is what one-game semantics means.

## Pool shrink

`kForeignPoolMMV1` drops `RI_PROGRESSIVE_WALLET`, `RI_WALLET_ADULT`, `RI_WALLET_GIANT`, `RI_DOUBLE_DEFENSE`, `RI_HEART_CONTAINER`, `RI_HEART_PIECE` — **134 → 128**. With one wallet and one health bar there is nothing left for those items to carry across; shipping them would hand the player a second copy of a capacity they already have.

Added as membership **criterion (6)** rather than a silent delete. Note `RI_DOUBLE_DEFENSE` sat under *core equipment*, not the health block, so a block-shaped delete misses it. OoT's `kForeignPoolV1` is unchanged, so the "Bomb Bag" cross-pool collision test keeps its subject.

## Testing

Both tiers green locally: **63/63 redship**, **14/14 rando**. The rando tier matters here specifically — it drives the play-state paths this change newly fires.

New `shared-resources` row, plus criterion 6 on `foreign-pool-mm` (keyed on the display name, because `src/common` has no MM headers in scope by design — the same reason the giveable/junk checks go through MM-side bridge predicates).

Every new assertion was falsified — fix reverted, specific failure confirmed, fix restored:

| Mutation | Assertion that fired |
|---|---|
| Watermark records the pool value, not what was materialized | `SR_Pool(RUPEES) == 800` (line 131) |
| Seed always 0 (the `.redsave` double-count) | `SR_Pool(RUPEES) == 300` (line 216) |
| Wallet tier treated as consumable | `higher == 3` (line 184) |
| 20-heart clamp removed | `MakeHealthQuarters(0x140,3) == MAX` (line 265) |
| Monotonic zero guard removed | `CountSharedResources() == 0` (line 106) |
| `RI_HEART_PIECE` row restored | criterion 6 name assert (129 items registered) |

New symbols verified 0 → present in `build-cmake/redship.map`.

## Notes for review

- **End-to-end behavior is gameplay-tier and rests on playtest.** The ROM-free tiers lock the arithmetic and the wiring; they cannot observe an actual OoT↔MM crossing.
- Risk 5 from the plan is moot: **#487 is closed**, so the owl-save flash readback can no longer revert applied values.
- Apply is ordered **before** the shared-item consumer in both `z_play.c` sites. Apply authors an absolute rupee count and heart capacity, so an item given first would be silently overwritten; applied first, a give layers on top and the next harvest picks it up as a delta.
- Harvest writes the pool, apply only reads it. Worth keeping — it means every pool mutation is at a suspend or pre-save point, never mid-scene.
- Known v1 limitation, unchanged from shared items: a plain `.redsave` load without a switch does not apply. The seed rule makes that safe (no decay, no double-count); the residual is a small generous divergence, and the issue lists "apply on load" as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!--- section:artifacts:start -->
### Build Artifacts
  - [rsbs-windows.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/8717440833.zip)
  - [rsbs-linux.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/8717146145.zip)
<!--- section:artifacts:end -->