### PR TITLE
Keep the generation-authored reverse placement table across new-file invalidation (#534)

### DIFF
--- a/games/oot/src/code/z_sram.c
+++ b/games/oot/src/code/z_sram.c
@@ -283,6 +283,18 @@ void OoT_Sram_InitSave(FileChooseContext* fileChooseCtx) {
     // cleared state, instead of persisting the dead session's crossings into
     // the new file's very first save.
     //
+    // INVARIANT (#534): ordering alone cannot protect what GENERATION already
+    // authored, because generation ran minutes ago in the menu — before this
+    // function. Two gComboCtx artifacts exist by now precisely because
+    // isRandoFile is true: the seed stamp and the reverse placement table
+    // (foreignPlacementsOoT, the MM items #524 hosts in this seed's OoT
+    // checks), written back-to-back by Playthrough_Init. Both must survive
+    // this clear — nothing re-places the reverse table afterwards, so a wipe
+    // here silences every reverse delivery, and the (b) write below then
+    // persists the loss into the slot's first .redsave. The KEEP policy
+    // inside the call preserves exactly those two; everything the dead
+    // session authored still goes.
+    //
     // isRandoFile is exactly the condition the branch below uses, so the seed
     // stamp is kept precisely when generation has already authored it for this
     // file and dropped for a vanilla file (where a surviving stamp would leave

--- a/src/common/context.cpp
+++ b/src/common/context.cpp
@@ -12,6 +12,10 @@
 // than from context.h so the header keeps its no-dependency shape.
 #include "shared_items.h"
 #include "shared_resources.h"
+// Combo_CountForeignPlacementsOoT() — invalidation reports how much of the
+// generation-authored reverse table each policy kept (#534). Same .cpp-only
+// placement rationale as shared_items.h above.
+#include "foreign_items.h"
 // Combo_HasStartupEntrance() — the discriminator that keeps the return-to-title
 // hook from eating a cross-game arrival's blob.
 #include "entrance.h"
@@ -322,12 +326,25 @@ bool Context_HasPendingSwitch(void) {
 // ----------------------------------------------------------------------------
 
 void Context_InvalidateSessionState(ComboSeedStampPolicy seedPolicy) {
-    // Snapshot the Lane B stamp BEFORE the re-init below wipes it. This is the
-    // only part of gComboCtx that can legitimately outlive the session, and
-    // only in the KEEP case — see ComboSeedStampPolicy.
+    // Snapshot the generation-authored state BEFORE the re-init below wipes
+    // it. These fields are the only part of gComboCtx that can legitimately
+    // outlive the session, and only in the KEEP case — see ComboSeedStampPolicy.
     const bool savedSourceIsRando = gComboCtx.sourceIsRando;
     const uint32_t savedSeed = gComboCtx.sharedRandoSeed;
     const uint32_t savedSettingsHash = gComboCtx.sharedRandoSettingsHash;
+    // #534: the reverse placement table (OoT checks hosting MM items, #524)
+    // travels WITH the stamp because it has the same author and the same
+    // moment of authorship: Playthrough_Init stamps the pairing identity and
+    // immediately derives these placements from it (OoT_PlaceForeignItems),
+    // both BEFORE the file being created exists. Nothing re-places the
+    // reverse table after generation — unlike the FORWARD table
+    // (foreignPlacements), which MM re-authors at its own OnFileCreate on the
+    // next arrival and is therefore deliberately NOT snapshotted (at this
+    // point it can only hold a dead session's rows). Wiping the reverse table
+    // here made #524 inert in every real playthrough: the new file's first
+    // .redsave write then persisted the zeroed table.
+    ComboForeignPlacement savedPlacementsOoT[RSBS_FOREIGN_PLACEMENT_CAP];
+    memcpy(savedPlacementsOoT, gComboCtx.foreignPlacementsOoT, sizeof(savedPlacementsOoT));
 
     // Frozen blobs and shadow copies in one call — they are the same storage
     // (FrozenStateManager::ClearFrozenState memsets the buffer AND clears
@@ -359,6 +376,10 @@ void Context_InvalidateSessionState(ComboSeedStampPolicy seedPolicy) {
         gComboCtx.sourceIsRando = savedSourceIsRando;
         gComboCtx.sharedRandoSeed = savedSeed;
         gComboCtx.sharedRandoSettingsHash = savedSettingsHash;
+        // The other generation-authored artifact (#534) — see the snapshot
+        // note above. KEEP-only on purpose: on a DROP path a populated table
+        // belongs to a dead session and must go with it.
+        memcpy(gComboCtx.foreignPlacementsOoT, savedPlacementsOoT, sizeof(gComboCtx.foreignPlacementsOoT));
     }
 
     // The unified save's ACTIVE SLOT is session state too, and it lived outside
@@ -376,9 +397,12 @@ void Context_InvalidateSessionState(ComboSeedStampPolicy seedPolicy) {
     // OnLoadFile / OnSaveFile hooks, or the departure publish.
     RsbsSave_SetActiveSlot(-1);
 
-    fprintf(stderr, "[Context] Session state invalidated (seed stamp %s: rando=%d seed=%u settings=%08X)\n",
+    fprintf(stderr,
+            "[Context] Session state invalidated (seed stamp %s: rando=%d seed=%u settings=%08X "
+            "reversePlacements=%d)\n",
             (seedPolicy == RSBS_SEED_STAMP_KEEP) ? "kept" : "dropped", (int)gComboCtx.sourceIsRando,
-            (unsigned)gComboCtx.sharedRandoSeed, (unsigned)gComboCtx.sharedRandoSettingsHash);
+            (unsigned)gComboCtx.sharedRandoSeed, (unsigned)gComboCtx.sharedRandoSettingsHash,
+            Combo_CountForeignPlacementsOoT());
 }
 
 int Context_InvalidateSessionOnReturnToTitle(void) {

--- a/src/common/context.h
+++ b/src/common/context.h
@@ -774,29 +774,38 @@ bool Context_HasPendingSwitch(void);
 // .redsave would keep inheriting the previous session.
 
 /**
- * What Context_InvalidateSessionState does with the Lane B seed stamp
- * (sourceIsRando / sharedRandoSeed / sharedRandoSettingsHash).
+ * What Context_InvalidateSessionState does with the GENERATION-AUTHORED state:
+ * the Lane B seed stamp (sourceIsRando / sharedRandoSeed /
+ * sharedRandoSettingsHash) and, since #534, the reverse placement table
+ * (foreignPlacementsOoT) that generation derives from that stamp.
  *
- * The stamp is the one part of gComboCtx that is NOT authored by the session
- * being torn down: Playthrough_Init writes it at GENERATION time, which for a
- * new file happens BEFORE the file is created (generate a seed in the menu,
- * then name the file). So the new-file call site must keep a stamp that
- * generation just authored, while a return-to-title must drop one that nothing
- * stands behind. Making that an explicit argument rather than a hidden policy
- * means every call site has to state which situation it is in.
+ * These are the one part of gComboCtx that is NOT authored by the session
+ * being torn down: Playthrough_Init writes the stamp at GENERATION time and
+ * immediately derives the reverse placements from it (OoT_PlaceForeignItems),
+ * which for a new file happens BEFORE the file is created (generate a seed in
+ * the menu, then name the file). So the new-file call site must keep what
+ * generation just authored, while a return-to-title must drop a stamp that
+ * nothing stands behind. Making that an explicit argument rather than a
+ * hidden policy means every call site has to state which situation it is in.
  */
 typedef enum {
     /**
-     * Drop the stamp. Correct wherever no generation stands behind it: a soft
-     * reset to title, and a NON-rando new file. A surviving stamp is not inert
-     * — Combo_ForeignPairingActive() is literally
+     * Drop the stamp (and the reverse placement table with it). Correct
+     * wherever no generation stands behind it: a soft reset to title, and a
+     * NON-rando new file. A surviving stamp is not inert —
+     * Combo_ForeignPairingActive() is literally
      * `sourceIsRando && sharedRandoSettingsHash != 0`, so a dead session's
      * stamp makes MM believe a paired world exists for a seed that is gone.
      */
     RSBS_SEED_STAMP_DROP = 0,
     /**
-     * Keep the stamp. Correct ONLY where generation has already authored it
-     * for the file now being created (OoT_Sram_InitSave on a randomizer file).
+     * Keep the stamp AND the reverse placement table (#534) — they were
+     * authored together and are only coherent together. Correct ONLY where
+     * generation has already authored them for the file now being created
+     * (OoT_Sram_InitSave on a randomizer file). The FORWARD table
+     * (foreignPlacements) is dropped even here: MM re-authors it at its own
+     * OnFileCreate on the next arrival, so at file-creation time it can only
+     * hold a dead session's rows.
      */
     RSBS_SEED_STAMP_KEEP = 1,
 } ComboSeedStampPolicy;
@@ -828,7 +837,9 @@ typedef enum {
  *     foreignPlacements. A stale sharedItemsTagged is how another player's
  *     grants from a dead room would reach a fresh seed.
  *
- * The seed stamp is governed by @p seedPolicy; see ComboSeedStampPolicy.
+ * The seed stamp and the generation-authored reverse placement table
+ * (foreignPlacementsOoT, #534) are governed by @p seedPolicy; see
+ * ComboSeedStampPolicy.
  *
  * Deliberately does NOT touch gCurrentGame (which game is running right now is
  * still true) and does NOT arm a frozen blob from anything.
@@ -883,10 +894,11 @@ int Context_InvalidateSessionOnReturnToTitle(void);
  *
  * @param isRandoFile non-zero iff the file being created is a randomizer file
  *        whose seed has already been generated. That is the ONLY case where the
- *        seed stamp is kept: generation ran moments ago, in the menu, and
- *        authored the stamp FOR this file. A vanilla new file passes 0 and the
- *        stamp goes with the rest of the dead session — otherwise
- *        Combo_ForeignPairingActive() would still report a paired world.
+ *        seed stamp and the reverse placement table are kept: generation ran
+ *        moments ago, in the menu, and authored both FOR this file (#534). A
+ *        vanilla new file passes 0 and the stamp goes with the rest of the dead
+ *        session — otherwise Combo_ForeignPairingActive() would still report a
+ *        paired world.
  */
 void Context_InvalidateSessionOnNewGame(int isRandoFile);
 

--- a/src/common/tests/test_session_invalidation.c
+++ b/src/common/tests/test_session_invalidation.c
@@ -38,7 +38,12 @@
  *      it does, and the paired world is never generated at all. The dependency
  *      is one-directional: invalidating the blob restores correct pairing with
  *      no change to the guard.
- *   5. New game keeps a generated seed stamp and drops everything else.
+ *   5. New game keeps a generated seed stamp — and (#534) the reverse
+ *      placement table generation authored WITH that stamp — and drops
+ *      everything else. Generation runs before the file is created and
+ *      nothing re-places the reverse table afterwards, so a wipe here is a
+ *      permanent loss: #524's MM-items-in-OoT-checks never deliver and the
+ *      zeroed table is persisted by the new slot's first .redsave.
  *   6. A NON-rando new file drops the seed stamp too, or
  *      Combo_ForeignPairingActive() would keep reporting a paired world.
  *   7. A legitimate existing-slot load STILL restores that slot's .redsave.
@@ -96,6 +101,14 @@ const size_t kSessionBuf = 512;
 const uint8_t kSessionAByte = 0xA5;
 const uint8_t kSessionBByte = 0x5B;
 
+// Reverse-table rows (OoT checks hosting MM items, #524): one belonging to the
+// dead session A, one authored by the mirrored generation pass below. Distinct
+// on purpose — case 5 must be able to tell "generation's table was kept" from
+// "the dead session's table leaked through the keep-set" (#534).
+const uint16_t kSessionAReverseCheck = 501;
+const uint16_t kGenReverseCheck = 777;
+const uint16_t kGenReverseItemId = 91;
+
 // Put a recognizable, fully-populated session into every global the bug leaks
 // through: both frozen blobs, both shadows, the seed stamp, the crossing
 // tables, and a staged-but-uncommitted pickup in the RAM outbox.
@@ -122,6 +135,15 @@ void SeedSessionA(uint32_t seed, uint32_t settingsHash) {
     foreign.flags = 0;
     foreign.id = 77;
     Combo_SetForeignPlacement(/*mmCheckId=*/9, foreign);
+
+    // The dead session's REVERSE row. Present so every DROP path below is
+    // proven to wipe it — the keep-set (#534) is generation's table, never a
+    // dead session's.
+    SharedItem foreignRev;
+    foreignRev.originGame = (uint8_t)GAME_MM;
+    foreignRev.flags = 0;
+    foreignRev.id = 88;
+    Combo_SetForeignPlacementOoT(kSessionAReverseCheck, foreignRev);
 
     // Staged but never committed — the session died mid-pickup.
     Combo_StageSharedItem(GAME_OOT, 43);
@@ -159,12 +181,23 @@ PairDecision ArrivalPairDecision(int hadFrozenState) {
     return PAIR_PROCEED;
 }
 
-// Stamp the seed fields the way Playthrough_Init does at generation time —
-// which for a new file happens BEFORE the file is created.
+// Author the generation-time gComboCtx state the way Playthrough_Init does —
+// which for a new file happens BEFORE the file is created: the seed stamp,
+// then immediately the reverse placement table derived from it
+// (OoT_PlaceForeignItems clears a predecessor's rows and re-places; #510).
+// Mirrored rather than called for the usual reason: the real pass needs a
+// finished fill, which a headless src/common test has no business booting.
 void StampGeneratedSeed(uint32_t seed, uint32_t settingsHash) {
     gComboCtx.sourceIsRando = true;
     gComboCtx.sharedRandoSeed = seed;
     gComboCtx.sharedRandoSettingsHash = settingsHash;
+
+    Combo_ClearForeignPlacementsOoT();
+    SharedItem mmItem;
+    mmItem.originGame = (uint8_t)GAME_MM;
+    mmItem.flags = 0;
+    mmItem.id = kGenReverseItemId;
+    Combo_SetForeignPlacementOoT(kGenReverseCheck, mmItem);
 }
 
 // Every session field must read as freshly initialized.
@@ -182,6 +215,13 @@ bool SessionIsClear(bool expectSeedStamp) {
         return false;
     }
     if (Combo_CountForeignPlacements() != 0) {
+        return false;
+    }
+    // The reverse table follows the seed stamp's policy (#534): generation
+    // authors both together, so it may outlive invalidation ONLY when the
+    // stamp does. On every DROP path it must read empty; the KEEP case's exact
+    // expected content is asserted at the call site.
+    if (!expectSeedStamp && Combo_CountForeignPlacementsOoT() != 0) {
         return false;
     }
     if (expectSeedStamp != gComboCtx.sourceIsRando) {
@@ -216,6 +256,7 @@ TestResult Test_SessionInvalidation(void) {
     SESSION_ASSERT(Context_HasFrozenState(GAME_OOT) == 1);
     SESSION_ASSERT(Combo_CountSharedItems(GAME_OOT, true) == 1);
     SESSION_ASSERT(Combo_CountForeignPlacements() == 1);
+    SESSION_ASSERT(Combo_CountForeignPlacementsOoT() == 1);
     SESSION_ASSERT(Combo_ForeignPairingActive());
 
     // ---- 2. NEGATIVE CONTROL: an arrival must not invalidate --------------
@@ -229,6 +270,7 @@ TestResult Test_SessionInvalidation(void) {
     SESSION_ASSERT(Context_InvalidateSessionOnReturnToTitle() == 0);
     SESSION_ASSERT(Context_HasFrozenState(GAME_MM) == 1);
     SESSION_ASSERT(Combo_CountForeignPlacements() == 1);
+    SESSION_ASSERT(Combo_CountForeignPlacementsOoT() == 1);
     Entrance_ClearStartupEntrance();
 
     // ---- 3. Soft reset to title retires the session -----------------------
@@ -240,6 +282,10 @@ TestResult Test_SessionInvalidation(void) {
     SESSION_ASSERT(gComboCtx.sharedRandoSeed == 0);
     SESSION_ASSERT(gComboCtx.sharedRandoSettingsHash == 0);
     SESSION_ASSERT(!Combo_ForeignPairingActive());
+    // Both placement tables go with the session on a DROP — the reverse one
+    // included, because at the title nothing stands behind it any more than
+    // behind the stamp it was derived from (#534).
+    SESSION_ASSERT(Combo_CountForeignPlacementsOoT() == 0);
     // The shadows are the same storage as the blobs and must be wiped with
     // them, or a tracker (or a .redsave written afterwards) would still be
     // reading the dead session's bytes.
@@ -316,6 +362,22 @@ TestResult Test_SessionInvalidation(void) {
     SESSION_ASSERT(SessionIsClear(/*expectSeedStamp=*/true));
     SESSION_ASSERT(gComboCtx.sharedRandoSeed == 0x99999999u);
     SESSION_ASSERT(gComboCtx.sharedRandoSettingsHash == 0x5555u);
+    // ---- 5b. #534: generation's REVERSE placement table survives too -------
+    // Playthrough_Init authored it seconds after the stamp, for THIS file, and
+    // nothing re-places it after file creation (the forward direction is
+    // re-authored by MM at arrival; the reverse has no such second chance). A
+    // wipe here is what made #524 inert in every real playthrough — with the
+    // loss then persisted by the new slot's first .redsave write.
+    SESSION_ASSERT(Combo_CountForeignPlacementsOoT() == 1);
+    {
+        const SharedItem* kept = Combo_GetForeignPlacementForOoTCheck(kGenReverseCheck);
+        SESSION_ASSERT(kept != NULL);
+        SESSION_ASSERT(kept->originGame == (uint8_t)GAME_MM);
+        SESSION_ASSERT(kept->id == kGenReverseItemId);
+    }
+    // ...and it is GENERATION's table that survived, not the dead session's
+    // leaking through the keep-set.
+    SESSION_ASSERT(Combo_GetForeignPlacementForOoTCheck(kSessionAReverseCheck) == NULL);
     // The dead session's crossings must not reach the new seed. This is the
     // assertion the netplay agents' grant model composes with (#460): a stale
     // sharedItemsTagged is another player's grants from a dead room.
@@ -332,6 +394,9 @@ TestResult Test_SessionInvalidation(void) {
     SESSION_ASSERT(SessionIsClear(/*expectSeedStamp=*/false));
     SESSION_ASSERT(gComboCtx.sharedRandoSeed == 0);
     SESSION_ASSERT(gComboCtx.sharedRandoSettingsHash == 0);
+    // No generation stands behind a vanilla file, so the reverse table is the
+    // dead session's and goes with it — the #534 keep-set is KEEP-only.
+    SESSION_ASSERT(Combo_CountForeignPlacementsOoT() == 0);
     // A surviving stamp would leave MM believing a paired world exists for a
     // seed that no longer does — the arrival must decline, and for the RIGHT
     // reason (no paired world, not "the save already exists").
@@ -371,6 +436,11 @@ TestResult Test_SessionInvalidation(void) {
         SESSION_ASSERT(Combo_CountSharedItems(GAME_OOT, true) == 1);
         SESSION_ASSERT(Combo_CountForeignPlacements() == 1);
         SESSION_ASSERT(Combo_GetForeignPlacementForCheck(9) != nullptr);
+        // ...and the slot's own reverse table (#534) — the durable complement
+        // of case 5b: what the keep-set preserved at creation, the .redsave
+        // must keep returning on every subsequent load.
+        SESSION_ASSERT(Combo_CountForeignPlacementsOoT() == 1);
+        SESSION_ASSERT(Combo_GetForeignPlacementForOoTCheck(kSessionAReverseCheck) != nullptr);
         {
             const uint8_t* mmShadow = static_cast<const uint8_t*>(Context_GetMMSaveContext());
             SESSION_ASSERT(mmShadow != nullptr);
@@ -440,7 +510,9 @@ TestResult Test_SessionInvalidation(void) {
     }
 
     printf("[TEST] PASS: a dead session's frozen blobs, shadows and gComboCtx crossings do not "
-           "survive a soft reset or a new game; arrivals and existing-slot loads still restore\n");
+           "survive a soft reset or a new game; the generation-authored seed stamp and reverse "
+           "placement table survive rando file creation (#534); arrivals and existing-slot loads "
+           "still restore\n");
 
     // Leave global state clean for any subsequent test.
     Context_ClearAllFrozenStates();

--- a/src/common/tests/test_session_invalidation.c
+++ b/src/common/tests/test_session_invalidation.c
@@ -51,6 +51,10 @@
  *      worse bug than the leak.
  *   8. Loading a slot with NO .redsave yields no cross-game state rather than
  *      inheriting the previous session's.
+ *  7b. (runs last, so case 8 still sees an unwritten slot) The table case 5
+ *      kept must reach the slot's FIRST .redsave — file creation is followed
+ *      immediately by Save_SaveFile, so a wipe at creation is what gets
+ *      stored, not just what is in RAM.
  *
  * Included at FILE SCOPE (compiled as C++, NOT inside an extern "C" block) so
  * it can drive the C++-linkage rsbs::SaveManager for cases 7 and 8, the same
@@ -371,13 +375,13 @@ TestResult Test_SessionInvalidation(void) {
     SESSION_ASSERT(Combo_CountForeignPlacementsOoT() == 1);
     {
         const SharedItem* kept = Combo_GetForeignPlacementForOoTCheck(kGenReverseCheck);
-        SESSION_ASSERT(kept != NULL);
+        SESSION_ASSERT(kept != nullptr);
         SESSION_ASSERT(kept->originGame == (uint8_t)GAME_MM);
         SESSION_ASSERT(kept->id == kGenReverseItemId);
     }
     // ...and it is GENERATION's table that survived, not the dead session's
     // leaking through the keep-set.
-    SESSION_ASSERT(Combo_GetForeignPlacementForOoTCheck(kSessionAReverseCheck) == NULL);
+    SESSION_ASSERT(Combo_GetForeignPlacementForOoTCheck(kSessionAReverseCheck) == nullptr);
     // The dead session's crossings must not reach the new seed. This is the
     // assertion the netplay agents' grant model composes with (#460): a stale
     // sharedItemsTagged is another player's grants from a dead room.
@@ -506,13 +510,39 @@ TestResult Test_SessionInvalidation(void) {
         SESSION_ASSERT(gComboCtx.sharedRandoSeed == 0);
         SESSION_ASSERT(!Combo_ForeignPairingActive());
 
+        // ---- 7b. #534 END TO END: the KEPT table reaches the slot's FIRST
+        // .redsave. Case 7 round-trips a table that was already durable before
+        // the invalidation; only this case round-trips the one the KEEP policy
+        // handed forward. That is the seam the bug actually lived on: file
+        // creation is immediately followed by Save_SaveFile (z_sram.c), so a
+        // wipe there is not a RAM-only loss — the zeroed table is what the new
+        // slot stores, and every later load re-reads the zeros. Runs after
+        // case 8 so slot 2 is still unwritten where that case needs it.
+        SeedSessionA(0x3333u, 0x4444u);
+        StampGeneratedSeed(0x99999999u, 0x5555u);
+        Context_InvalidateSessionOnNewGame(/*isRandoFile=*/1);
+        SESSION_ASSERT(Combo_CountForeignPlacementsOoT() == 1);
+        SESSION_ASSERT(mgr.Save(2));
+        // Clear first, so what the assertions below read came out of the file
+        // rather than surviving in RAM.
+        Context_InvalidateSessionOnSlotLoad();
+        SESSION_ASSERT(Combo_CountForeignPlacementsOoT() == 0);
+        SESSION_ASSERT(mgr.Load(2));
+        SESSION_ASSERT(Combo_CountForeignPlacementsOoT() == 1);
+        {
+            const SharedItem* stored = Combo_GetForeignPlacementForOoTCheck(kGenReverseCheck);
+            SESSION_ASSERT(stored != nullptr);
+            SESSION_ASSERT(stored->originGame == (uint8_t)GAME_MM);
+            SESSION_ASSERT(stored->id == kGenReverseItemId);
+        }
+
         std::filesystem::remove_all(kSessionTestDir, ec);
     }
 
     printf("[TEST] PASS: a dead session's frozen blobs, shadows and gComboCtx crossings do not "
            "survive a soft reset or a new game; the generation-authored seed stamp and reverse "
-           "placement table survive rando file creation (#534); arrivals and existing-slot loads "
-           "still restore\n");
+           "placement table survive rando file creation and reach the new slot's first .redsave "
+           "(#534); arrivals and existing-slot loads still restore\n");
 
     // Leave global state clean for any subsequent test.
     Context_ClearAllFrozenStates();


### PR DESCRIPTION
## Summary

Creating the OoT rando file wiped the reverse foreign-placement table that generation had authored for that very file, so #524's headline feature (MM items hosted in OoT checks) never delivered in a real playthrough — and the loss was persisted into the slot's first `.redsave`. This scopes the wipe: `Context_InvalidateSessionState` now snapshots `gComboCtx.foreignPlacementsOoT` alongside the Lane B seed stamp and restores it under `RSBS_SEED_STAMP_KEEP` only.

## Mechanism

The two halves run minutes apart and in the wrong order relative to each other:

1. `Playthrough_Init` (`playthrough.cpp:120-137`) stamps the pairing identity and *immediately* derives the reverse placements from it — `OoT_PlaceForeignItems` clears the table and places up to 8 MM items into eligible OoT checks. This happens at GENERATION time, in the file-select menu, before the file exists.
2. The player then names the file. `OoT_Sram_InitSave` derives `isRandoFile` (true precisely *because* generation already ran) and calls `Context_InvalidateSessionOnNewGame(1)` at `games/oot/src/code/z_sram.c:303`.
3. That reaches `Context_InvalidateSessionState(RSBS_SEED_STAMP_KEEP)` → `ComboContext_Init`, which memsets the whole struct. The KEEP policy restored only the three stamp fields; #524 added a second generation-authored artifact without extending the keep-set.
4. Nothing re-places the reverse table. The FORWARD table survives because MM re-authors it at its own `OnFileCreate` on the next arrival; the reverse direction has no such second chance.
5. `Save_SaveFile` ten lines later persists the zeroed table, making the loss durable for that slot forever.

Result: `Combo_GetForeignPlacementForOoTCheck` returns `nullptr` at every hosting check (`hook_handlers.cpp:383`), each one silently yields its junk fallback, and the spoiler disagrees with the world.

## What changed

- `src/common/context.cpp` — snapshot `foreignPlacementsOoT` before `ComboContext_Init` and restore it under KEEP, next to the stamp it was derived from. The invalidation log line now also reports the surviving row count, so `.redsave` forensics can see which policy ran.
- `src/common/context.h` — `ComboSeedStampPolicy` and `Context_InvalidateSessionOnNewGame` now document the keep-set as "the generation-authored state", and state explicitly why the FORWARD table is deliberately *not* in it.
- `games/oot/src/code/z_sram.c` — the invariant, stated at the wipe site: ordering alone cannot protect what generation authored before this function ran, so the protection has to be the KEEP policy's scope.

The shape was chosen over "move invalidation before generation", which cannot work: generation happens in the menu, arbitrarily far ahead of `OoT_Sram_InitSave`, and session state (frozen blobs, staged outbox) can accumulate in between — the wipe has to stay at file creation.

Every DROP path is unchanged and still wipes the table with the rest of the dead session: return-to-title, vanilla new file, slot load. `ComboContext_Init` itself is untouched, so the ADR 0002 growth contract and the `.redsave` layout asserts are unaffected.

## Lock

`src/common/tests/test_session_invalidation.c` (ROM-free, runs in the Context/AllTests ctest rows):

- **Case 5b** authors the table the way generation does — stamp, then clear-and-place, mirroring `OoT_PlaceForeignItems` — runs the exact call `z_sram.c` makes at file creation, and asserts generation's row survives *by content* (host check, `originGame`, id) while the dead session's row does not. Reverting the KEEP restore makes the count read 0 and this goes RED.
- **Case 7b** is the durable complement, added in review: save the slot after creation, drop, reload, and assert the row comes back out of the file. Case 7 alone would have stayed green if the kept table never reached storage, because it round-trips a table that was already durable before the invalidation.
- The inverse invariant is locked too: session A now carries a dead-session reverse row that every DROP path must wipe, enforced in `SessionIsClear` and asserted at the soft-reset and vanilla-new-file cases.

## Remaining risk (pre-existing, not introduced here)

The keep-set can only preserve what is still resident. A player who generates a seed *during gameplay* and then quits to title before creating the file passes through `TitleSetup_Init` → return-to-title DROP, which zeroes the stamp and now the table alike; KEEP then restores zeros. That exposure is identical for the seed stamp and predates this change (#440), so it is out of scope here, but it is the same failure mode wearing a different hat. Spoiler-imported seeds (`Randomizer_IsSpoilerLoaded`) never run `Playthrough_Init` and so have no reverse table to keep at all.

Closes #534

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!--- section:artifacts:start -->
### Build Artifacts
  - [rsbs-windows.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/8735071675.zip)
  - [rsbs-linux.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/8734707476.zip)
<!--- section:artifacts:end -->