### PR TITLE
Dispatch the pause-menu and file-select hooks MM registers but never runs (#438)

### DIFF
--- a/games/mm/2s2h/Enhancements/Masks/PersistentMasks.cpp
+++ b/games/mm/2s2h/Enhancements/Masks/PersistentMasks.cpp
@@ -22,7 +22,13 @@ void UpdatePersistentMasksState() {
     static Vtx* persistentMasksVtx;
     static HOOK_ID beforePageDrawHook = 0;
     static HOOK_ID onPlayerPostLimbDrawHook = 0;
-    S2H::GameHooks::Unregister<GameInteractor::BeforeKaleidoDrawPage>(beforePageDrawHook);
+    // ForID leg, matching the RegisterForID below. Upstream 2S2H pairs this
+    // registration with the plain UnregisterGameHook leg, which addresses a
+    // different map — the pending id never matches its bucket, so re-running
+    // this function stacks a stale registration per call and the active-border
+    // quad draws once per stack entry. Preserved while BeforeKaleidoDrawPage
+    // was dormant (see mm_game_hooks.h); fixed with its dispatch wiring (#438).
+    S2H::GameHooks::UnregisterForID<GameInteractor::BeforeKaleidoDrawPage>(beforePageDrawHook);
     S2H::GameHooks::UnregisterForID<GameInteractor::OnPlayerPostLimbDraw>(onPlayerPostLimbDrawHook);
 
     if (!CVAR) {

--- a/games/mm/2s2h/GameExports_SingleExe.cpp
+++ b/games/mm/2s2h/GameExports_SingleExe.cpp
@@ -2607,4 +2607,67 @@ extern "C" GameOps* MM_GetGameOps(void) {
     return &sMMOps;
 }
 
+// ============================================================================
+// Pause-menu / file-select hook dispatch (#438)
+// ============================================================================
+//
+// The last hook types that combined a LIVE registrant (2ship_rando links with
+// WHOLE_ARCHIVE, so Rando::MiscBehavior's registrations are in the binary)
+// with dead dispatch. Same class and remedy as the #512/#514/#515 blocks
+// above: the rebind block at the bottom of MM's GameInteractor.h routes each
+// upstream-spelled call site here, and these bridges consult ONLY the MM-owned
+// S2H::GameHooks registries. Locked by mm_hook_dispatch_test.cpp checks 9-11.
+//
+//  - OnKaleidoUpdate (z_kaleido_scope_NES.c KaleidoScope_Update): bound OoT's
+//    0-arg gated wrapper — C linkage hid the arity mismatch. KaleidoItemPage's
+//    registrant is the trade-slot item-cycling input handler; while it was
+//    dead, left/right on SLOT_TRADE_DEED/KEY_MAMA/COUPLE did nothing, so
+//    alternate shuffled trade items in those slots were unreachable from the
+//    pause menu.
+//  - Before/AfterKaleidoDrawPage (z_kaleido_scope_NES.c brackets every page
+//    draw with the pair): bound the mm_stubs.c no-ops. After carries
+//    KaleidoItemPage's COND_ID_HOOK(PAUSE_ITEM) cycling arrows and adjacent-
+//    item previews for those same slots — dead, and combined with the LIVE
+//    VB_KALEIDO_DISPLAY_ITEM_TEXT suppression that made the slots strictly
+//    worse than vanilla (static icon, no name, no arrows). Before's only
+//    registrant (PersistentMasks.cpp, 2ship_enh) stays link-elided today; it
+//    is wired here as a pair with After per the pairing rule mm_game_hooks.h
+//    records, and its plain-Unregister-vs-RegisterForID leg mismatch was
+//    fixed in the same change so un-elision cannot accumulate stale entries.
+//    Both ForID legs mirror the excluded GameInteractor.cpp twin (keyed on
+//    pauseIndex); upstream has no ForPtr/ForFilter legs for these.
+//  - OnFileSelectSaveLoad (five z_sram_NES.c file-select flows): bound a
+//    mm_stubs.c no-op whose (void*, int) signature had drifted from the real
+//    (s16, bool, SaveContext*) — the #372/#424 hazard class, retired with the
+//    stub. FileSelect.cpp's registrant is the sole isRando[] writer, so a
+//    randomizer file on MM's file-select list rendered exactly like a vanilla
+//    one.
+//
+// HEADLESS SAFETY (the #516 SIGSEGV class): KaleidoItemPage's OnKaleidoUpdate
+// and AfterKaleidoDrawPage registrants dereference MM_gPlayState with no null
+// check. Every call site newly reached here runs inside an active pause/file-
+// select flow — KaleidoScope_Update and the page draws only execute under a
+// live PlayState, and the z_sram_NES.c flows only under the file-select game
+// state — and no ROM-free CTest row drives any of them. The MMHookDispatch row
+// resets these registries before dispatching its own probes, so it cannot run
+// the production registrants against a null play state.
+
+extern "C" void MM_GameHooks_ExecuteOnKaleidoUpdate(PauseContext* pauseCtx) {
+    S2H::GameHooks::Execute<GameInteractor::OnKaleidoUpdate>(pauseCtx);
+}
+
+extern "C" void MM_GameHooks_ExecuteBeforeKaleidoDrawPage(PauseContext* pauseCtx, u16 pauseIndex) {
+    S2H::GameHooks::Execute<GameInteractor::BeforeKaleidoDrawPage>(pauseCtx, pauseIndex);
+    S2H::GameHooks::ExecuteForID<GameInteractor::BeforeKaleidoDrawPage>(pauseIndex, pauseCtx, pauseIndex);
+}
+
+extern "C" void MM_GameHooks_ExecuteAfterKaleidoDrawPage(PauseContext* pauseCtx, u16 pauseIndex) {
+    S2H::GameHooks::Execute<GameInteractor::AfterKaleidoDrawPage>(pauseCtx, pauseIndex);
+    S2H::GameHooks::ExecuteForID<GameInteractor::AfterKaleidoDrawPage>(pauseIndex, pauseCtx, pauseIndex);
+}
+
+extern "C" void MM_GameHooks_ExecuteOnFileSelectSaveLoad(s16 fileNum, bool isOwlSave, SaveContext* saveContext) {
+    S2H::GameHooks::Execute<GameInteractor::OnFileSelectSaveLoad>(fileNum, isOwlSave, saveContext);
+}
+
 #endif /* RSBS_SINGLE_EXECUTABLE */

--- a/games/mm/2s2h/GameInteractor/GameInteractor.h
+++ b/games/mm/2s2h/GameInteractor/GameInteractor.h
@@ -695,6 +695,34 @@ void MM_GameHooks_ExecuteOnActorDestroy(Actor* actor);
 // stamp) went live with #520; the call sites bound the mm_stubs.c no-op until this.
 void MM_GameHooks_ExecuteOnGameCompletion(void);
 #define GameInteractor_ExecuteOnGameCompletion MM_GameHooks_ExecuteOnGameCompletion
+
+// The pause-menu / file-select batch (#438) — the last hook types that combine
+// a LIVE registrant (2ship_rando links with WHOLE_ARCHIVE, so
+// Rando::MiscBehavior's registrations are in the binary) with dead dispatch.
+//
+// OnKaleidoUpdate is the subtle one: OoT DEFINES the same extern "C" name as a
+// 0-ARG wrapper (GameInteractor_Hooks.cpp) for its own z_kaleido_scope_call.c,
+// so MM's 1-arg call in z_kaleido_scope_NES.c linked without complaint — C
+// linkage encodes no arity — and bound a gated no-op for the whole MM session.
+// That is KaleidoItemPage.cpp's trade-slot cycling input handler: without it,
+// left/right on SLOT_TRADE_DEED/KEY_MAMA/COUPLE does nothing and shuffled
+// alternate trade items are unreachable from the pause menu.
+//
+// The Before/AfterKaleidoDrawPage pair and OnFileSelectSaveLoad are MM-only
+// names whose mm_stubs.c no-ops are deleted with this rebind, so a dropped
+// rebind or bridge is a LINK error, not a silent pass. Both stubs also carried
+// the #372/#424 signature-drift hazard ((void*, int) against
+// (PauseContext*, u16) and (s16, bool, SaveContext*)). The draw pair is
+// rebound TOGETHER on purpose — z_kaleido_scope_NES.c brackets every page
+// draw with the pair, and mm_game_hooks.h records the pairing rule.
+void MM_GameHooks_ExecuteOnKaleidoUpdate(PauseContext* pauseCtx);
+void MM_GameHooks_ExecuteBeforeKaleidoDrawPage(PauseContext* pauseCtx, u16 pauseIndex);
+void MM_GameHooks_ExecuteAfterKaleidoDrawPage(PauseContext* pauseCtx, u16 pauseIndex);
+void MM_GameHooks_ExecuteOnFileSelectSaveLoad(s16 fileNum, bool isOwlSave, SaveContext* saveContext);
+#define GameInteractor_ExecuteOnKaleidoUpdate MM_GameHooks_ExecuteOnKaleidoUpdate
+#define GameInteractor_ExecuteBeforeKaleidoDrawPage MM_GameHooks_ExecuteBeforeKaleidoDrawPage
+#define GameInteractor_ExecuteAfterKaleidoDrawPage MM_GameHooks_ExecuteAfterKaleidoDrawPage
+#define GameInteractor_ExecuteOnFileSelectSaveLoad MM_GameHooks_ExecuteOnFileSelectSaveLoad
 #endif // RSBS_SINGLE_EXECUTABLE
 
 #ifdef __cplusplus

--- a/games/mm/2s2h/mm_hook_dispatch_test.cpp
+++ b/games/mm/2s2h/mm_hook_dispatch_test.cpp
@@ -138,6 +138,7 @@ int sOnActorKillForIdRuns = 0;
 int sOnActorDestroyForIdRuns = 0;
 int sOnGameCompletionRuns = 0;
 int sOnKaleidoUpdateRuns = 0;
+int sBeforeKaleidoDrawRuns = 0;
 int sBeforeKaleidoDrawForIdRuns = 0;
 int sAfterKaleidoDrawRuns = 0;
 int sAfterKaleidoDrawForIdRuns = 0;
@@ -466,6 +467,7 @@ extern "C" int MM_HookDispatch_RunHeadless(void) {
     // separately from the unkeyed one: an Execute-only bridge would revive
     // plain COND_HOOK registrants and leave both production draws dead.
     {
+        sBeforeKaleidoDrawRuns = 0;
         sBeforeKaleidoDrawForIdRuns = 0;
         sAfterKaleidoDrawRuns = 0;
         sAfterKaleidoDrawForIdRuns = 0;
@@ -477,6 +479,15 @@ extern "C" int MM_HookDispatch_RunHeadless(void) {
                 (void)pauseIndex;
                 sBeforeKaleidoDrawForIdRuns++;
             });
+        // Both legs of BOTH halves are probed, not just the leg each production
+        // registrant happens to use today: the bridges are four independent
+        // Execute/ExecuteForID lines, so dropping any one of them is a
+        // single-line regression that the other three cannot catch.
+        S2H::GameHooks::Register<GameInteractor::BeforeKaleidoDrawPage>([](PauseContext* pauseCtx, u16 pauseIndex) {
+            (void)pauseCtx;
+            (void)pauseIndex;
+            sBeforeKaleidoDrawRuns++;
+        });
         // A plain COND_HOOK would use the unkeyed leg.
         S2H::GameHooks::Register<GameInteractor::AfterKaleidoDrawPage>([](PauseContext* pauseCtx, u16 pauseIndex) {
             (void)pauseCtx;
@@ -491,7 +502,8 @@ extern "C" int MM_HookDispatch_RunHeadless(void) {
                                                                                 sAfterKaleidoDrawForIdRuns++;
                                                                             });
 
-        HOOK_ASSERT(sBeforeKaleidoDrawForIdRuns == 0, 10, "BeforeKaleidoDrawPage ran at registration time");
+        HOOK_ASSERT(sBeforeKaleidoDrawForIdRuns == 0, 10, "BeforeKaleidoDrawPage (id-keyed) ran at registration time");
+        HOOK_ASSERT(sBeforeKaleidoDrawRuns == 0, 10, "BeforeKaleidoDrawPage ran at registration time");
         HOOK_ASSERT(sAfterKaleidoDrawRuns == 0, 10, "AfterKaleidoDrawPage ran at registration time");
         HOOK_ASSERT(sAfterKaleidoDrawForIdRuns == 0, 10, "AfterKaleidoDrawPage (id-keyed) ran at registration time");
 
@@ -502,6 +514,8 @@ extern "C" int MM_HookDispatch_RunHeadless(void) {
         GameInteractor_ExecuteBeforeKaleidoDrawPage(&pauseCtx, kPauseIndexKaleido);
         HOOK_ASSERT(sBeforeKaleidoDrawForIdRuns == 1, 10,
                     "BeforeKaleidoDrawPage id-keyed registrant never ran -- the pre-draw bracket is dead");
+        HOOK_ASSERT(sBeforeKaleidoDrawRuns == 1, 10,
+                    "BeforeKaleidoDrawPage unkeyed registrant never ran -- the pre-draw bracket is dead");
         HOOK_ASSERT(sAfterKaleidoDrawRuns == 0, 10, "the Before dispatcher also ran After registrants");
         HOOK_ASSERT(sAfterKaleidoDrawForIdRuns == 0, 10, "the Before dispatcher also ran id-keyed After registrants");
 
@@ -510,6 +524,7 @@ extern "C" int MM_HookDispatch_RunHeadless(void) {
         GameInteractor_ExecuteBeforeKaleidoDrawPage(&pauseCtx, kPauseIndexKaleido + 1);
         HOOK_ASSERT(sBeforeKaleidoDrawForIdRuns == 1, 10,
                     "BeforeKaleidoDrawPage id-keyed leg fired for the wrong page index");
+        HOOK_ASSERT(sBeforeKaleidoDrawRuns == 2, 10, "BeforeKaleidoDrawPage unkeyed leg skipped another page index");
 
         GameInteractor_ExecuteAfterKaleidoDrawPage(&pauseCtx, kPauseIndexKaleido);
         HOOK_ASSERT(sAfterKaleidoDrawRuns == 1, 10,
@@ -517,6 +532,7 @@ extern "C" int MM_HookDispatch_RunHeadless(void) {
         HOOK_ASSERT(sAfterKaleidoDrawForIdRuns == 1, 10,
                     "AfterKaleidoDrawPage id-keyed registrant never ran -- trade-slot cycling draws no affordance");
         HOOK_ASSERT(sBeforeKaleidoDrawForIdRuns == 1, 10, "the After dispatcher also re-ran Before registrants");
+        HOOK_ASSERT(sBeforeKaleidoDrawRuns == 2, 10, "the After dispatcher also re-ran unkeyed Before registrants");
 
         GameInteractor_ExecuteAfterKaleidoDrawPage(&pauseCtx, kPauseIndexKaleido + 1);
         HOOK_ASSERT(sAfterKaleidoDrawRuns == 2, 10, "AfterKaleidoDrawPage unkeyed leg skipped another page index");

--- a/games/mm/2s2h/mm_hook_dispatch_test.cpp
+++ b/games/mm/2s2h/mm_hook_dispatch_test.cpp
@@ -60,6 +60,22 @@
  * dead -- and it asserts Destroy in the same block, because Destroy is what
  * frees the entries Kill creates.
  *
+ * Checks 9-11 (#438 pause-menu/file-select batch) close out the hooks with a
+ * live 2ship_rando registrant and dead dispatch. OnKaleidoUpdate (9) is the
+ * check-7 shape with a twist: OoT's identically-spelled definition is 0-ARG
+ * against MM's 1-arg call, and C linkage encodes no arity, so the wrong bind
+ * was silent -- a dropped rebind still links and FAIL(9)s here. The
+ * KaleidoDrawPage pair (10) is asserted in one block like check 6, because
+ * z_kaleido_scope_NES.c brackets every page draw with both halves; both its
+ * dispatchers need an id-keyed leg (KaleidoItemPage keys After on PAUSE_ITEM,
+ * PersistentMasks keys Before on PAUSE_MASK), so an Execute-only bridge is
+ * the plausible half-fix and each ForID leg is asserted separately.
+ * OnFileSelectSaveLoad (11) additionally asserts argument fidelity, because
+ * its retired stub was the worst signature drift in mm_stubs.c ((void*, int)
+ * against (s16, bool, SaveContext*)) and the registrant indexes isRando[] off
+ * fileNum/isOwlSave -- a bridge that dispatches but marshals wrong would
+ * corrupt that array while passing a run-count-only check.
+ *
  * WHAT THIS DOES NOT COVER -- READ BEFORE TRUSTING THE SUITE ON IT. The
  * z_actor.c half (two stale `#ifdef RSBS_SINGLE_EXECUTABLE` blocks that skipped
  * the ShouldActorInit call site outright) is a call-site edit in ROM-dependent
@@ -121,6 +137,14 @@ int sOnActorKillRuns = 0;
 int sOnActorKillForIdRuns = 0;
 int sOnActorDestroyForIdRuns = 0;
 int sOnGameCompletionRuns = 0;
+int sOnKaleidoUpdateRuns = 0;
+int sBeforeKaleidoDrawForIdRuns = 0;
+int sAfterKaleidoDrawRuns = 0;
+int sAfterKaleidoDrawForIdRuns = 0;
+int sOnFileSelectSaveLoadRuns = 0;
+s16 sFileSelectLastFileNum = -1;
+bool sFileSelectLastOwl = false;
+SaveContext* sFileSelectLastCtx = nullptr;
 
 // Distinct sentinel ids, so no check can be satisfied by another's registrant.
 constexpr s16 kActorIdInit = 0x0BAD;
@@ -128,6 +152,13 @@ constexpr s16 kActorIdDraw = 0x0BAE;
 constexpr s16 kActorIdKill = 0x0BAF;
 constexpr s16 kActorIdDestroy = 0x0BB0;
 constexpr u16 kTextIdPlain = 0x0C0D;
+constexpr u16 kPauseIndexKaleido = 0x0BB1;
+constexpr s16 kFileSelectFileNum = 2;
+
+// Pointer target for check 11 only; the probe never reads through it, it just
+// proves the dispatcher forwards the pointer untouched. Static because MM's
+// port-side SaveContext is ~64KB -- too big to put on the test's stack.
+SaveContext sFileSelectProbeSave;
 
 // ResetForTest is per-hook-type (templated on H), so the types this row touches
 // are cleared explicitly rather than through one global reset.
@@ -141,6 +172,15 @@ void ResetAll() {
     S2H::GameHooks::ResetForTest<GameInteractor::OnActorKill>();
     S2H::GameHooks::ResetForTest<GameInteractor::OnActorDestroy>();
     S2H::GameHooks::ResetForTest<GameInteractor::OnGameCompletion>();
+    // The pause-menu/file-select batch (checks 9-11). Resetting these before
+    // dispatch is also the headless-safety guarantee: KaleidoItemPage's
+    // production registrants dereference MM_gPlayState, which is null in this
+    // ROM-free row, so only this row's own probes may be in the registries
+    // when the dispatchers below run.
+    S2H::GameHooks::ResetForTest<GameInteractor::OnKaleidoUpdate>();
+    S2H::GameHooks::ResetForTest<GameInteractor::BeforeKaleidoDrawPage>();
+    S2H::GameHooks::ResetForTest<GameInteractor::AfterKaleidoDrawPage>();
+    S2H::GameHooks::ResetForTest<GameInteractor::OnFileSelectSaveLoad>();
 }
 
 } // namespace
@@ -387,6 +427,140 @@ extern "C" int MM_HookDispatch_RunHeadless(void) {
                     "OnGameCompletion registrant never ran -- the game-completion stamp is dropped");
     }
 
+    // ---------------------------------------------------------------- 9
+    // OnKaleidoUpdate (#438): the trade-slot cycling input handler
+    // (KaleidoItemPage.cpp, COND_HOOK -> unkeyed). Dead the check-7 way -- OoT
+    // defines the same extern "C" name -- but with an arity twist: OoT's
+    // definition is 0-ARG against MM's 1-arg call site
+    // (z_kaleido_scope_NES.c KaleidoScope_Update), and C linkage encodes no
+    // arity, so the wrong bind linked without a diagnostic. Dropping the
+    // rebind re-creates exactly that, which is why this runtime check is
+    // load-bearing and not a link error.
+    {
+        sOnKaleidoUpdateRuns = 0;
+        S2H::GameHooks::Register<GameInteractor::OnKaleidoUpdate>([](PauseContext* pauseCtx) {
+            (void)pauseCtx;
+            sOnKaleidoUpdateRuns++;
+        });
+
+        HOOK_ASSERT(sOnKaleidoUpdateRuns == 0, 9, "OnKaleidoUpdate ran at registration time");
+
+        PauseContext pauseCtx;
+        memset(&pauseCtx, 0, sizeof(pauseCtx));
+
+        // Spelled exactly as z_kaleido_scope_NES.c's KaleidoScope_Update
+        // spells it.
+        GameInteractor_ExecuteOnKaleidoUpdate(&pauseCtx);
+
+        HOOK_ASSERT(sOnKaleidoUpdateRuns == 1, 9,
+                    "OnKaleidoUpdate registrant never ran -- trade-slot cycling input is dead in the pause menu");
+    }
+
+    // ---------------------------------------------------------------- 10
+    // Before/AfterKaleidoDrawPage (#438): the draw pair bracketing every
+    // kaleido page draw. One block like check 6, because the call sites come
+    // in pairs and a half-wired bracket is the plausible regression. Both
+    // dispatchers need an id-keyed leg -- KaleidoItemPage keys After on
+    // PAUSE_ITEM (the cycling arrows/previews), PersistentMasks keys Before
+    // on PAUSE_MASK (the active-border quad) -- so each ForID leg is asserted
+    // separately from the unkeyed one: an Execute-only bridge would revive
+    // plain COND_HOOK registrants and leave both production draws dead.
+    {
+        sBeforeKaleidoDrawForIdRuns = 0;
+        sAfterKaleidoDrawRuns = 0;
+        sAfterKaleidoDrawForIdRuns = 0;
+
+        // The PersistentMasks.cpp shape (RegisterForID on a page index).
+        S2H::GameHooks::RegisterForID<GameInteractor::BeforeKaleidoDrawPage>(
+            kPauseIndexKaleido, [](PauseContext* pauseCtx, u16 pauseIndex) {
+                (void)pauseCtx;
+                (void)pauseIndex;
+                sBeforeKaleidoDrawForIdRuns++;
+            });
+        // A plain COND_HOOK would use the unkeyed leg.
+        S2H::GameHooks::Register<GameInteractor::AfterKaleidoDrawPage>([](PauseContext* pauseCtx, u16 pauseIndex) {
+            (void)pauseCtx;
+            (void)pauseIndex;
+            sAfterKaleidoDrawRuns++;
+        });
+        // The KaleidoItemPage.cpp shape (COND_ID_HOOK on PAUSE_ITEM).
+        S2H::GameHooks::RegisterForID<GameInteractor::AfterKaleidoDrawPage>(kPauseIndexKaleido,
+                                                                            [](PauseContext* pauseCtx, u16 pauseIndex) {
+                                                                                (void)pauseCtx;
+                                                                                (void)pauseIndex;
+                                                                                sAfterKaleidoDrawForIdRuns++;
+                                                                            });
+
+        HOOK_ASSERT(sBeforeKaleidoDrawForIdRuns == 0, 10, "BeforeKaleidoDrawPage ran at registration time");
+        HOOK_ASSERT(sAfterKaleidoDrawRuns == 0, 10, "AfterKaleidoDrawPage ran at registration time");
+        HOOK_ASSERT(sAfterKaleidoDrawForIdRuns == 0, 10, "AfterKaleidoDrawPage (id-keyed) ran at registration time");
+
+        PauseContext pauseCtx;
+        memset(&pauseCtx, 0, sizeof(pauseCtx));
+
+        // Spelled exactly as z_kaleido_scope_NES.c spells them.
+        GameInteractor_ExecuteBeforeKaleidoDrawPage(&pauseCtx, kPauseIndexKaleido);
+        HOOK_ASSERT(sBeforeKaleidoDrawForIdRuns == 1, 10,
+                    "BeforeKaleidoDrawPage id-keyed registrant never ran -- the pre-draw bracket is dead");
+        HOOK_ASSERT(sAfterKaleidoDrawRuns == 0, 10, "the Before dispatcher also ran After registrants");
+        HOOK_ASSERT(sAfterKaleidoDrawForIdRuns == 0, 10, "the Before dispatcher also ran id-keyed After registrants");
+
+        // Another page index must NOT reach the id-keyed leg -- the
+        // discrimination both production registrants depend on.
+        GameInteractor_ExecuteBeforeKaleidoDrawPage(&pauseCtx, kPauseIndexKaleido + 1);
+        HOOK_ASSERT(sBeforeKaleidoDrawForIdRuns == 1, 10,
+                    "BeforeKaleidoDrawPage id-keyed leg fired for the wrong page index");
+
+        GameInteractor_ExecuteAfterKaleidoDrawPage(&pauseCtx, kPauseIndexKaleido);
+        HOOK_ASSERT(sAfterKaleidoDrawRuns == 1, 10,
+                    "AfterKaleidoDrawPage unkeyed registrant never ran -- the post-draw bracket is dead");
+        HOOK_ASSERT(sAfterKaleidoDrawForIdRuns == 1, 10,
+                    "AfterKaleidoDrawPage id-keyed registrant never ran -- trade-slot cycling draws no affordance");
+        HOOK_ASSERT(sBeforeKaleidoDrawForIdRuns == 1, 10, "the After dispatcher also re-ran Before registrants");
+
+        GameInteractor_ExecuteAfterKaleidoDrawPage(&pauseCtx, kPauseIndexKaleido + 1);
+        HOOK_ASSERT(sAfterKaleidoDrawRuns == 2, 10, "AfterKaleidoDrawPage unkeyed leg skipped another page index");
+        HOOK_ASSERT(sAfterKaleidoDrawForIdRuns == 1, 10,
+                    "AfterKaleidoDrawPage id-keyed leg fired for the wrong page index");
+    }
+
+    // ---------------------------------------------------------------- 11
+    // OnFileSelectSaveLoad (#438): the isRando[] writer behind the rando
+    // file-select presentation (FileSelect.cpp, plain Register -> unkeyed).
+    // Argument FIDELITY is asserted, not just the run count: the retired
+    // mm_stubs.c stub was (void*, int) against the real
+    // (s16, bool, SaveContext*), and the production registrant indexes
+    // isRando[] off fileNum/isOwlSave and reads saveType through the pointer,
+    // so a bridge that dispatches but marshals wrong corrupts that array
+    // while a count-only check stays green.
+    {
+        sOnFileSelectSaveLoadRuns = 0;
+        sFileSelectLastFileNum = -1;
+        sFileSelectLastOwl = false;
+        sFileSelectLastCtx = nullptr;
+        S2H::GameHooks::Register<GameInteractor::OnFileSelectSaveLoad>(
+            [](s16 fileNum, bool isOwlSave, SaveContext* saveContext) {
+                sOnFileSelectSaveLoadRuns++;
+                sFileSelectLastFileNum = fileNum;
+                sFileSelectLastOwl = isOwlSave;
+                sFileSelectLastCtx = saveContext;
+            });
+
+        HOOK_ASSERT(sOnFileSelectSaveLoadRuns == 0, 11, "OnFileSelectSaveLoad ran at registration time");
+
+        // Spelled exactly as z_sram_NES.c's five file-select flows spell it.
+        GameInteractor_ExecuteOnFileSelectSaveLoad(kFileSelectFileNum, true, &sFileSelectProbeSave);
+
+        HOOK_ASSERT(sOnFileSelectSaveLoadRuns == 1, 11,
+                    "OnFileSelectSaveLoad registrant never ran -- rando files render as vanilla on file select");
+        HOOK_ASSERT(sFileSelectLastFileNum == kFileSelectFileNum, 11,
+                    "OnFileSelectSaveLoad fileNum arrived corrupted -- isRando[] would index the wrong slot");
+        HOOK_ASSERT(sFileSelectLastOwl == true, 11,
+                    "OnFileSelectSaveLoad isOwlSave arrived corrupted -- owl rows would alias file rows");
+        HOOK_ASSERT(sFileSelectLastCtx == &sFileSelectProbeSave, 11,
+                    "OnFileSelectSaveLoad saveContext pointer arrived corrupted");
+    }
+
     // NOTE ON WHAT COVERS THE REBIND. An earlier draft of this row compared
     // &GameInteractor_ExecuteOnOpenText against &MM_GameHooks_ExecuteOnOpenText
     // to prove the #define was in place. That check is tautological: the rebind
@@ -397,7 +571,7 @@ extern "C" int MM_HookDispatch_RunHeadless(void) {
     // each drives the dispatcher through the UPSTREAM spelling and asserts a
     // hook registered on the MM-owned registry ran. Drop the #define and those
     // calls bind OoT's active-game-gated wrapper instead, which links fine,
-    // does nothing, and fails FAIL(1)/FAIL(3)/FAIL(4)/FAIL(5)/FAIL(7).
+    // does nothing, and fails FAIL(1)/FAIL(3)/FAIL(4)/FAIL(5)/FAIL(7)/FAIL(9).
 
     ResetAll();
 

--- a/games/mm/include/mm_game_hooks.h
+++ b/games/mm/include/mm_game_hooks.h
@@ -135,33 +135,31 @@ GIEvent& MM_GameEvents_Current();
  * migration moved that target's direct Register* sites onto this registry.
  * Most of the hook types involved were ALREADY dormant — they carry
  * COND_HOOK/COND_ID_HOOK registrants from other MM targets and are listed in
- * #438's table (OnOpenText, OnActorInit, OnActorKill). Two types reach this
- * registry for the first time with that migration and have no Execute
- * placement, plus one that #438's table did not yet name:
+ * #438's table (OnOpenText, OnActorInit, OnActorKill). Two remain with no
+ * Execute placement:
  *
  *   - OnPlayDestroy       (Modes/PlayAsKafei.cpp, Songs/BetterSongOfDoubleTime.cpp)
- *   - BeforeKaleidoDrawPage (Masks/PersistentMasks.cpp)
  *   - OnPlayerPostLimbDraw  (Masks/PersistentMasks.cpp)
  *
  * These are dormant, NOT newly broken: before the migration the same
  * registrations went into MM's `GameInteractor::RegisteredGameHooks<H>`
  * statics while MM's call sites for GameInteractor_ExecuteOnPlayDestroy /
- * ExecuteBeforeKaleidoDrawPage / ExecuteOnPlayerPostLimbDraw resolved to
- * OoT's active-game-gated wrappers or to src/common/mm_stubs.c no-ops — so
- * the handlers never ran either way. What the migration removes is the #395
- * out-of-bounds write the raw registration performed on the way to being
- * dead. Wiring them is #438's job, and BeforeKaleidoDrawPage in particular
- * should be wired together with its AfterKaleidoDrawPage pair rather than
- * half-fixed (the reasoning mm_stubs.c records for the EndOfCycleSave pair).
+ * ExecuteOnPlayerPostLimbDraw resolved to OoT's active-game-gated wrappers or
+ * to src/common/mm_stubs.c no-ops — so the handlers never ran either way.
+ * What the migration removes is the #395 out-of-bounds write the raw
+ * registration performed on the way to being dead. Wiring them is #438's job;
+ * both registrant TUs are link-elided today (plain-archive 2ship_enh), so
+ * dispatch for them stays deliberately deferred to the WHOLE_ARCHIVE flip
+ * (ADR 0004 §5) — wiring now would execute an always-empty registry.
  *
- * One upstream quirk is preserved deliberately rather than repaired here:
- * PersistentMasks.cpp unregisters BeforeKaleidoDrawPage through the plain
- * Unregister<> leg while registering it through RegisterForID<>, so the
- * pending id never matches and the registration is never removed — exactly
- * what upstream 2S2H does (its UnregisterGameHook and RegisterGameHookForID
- * likewise address different maps). While the type stays dormant the stale
- * entry is inert; whoever wires its Execute under #438 must fix the leg
- * pairing at the same time, or the mask border will draw twice.
+ * BeforeKaleidoDrawPage left this list with the #438 pause-menu batch: it is
+ * dispatched from z_kaleido_scope_NES.c as a pair with AfterKaleidoDrawPage
+ * (the reasoning mm_stubs.c records for the EndOfCycleSave pair), and the
+ * upstream quirk this note used to preserve — PersistentMasks.cpp pairing a
+ * plain Unregister<> with RegisterForID<>, so the pending id never matched
+ * its bucket and stale registrations stacked per re-run — was repaired in
+ * the same change, as required here, so un-elision cannot make the mask
+ * border draw once per stack entry.
  *
  * Deviation from upstream, on purpose: iteration uses std::map (stable id
  * order) rather than unordered_map, so dispatch order is deterministic —

--- a/src/common/mm_stubs.c
+++ b/src/common/mm_stubs.c
@@ -122,8 +122,21 @@ void MM_FaultDrawer_SetCharPad(int xPad, int yPad) { (void)xPad; (void)yPad; }
 void GameInteractor_ExecuteOnGameStateMainFinish(void* state) { (void)state; }
 void GameInteractor_ExecuteOnPlayDrawWorldEnd(void* play) { (void)play; }
 void GameInteractor_ExecuteOnInterfaceDrawStart(void* play) { (void)play; }
-void GameInteractor_ExecuteBeforeKaleidoDrawPage(void* state, int page) { (void)state; (void)page; }
-void GameInteractor_ExecuteAfterKaleidoDrawPage(void* state, int page) { (void)state; (void)page; }
+/* GameInteractor_ExecuteBeforeKaleidoDrawPage / ExecuteAfterKaleidoDrawPage
+ * moved to real, header-checked dispatch in
+ * games/mm/2s2h/GameExports_SingleExe.cpp (#438), reached through the
+ * single-exe macro rebind at the bottom of MM's GameInteractor.h — wired as a
+ * PAIR on purpose, matching how z_kaleido_scope_NES.c brackets every page
+ * draw (the same both-or-neither reasoning the EndOfCycleSave pair below
+ * records). The After half had a live registrant the whole time:
+ * KaleidoItemPage.cpp's COND_ID_HOOK(PAUSE_ITEM) draws the trade-slot cycling
+ * arrows and adjacent-item previews, which these no-ops kept invisible while
+ * the LIVE VB_KALEIDO_DISPLAY_ITEM_TEXT override still suppressed the vanilla
+ * item text — strictly worse than vanilla. Both stubs also carried the
+ * #372/#424 signature-drift hazard ((void*, int) against the real
+ * (PauseContext*, u16)), retired with them. Re-stubbing either here would
+ * silently sever the dispatch again. (MM-only symbols — OoT defines no
+ * twins.) */
 /* GameInteractor_ExecuteOnSaveInit / GameInteractor_ExecuteOnSaveLoad moved to
  * real, header-checked dispatch in games/mm/2s2h/GameExports_SingleExe.cpp
  * (Lane C1, #392): they now Execute the MM-owned S2H::GameHooks registries
@@ -157,7 +170,15 @@ void GameInteractor_ExecuteOnPlayerPostLimbDraw(void* player, int limbIndex) { (
 void GameInteractor_ExecuteOnBossDefeated(int bossId) { (void)bossId; }
 void GameInteractor_ExecuteOnBottleContentsUpdate(int slotId) { (void)slotId; }
 void GameInteractor_ExecuteOnConsoleLogoUpdate(void) {}
-void GameInteractor_ExecuteOnFileSelectSaveLoad(void* state, int fileNum) { (void)state; (void)fileNum; }
+/* GameInteractor_ExecuteOnFileSelectSaveLoad moved to real, header-checked
+ * dispatch in games/mm/2s2h/GameExports_SingleExe.cpp (#438), reached through
+ * the single-exe macro rebind at the bottom of MM's GameInteractor.h. The stub
+ * was both dead dispatch — FileSelect.cpp's registrant is the sole isRando[]
+ * writer, so a randomizer file on MM's file-select list rendered exactly like
+ * a vanilla one — and the worst signature drift in this file: (void*, int)
+ * against the real (s16, bool, SaveContext*), so even a future caller-side
+ * fix would have marshalled garbage. Re-stubbing it here would silently sever
+ * the dispatch again. (MM-only symbol — OoT defines no twin.) */
 /* GameInteractor_ExecuteOnGameCompletion moved to real, header-checked dispatch
  * in games/mm/2s2h/GameExports_SingleExe.cpp (#438), reached through the
  * single-exe macro rebind at the bottom of MM's GameInteractor.h. Its registrant


### PR DESCRIPTION
## Summary

Wires MM single-exe dispatch for the last four hook types that combine a **live registrant** with **dead dispatch**: `OnKaleidoUpdate`, `BeforeKaleidoDrawPage`, `AfterKaleidoDrawPage`, `OnFileSelectSaveLoad`. This is the #438 audit's fix 4 plus the one member of its fix-8 batch whose registrant is not link-elided.

Everything else in the audit's remaining list stays deferred on purpose — see "What was deliberately skipped".

## Mechanism

Same class as #512 / #514 / #515 / #521: MM's `COND_HOOK` / `COND_ID_HOOK` macros park every registrant in the MM-owned `S2H::GameHooks` registry (`games/mm/include/mm_game_hooks.h`), but the call sites in MM's C code still spelled the upstream `GameInteractor_Execute*` names, which resolved to something that never reads that registry.

Two shapes here, both fixed by a rebind at the bottom of MM's `GameInteractor.h` plus a typed MM-side bridge:

- **`OnKaleidoUpdate` — the arity trap.** OoT *defines* the same `extern "C"` name as a **0-arg** wrapper (`GameInteractor_Hooks.cpp:476`) for its own `z_kaleido_scope_call.c`, while MM calls it with one argument (`z_kaleido_scope_NES.c:4327`). C linkage encodes no arity, so the wrong bind linked silently and hit `GI_SINGLE_EXE_GATE()` for the whole MM session. Its live registrant is `Rando/MiscBehavior/KaleidoItemPage.cpp:234` (2ship_rando, WHOLE_ARCHIVE), the trade-slot cycling **input handler** — with it dead, left/right on `SLOT_TRADE_DEED` / `SLOT_TRADE_KEY_MAMA` / `SLOT_TRADE_COUPLE` did nothing and shuffled alternate trade items were unreachable from the pause menu.
- **The draw pair and `OnFileSelectSaveLoad` — MM-only names** that bound `src/common/mm_stubs.c` no-ops. `AfterKaleidoDrawPage` carries `KaleidoItemPage.cpp:385`'s `COND_ID_HOOK(PAUSE_ITEM)` cycling arrows and adjacent-item previews; combined with the **live** `VB_KALEIDO_DISPLAY_ITEM_TEXT` suppression on those same slots, the result was strictly worse than vanilla (static icon, no name, no arrows, no response to input). `OnFileSelectSaveLoad`'s registrant (`Rando/MiscBehavior/FileSelect.cpp:221`) is the sole writer of `isRando[]`, so a randomizer file on MM's file-select list rendered exactly like a vanilla one.

All three stubs are **deleted** rather than left in place, so a future dropped rebind or bridge is an unresolved external instead of a silent no-op. Both retired stubs also carried the #372/#424 signature-drift hazard — `(void*, int)` against the real `(PauseContext*, u16)` and `(s16, bool, SaveContext*)`.

## What changed

- `games/mm/2s2h/GameInteractor/GameInteractor.h` — four prototypes + four `#define` rebinds, appended to the existing single-exe block. `z_kaleido_scope_NES.c:32` and `z_sram_NES.c:9` both already include this header, so the rebind reaches all 18 C call sites with no call-site edits.
- `games/mm/2s2h/GameExports_SingleExe.cpp` — four `extern "C"` bridges, **appended at the end of the file** so the diff rebases trivially against concurrent work. Leg semantics mirror the CMake-excluded `GameInteractor.cpp:34-58` twin exactly: `Execute` only for `OnKaleidoUpdate` and `OnFileSelectSaveLoad` (both registrants are unkeyed), `Execute` **and** `ExecuteForID` keyed on `pauseIndex` for the draw pair.
- `src/common/mm_stubs.c` — three no-ops deleted, each replaced by the note recording why re-stubbing would silently sever dispatch.
- `games/mm/2s2h/Enhancements/Masks/PersistentMasks.cpp` — **required by the pairing rule, not incidental.** It registered `BeforeKaleidoDrawPage` through `RegisterForID<>(PAUSE_MASK, ...)` but unregistered through the plain `Unregister<>` leg, which addresses a different map, so the pending id never matched its bucket. Inert while the type was dormant; with dispatch live it would stack one stale registration per re-run and draw the mask's active-border quad once per stack entry. Now `UnregisterForID<>`.
- `games/mm/include/mm_game_hooks.h` — the recorded quirk/pairing note updated to match the repair, and `BeforeKaleidoDrawPage` moved off the "no Execute placement" list.

## Lock

`MMHookDispatch` (existing CTest row, redship tier) gains checks 9-11, all driven through the **upstream** spelling so a dropped rebind falsifies them:

- **9 — `OnKaleidoUpdate`.** Deliberately a runtime check rather than a link error: drop the rebind and the call binds OoT's 0-arg gated wrapper, which links fine and does nothing, so only a run count catches it. `FAIL(9)`.
- **10 — the draw pair in one block.** All four bridge legs are probed independently (unkeyed + id-keyed on both halves), because each is a separate line that the other three cannot cover. Plus cross-dispatcher isolation (Before must not run After's registrants and vice versa) and wrong-page-index discrimination on the id-keyed legs.
- **11 — `OnFileSelectSaveLoad`.** Asserts run count *and* argument fidelity (`fileNum` / `isOwlSave` / `SaveContext*` passthrough), because the registrant indexes `isRando[]` off the first two arguments and reads `saveType` through the third — a bridge that dispatches but marshals wrong would corrupt that array while a count-only check stayed green.

For the three MM-only names the stubs are gone, so reverting a rebind or bridge is *additionally* a link error on the strict Linux leg.

## Headless safety (the #516 SIGSEGV class)

`KaleidoItemPage`'s `OnKaleidoUpdate` and `AfterKaleidoDrawPage` registrants dereference `MM_gPlayState` unconditionally. Verified no ROM-free CTest row reaches any newly-armed call site: `KaleidoScope_Update` and the page draws run only under an active pause flow, and the five `z_sram_NES.c` call sites live in `func_801457CC` / `Sram_CopySave` / `MM_Sram_InitSave` — none of which the suite drives (`mm-owl-save-arm-state` calls `func_80147414` and `MM_Sram_InitNewSave`, neither of which contains a call site). The `MMHookDispatch` row's `ResetAll()` clears these four registries before dispatching its own probes, so production registrants cannot run against a null play state there either.

## What was deliberately skipped, and why

- **`OnSceneInit` and `OnActorDestroy`** — named as priorities but **already live** at `origin/main` (`MM_GameHooks_ExecuteOnSceneInit` + `z_play.c:2732`; `OnActorDestroy` wired by #517). Re-derived, not assumed.
- **The ~13-type `2ship_enh` latent batch** (`OnPlayerPostLimbDraw`, `OnPlayDestroy`, `OnItemGive`, `OnBossDefeated`, the clock-draw pair, …) — every registrant is link-elided under plain-archive semantics, so wiring them now would dispatch an always-empty registry. Correctly deferred to the WHOLE_ARCHIVE flip (ADR 0004 §5), as #521 already records.
- **`AfterRoomSceneCommands` / `OnRoomInit`** — a registry *swap* (its dispatcher walks `GameInteractor::Instance`'s registry, not `S2H::GameHooks`), which is a non-additive mid-file edit to `GameExports_SingleExe.cpp` and conflicts with keeping this diff append-only. **Hand-off: that swap must land before any `2ship_enh` WHOLE_ARCHIVE flip** — JPGrottos' `ShouldActorInit` legs are already live and would delete Deku Palace's vanilla grottos the day the TU links with `isSpawningJPGrottos` armed by nothing.

## Behavior note

Arming `OnKaleidoUpdate` also un-breaks the CVar-gated `PauseOwlWarp` and `SkipMagicArrowEquip` registrants if their TUs are ever pulled into the link. Both are `COND_HOOK`-gated on their own CVar (off by default), so the only reachable change is the enhancement doing what it advertises.

Part of #438

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!--- section:artifacts:start -->
### Build Artifacts
  - [rsbs-windows.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/8736179349.zip)
  - [rsbs-linux.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/8735394308.zip)
<!--- section:artifacts:end -->