### PR TITLE
Tag-scope MM's GameInteractor hook types so the two ports' hook registries cannot COMDAT-fold (#470)

### DIFF
--- a/.github/scripts/check-symbol-collisions.sh
+++ b/.github/scripts/check-symbol-collisions.sh
@@ -139,3 +139,57 @@ if [ -s "$TMP_DIR/new" ]; then
 fi
 
 echo "OK: soh_*/2ship_* symbol intersection matches baseline ($COUNT symbol(s), all tolerated)"
+
+# --------------------------------------------------------------------------
+# #470: GameInteractor hook-registry statics. These are WEAK/unique symbols
+# and so exempt from the strong-symbol gate above — but they are the one
+# vague-linkage family where cross-tree folding is NOT legitimate: both ports
+# define global-namespace GameInteractor::RegisteredGameHooks<H> /
+# HooksToUnregister<H>, mangled on the enclosing class + hook-type NAME only,
+# while H::fn (the std::function payload, divergent for 14 of the 16 shared
+# hook names) never enters the symbol. A fold merges two incompatible
+# registries into one object. MM's hook types are tag-scoped under
+# GameInteractor::MM_HookTypes (games/mm/2s2h/GameInteractor/GameInteractor.h)
+# precisely so no such symbol can be emitted by both trees; this probe fails
+# the build if one ever is. Anti-vacuity: GameExports_SingleExe.cpp
+# instantiates MM's OnSceneInit registry on purpose (a hook name OoT also
+# defines), so a tag revert produces a real intersection here instead of an
+# empty-set pass.
+collect_gi_registry() {
+    local out="$1"
+    shift
+    : > "$out.raw"
+    local lib
+    for lib in "$@"; do
+        [ -f "$lib" ] || continue
+        # Keep ALL defined external symbols (weak W/V and GNU-unique u
+        # included — inline statics land there); match the two registry
+        # templates by their Itanium-mangled scope prefix.
+        nm --defined-only --extern-only "$lib" 2>/dev/null |
+            awk 'NF == 3 { print $3 }' |
+            grep -E '^_ZN14GameInteractor(19RegisteredGameHooks|17HooksToUnregister)I' >> "$out.raw" || true
+    done
+    sort -u "$out.raw" > "$out"
+    if [ ! -s "$out" ]; then
+        echo "error: zero GameInteractor hook-registry symbols in: $* — the #470 probe instantiations" >&2
+        echo "(OoT: GameInteractor_Hooks.cpp, MM: GameExports_SingleExe.cpp) or the mangling scheme moved?" >&2
+        echo "Refusing to pass vacuously; fix the collection here rather than losing the guard." >&2
+        exit 2
+    fi
+}
+
+collect_gi_registry "$TMP_DIR/soh_gireg"   "$BUILD_DIR"/games/oot/libsoh_*.a
+collect_gi_registry "$TMP_DIR/2ship_gireg" "$BUILD_DIR"/games/mm/lib2ship_*.a
+
+comm -12 "$TMP_DIR/soh_gireg" "$TMP_DIR/2ship_gireg" > "$TMP_DIR/gireg_folded"
+
+if [ -s "$TMP_DIR/gireg_folded" ]; then
+    echo "FAIL: GameInteractor hook-registry symbol(s) emitted by BOTH soh_* and 2ship_* archives:" >&2
+    demangle < "$TMP_DIR/gireg_folded" | sed 's/^/  /' >&2
+    echo "The linker will keep ONE of each — merging two hook registries whose std::function" >&2
+    echo "payloads have different call signatures (#470). MM hook types must stay tag-scoped" >&2
+    echo "under GameInteractor::MM_HookTypes (games/mm/2s2h/GameInteractor/GameInteractor.h)." >&2
+    exit 1
+fi
+
+echo "OK: GameInteractor hook-registry symbols are disjoint across the two trees (#470)"

--- a/games/mm/2s2h/GameExports_SingleExe.cpp
+++ b/games/mm/2s2h/GameExports_SingleExe.cpp
@@ -19,7 +19,8 @@
 
 #ifdef RSBS_SINGLE_EXECUTABLE
 
-#include <cstddef> // offsetof for the #395 layout facts; ptrdiff_t
+#include <cstddef>     // offsetof for the #395 layout facts; ptrdiff_t
+#include <type_traits> // std::is_same_v for the #470 payload-divergence premise
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
@@ -689,6 +690,29 @@ extern "C" size_t MM_GI_InstanceSize(void) {
 
 extern "C" size_t MM_GI_NextHookIdOffset(void) {
     return offsetof(GameInteractor, nextHookId);
+}
+
+// #470 registry-identity probes — MM's view of the OnSceneInit hook registry.
+// Naming RegisteredGameHooks<OnSceneInit> here instantiates, from a linked MM
+// TU, exactly the symbol #470's arming scenario would create: OnSceneInit is
+// a hook NAME both ports' tables define, with divergent payloads (OoT
+// std::function<void(int16_t)>, MM the two-arg form the static_assert pins).
+// The MM_HookTypes tag scope (2s2h/GameInteractor/GameInteractor.h) keeps
+// this instantiation's mangled name disjoint from OoT's, so it is safe to
+// emit — and it is emitted ON PURPOSE: the mm-gi-shim lock asserts these
+// addresses differ from the OoT twins' (GameInteractor_Hooks.cpp), and the
+// check-symbol-collisions.sh #470 probe needs a same-named-hook registry in
+// the 2ship archives so a tag revert folds a real symbol instead of passing
+// vacuously.
+static_assert(std::is_same_v<GameInteractor::OnSceneInit::fn, std::function<void(s8, s8)>>,
+              "MM's OnSceneInit payload changed shape — revisit the #470 registry-identity lock");
+
+extern "C" void* MM_GI_OnSceneInitRegistryAddr(void) {
+    return &GameInteractor::RegisteredGameHooks<GameInteractor::OnSceneInit>::functions;
+}
+
+extern "C" void* MM_GI_OnSceneInitUnregQueueAddr(void) {
+    return &GameInteractor::HooksToUnregister<GameInteractor::OnSceneInit>::hooks;
 }
 
 // ============================================================================

--- a/games/mm/2s2h/GameInteractor/GameInteractor.h
+++ b/games/mm/2s2h/GameInteractor/GameInteractor.h
@@ -469,6 +469,42 @@ class GameInteractor {
         }
     };
 
+#if defined(RSBS_SINGLE_EXECUTABLE)
+    //
+    // Single-exe hook-type tag scope (#470).
+    //
+    // Both ports define this same-named global class, and every hook-keyed
+    // template member above — RegisteredGameHooks<H> / HooksToUnregister<H>
+    // and the Register*/Unregister*/Execute*/GetHookData<H> bodies — mangles
+    // on the enclosing class name plus the hook-TYPE name. H::fn (the
+    // std::function payload, divergent for 14 of the 16 hook names the two
+    // ports' tables share) never enters an Itanium variable mangling, so on
+    // the Linux/macOS links an MM instantiation of any same-named hook's
+    // registry COMDAT-folds with OoT's into ONE object invoked through two
+    // incompatible payload views — GNU ld dedups vague linkage silently.
+    // MSVC does embed the variable's type, so Windows only folds the
+    // identical-payload names (OnGameStateMainStart, OnPlayDestroy,
+    // OnOpenText, OnSeqPlayerInit) — no garbage arguments there, but still
+    // one registry silently shared across both games. Nesting MM's hook
+    // types under MM_HookTypes puts an MM-distinct tag into every such
+    // mangled name (including S2H::GameHooks::Registry<H> keys), so no
+    // hook-keyed MM symbol can share a name with OoT's tree on either
+    // mangling: folding becomes impossible by construction instead of merely
+    // unexercised.
+    //
+    // The upstream DEFINE_HOOK block below stays textually unchanged; the
+    // alias re-expansion after it keeps every `GameInteractor::<Hook>`
+    // spelling (COND_* macros, S2H::GameHooks call sites, the executors in
+    // GameExports_SingleExe.cpp) compiling as-is.
+    //
+    // Locks: the mm-gi-shim ctest row asserts OoT's and MM's
+    // RegisteredGameHooks<OnSceneInit> are distinct objects at runtime, and
+    // .github/scripts/check-symbol-collisions.sh fails the build if any
+    // GameInteractor registry symbol is emitted by both trees.
+    //
+    struct MM_HookTypes {
+#endif // RSBS_SINGLE_EXECUTABLE
+
 #define DEFINE_HOOK(name, args)                  \
     struct name {                                \
         typedef std::function<void args> fn;     \
@@ -478,6 +514,14 @@ class GameInteractor {
 #include "GameInteractor_HookTable.h"
 
 #undef DEFINE_HOOK
+
+#if defined(RSBS_SINGLE_EXECUTABLE)
+    };
+
+#define DEFINE_HOOK(name, args) using name = MM_HookTypes::name;
+#include "GameInteractor_HookTable.h"
+#undef DEFINE_HOOK
+#endif // RSBS_SINGLE_EXECUTABLE
 };
 
 extern "C" {

--- a/games/mm/2s2h/GameInteractor/GameInteractor.h
+++ b/games/mm/2s2h/GameInteractor/GameInteractor.h
@@ -751,9 +751,11 @@ void MM_GameHooks_ExecuteOnGameCompletion(void);
 // The upstream macro definitions above expand to
 // GameInteractor::Instance->RegisterGameHook<...> — in the single exe the
 // one GameInteractor allocation is OoT's 4-byte object, so an MM-compiled
-// registration writes past its end, and the C++ registry statics the members
-// touch COMDAT-contend with OoT's incompatible instantiations
-// (mm_game_hooks.h has the full story). Rather than editing the ~650
+// registration writes past its end (mm_game_hooks.h has the full story). The
+// registry statics those members touch no longer COMDAT-contend with OoT's
+// incompatible instantiations — the MM_HookTypes tag scope above closed that
+// half in #470 — but the #395 out-of-bounds write is untouched by it, so the
+// redirection below stands on its own. Rather than editing the ~650
 // COND_HOOK / COND_ID_HOOK / COND_VB_SHOULD / REGISTER_VB_SHOULD sites
 // across 2s2h/Rando and 2s2h/Enhancements, the macros themselves are
 // redefined here — after the upstream definitions, inside this

--- a/games/mm/2s2h/mm_gi_shim_test.cpp
+++ b/games/mm/2s2h/mm_gi_shim_test.cpp
@@ -23,12 +23,21 @@
  * (games/mm/include/mm_game_hooks.h), dispatched from MM's own frame loop,
  * and this test pins the folded copy to OoT's layout.
  *
- * Three locks, in order of strength:
+ * Four locks, in order of strength:
  *
  * 1. LAYOUT PREMISE (machine-verified, not assumed). The two ports' sizeof /
  *    offsetof(nextHookId) are compared at runtime, each reported from its own
  *    TU with its own production headers and flags. If they ever agree, the
  *    fault class evaporates and this test should be revisited.
+ *
+ * 1b. REGISTRY IDENTITY (#470). Both trees export the address of their
+ *    RegisteredGameHooks<OnSceneInit> / HooksToUnregister<OnSceneInit>
+ *    statics for a hook NAME the two hook tables share with divergent
+ *    std::function payloads; the addresses must differ. MM's side stays a
+ *    distinct symbol because its hook types are tag-scoped under
+ *    GameInteractor::MM_HookTypes — revert that and the two registries
+ *    COMDAT-fold into one object, which this catches at runtime (and
+ *    .github/scripts/check-symbol-collisions.sh catches at the archives).
  *
  * 2. FOLD/CALL-SITE BEHAVIOR (the lock linker ICF cannot defeat). OoT-side
  *    registration is run against an oversized zeroed buffer twice — once as a
@@ -80,6 +89,16 @@ void OoT_GI_ProbePumpOnMainStart(void);
 size_t MM_GI_InstanceSize(void);
 size_t MM_GI_NextHookIdOffset(void);
 void MM_GIShim_TestArmIntegrationHooks(void);
+// #470 registry-identity probes: each side's address of its
+// RegisteredGameHooks<OnSceneInit>/HooksToUnregister<OnSceneInit> statics,
+// exported from a real TU of that tree. OnSceneInit is a hook NAME both
+// ports define with divergent std::function payloads (each probe TU
+// static_asserts its own side's shape, so the divergence premise is pinned
+// at compile time). Distinct addresses == distinct symbols == no COMDAT fold.
+void* OoT_GI_OnSceneInitRegistryAddr(void);
+void* OoT_GI_OnSceneInitUnregQueueAddr(void);
+void* MM_GI_OnSceneInitRegistryAddr(void);
+void* MM_GI_OnSceneInitUnregQueueAddr(void);
 }
 
 namespace {
@@ -138,6 +157,26 @@ extern "C" int MM_GIShim_RunHeadless(void) {
                "MM and OoT GameInteractor layouts agree — the premise of #395 no longer holds, revisit this lock");
     GIS_ASSERT(mmOff + sizeof(uint32_t) > ootSize,
                "MM's nextHookId lies inside OoT's allocation — probe confinement below would be vacuous, revisit");
+
+    // ---- 1b. Registry identity (#470): same hook NAME, two symbols -------
+    // MM's probe TU deliberately instantiates the registry for OnSceneInit —
+    // a hook name BOTH tables define, with divergent payloads. Without the
+    // MM_HookTypes tag scope (MM GameInteractor.h) the two trees' statics
+    // mangle identically under Itanium and the linker keeps ONE object;
+    // these getters are opaque cross-TU calls, and the maps are writable
+    // data, so equal addresses can only mean that fold happened. Teeth are
+    // on the Linux/macOS legs: MSVC manglings embed the divergent payload
+    // type, so Windows never folds THIS pair and passes either way — do not
+    // "verify" a revert of the tag scope on Windows alone.
+    printf("[TEST] OnSceneInit registries — OoT functions=%p unregQueue=%p, MM functions=%p unregQueue=%p\n",
+           OoT_GI_OnSceneInitRegistryAddr(), OoT_GI_OnSceneInitUnregQueueAddr(), MM_GI_OnSceneInitRegistryAddr(),
+           MM_GI_OnSceneInitUnregQueueAddr());
+    GIS_ASSERT(OoT_GI_OnSceneInitRegistryAddr() != MM_GI_OnSceneInitRegistryAddr(),
+               "OoT and MM RegisteredGameHooks<OnSceneInit> folded into one object — the #470 MM_HookTypes tag "
+               "scope is gone, divergent std::function payloads now share one map");
+    GIS_ASSERT(OoT_GI_OnSceneInitUnregQueueAddr() != MM_GI_OnSceneInitUnregQueueAddr(),
+               "OoT and MM HooksToUnregister<OnSceneInit> folded into one queue — the #470 MM_HookTypes tag "
+               "scope is gone, cross-game unregister ids would leak between registries");
 
     // ---- 2. Registration writes stay inside OoT's allocation -------------
     // Direct = what OoT's real call sites execute (inlining included).
@@ -238,8 +277,9 @@ extern "C" int MM_GIShim_RunHeadless(void) {
     MM_GameHooks_ResetForTest();
     Context_SetCurrentGame(prevGame);
 
-    printf("[TEST] PASS: mm-gi-shim — MM hook registration stays off the shared 4-byte instance, all four "
-           "hook-driven integration modes arm through the MM-owned shim\n");
+    printf("[TEST] PASS: mm-gi-shim — MM hook registration stays off the shared 4-byte instance, the two ports' "
+           "same-named hook registries are distinct symbols, all four hook-driven integration modes arm through "
+           "the MM-owned shim\n");
     return 0;
 }
 

--- a/games/mm/include/mm_game_hooks.h
+++ b/games/mm/include/mm_game_hooks.h
@@ -105,12 +105,20 @@ GIEvent& MM_GameEvents_Current();
  * migration (#392, contract in PR #415).
  *
  * MM's upstream registry lives in `GameInteractor::RegisteredGameHooks<H>` /
- * `HooksToUnregister<H>` inline statics. Those mangle under the shared
- * `class GameInteractor` scope, so an MM instantiation COMDAT-contends with
- * OoT's identically-named instantiations — with incompatible H::fn signatures
- * for 14 of the 16 shared hook names (#395/#367 class) — and the registering
- * members read/write `this->nextHookId` on the 4-byte shared allocation (the
- * #395 OOB). This registry reproduces the upstream semantics MM's Rando code
+ * `HooksToUnregister<H>` inline statics, and the registering members
+ * read/write `this->nextHookId` on the 4-byte shared allocation — the #395
+ * OOB, which is the standing reason MM must not use them and which
+ * include/mm_gi_hook_guard.h enforces per target.
+ *
+ * Those statics ALSO used to COMDAT-contend with OoT's identically-named
+ * instantiations, whose H::fn payloads differ for 14 of the 16 shared hook
+ * names (#395/#367 class). That half is closed since #470: MM's hook types
+ * are tag-scoped under `GameInteractor::MM_HookTypes` (2s2h/GameInteractor/
+ * GameInteractor.h), so no MM hook-keyed symbol can share a mangled name
+ * with OoT's tree. Do not re-derive the folding argument from this file —
+ * the #395 OOB alone is what keeps registration off the upstream members.
+ *
+ * This registry reproduces the upstream semantics MM's Rando code
  * expects (shared id counter, deferred unregistration flushed at dispatch)
  * under the S2H namespace: only MM TUs instantiate it, so every fold partner
  * agrees on MM's types, and no instance member of the shared class is ever

--- a/games/mm/include/mm_gi_hook_guard.h
+++ b/games/mm/include/mm_gi_hook_guard.h
@@ -14,7 +14,13 @@
  * The Execute*, Unregister*, and GetHookData members only touch the
  * inline-static per-hook-type maps (no instance state), so they stay usable
  * — e.g. the GameInteractor_ExecuteOnRoomInit wrappers in
- * GameExports_SingleExe.cpp.
+ * GameExports_SingleExe.cpp. That permission is fold-safe as well as
+ * OOB-safe: since #470 MM's hook types are tag-scoped under
+ * GameInteractor::MM_HookTypes (see the DEFINE_HOOK block in
+ * 2s2h/GameInteractor/GameInteractor.h), so the per-hook-type statics an MM
+ * Execute*/GetHookData instantiation touches mangle MM-distinct and cannot
+ * COMDAT-fold with OoT's divergent-payload instantiations of the same hook
+ * NAME.
  *
  * Mechanism: force-included AFTER GameInteractor.h (games/mm/CMakeLists.txt,
  * the _force_include_cxx_guarded list), so the class definition itself parses

--- a/games/mm/include/mm_gi_hook_guard.h
+++ b/games/mm/include/mm_gi_hook_guard.h
@@ -18,7 +18,7 @@
  * OOB-safe: since #470 MM's hook types are tag-scoped under
  * GameInteractor::MM_HookTypes (see the DEFINE_HOOK block in
  * 2s2h/GameInteractor/GameInteractor.h), so the per-hook-type statics an MM
- * Execute*/GetHookData instantiation touches mangle MM-distinct and cannot
+ * Execute* or GetHookData instantiation touches mangle MM-distinct and cannot
  * COMDAT-fold with OoT's divergent-payload instantiations of the same hook
  * NAME.
  *

--- a/games/oot/soh/Enhancements/game-interactor/GameInteractor_Hooks.cpp
+++ b/games/oot/soh/Enhancements/game-interactor/GameInteractor_Hooks.cpp
@@ -3,7 +3,8 @@
 #ifdef RSBS_SINGLE_EXECUTABLE
 #include <cstddef> // offsetof/size_t for the #395 layout probes below
 #include <cstdint>
-#include "context.h" // src/common/context.h via redship_common's public include dir
+#include <type_traits> // std::is_same_v for the #470 payload-divergence premise
+#include "context.h"   // src/common/context.h via redship_common's public include dir
 // In the single executable MM's own GameInteractor layer is not compiled, so
 // MM code links against these unprefixed extern "C" wrappers, and MM's
 // GIVanillaBehavior ordinals alias OoT's (e.g. MM VB_SETUP_TRANSITION == OoT
@@ -579,5 +580,27 @@ extern "C" void OoT_GI_ProbePumpOnMainStart(void) {
     // executes nothing in the unit-test harness.
     GameInteractor gi;
     gi.ExecuteHooks<GameInteractor::OnGameStateMainStart>();
+}
+
+// MARK: - #470 registry-identity probes (redship --test mm-gi-shim)
+//
+// OoT's view of the OnSceneInit hook registry, from a real OoT TU. The
+// mm-gi-shim lock compares these against the MM-side twins exported from
+// games/mm/2s2h/GameExports_SingleExe.cpp: the addresses must DIFFER, or the
+// linker has folded both ports' same-named registries into one object whose
+// std::function payloads disagree (MM's OnSceneInit::fn is the two-arg
+// (s8, s8) form — the static_assert below pins this side's one-arg premise,
+// its MM twin pins the divergence, so the fault class is proven live rather
+// than assumed). MM's side stays un-foldable because its hook types are
+// tag-scoped under GameInteractor::MM_HookTypes (#470).
+static_assert(std::is_same_v<GameInteractor::OnSceneInit::fn, std::function<void(int16_t)>>,
+              "OoT's OnSceneInit payload changed shape — revisit the #470 registry-identity lock");
+
+extern "C" void* OoT_GI_OnSceneInitRegistryAddr(void) {
+    return &GameInteractor::RegisteredGameHooks<GameInteractor::OnSceneInit>::functions;
+}
+
+extern "C" void* OoT_GI_OnSceneInitUnregQueueAddr(void) {
+    return &GameInteractor::HooksToUnregister<GameInteractor::OnSceneInit>::hooks;
 }
 #endif


### PR DESCRIPTION
## Summary

Closes the latent ODR hazard in #470: OoT's and MM's `GameInteractor::RegisteredGameHooks<H>` / `HooksToUnregister<H>` inline statics mangle on the enclosing class name plus the hook-**type name** only, so a same-named hook instantiated by both trees folds into one object whose `std::function` payloads have different call signatures.

In single-exe builds MM's hook types are now defined inside a nested `GameInteractor::MM_HookTypes` tag scope, with X-macro-generated `using` aliases re-exporting every name at the old `GameInteractor::<Hook>` spelling. Every hook-keyed MM mangled name therefore embeds the tag and can never collide with OoT's.

## Mechanism / motivation

`H::fn` — the divergent part — never enters an Itanium variable mangling, so `_ZN14GameInteractor19RegisteredGameHooksINS_11OnSceneInitEE9functionsE` is emitted identically by both trees and GNU ld silently keeps one. 14 of the 16 hook names shared by the two `GameInteractor_HookTable.h` files have divergent payloads; `OnSceneInit` (OoT `void(int16_t)` vs MM `void(s8, s8)`) and `OnKaleidoUpdate` differ in **arity**. MSVC embeds the variable's type in static-data-member manglings, so Windows only folds the four identical-payload names — Linux/macOS are where the fault bites, and where the locks have teeth.

Route B from the issue, narrowed: the class name is untouched, so the `Instance` cross-binding and the #395 shim contract are unaffected (the #395 objection to namespacing MM's `GameInteractor` wholesale does not apply). Tagging the hook types rather than renaming only the registry struct also kills the sibling hazard where `ExecuteHooks<H, Args...>` instantiations with mangle-identical `Args` (`OnSeqPlayerInit(s32,s32)`, `OnOpenText(u16*,bool*)`) would still fold cross-tree with divergent bodies. `S2H::GameHooks` is untouched; non-single-exe builds see pristine upstream (`#if defined(RSBS_SINGLE_EXECUTABLE)` on both added blocks, the upstream `DEFINE_HOOK` block itself textually unchanged).

## What changed

- `games/mm/2s2h/GameInteractor/GameInteractor.h` — `struct MM_HookTypes { ... }` around the `DEFINE_HOOK` expansion, then a second table pass emitting `using <Hook> = MM_HookTypes::<Hook>;` at class scope. All ~650 `COND_HOOK` / `COND_ID_HOOK` / `COND_VB_SHOULD` sites, `HookDebugger.cpp`, and the `GameExports_SingleExe.cpp` executors compile textually unchanged.
- `games/mm/2s2h/GameExports_SingleExe.cpp`, `games/oot/soh/Enhancements/game-interactor/GameInteractor_Hooks.cpp` — per-tree probes exporting the addresses of that tree's `RegisteredGameHooks<OnSceneInit>::functions` / `HooksToUnregister<OnSceneInit>::hooks`, each with a `static_assert` pinning its own side's payload shape so the divergence premise is machine-verified rather than assumed.
- `games/mm/2s2h/mm_gi_shim_test.cpp` — new section 1b in the existing `mm-gi-shim` row.
- `.github/scripts/check-symbol-collisions.sh` — new #470 section (see below).
- `games/mm/include/mm_gi_hook_guard.h`, `games/mm/include/mm_game_hooks.h`, MM `GameInteractor.h` macro-redirection header comment — the guard's "`Execute*` stays usable" rationale now documents *why* that permission is fold-safe, and the two comments that still asserted the fold hazard was live are corrected. `mm_game_hooks.h` in particular was the canonical narrative for why `S2H::GameHooks` exists; after this change the #395 out-of-bounds write on the shared 4-byte instance is the standing reason on its own, and the file now says so instead of leaving a future reader to re-derive a stale folding argument.

## Lock note

Two falsifiable locks, both red if the tag scope is reverted:

1. **Runtime** — `redship --test mm-gi-shim` (CTest `MMGIShim`) asserts the two trees' `RegisteredGameHooks<OnSceneInit>::functions` and `HooksToUnregister<OnSceneInit>::hooks` are at different addresses. The getters are opaque cross-TU calls returning addresses of writable data, so equal addresses can only mean a fold. MM's probe TU instantiates the same-named-hook registry **on purpose** — that is precisely the arming scenario the issue describes.
2. **Archive-level** — `.github/scripts/check-symbol-collisions.sh` now intersects the `_ZN14GameInteractor{19RegisteredGameHooks,17HooksToUnregister}I…` symbols of `libsoh_*.a` against `lib2ship_*.a` (weak/unique included — deliberately outside the strong-symbol gate's documented scope) and fails on any intersection. It refuses to pass vacuously if either side collects zero such symbols, and the deliberate MM probe instantiation guarantees a real symbol exists to fold on revert.

Teeth are on the Linux legs: MSVC never folds this particular pair, so a revert must not be "verified" on Windows alone. The header, the test, and the gate all say this explicitly.

Not built locally (submodules uninitialised in the review worktree); correctness rests on reading the real headers and the two hook tables, plus CI. Reviewed adversarially against the real declarations: hook-type access is `public` throughout `GameInteractor`, `RemoveAllQueuedHooks`'s earlier `ProcessUnregisteredHooks<name>()` expansion resolves through the aliases because member-function bodies are complete-class contexts, the two `);`-terminated table entries yield a permitted empty-declaration at class scope, `GameInteractor_HookTable.h` has no include guard (it is already double-included upstream), `RSBS_SINGLE_EXECUTABLE` is set on all five MM targets so no MM TU can see an untagged variant, and both probe TUs land in archives the gate's globs cover (`libsoh_enh.a`, `lib2ship_port.a`).

Closes #470

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!--- section:artifacts:start -->
### Build Artifacts
  - [rsbs-windows.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/8738619306.zip)
  - [rsbs-linux.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/8736658111.zip)
<!--- section:artifacts:end -->