### PR TITLE
Register MM's tracker windows at startup so their four menu rows draw at all (#535)

### DIFF
--- a/games/mm/2s2h/GameExports_SingleExe.cpp
+++ b/games/mm/2s2h/GameExports_SingleExe.cpp
@@ -1458,6 +1458,11 @@ extern "C" void MM_Rando_Init(void) {
     // only while MM is the active game. Upstream did this from BenGui.cpp's
     // SetupGuiElements (excluded); the bypass surface lives in
     // 2s2h/TrackersGuiSingleExe.cpp. No-op when the harness has no window.
+    //
+    // No longer the first caller (#535): rsbs/src/main.cpp registers them at
+    // startup so an OoT-first session can reach the menu rows that name them.
+    // Registration here is then idempotent, and what this call still does is
+    // load the tracker icons, which needs the mm.o2r this path has mounted.
     MM_TrackersGui_Init();
 
     // Shared cross-game resources (#525): keep the SHARED rupee pool alive

--- a/games/mm/2s2h/TrackersGuiSingleExe.cpp
+++ b/games/mm/2s2h/TrackersGuiSingleExe.cpp
@@ -352,11 +352,10 @@ extern "C" void MM_TrackersGui_Init(void) {
 
     S2H::TrackersGui::RegisterWindows(gui);
 
-    // #489 cause 1: honour the PERSISTED visibility CVars. Registration is
-    // once-only per process (MM_Rando_Init's sRandoInitDone), and libultraship
-    // never re-reads a window's visibility CVar after its ctor, so a config
-    // that already says "gWindows.ItemTracker=1" from a previous session must
-    // be applied here or the window silently stays shut. Runtime toggling is
+    // #489 cause 1: honour the PERSISTED visibility CVars. libultraship never
+    // re-reads a window's visibility CVar after its ctor, so a config that
+    // already says "gWindows.ItemTracker=1" from a previous session must be
+    // applied here or the window silently stays shut. Runtime toggling is
     // handled per-frame by the MMActiveGated Draw wrapper.
     S2H::TrackersGui::SyncVisibilityFromCVars();
 
@@ -364,8 +363,18 @@ extern "C" void MM_TrackersGui_Init(void) {
     // these from BenPort.cpp's InitOTR; gated on the archive because the
     // string-path LoadGuiTexture crashes on a missing resource (#330 class),
     // and mm-rando-gen brings this path up windowed but archive-free.
-    if (MM_Rando_AssetsReady()) {
+    //
+    // Once-only, unlike the two calls above: Gui::LoadGuiTexture overwrites
+    // mGuiTextures[name] without unloading the handle it replaces, so a second
+    // pass would leak one GPU texture per icon. This function stopped being
+    // called once per process with #535 — rsbs/src/main.cpp now also calls it
+    // at startup, which in an MM-first session lands after MM_Rando_Init has
+    // already loaded the icons, and in an OoT-first session runs archive-free
+    // and leaves the load to MM_Rando_Init.
+    static bool sTexturesLoaded = false;
+    if (!sTexturesLoaded && MM_Rando_AssetsReady()) {
         MM_LoadGuiTextures();
+        sTexturesLoaded = true;
     }
 }
 

--- a/games/mm/2s2h/TrackersGuiSingleExe.h
+++ b/games/mm/2s2h/TrackersGuiSingleExe.h
@@ -115,10 +115,16 @@ bool MM_TrackersGui_ShouldDraw(void);
 bool MM_TrackersGui_ShouldShow(const char* windowName);
 
 /**
- * Production entry point, called from MM_Rando_Init (once-only by its guard):
- * registers the tracker windows on the shared Ship::Context Gui and loads
- * MM's tracker icon textures when mm.o2r is available. Safe no-op when the
- * context has no window/Gui (ROM-free unit harness).
+ * Production entry point: registers the tracker windows on the shared
+ * Ship::Context Gui and loads MM's tracker icon textures when mm.o2r is
+ * available. Safe no-op when the context has no window/Gui (ROM-free unit
+ * harness).
+ *
+ * TWO callers, and it must stay re-entrant for both. rsbs/src/main.cpp calls
+ * it at startup so an OoT-first session can reach the windows before MM has
+ * booted (#535); MM_Rando_Init calls it on MM's boot, which is where the icons
+ * load once mm.o2r is mounted. Registration is idempotent per Gui and the icon
+ * load is once-only per process.
  */
 void MM_TrackersGui_Init(void);
 

--- a/games/mm/2s2h/mm_trackers_gui_test.cpp
+++ b/games/mm/2s2h/mm_trackers_gui_test.cpp
@@ -30,6 +30,14 @@
  * 3. HEADLESS SAFETY of the production entry point: MM_TrackersGui_Init()
  *    must no-op cleanly when the shared context has no window (the exact
  *    state MM_Rando_Init sees in ROM-free harnesses).
+ *
+ * 4. BOOT INDEPENDENCE (#535, leg 6 below). rsbs/src/main.cpp registers them at
+ *    startup so the Randomizer > Cross-Game rows that name them resolve in a
+ *    default OoT-first session; that is only sound while RegisterWindows needs
+ *    nothing of MM's boot. Registration with OoT active and mm.o2r unmounted
+ *    must still land all four names and leave the windows inert. Pins the
+ *    premise, not the call site — MM_TrackersGui_Init needs a Ship::Window,
+ *    which this harness deliberately does not have.
  */
 
 #ifdef RSBS_SINGLE_EXECUTABLE
@@ -48,6 +56,10 @@
 #include "2s2h/Rando/StaticData/StaticData.h" // CheckNames / Checks
 #include "2s2h/ShipUtils.h"                   // convertEnumToReadableName
 #include "context.h"
+
+// games/mm/2s2h/GameExports_SingleExe.cpp — true once LoadMMArchives mounted
+// mm.o2r. Read here only to keep the archive-free half of leg 6 honest.
+extern "C" bool MM_Rando_AssetsReady(void);
 
 namespace BenGui {
 // Defined in 2s2h/TrackersGuiSingleExe.cpp; populated by RegisterWindows.
@@ -287,6 +299,61 @@ extern "C" int MM_TrackersGui_RunHeadless(void) {
                    "PopulateCheckNames left named checks behind (only RC_UNKNOWN may be empty)");
     }
 
+    // ---- 6. Registration does not depend on MM having booted -------------
+    // #535. The Randomizer > Cross-Game rows resolve these windows by name on
+    // every frame they are drawn, and rsbs/src/main.cpp registers them at
+    // startup — before MM_Rando_Init has run, while OoT is the active game and
+    // with MM's archives unmounted. That call site is only legitimate as long
+    // as RegisterWindows stays independent of MM boot state, which is what this
+    // leg pins: fresh Gui, OoT active, no mm.o2r, all four names must still
+    // resolve, and the windows must still be inert.
+    //
+    // Scope honesty: this pins the PREMISE, not the call site. The call site is
+    // unreachable ROM-free — MM_TrackersGui_Init needs a Ship::Window, and the
+    // assertion at the top of this test is that the harness has none.
+    {
+        TGT_ASSERT(!MM_Rando_AssetsReady(),
+                   "harness unexpectedly has mm.o2r — the archive-free half of this leg would be vacuous");
+
+        // Forced ON before construction, as in leg 1: an ungated Draw() must
+        // not be able to early-out on !IsVisible() before reaching ImGui.
+        for (const char* cvar : kMMWindowVisibilityCVars) {
+            CVarSetInteger(cvar, 1);
+        }
+
+        auto preBootGui = std::make_shared<Ship::Gui>();
+        for (const char* name : S2H::TrackersGui::kAllTrackerWindowNames) {
+            TGT_ASSERT(preBootGui->GetGuiWindow(name) == nullptr, "fresh Gui already carries an MM tracker window");
+        }
+
+        // Every early return below this point restores the active game first —
+        // this leg is not the last one to read it.
+        const GameId prevPreBootGame = Context_GetCurrentGame();
+        Context_SetCurrentGame(GAME_OOT);
+
+        S2H::TrackersGui::RegisterWindows(preBootGui);
+
+        for (const char* name : S2H::TrackersGui::kAllTrackerWindowNames) {
+            if (preBootGui->GetGuiWindow(name) == nullptr) {
+                printf("[TEST] FAIL: %s unresolvable with OoT active and MM unbooted — the menu row that names "
+                       "it would draw nothing (#535) (%s:%d)\n",
+                       name, __FILE__, __LINE__);
+                Context_SetCurrentGame(prevPreBootGame);
+                return 1;
+            }
+        }
+
+        // Same hard tripwire as leg 2, on the windows the startup path would
+        // have produced: no ImGui context, visibility forced on, OoT active.
+        for (const char* name : S2H::TrackersGui::kAllTrackerWindowNames) {
+            auto window = preBootGui->GetGuiWindow(name);
+            window->Draw();
+            window->Update();
+        }
+
+        Context_SetCurrentGame(prevPreBootGame);
+    }
+
     // Cleanup: don't leak forced-visible tracker CVars into later tests or a
     // saved cvar file.
     for (const char* cvar : kMMWindowVisibilityCVars) {
@@ -294,8 +361,8 @@ extern "C" int MM_TrackersGui_RunHeadless(void) {
     }
 
     printf("[TEST] PASS: mm-trackers-gui — four MM tracker windows register under de-collided names beside "
-           "SoH's, their draw path is inert unless MM is the active game, their visibility tracks the live "
-           "CVar, and CheckNames is populated\n");
+           "SoH's without MM having booted, their draw path is inert unless MM is the active game, their "
+           "visibility tracks the live CVar, and CheckNames is populated\n");
     return 0;
 }
 

--- a/games/oot/soh/SohGui/Menu.cpp
+++ b/games/oot/soh/SohGui/Menu.cpp
@@ -7,6 +7,7 @@
 #include <variant>
 #include <spdlog/fmt/fmt.h>
 #include <tuple>
+#include <unordered_set>
 
 extern "C" {
 #include "z64.h"
@@ -493,6 +494,17 @@ void Menu::MenuDrawItem(WidgetInfo& widget, uint32_t width, UIWidgets::Colors me
                     // over nothing. Grey the row out but keep its name, the
                     // treatment #497 settled on — a row that disappears reads
                     // as a broken menu rather than as a not-yet state.
+                    //
+                    // Still reported, but ONCE per name and at warn: a row
+                    // naming a window nothing ever registers is a real
+                    // authoring bug, and dropping the log entirely would make
+                    // it invisible. Per-frame is what made the old line
+                    // useless, not the line itself.
+                    static std::unordered_set<std::string> reportedMissingWindows;
+                    if (reportedMissingWindows.insert(widget.windowName).second) {
+                        SPDLOG_WARN("windowName {} is not registered; drawing \"{}\" disabled until it is",
+                                    widget.windowName, widget.name);
+                    }
                     if (options->showButton) {
                         disabledTempTooltip += "\n- Its window is not available yet";
                         ImGui::PushStyleVar(ImGuiStyleVar_ButtonTextAlign, ImVec2(0, 0));

--- a/games/oot/soh/SohGui/Menu.cpp
+++ b/games/oot/soh/SohGui/Menu.cpp
@@ -481,15 +481,28 @@ void Menu::MenuDrawItem(WidgetInfo& widget, uint32_t width, UIWidgets::Colors me
                     SPDLOG_ERROR(msg.c_str());
                     break;
                 }
-                auto window = Ship::Context::GetInstance()->GetWindow()->GetGui()->GetGuiWindow(widget.windowName);
-                if (!window) {
-                    std::string msg =
-                        fmt::format("Error drawing window contents: windowName {} does not exist", widget.windowName);
-                    SPDLOG_ERROR(msg.c_str());
-                    break;
-                }
                 auto options = std::static_pointer_cast<UIWidgets::WindowButtonOptions>(widget.options);
                 options->color = menuThemeIndex;
+                auto window = Ship::Context::GetInstance()->GetWindow()->GetGui()->GetGuiWindow(widget.windowName);
+                if (!window) {
+                    // Expected state, not an error (#535): a row may name a
+                    // window whose owner has not registered it on the shared
+                    // Gui yet. This used to SPDLOG_ERROR and skip the draw, so
+                    // an affected page cost one log line per row per frame for
+                    // as long as it stayed open and showed a labelled separator
+                    // over nothing. Grey the row out but keep its name, the
+                    // treatment #497 settled on — a row that disappears reads
+                    // as a broken menu rather than as a not-yet state.
+                    if (options->showButton) {
+                        disabledTempTooltip += "\n- Its window is not available yet";
+                        ImGui::PushStyleVar(ImGuiStyleVar_ButtonTextAlign, ImVec2(0, 0));
+                        UIWidgets::Button((ICON_FA_EXTERNAL_LINK_SQUARE " " + widget.name).c_str(),
+                                          { { options->tooltip, true, disabledTempTooltip.c_str() }, options->size,
+                                            options->padding, options->color });
+                        ImGui::PopStyleVar();
+                    }
+                    break;
+                }
                 if (options->showButton) {
                     UIWidgets::WindowButton(widget.name.c_str(), widget.cVar, window, *options);
                 }

--- a/games/oot/soh/SohGui/SohMenuRandomizer.cpp
+++ b/games/oot/soh/SohGui/SohMenuRandomizer.cpp
@@ -848,8 +848,21 @@ void SohMenu::AddMenuRandomizer() {
     // Names and CVars are the constants in games/mm/2s2h/TrackersGuiSingleExe.h
     // (kCheckTracker*/kItemTracker*), spelled as literals to match the rows
     // above. The windows are MMActiveGated, so they draw only while MM is the
-    // running game — the buttons are always usable, the window simply stays
-    // blank under OoT, which is the upstream behavior.
+    // running game — the buttons are usable from the first frame, the window
+    // simply stays blank under OoT, which is the upstream behavior.
+    //
+    // "From the first frame" only holds because rsbs/src/main.cpp registers the
+    // four windows at startup (#535). They used to register from MM_Rando_Init,
+    // i.e. only once MM had booted in this process, which left this separator
+    // sitting over four rows whose per-frame GetGuiWindow lookup failed. Menu.cpp
+    // now greys such a row out instead of skipping it, but that is the fallback.
+    //
+    // EmbedWindow(false) on all four, unlike the OoT settings rows above: the
+    // embed path calls window->DrawElement() directly, which bypasses the
+    // MMActiveGated Draw wrapper — the only thing keeping MM tracker UI from
+    // drawing while OoT is the running game, and (before mm.o2r is mounted) from
+    // reaching for tracker icons that are not loaded. Pop-out only, so the gate
+    // stays the single authority on when MM tracker UI draws.
     AddWidget(path, "Majora's Mask Trackers", WIDGET_SEPARATOR_TEXT);
     AddWidget(path, "Toggle MM Item Tracker", WIDGET_WINDOW_BUTTON)
         .CVar("gWindows.ItemTracker")
@@ -862,7 +875,9 @@ void SohMenu::AddMenuRandomizer() {
         .RaceDisable(false)
         .WindowName("MM Item Tracker Settings")
         .HideInSearch(true)
-        .Options(WindowButtonOptions().Tooltip("Enables the Majora's Mask Item Tracker Settings window."));
+        .Options(WindowButtonOptions()
+                     .Tooltip("Enables the Majora's Mask Item Tracker Settings window.")
+                     .EmbedWindow(false));
     AddWidget(path, "Toggle MM Check Tracker", WIDGET_WINDOW_BUTTON)
         .CVar("gWindows.CheckTracker")
         .RaceDisable(false)
@@ -874,7 +889,9 @@ void SohMenu::AddMenuRandomizer() {
         .RaceDisable(false)
         .WindowName("MM Check Tracker Settings")
         .HideInSearch(true)
-        .Options(WindowButtonOptions().Tooltip("Enables the Majora's Mask Check Tracker Settings window."));
+        .Options(WindowButtonOptions()
+                     .Tooltip("Enables the Majora's Mask Check Tracker Settings window.")
+                     .EmbedWindow(false));
 }
 
 } // namespace SohGui

--- a/rsbs/src/main.cpp
+++ b/rsbs/src/main.cpp
@@ -103,6 +103,11 @@ extern "C" {
     // games/mm/2s2h/GameExports_SingleExe.cpp. Success is observed by
     // re-checking archive availability, not via a return value.
     void MM_Extract_OfferAndRun(void);
+    // Registers MM's four tracker windows on the shared Gui (#392 bypass
+    // surface, games/mm/2s2h/TrackersGuiSingleExe.cpp). Declared here rather
+    // than included: TrackersGuiSingleExe.h lives under games/mm/2s2h, which is
+    // not on this target's include path.
+    void MM_TrackersGui_Init(void);
     // Build-version strings baked into each game library
     // (games/*/src/boot/build.c); declarations match each game's own header.
     extern const char OoT_gBuildVersion[];
@@ -528,6 +533,23 @@ int main(int argc, char** argv) {
     // exist after the point at which it could still change anything. It has to
     // be reachable while OoT is the running game.
     Combo_MMOptionsWindow_Init();
+
+    // MM's four tracker windows (#535). Same seam, same reason: registration
+    // used to hang off MM_Rando_Init, so the windows existed only once MM had
+    // booted in this process and the Randomizer > Cross-Game rows that name
+    // them resolved to nothing for the whole of a default OoT-first session.
+    //
+    // Safe before MM boots. MM_TrackersGui_Init needs a Ship::Context with a
+    // window and a Gui (it no-ops otherwise) and nothing else of MM's: it
+    // populates two static tables (Rando::StaticData::CheckNames,
+    // safeItemsForInventorySlot) and constructs four windows whose InitElements
+    // are empty but for the item-tracker settings pane, which reads only Config
+    // and CVars. The tracker ICON load inside is gated on MM_Rando_AssetsReady()
+    // and so is skipped here; MM_Rando_Init still calls this function once
+    // mm.o2r is mounted, where registration is an idempotent no-op and the
+    // icons load. Every registered window is MMActiveGated, so it draws nothing
+    // while OoT is the running game.
+    MM_TrackersGui_Init();
 
     // Belt and braces: re-assert the unattended-safe handlers after game init.
     // The claim above already makes Ship::Context::InitCrashHandler a no-op


### PR DESCRIPTION
## Summary

The four "Majora's Mask Trackers" rows added to Randomizer > Cross-Game by #523 drew no button and logged an error every frame until MM had booted once in the process. This registers the windows at startup so the rows work from frame one, and makes a missing window an expected state in the menu rather than an error.

## Mechanism

`Menu.cpp`'s `WIDGET_WINDOW_BUTTON` case resolves each row's window by name on every frame it draws. On `nullptr` it formatted a message, `SPDLOG_ERROR`'d it, and `break`'d — and the `WindowButton` call sat *after* that `break`, so a failed lookup meant no button at all plus one log line per row per frame (~240/s at 60fps with the page open).

The four MM tracker windows were created only by `MM_TrackersGui_Init`, whose sole production caller was `MM_Rando_Init` — reached only via `MM_Game_Init`. `rsbs/src/main.cpp` registered the two combo windows at startup but not these. So in the default OoT-first session the names stayed unregistered until the player first crossed into MM, and every relaunch reset to the broken state. Same registered-vs-reachable timing class as #512/#516.

## What changed

**Registration timing.** `rsbs/src/main.cpp` calls `MM_TrackersGui_Init()` right after `GameRunner_StartGame`, at the same seam and for the same reason as `Combo_SpoilerWindow_Init` / `Combo_MMOptionsWindow_Init`. Verified safe pre-MM-boot by reading everything the call reaches: `PopulateCheckNames()` walks the static `Checks` map, `InitSafeItemsForInventorySlot()` walks the static `MM_gItemSlots` array, three of the four `InitElement`s are empty, and the fourth (`ItemTrackerSettingsWindow`) reaches only `LoadAvailableWindows` / `ApplyDefaultItemPreset` / `LoadItemTrackerConfig`, which touch Config, CVars and static vectors — no `gSaveContext`, no play state, no archives. The icon load inside stays gated on `MM_Rando_AssetsReady()` and is skipped pre-`mm.o2r`. `MM_Rando_Init` keeps its call: registration there is now idempotent, and that call is what loads the icons once the archive is mounted.

**Second-call safety.** Two callers made the icon load reachable twice in an MM-first session, and `Gui::LoadGuiTexture` assigns `mGuiTextures[name] = asset` without unloading the handle it replaces — one leaked GPU texture per icon. The load is now once-only per process.

**Log spam.** `Menu.cpp` no longer treats a missing window as an error. The row is drawn named-but-disabled — the same `ICON_FA_EXTERNAL_LINK_SQUARE`-prefixed label `WindowButton` would use, through `UIWidgets::Button` with `disabled=true` and the reason appended to the existing `disabledTempTooltip` machinery, matching how Race Lockout already reads. That is the #497 Option B treatment: grey out but keep the name, never hide. The empty-`windowName` branch keeps its error — that one is a genuine authoring bug, not a not-yet state.

A missing window is still *reported*, but once per window name and at warn. Dropping the log outright would also have dropped the only signal that a row names a window nothing ever registers, which is indistinguishable at that call site from the pre-boot case. Per-frame was the defect, not the line.

**A hazard the fix would have armed.** The two MM settings rows used the default `embedWindow = true`. `Menu.cpp` implements embed as a direct `window->DrawElement()`, which bypasses `MMActiveGated::Draw` — the only thing keeping MM tracker UI from drawing while OoT is the running game, and from reaching for tracker icons before `mm.o2r` is mounted (`MMActiveGated` overrides `Draw()` and `UpdateElement()`, not `DrawElement()`). Both rows now set `.EmbedWindow(false)`, matching the two tracker rows that already did, so all four are pop-out only and the gate stays the single authority. This was already live after MM's first boot; startup registration would have made it reachable from frame one.

## Lock

`games/mm/2s2h/mm_trackers_gui_test.cpp` (ROM-free ctest row `mm-trackers-gui`) grows leg 6: with `Context_SetCurrentGame(GAME_OOT)`, `mm.o2r` unmounted and `MM_Rando_Init` never having run, `RegisterWindows` on a fresh `Ship::Gui` must land all four "MM "-prefixed names, and each resulting window must survive `Draw()`/`Update()` with its visibility CVar forced ON — the same hard tripwire leg 2 uses (no ImGui context, so an ungated `Draw` reaches `ImGui::Begin` and aborts the process). Preconditions are asserted so the leg cannot go vacuous: `!MM_Rando_AssetsReady()`, and the fresh Gui carries none of the four names before registration.

Scope honesty, stated in the test's own header and in the leg comment: this pins the **premise** the startup call rests on (registration is independent of MM boot state and of MM's archives), not the call site. The call site is not drivable ROM-free — `MM_TrackersGui_Init` early-returns unless `Ship::Context::GetWindow()` is non-null, and this same test already asserts as a precondition that the harness has no window. A revert of the `main.cpp` line therefore does not turn this red; what it does turn red is the most plausible future break — gating `RegisterWindows` on MM being active, or folding the archive-dependent icon load into it.

## Verification

Not built locally (submodules uninitialised in the work tree); CI is the compile gate. Correctness came from reading the real declarations: `Gui::AddGuiWindow` (calls `Init()` -> `InitElement()` at registration time), `Gui::LoadGuiTexture`, the `GuiWindow` ctor / `SyncVisibilityConsoleVariable`, `UIWidgets.hpp`'s `WidgetOptions`/`ButtonOptions`/`WindowButtonOptions`, and `UIWidgets.cpp:194`'s existing `Button(label, { {tooltip, disabled, disabledTooltip}, size, padding, color })` aggregate-init, which the new `Menu.cpp` call copies exactly. `ICON_FA_EXTERNAL_LINK_SQUARE` reaches `Menu.cpp` through `UIWidgets.hpp` -> `libultraship.h` -> `classes.h` -> `Gui.h`.

The `--test <name>` unit path `_Exit`s in `main` well before the new call, so the ROM-free harness never reaches it and the `mm-trackers-gui` `GetWindow() == nullptr` precondition is unaffected. Integration tests do continue through game init and will register — same as the two combo windows already do at that point.

Operator verification is still worth doing, since the call site has no headless coverage: fresh OoT-first launch, open Randomizer > Cross-Game — expect four live buttons and a silent log; toggle each and confirm the window stays blank under OoT and populates after crossing into MM. One MM-first launch confirms the second `MM_TrackersGui_Init` is inert.

Closes #535

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!--- section:artifacts:start -->
### Build Artifacts
  - [rsbs-windows.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/8735438490.zip)
  - [rsbs-linux.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/8735077155.zip)
<!--- section:artifacts:end -->