### PR TITLE
Fix #536 (active slot outlives its session) and #538 (armed entrance 0 = Mayor's Residence)

### DIFF
--- a/games/oot/soh/SaveManager.cpp
+++ b/games/oot/soh/SaveManager.cpp
@@ -188,13 +188,18 @@ SaveManager::SaveManager() {
         if (fileNum < 0 || fileNum >= RSBS_SAVE_MAX_SLOTS) {
             return;
         }
-        // Establish the session's slot BEFORE the clear-and-reload below, so
-        // it survives regardless of whether this slot has a companion
-        // .redsave. A slot the player opened is the session's slot even when
-        // no cross-game state exists for it yet — that is exactly the case
-        // where MM is entered for the first time and needs somewhere to save.
-        RsbsSave_SetActiveSlot(fileNum);
+        // Order matters: the clear runs FIRST, then the new slot is
+        // established. Session invalidation now also drops the active slot
+        // (it is session state that used to outlive its session), so
+        // publishing before the clear would wipe what we just set.
+        //
+        // Establishing it here — rather than only when a companion .redsave
+        // exists — is deliberate: a slot the player opened is the session's
+        // slot even when no cross-game state exists for it yet, which is
+        // exactly the case where MM is entered for the first time and needs
+        // somewhere to save.
         Context_InvalidateSessionOnSlotLoad();
+        RsbsSave_SetActiveSlot(fileNum);
         if (RsbsSave_HasSave(fileNum)) {
             RsbsSave_Load(fileNum);
         }

--- a/src/common/context.cpp
+++ b/src/common/context.cpp
@@ -14,6 +14,13 @@
 // Combo_HasStartupEntrance() — the discriminator that keeps the return-to-title
 // hook from eating a cross-game arrival's blob.
 #include "entrance.h"
+
+// The unified save's session-scoped active slot. Declared rather than pulled in
+// via save.h so the context layer keeps no compile-time dependency on the save
+// layer — save.h already depends on context.h, and the reverse include would
+// make that circular. Same convention game-side TUs use to reach Combo_*.
+extern "C" void RsbsSave_SetActiveSlot(int slot);
+
 #include <cstdio>
 #include <cstring>
 #include <vector>
@@ -346,6 +353,21 @@ void Context_InvalidateSessionState(ComboSeedStampPolicy seedPolicy) {
         gComboCtx.sharedRandoSeed = savedSeed;
         gComboCtx.sharedRandoSettingsHash = savedSettingsHash;
     }
+
+    // The unified save's ACTIVE SLOT is session state too, and it lived outside
+    // this function's reach: SaveManager owns it, three sites set it, and
+    // nothing ever cleared it. "Which .redsave am I part of" therefore outlived
+    // the session it described — load slot 0, quit to title, F10 into a fresh
+    // bootstrap MM session, owl-save, and the capture wrote MM's throwaway
+    // state straight over redship_slot0.redsave, destroying that slot's MM
+    // progress and its rando pairing identity.
+    //
+    // Declared here rather than by including save.h: this keeps the context
+    // layer free of a compile-time dependency on the save layer (save.h already
+    // depends on context.h), matching how game-side TUs reach Combo_*.
+    // Re-establishing a slot is the job of whatever opens one next — OoT's
+    // OnLoadFile / OnSaveFile hooks, or the departure publish.
+    RsbsSave_SetActiveSlot(-1);
 
     fprintf(stderr, "[Context] Session state invalidated (seed stamp %s: rando=%d seed=%u settings=%08X)\n",
             (seedPolicy == RSBS_SEED_STAMP_KEEP) ? "kept" : "dropped", (int)gComboCtx.sourceIsRando,

--- a/src/common/save.cpp
+++ b/src/common/save.cpp
@@ -9,6 +9,7 @@
 #include "save.h"
 
 #include "context.h"
+#include "entrance.h" // MM_ENTR_SOUTH_CLOCK_TOWN_0 — the armed blob's return entrance
 #include "game.h"
 
 #include <cstdio>
@@ -332,10 +333,20 @@ bool SaveManager::Load(int slot) {
     // Arming is refused for an all-zero tier (see Context_ArmShadowAsFrozen),
     // which is exactly a slot saved before the player ever entered MM: that
     // must keep cold-booting MM's own bootstrap rather than restoring a zeroed
-    // SaveContext over it. Entrance 0 is a placeholder, not a spawn decision —
-    // where a resumed MM session actually lands is MM's own owl / new-cycle
+    // SaveContext over it.
+    //
+    // The return entrance is NOT a free placeholder. An earlier revision passed
+    // 0 and called it inert; that was wrong the moment arming made this blob
+    // reachable. rsbs/src/main.cpp's hot-swap path sets the arriving game's
+    // startup entrance from Context_GetFrozenReturnEntrance, entrance presence
+    // is tracked by a separate flag so 0 is a real consumable value, and
+    // ENTR_SCENE_MAYORS_RESIDENCE is 0 — so F10 into a freshly loaded MM half
+    // spawned Link inside the Mayor's Residence. Use the same safe arrival
+    // entrance the real hot-swap freeze records (Switch_GetHotSwapReturnEntrance),
+    // so the two armers agree. A slot-resume that wants MM's own owl /
+    // new-cycle spawn policy overrides this later; this is the floor, not the
     // policy.
-    const int armed = Context_ArmShadowAsFrozen(GAME_MM, 0);
+    const int armed = Context_ArmShadowAsFrozen(GAME_MM, MM_ENTR_SOUTH_CLOCK_TOWN_0);
     std::fprintf(stderr, "[RsbsSave] slot %d loaded; MM half %s\n", slot,
                  armed ? "armed for restore" : "empty (MM will cold-boot)");
     return true;

--- a/src/common/tests/test_session_invalidation.c
+++ b/src/common/tests/test_session_invalidation.c
@@ -187,6 +187,17 @@ bool SessionIsClear(bool expectSeedStamp) {
     if (expectSeedStamp != gComboCtx.sourceIsRando) {
         return false;
     }
+    // The unified save's active slot is session state and must not outlive the
+    // session. It used to: SaveManager owned it, three sites set it, and no
+    // invalidation path cleared it — so "which .redsave am I part of" survived
+    // a quit to title, and an F10 into a fresh bootstrap MM session would
+    // owl-save straight over the previously-loaded slot, destroying that slot's
+    // MM progress and its rando pairing identity. Checked here rather than at
+    // one call site so EVERY invalidation entry point is covered by the
+    // assertions that already exist.
+    if (RsbsSave_GetActiveSlot() != -1) {
+        return false;
+    }
     return true;
 }
 
@@ -378,6 +389,13 @@ TestResult Test_SessionInvalidation(void) {
         // or on any other occasion. The old assertion was the operator's "MM
         // will be reset after game restart" written down as required behavior.
         SESSION_ASSERT(Context_HasFrozenState(GAME_MM) == 1);
+        // The armed blob must carry a SAFE return entrance, not 0. The F10
+        // hot-swap path sets the arriving game's startup entrance from
+        // Context_GetFrozenReturnEntrance, and entrance presence is a separate
+        // flag, so 0 is a real consumable id — and ENTR_SCENE_MAYORS_RESIDENCE
+        // is 0, which put Link inside the Mayor's Residence. Must match what
+        // the real hot-swap freeze records.
+        SESSION_ASSERT(Context_GetFrozenReturnEntrance(GAME_MM) == MM_ENTR_SOUTH_CLOCK_TOWN_0);
         // OoT stays unarmed on purpose: OoT's own file{N+1}.sav is the
         // authority for OoT state and Sram_OpenSave applies it on the normal
         // load path. Arming Tier-2 too would race a second, staler copy of


### PR DESCRIPTION
Fixes #536, fixes #538.

Both are P0 defects in my own recently-landed work, found by an independent
bugbash of `main`. Fixing them before building resume-routing on top, because
routing on a stale slot would turn a data-loss bug into one that fires on every
load.

## #536 — data loss (regression from #527)

`SaveManager::mActiveSlot` is process-lifetime state. Three sites set it,
nothing cleared it, and no session-invalidation path reached it — so *"which
`.redsave` am I part of"* outlived the session it described.

Repro: load slot 0 → quit to title → F10 into a fresh bootstrap MM session →
owl-save. The capture writes MM's throwaway state straight over
`redship_slot0.redsave`, destroying that slot's MM progress **and** its rando
pairing identity.

`Context_InvalidateSessionState` now clears it, covering all three entry points
(return-to-title, new game, slot load) at once. The declaration is a local
`extern` rather than an include, so the context layer keeps no compile-time
dependency on the save layer — `save.h` already depends on `context.h`, and the
reverse include would be circular.

OoT's `OnLoadFile` ordering is flipped to match: **clear first, then establish
the new slot.** Publishing before the clear would now wipe it.

## #538 — wrong spawn (regression from #528)

`Load` armed the MM shadow with `returnEntrance 0`, and my in-line comment
called it *"a placeholder, not a spawn decision."*

That was true when written and **became false in the same PR**. Arming is
precisely what made the F10 hot-swap path read it: `main.cpp` sets the arriving
game's startup entrance from `Context_GetFrozenReturnEntrance`, entrance
presence is tracked by a separate flag so `0` is a real consumable id, and
`ENTR_SCENE_MAYORS_RESIDENCE == 0`. Hot-swapping into a freshly loaded MM half
spawned Link inside the Mayor's Residence.

Now arms with `MM_ENTR_SOUTH_CLOCK_TOWN_0` — the same value the real hot-swap
freeze records via `Switch_GetHotSwapReturnEntrance`, so the two armers agree. A
slot-resume that wants MM's own owl / new-cycle policy overrides it later; this
is the floor, not the policy.

## Tests

The slot-clear assertion goes **inside `SessionIsClear`**, so every invalidation
entry point is covered by assertions that already exist rather than at one call
site. The entrance assertion is pinned in case 7.

**Negative control:** restoring the `0` entrance fails
`test_session_invalidation.c:398`, exit 1.

Local: **62/62 redship, 14/14 rando.** No format change.

## Still open in this lane

Not addressed here, and worth knowing before the resume work continues:

- **#532 (P0)** — the owl exit runs `TitleSetup`, which authors a bootstrap over
  the live session; the departure freeze then launders it into Tier-3. My owl
  capture writes a good file first, but nothing stops the bootstrap overwriting
  it after. **Owl saves are not durable until this is fixed** (it's the Stage 5
  interception).
- **#530 (P1)** — Song of Time new-cycle, game-over and autosave still capture
  nothing; #529 covered the pause-save leg only.
- **#531, #533, #537** — Tier-1/`.sav` freshness skew, refused-`.redsave`
  overwrite, and torn commits from the worker thread.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!--- section:artifacts:start -->
### Build Artifacts
  - [rsbs-windows.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/8717532068.zip)
  - [rsbs-linux.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/8717267529.zip)
<!--- section:artifacts:end -->