### PR TITLE
Give agent-branch pushes a fast Linux link + symbol-census gate (#387)

### DIFF
--- a/.github/scripts/check-symbol-collisions.sh
+++ b/.github/scripts/check-symbol-collisions.sh
@@ -46,8 +46,13 @@
 #            global absent from the baseline, (c) passes that same collision
 #            once it is baselined, (d) regenerates a baseline containing
 #            exactly the intersection under --write-baseline and accepts it
-#            on the next run, and (e) refuses to pass vacuously when no
-#            archives match. Exit 0: all five hold. Exit 1: the detection
+#            on the next run, (e) refuses to pass vacuously when no archives
+#            match, and (f) refuses to pass vacuously when the archives exist
+#            but yield zero strong external symbols. (e) and (f) are separate
+#            because they trip DIFFERENT guards: with only (e), deleting the
+#            zero-symbols guard would let a broken nm disarm the gate in
+#            silence, which is the exact failure that guard exists for.
+#            Exit 0: all six hold. Exit 1: the detection
 #            logic itself is broken. Exit 2: no usable toolchain found.
 #            Mirrors the --self-test in check-registrar-elision.sh and
 #            check-exporter-symbol-collisions.sh for the same "guard the
@@ -150,6 +155,33 @@ selftest_build_archive() {
     rm -rf "$tmp"
 }
 
+# selftest_build_symbolless_archive <out-archive>
+# An archive that EXISTS but contributes no strong external symbol — what a
+# broken nm or an archive-format change looks like from collect_defined's
+# side. Only file-local storage, so --defined-only --extern-only yields
+# nothing. Mirrors build_selftest_funconly_archive in
+# check-exporter-symbol-collisions.sh.
+selftest_build_symbolless_archive() {
+    local out_archive="$1"
+    local tmp
+    tmp="$(mktemp -d)"
+    echo "static int rsbs_selftest_file_local = 1;" > "$tmp/src.c"
+    if ! "$CC_BIN" -c -o "$tmp/src.o" "$tmp/src.c" 2> "$tmp/cc.err"; then
+        echo "error: self-test symbol-less TU failed to compile with $CC_BIN:" >&2
+        sed 's/^/  /' < "$tmp/cc.err" >&2
+        rm -rf "$tmp"
+        return 2
+    fi
+    mkdir -p "$(dirname "$out_archive")"
+    rm -f "$out_archive"
+    if ! ar rcs "$out_archive" "$tmp/src.o"; then
+        echo "error: self-test failed to archive $out_archive" >&2
+        rm -rf "$tmp"
+        return 2
+    fi
+    rm -rf "$tmp"
+}
+
 # selftest_make_build_dir <dir> <include-shared:0|1>
 # A tree shaped like the real build layout, so the child invocation below
 # resolves it through the same games/oot/libsoh_*.a and games/mm/lib2ship_*.a
@@ -238,10 +270,22 @@ run_self_test() {
     rc=$?
     selftest_expect "vacuous-collection guard (no archives present)" 2 "$dir/log.empty" "$rc" || overall=1
 
+    # (f) Archives present but defining zero strong external symbols -> also a
+    # collection error. This trips the SECOND guard, which (e) never reaches:
+    # (e) exits on "none of the archives exist" before symbol collection runs.
+    # Deleting the zero-symbols guard is a silent disarm — a broken nm would
+    # yield an empty intersection that matches an empty baseline and reports
+    # OK — and this scenario is the only thing that turns red for it.
+    selftest_build_symbolless_archive "$dir/symbolless/games/oot/libsoh_selftest.a" || { rm -rf "$dir"; return 2; }
+    selftest_build_symbolless_archive "$dir/symbolless/games/mm/lib2ship_selftest.a" || { rm -rf "$dir"; return 2; }
+    bash "$0" "$dir/symbolless" --baseline "$dir/empty-baseline.txt" > "$dir/log.symbolless" 2>&1
+    rc=$?
+    selftest_expect "vacuous-collection guard (archives with no strong external symbols)" 2 "$dir/log.symbolless" "$rc" || overall=1
+
     rm -rf "$dir"
 
     if [ "$overall" -eq 0 ]; then
-        echo "self-test: OK (all 5 scenarios behaved as expected)"
+        echo "self-test: OK (all 6 scenarios behaved as expected)"
     fi
     return "$overall"
 }

--- a/.github/scripts/check-symbol-collisions.sh
+++ b/.github/scripts/check-symbol-collisions.sh
@@ -25,22 +25,231 @@
 # nm-based, Linux-only (mirrors check-registrar-elision.sh; the Windows-side
 # equivalent audit uses dumpbin over the same lib split).
 #
-# Usage: check-symbol-collisions.sh [build-dir] [--write-baseline]
+# Usage: check-symbol-collisions.sh [build-dir] [--baseline <path>]
+#                                   [--write-baseline]
+#   --baseline <path>: use <path> instead of .github/symbol-collision-
+#                     baseline.txt. Used by --self-test to run against a
+#                     throwaway baseline, and by CI to regenerate one into an
+#                     artifact directory without dirtying the checkout.
 #   --write-baseline: regenerate the baseline from the current build instead
 #                     of checking. For deliberate refreshes only.
+#
+#        check-symbol-collisions.sh --self-test
+#            Synthesizes a build-dir-shaped tree of tiny archives with gcc/ar
+#            (no real soh/2ship content) and drives THIS script over it as a
+#            child process, so every scenario exercises the real glob, the
+#            real nm collection and the real baseline comparison rather than
+#            a parallel reimplementation. Asserts that the gate still (a)
+#            passes archives sharing only a weak global and a
+#            _GLOBAL__sub_I_ name — the two things the filters exist to drop,
+#            so those filters stay falsifiable, (b) FAILS on a shared strong
+#            global absent from the baseline, (c) passes that same collision
+#            once it is baselined, (d) regenerates a baseline containing
+#            exactly the intersection under --write-baseline and accepts it
+#            on the next run, and (e) refuses to pass vacuously when no
+#            archives match. Exit 0: all five hold. Exit 1: the detection
+#            logic itself is broken. Exit 2: no usable toolchain found.
+#            Mirrors the --self-test in check-registrar-elision.sh and
+#            check-exporter-symbol-collisions.sh for the same "guard the
+#            guard" reason — scenario (d) matters most, because the CI
+#            baseline-regeneration path below has no other cover.
+#
+# REGENERATING THE BASELINE — one command, from any machine:
+#
+#   On a Linux box with a build:
+#     bash .github/scripts/check-symbol-collisions.sh build-cmake --write-baseline
+#
+#   Without one (the #387 path — local iteration happens on Windows, where
+#   nm-over-ELF-archives does not exist). Every .github/workflows/link-check.yml
+#   run uploads a regenerated baseline as the `symbol-collision-baseline`
+#   artifact, pass or fail, so there is no separate "regenerate" dispatch to
+#   remember. Take the newest run of that workflow and:
+#     gh run download <run-id> -R spencerduncan/redshipblueship \
+#         -n symbol-collision-baseline -D .github
+#   which lands the file directly at .github/symbol-collision-baseline.txt,
+#   ready to commit. The companion `symbol-census` artifact from the same run
+#   carries the demangled listing and a diff against the committed baseline —
+#   read that BEFORE committing. Every entry is a latent cross-game aliasing
+#   bug or deliberate glue; the baseline is a burn-down list, not a
+#   suppression file.
 
 set -uo pipefail
 
 BUILD_DIR="build-cmake"
 WRITE_BASELINE=0
-for arg in "$@"; do
-    case "$arg" in
+SELF_TEST=0
+BASELINE="$(dirname "$0")/../symbol-collision-baseline.txt"
+
+while [ "$#" -gt 0 ]; do
+    case "$1" in
         --write-baseline) WRITE_BASELINE=1 ;;
-        *) BUILD_DIR="$arg" ;;
+        --self-test) SELF_TEST=1 ;;
+        --baseline)
+            if [ "$#" -lt 2 ]; then
+                echo "usage: $0 [build-dir] [--baseline <path>] [--write-baseline]" >&2
+                exit 2
+            fi
+            BASELINE="$2"
+            shift
+            ;;
+        --*)
+            echo "error: unknown option $1" >&2
+            echo "usage: $0 [build-dir] [--baseline <path>] [--write-baseline] | $0 --self-test" >&2
+            exit 2
+            ;;
+        *) BUILD_DIR="$1" ;;
     esac
+    shift
 done
 
-BASELINE="$(dirname "$0")/../symbol-collision-baseline.txt"
+# ---------------------------------------------------------------------------
+# --self-test machinery: entirely synthetic, no soh/2ship content. Defined
+# before the production body so the dispatch below can short-circuit it.
+# ---------------------------------------------------------------------------
+
+SELFTEST_SHARED_SYMBOL="rsbs_selftest_shared_strong"
+
+CC_BIN="$(command -v "${CC:-}" 2>/dev/null || command -v cc 2>/dev/null || command -v gcc 2>/dev/null || command -v gcc-11 2>/dev/null || true)"
+
+# selftest_build_archive <out-archive> <unique-symbol> <include-shared:0|1>
+# One TU carrying: the shared strong global (optional), a per-side unique
+# strong global, a WEAK global, and a global whose assembler name is a
+# _GLOBAL__sub_I_ static-init aggregator. The last two carry the SAME name on
+# both sides deliberately — they are exactly what collect_defined's type and
+# name filters exist to drop, so the clean scenario passing with them present
+# is what makes those filters falsifiable rather than assumed.
+selftest_build_archive() {
+    local out_archive="$1" unique_symbol="$2" include_shared="$3"
+    local tmp
+    tmp="$(mktemp -d)"
+    {
+        if [ "$include_shared" -eq 1 ]; then
+            echo "int ${SELFTEST_SHARED_SYMBOL} = 1;"
+        fi
+        echo "int ${unique_symbol} = 2;"
+        echo "int rsbs_selftest_weak __attribute__((weak)) = 3;"
+        echo "int rsbs_selftest_ctor_alias __asm__(\"_GLOBAL__sub_I_rsbs_selftest\") = 4;"
+    } > "$tmp/src.c"
+    # Named failure rather than a missing archive: without this, a toolchain
+    # problem reaches the scenarios below as "gate returned 2 where 0 was
+    # expected" and reads as a broken gate instead of a broken self-test.
+    if ! "$CC_BIN" -c -o "$tmp/src.o" "$tmp/src.c" 2> "$tmp/cc.err"; then
+        echo "error: self-test TU failed to compile with $CC_BIN:" >&2
+        sed 's/^/  /' < "$tmp/cc.err" >&2
+        sed 's/^/  | /' < "$tmp/src.c" >&2
+        rm -rf "$tmp"
+        return 2
+    fi
+    mkdir -p "$(dirname "$out_archive")"
+    rm -f "$out_archive"
+    if ! ar rcs "$out_archive" "$tmp/src.o"; then
+        echo "error: self-test failed to archive $out_archive" >&2
+        rm -rf "$tmp"
+        return 2
+    fi
+    rm -rf "$tmp"
+}
+
+# selftest_make_build_dir <dir> <include-shared:0|1>
+# A tree shaped like the real build layout, so the child invocation below
+# resolves it through the same games/oot/libsoh_*.a and games/mm/lib2ship_*.a
+# globs the production path uses.
+selftest_make_build_dir() {
+    local dir="$1" include_shared="$2"
+    selftest_build_archive "$dir/games/oot/libsoh_selftest.a" rsbs_selftest_oot_only "$include_shared" || return 2
+    selftest_build_archive "$dir/games/mm/lib2ship_selftest.a" rsbs_selftest_mm_only "$include_shared" || return 2
+}
+
+# selftest_expect <label> <expected-rc> <log-file> <actual-rc>
+# Returns 0 when the scenario behaved as expected, 1 otherwise (printing the
+# child's own output, which is the only place the reason lives).
+selftest_expect() {
+    local label="$1" want="$2" log="$3" got="$4"
+    if [ "$got" -eq "$want" ]; then
+        echo "self-test: $label behaved as expected (rc=$got)"
+        return 0
+    fi
+    echo "self-test FAIL: $label returned rc=$got, expected $want. Child output:" >&2
+    sed 's/^/  /' < "$log" >&2
+    return 1
+}
+
+run_self_test() {
+    if [ -z "$CC_BIN" ]; then
+        echo "error: no C compiler found (checked \$CC, cc, gcc, gcc-11) — cannot self-test" >&2
+        return 2
+    fi
+    if ! command -v ar > /dev/null 2>&1; then
+        echo "error: ar not found — cannot self-test" >&2
+        return 2
+    fi
+
+    local dir
+    dir="$(mktemp -d)"
+    local overall=0 rc written
+
+    : > "$dir/empty-baseline.txt"
+
+    # (a) Only a weak global and a _GLOBAL__sub_I_ name are shared -> PASS.
+    selftest_make_build_dir "$dir/clean" 0 || { rm -rf "$dir"; return 2; }
+    bash "$0" "$dir/clean" --baseline "$dir/empty-baseline.txt" > "$dir/log.clean" 2>&1
+    rc=$?
+    selftest_expect "clean scenario (weak + _GLOBAL__sub_I_ shared, filtered)" 0 "$dir/log.clean" "$rc" || overall=1
+
+    # (b) A shared STRONG global with an empty baseline -> FAIL.
+    selftest_make_build_dir "$dir/collide" 1 || { rm -rf "$dir"; return 2; }
+    bash "$0" "$dir/collide" --baseline "$dir/empty-baseline.txt" > "$dir/log.collide" 2>&1
+    rc=$?
+    selftest_expect "collision scenario (shared strong global, unbaselined)" 1 "$dir/log.collide" "$rc" || overall=1
+
+    # (c) The same collision, baselined -> PASS. Without this the gate could
+    # be "detects everything, tolerates nothing", which is a different tool.
+    printf '# self-test baseline\n%s\n' "$SELFTEST_SHARED_SYMBOL" > "$dir/tolerating-baseline.txt"
+    bash "$0" "$dir/collide" --baseline "$dir/tolerating-baseline.txt" > "$dir/log.tolerated" 2>&1
+    rc=$?
+    selftest_expect "baselined collision scenario" 0 "$dir/log.tolerated" "$rc" || overall=1
+
+    # (d) --write-baseline regenerates EXACTLY the intersection, and the
+    # result is accepted on the next run. This is the CI baseline-generation
+    # path (link-check.yml uploads what this writes); nothing else covers it.
+    bash "$0" "$dir/collide" --baseline "$dir/generated.txt" --write-baseline > "$dir/log.write" 2>&1
+    rc=$?
+    if selftest_expect "--write-baseline regeneration" 0 "$dir/log.write" "$rc"; then
+        written="$(grep -v '^[[:space:]]*#' "$dir/generated.txt" | grep -v '^[[:space:]]*$' || true)"
+        if [ "$written" = "$SELFTEST_SHARED_SYMBOL" ]; then
+            echo "self-test: regenerated baseline contains exactly the intersection"
+        else
+            echo "self-test FAIL: regenerated baseline should contain exactly '$SELFTEST_SHARED_SYMBOL', got:" >&2
+            printf '%s\n' "$written" | sed 's/^/  /' >&2
+            overall=1
+        fi
+        bash "$0" "$dir/collide" --baseline "$dir/generated.txt" > "$dir/log.regen" 2>&1
+        rc=$?
+        selftest_expect "check against the regenerated baseline" 0 "$dir/log.regen" "$rc" || overall=1
+    else
+        overall=1
+    fi
+
+    # (e) No archives at all -> collection error, never a vacuous pass. An
+    # empty intersection is indistinguishable from a broken collection unless
+    # this refuses.
+    mkdir -p "$dir/empty/games/oot" "$dir/empty/games/mm"
+    bash "$0" "$dir/empty" --baseline "$dir/empty-baseline.txt" > "$dir/log.empty" 2>&1
+    rc=$?
+    selftest_expect "vacuous-collection guard (no archives present)" 2 "$dir/log.empty" "$rc" || overall=1
+
+    rm -rf "$dir"
+
+    if [ "$overall" -eq 0 ]; then
+        echo "self-test: OK (all 5 scenarios behaved as expected)"
+    fi
+    return "$overall"
+}
+
+if [ "$SELF_TEST" -eq 1 ]; then
+    run_self_test
+    exit $?
+fi
 
 TMP_DIR="$(mktemp -d)"
 trap 'rm -rf "$TMP_DIR"' EXIT
@@ -92,6 +301,7 @@ demangle() {
 }
 
 if [ "$WRITE_BASELINE" -eq 1 ]; then
+    mkdir -p "$(dirname "$BASELINE")"
     {
         echo "# Tolerated soh_*/2ship_* defined-symbol collisions (see"
         echo "# .github/scripts/check-symbol-collisions.sh). Every entry here is a"

--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -1,0 +1,231 @@
+name: link-check
+# Fast Linux link + symbol-census gate (#387).
+#
+# The duplicate-symbol class is structurally invisible to the development
+# loop. Local iteration happens on Windows, whose link carries
+# /FORCE:MULTIPLE by design (CMakeLists.txt:281) because the two ports
+# legitimately share symbol names — MSVC accepts the duplicates and silently
+# picks one. GNU ld has no such flag here and rejects them, which makes Linux
+# the ONLY place the class is observable. Until this file existed that signal
+# lived exclusively inside generate-builds' build-linux job: ~32 minutes, and
+# only on pull_request or a push to main. #368's collisions had existed for
+# months before three new TUs happened to drag the second definition into the
+# link.
+#
+# This job is that same signal minus everything that is not the link:
+#   * no generate-rsbs-otr dependency — the ROM-derived .o2r archives are
+#     consumed by cpack and the ROM-gated tests, never by compile or link;
+#   * `--target redship` rather than the default all target, so no asset
+#     extraction, no appimage packaging;
+#   * no ctest tier.
+# What remains is compile -> link -> the three nm gates, off a ccache warmed
+# by main's build-linux run. The link step itself is the primary check: a
+# duplicate strong symbol is a hard ld error there. The nm gates below catch
+# the silent variants — collisions that resolve first-wins without ever
+# producing a link error.
+#
+# TRIGGER: push to claude/** (agent work branches) and manual dispatch.
+# Deliberately NOT pull_request: build-linux already runs all three gates on
+# every PR, and duplicating a full compile there would double the compute for
+# a verdict the PR already receives. The gap #387 names is the push case — an
+# agent branch gets no Linux signal at all until a PR exists.
+#
+# This workflow is additive. It changes no existing job, and it is not one of
+# the "basic" ruleset's required status checks (build-linux remains the
+# authoritative gate); it is an early-warning signal, not a merge gate.
+
+on:
+  push:
+    branches:
+      - 'claude/**'
+    paths-ignore:
+      - '**.md'
+      - 'docs/**'
+      - 'LICENSE*'
+      - '.gitignore'
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  link-check:
+    runs-on: ubuntu-22.04
+    # Same prebuilt CI image as build-linux (.github/docker/build-base.Dockerfile).
+    # It already carries cmake 3.26+, gcc-11, ninja, ccache, binutils and the
+    # SDL2/SDL2_net/tinyxml2/libzip builds, so this job installs nothing: the
+    # packaging tools build-linux adds (imagemagick, file, desktop-file-utils)
+    # are baked in, and xvfb/mesa are only needed by the ctest tiers this job
+    # does not run.
+    container:
+      image: ghcr.io/spencerduncan/redshipblueship-build:latest
+    steps:
+    - name: Git Checkout
+      uses: actions/checkout@v4
+      with:
+        submodules: true
+        fetch-depth: 1
+
+    # Required inside the container: the workspace is owned by a different uid
+    # than the one the build runs as.
+    - name: Configure git safe directory
+      run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
+
+    - name: Restore ccache
+      uses: hendrikmuhs/ccache-action@v1.2
+      with:
+        # RESTORE ONLY. This job writes no cache on purpose: its whole value
+        # is speed off a cache someone else already paid for, and the repo has
+        # measured history of the 10GB Actions-cache quota LRU-evicting main's
+        # entries when extra ~GB-scale saves were added per branch (issue
+        # #177, see the sccache comment in generate-builds.yml). Restoring
+        # build-linux's main-keyed cache costs nothing and covers everything
+        # the branch did not touch; the branch's own delta recompiles each
+        # push, which is a bounded, constant cost.
+        save: false
+        # Must match build-linux's cap: the action writes this into the local
+        # ccache config, and a smaller value would make ccache prune the
+        # restored cache before the build could use it.
+        max-size: "1.5G"
+        key: ${{ runner.os }}-ccache-${{ github.ref }}
+        restore-keys: |
+          ${{ runner.os }}-ccache-${{ github.ref }}
+          ${{ runner.os }}-ccache-refs/heads/main
+          ${{ runner.os }}-ccache
+
+    # Configure and build are separate steps so the Actions UI attributes time
+    # to the right stage (same rationale as build-windows' split, issue #177).
+    # The flags below must stay BYTE-IDENTICAL to build-linux's: ccache keys on
+    # the preprocessed input plus the command line, so any divergence here
+    # turns every restored entry into a miss and this job stops being fast.
+    - name: CMake configure
+      run: cmake --no-warn-unused-cli -H. -Bbuild-cmake -GNinja -DCMAKE_BUILD_TYPE:STRING=Release -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DBUILD_REMOTE_CONTROL=1
+      env:
+        CC: gcc-11
+        CXX: g++-11
+
+    - name: Compile and link redship
+      id: link
+      # THE check. Duplicate strong symbols between the soh_* and 2ship_*
+      # archives are a hard "multiple definition" error from GNU ld here.
+      # --target redship prunes the asset-extraction and packaging targets
+      # from the graph; ZAPDLib_OoT/MM and OTRExporter_OoT/MM still build,
+      # because redship links them (CMake/SingleExecutable.cmake).
+      run: |
+        export PATH="/usr/lib/ccache:/usr/local/opt/ccache/libexec:$PATH"
+        cmake --build build-cmake --config Release --target redship -j10
+      env:
+        CC: gcc-11
+        CXX: g++-11
+        # Key the cache on the compiler's content hash rather than mtime+size,
+        # so entries survive container image rebuilds. Same reason and same
+        # value as build-linux — a divergence would cost every hit.
+        CCACHE_COMPILERCHECK: content
+
+    - name: ccache statistics
+      if: ${{ !cancelled() }}
+      # The honest measure of whether this job is fast for the reason claimed.
+      # A collapsed hit rate means the restore key or the flag parity above
+      # drifted, not that the build got slower.
+      run: ccache -s
+
+    - name: Self-test the cross-game collision gate
+      run: bash .github/scripts/check-symbol-collisions.sh --self-test
+
+    - name: Check cross-game symbol collisions (#375)
+      # Symbols defined by BOTH soh_* and 2ship_* archives resolve first-wins
+      # in the single-exe link, silently running one game's code against the
+      # other's data (the #367 / FrameInterpolation / AudioCollection failure
+      # class). Fails on any intersection growth beyond the committed baseline.
+      run: bash .github/scripts/check-symbol-collisions.sh build-cmake
+
+    - name: Self-test registrar elision gate
+      run: bash .github/scripts/check-registrar-elision.sh --self-test
+
+    - name: Check registrar elision (#341)
+      # Self-registering TUs (RegisterShipInitFunc static initializers) must
+      # survive the archive link — plain archive semantics silently drop them.
+      run: bash .github/scripts/check-registrar-elision.sh build-cmake
+
+    - name: Self-test exporter symbol-collision gate (#411)
+      run: bash .github/scripts/check-exporter-symbol-collisions.sh --self-test
+
+    - name: Check OTRExporter_OoT/OTRExporter_MM data-symbol collisions (#411)
+      # Both exporter variants are deliberately linked into redship, so a
+      # strong DATA symbol defined by both is double-constructed and
+      # double-destroyed under /FORCE:MULTIPLE (the Fault A class, #396).
+      run: bash .github/scripts/check-exporter-symbol-collisions.sh build-cmake
+
+    # Runs whether or not the gates above passed — a failing run is exactly
+    # when the regenerated baseline is most wanted. Gated on the LINK instead,
+    # because without archives the census scripts have nothing to read and
+    # would report a collection error that means nothing.
+    - name: Emit symbol census
+      id: census
+      if: ${{ !cancelled() && steps.link.outcome == 'success' }}
+      run: |
+        mkdir -p symbol-census
+        # Regenerate into the artifact directory rather than over the checkout,
+        # so the diff below compares against the committed file.
+        bash .github/scripts/check-symbol-collisions.sh build-cmake \
+          --baseline symbol-census/symbol-collision-baseline.txt --write-baseline
+        grep -v '^[[:space:]]*#' symbol-census/symbol-collision-baseline.txt \
+          | grep -v '^[[:space:]]*$' \
+          | c++filt > symbol-census/symbol-collision-demangled.txt || true
+        diff -u .github/symbol-collision-baseline.txt \
+                symbol-census/symbol-collision-baseline.txt \
+                > symbol-census/baseline.diff || true
+
+        {
+          echo "## Cross-game symbol census"
+          echo
+          count=$(grep -cv '^[[:space:]]*#' symbol-census/symbol-collision-baseline.txt || true)
+          echo "- soh_*/2ship_* strong-symbol intersection: **${count:-0}** symbol(s)"
+          if [ -s symbol-census/baseline.diff ]; then
+            echo "- **Differs from the committed baseline.**"
+            echo
+            echo '```diff'
+            # Bounded: the step summary has a size limit, and a first-ever
+            # census on a drifted tree can be hundreds of symbols. The full
+            # diff is in the symbol-census artifact either way.
+            head -n 200 symbol-census/baseline.diff
+            if [ "$(wc -l < symbol-census/baseline.diff)" -gt 200 ]; then
+              echo "... truncated; full diff in the symbol-census artifact."
+            fi
+            echo '```'
+          else
+            echo "- Matches \`.github/symbol-collision-baseline.txt\` exactly."
+          fi
+          echo
+          echo "To adopt the regenerated baseline (one command, from any machine):"
+          echo
+          echo '```'
+          echo "gh run download ${GITHUB_RUN_ID} -R ${GITHUB_REPOSITORY} -n symbol-collision-baseline -D .github"
+          echo '```'
+          echo
+          echo "Read \`symbol-census/symbol-collision-demangled.txt\` from the companion"
+          echo "artifact first — every entry is a latent cross-game aliasing bug or"
+          echo "deliberate glue. The baseline is a burn-down list, not a suppression file."
+        } >> "$GITHUB_STEP_SUMMARY"
+
+    # Uploaded as its OWN artifact containing exactly one file, so adopting it
+    # is a single command that lands the file at its committed path:
+    #   gh run download <run-id> -n symbol-collision-baseline -D .github
+    - name: Upload regenerated baseline
+      if: ${{ !cancelled() && steps.census.outcome == 'success' }}
+      uses: actions/upload-artifact@v4
+      with:
+        name: symbol-collision-baseline
+        path: symbol-census/symbol-collision-baseline.txt
+        if-no-files-found: error
+        retention-days: 14
+
+    - name: Upload symbol census
+      if: ${{ !cancelled() && steps.census.outcome == 'success' }}
+      uses: actions/upload-artifact@v4
+      with:
+        name: symbol-census
+        path: symbol-census/
+        if-no-files-found: error
+        retention-days: 14

--- a/docs/known-issues.md
+++ b/docs/known-issues.md
@@ -234,16 +234,24 @@ that does nothing is a plausible bug, and worth reporting.
 
 ## CI and quality gates (for contributors)
 
-Two gates currently **cannot fail**, which is worse than having no gate because
-they read as coverage:
+The two gates that once **could not fail** — the more dangerous state, because
+they read as coverage — are now armed:
+[#375](https://github.com/spencerduncan/redshipblueship/issues/375)
+(`check-symbol-collisions.sh` had no committed baseline, so it exited 0 in
+bootstrap mode on every run) and
+[#376](https://github.com/spencerduncan/redshipblueship/issues/376) (orphaned
+CTest labels no workflow ran, missing `--no-tests=error`, an unfailable
+`check-archives`, a frame-budgeted watchdog that always lost to the wall-clock
+timeout). Both are closed.
 
-- [#375](https://github.com/spencerduncan/redshipblueship/issues/375) —
-  `check-symbol-collisions.sh` has no committed baseline, so it exits 0 in bootstrap
-  mode on every run.
-- [#376](https://github.com/spencerduncan/redshipblueship/issues/376) — orphaned
-  CTest labels no workflow runs, missing `--no-tests=error`, an unfailable
-  `check-archives`, and a frame-budgeted watchdog that always loses to the wall-clock
-  timeout.
+The residual gap is **latency, not coverage**: duplicate-symbol bugs are only
+observable on Linux (Windows links with `/FORCE:MULTIPLE`), and the Linux
+verdict lives in build-linux at ~32 minutes, on PR or main-push only
+([#387](https://github.com/spencerduncan/redshipblueship/issues/387)).
+`.github/workflows/link-check.yml` narrows it for agent branches: on any push
+to `claude/**` it compiles, links, and runs the same three nm gates with no
+asset extraction, packaging or ctest tier, and uploads a regenerated
+collision baseline so it can be refreshed from a machine that has no `nm`.
 
 Also: clang-format is enforced against an incremental allowlist
 (`.github/clang-format-paths.txt`), not the full tree


### PR DESCRIPTION
## Summary

Adds `.github/workflows/link-check.yml`: a fast Linux compile + link + symbol-census job that runs on every push to `claude/**` (plus `workflow_dispatch`), and extends `check-symbol-collisions.sh` with `--baseline <path>` and a six-scenario `--self-test`.

**Measured, not estimated.** Run [30478293173](https://github.com/spencerduncan/redshipblueship/actions/runs/30478293173) on this branch: green in **2m27s** against build-linux's ~32 min, with a 99.73% (C) / 99.80% (C++) ccache hit rate — 20 misses total. The log shows `[3002/3002] Linking CXX executable redship`, so the link that this whole job exists to observe really ran.

## Why

Duplicate-symbol bugs are structurally invisible to the dev loop. Local iteration is on Windows, whose link carries `/FORCE:MULTIPLE` by design (`CMakeLists.txt:281`) because the two ports legitimately share symbol names — MSVC accepts the duplicates and silently picks one. GNU `ld` rejects them, which makes Linux the only place the class is observable, and until now that verdict lived exclusively inside `build-linux`: ~32 minutes, on PR or main-push only. #368's collisions had existed for months before three new TUs dragged the second definition into the link.

The second half of #387 is the same gap seen from the other side: `check-symbol-collisions.sh` is `nm`-based and Linux-only, so its baseline could not be regenerated from the workstation where the work happens. The tool meant to close the gap was blocked by the gap.

## What changed

**`.github/workflows/link-check.yml`** — the build-linux signal minus everything that is not the link:

- no `generate-rsbs-otr` dependency (the ROM-derived `.o2r` archives feed cpack and the ROM-gated tests, never compile or link);
- `--target redship` instead of the default `all`, so no asset extraction and no appimage packaging. Every `libsoh_*.a` / `lib2ship_*.a` the gates read is a component of the `redship` link (`SOH_COMPILE_TARGETS` / `TWOSHIP_COMPILE_TARGETS`), so the census this job computes is not a subset of build-linux's — verified in the run: all five archives present, exporter gate collected 11/11;
- no ctest tier.

Configure flags are byte-identical to build-linux's, because ccache keys on the command line; any divergence would turn every restored entry into a miss and the job would stop being fast. The 99.7% hit rate is the evidence that parity held.

**Baseline regeneration (the #375 unblock).** Every run uploads a regenerated baseline as its own single-file `symbol-collision-baseline` artifact, pass *or fail* — so adoption is one command from a machine with no `nm`:

```
gh run download <run-id> -R spencerduncan/redshipblueship -n symbol-collision-baseline -D .github
```

That lands the file directly at its committed path. It is generated into `symbol-census/`, never into `.github/`: `upload-artifact@v4` excludes dotted paths by default, which would have produced a silently empty artifact. The companion `symbol-census` artifact carries the demangled listing and a diff against the committed baseline — the header text is explicit that the baseline is a burn-down list, not a suppression file.

**`docs/known-issues.md`** — corrected. It claimed two gates "cannot fail", naming #375 (no committed baseline) and #376. Both issues are closed and both gates are armed in-tree (`.github/symbol-collision-baseline.txt` is committed, currently empty; `--no-tests=error` is on every ctest invocation), so the text directly contradicted what this PR ships. Rewritten to say the residual gap is latency rather than coverage.

## Lock

`bash .github/scripts/check-symbol-collisions.sh --self-test`, wired in as its own job step. It synthesizes a build-dir-shaped tree of tiny `gcc`/`ar` archives and drives the script over it **as a child process**, so each scenario exercises the real glob, the real `nm` collection and the real baseline comparison rather than a parallel reimplementation:

- **(a)** a pair sharing only a weak global and a `_GLOBAL__sub_I_`-named global must PASS — this is what makes the type and name filters falsifiable instead of assumed;
- **(b)** a shared strong global against an empty baseline must FAIL;
- **(c)** that same collision, baselined, must pass;
- **(d)** `--write-baseline` must regenerate a file containing *exactly* the intersection, and that file must be accepted on the next run — the load-bearing one, since the CI baseline-regeneration path this PR ships has no other cover;
- **(e)** an archive-free build dir must trip the missing-archive guard (rc 2) rather than pass on an empty intersection;
- **(f)** archives that exist but define only file-local storage must trip the *zero-symbols* guard.

(f) was added in review. The script has two independent anti-vacuity guards and (e) only reached the first: it exits on "none of the archives exist" before symbol collection runs. The second guard is the one that matters more — if `nm` or the awk filter breaks, both sides collect nothing, the intersection is empty, it matches the currently-empty committed baseline, and the gate prints `OK`. Nothing turned red for that. Now (f) does.

Deliberately a shell lock rather than a `src/common/tests/` row: the change is CI/shell only, and this mirrors the `--self-test` convention `check-registrar-elision.sh` and `check-exporter-symbol-collisions.sh` already established for exactly this "guard the guard" reason.

## Deliberate scope decisions

- **Not triggered on `pull_request`.** build-linux already runs all three identical gates on every PR; a second full compile there doubles compute for a verdict the PR already gets. The gap #387 names is the push case. Three-line trigger edit if that judgment turns out wrong.
- **Restore-only ccache** (`save: false`). #177 has measured history of ~GB-scale per-branch saves LRU-evicting main's entries out of the 10GB quota. The cost is that each push recompiles the branch's own delta (20 objects this run); a branch touching a widely-included header would pay more, every push. `save: true` is the lever.
- **Additive.** `generate-builds.yml`, `integration-tests.yml` and `static-analysis.yml` are untouched, and this is *not* a required status check — confirmed against the `basic` ruleset, whose required contexts are build-windows / build-linux / build-macos / clang-format. build-linux stays authoritative; this is early warning, not a merge gate.

## Known limitations

- **On a link *failure* — the primary case this job targets — the three `nm` gates and the census are skipped**, so the only output is `ld`'s own error (which does name the duplicate symbols). Running them anyway was rejected because a *compile* failure leaves a partial archive set, and a census computed from partial archives would emit a strict-subset baseline that looks adoptable and would then break build-linux. Diagnosability was traded for not shipping a poisoned artifact.
- **Pre-existing, surfaced not caused:** the registrar gate reports `lib2ship_enh.a: 368 registrar symbol(s), 355 missing [report-only]`. That is the known MM enhancement-TU elision class, report-only by design, identical to what build-linux already prints. 355/368 is a large number to have sitting in a report-only lane, but it is out of scope here.

Closes #387.

#387's "also worth considering" — whether Windows should keep `/FORCE:MULTIPLE` at all — is deliberately **not** addressed: the issue itself says it wants its own discussion, and it depends on the #382–#386 backlog clearing first. Worth opening as its own issue so closing this one does not bury it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!--- section:artifacts:start -->
### Build Artifacts
  - [rsbs-windows.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/8735376157.zip)
  - [rsbs-linux.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/8735031404.zip)
<!--- section:artifacts:end -->