### PR TITLE
Announce the MM arrival, and toast every foreign pickup in native colours (#494)

### DIFF
--- a/games/mm/2s2h/GameExports_SingleExe.cpp
+++ b/games/mm/2s2h/GameExports_SingleExe.cpp
@@ -2103,6 +2103,13 @@ extern "C" int MM_ForeignItem_Give(uint16_t riId);
  * cleared (the durable record of the crossing). A give that reports failure is
  * logged but still consumes the redemption — an unresolvable id is a data bug,
  * not something to retry on every future arrival.
+ *
+ * NO PLAYER-FACING PRESENTATION HERE, deliberately (#494). The arrival toast
+ * lives next to the give itself (2s2h/Rando/ForeignItemsSingleExe.cpp), which is
+ * the only point gameplay-gated by construction — this callback runs before
+ * `MM_gPlayState = this`, and the ROM-free rows drive it headlessly with no Gui
+ * (src/common/tests/test_foreign_award.c). A Notification::Emit added back here
+ * would fire before the item exists and on a display-free CI path.
  */
 static void MM_AwardSharedItem(const SharedItem* item, void* ctx) {
     (void)ctx;

--- a/games/mm/2s2h/Rando/ForeignItemsSingleExe.cpp
+++ b/games/mm/2s2h/Rando/ForeignItemsSingleExe.cpp
@@ -413,23 +413,52 @@ bool IsGiveableItemId(uint16_t riId) {
 }
 
 /**
- * What the arrival toast shows for `riId`, read from MM's OWN item table.
+ * The WHOLE arrival toast for `riId`, read from MM's OWN item table.
  *
- * Split out from the emit so the ROM-free tier can assert what the player is
- * shown without a Gui (MM_ForeignItem_TestArrivalText/Icon at the bottom of
- * this file). Both fields come from the same two accessors MM's native rando
- * pickup toast calls (Rando/MiscBehavior/CheckQueue.cpp) — this is an MM item
- * being received in MM, so nothing here is cross-game and nothing needs an
- * archive that is not mounted.
+ * Returns the complete Notification::Options rather than the item name alone,
+ * so that the ROM-free tier's assertion covers every field the player can read
+ * (MM_ForeignItem_TestArrivalText at the bottom of this file renders it the way
+ * the overlay does). A bridge that exposed only the name would let a re-added
+ * cross-game tell — an origin badge in `.prefix`, "from Ocarina of Time"
+ * appended to the verb — pass the lock untouched, which is exactly the
+ * regression #510 exists to prevent.
+ *
+ * Icon and name come from the same two accessors MM's native rando pickup toast
+ * calls (Rando/MiscBehavior/CheckQueue.cpp) — this is an MM item being received
+ * in MM, so nothing here is cross-game and nothing needs an archive that is not
+ * mounted. `.itemIcon` may be nullptr; Emit then renders text-only.
+ *
+ * Field arrangement matches that native toast exactly (verb in `.message`, item
+ * in `.suffix`, no `.prefix`), because Options colours each field differently
+ * and a bespoke arrangement would itself be a "this one is special" tell.
  */
-struct ArrivalToast {
-    const char* icon; // may be nullptr; Emit then renders text-only
-    std::string text; // MM's article + name, e.g. "the Bunny Hood"
-};
+Notification::Options BuildArrivalToast(RandoItemId randoItemId) {
+    return Notification::Options{
+        .itemIcon = Rando::StaticData::GetIconTexturePath(randoItemId),
+        .message = "You got",
+        .suffix = Rando::StaticData::GetItemName(randoItemId), // MM's article + name, e.g. "the Bunny Hood"
+    };
+}
 
-ArrivalToast BuildArrivalToast(RandoItemId randoItemId) {
-    return ArrivalToast{ Rando::StaticData::GetIconTexturePath(randoItemId),
-                         Rando::StaticData::GetItemName(randoItemId) };
+/**
+ * The toast as one line of text, joined the way Notification::Window::Draw lays
+ * it out: every non-empty field on the same line, one gap between neighbours
+ * (soh/Notification/Notification.cpp's ImGui::SameLine). The ROM-free lock's
+ * observable — see MM_ForeignItem_TestArrivalText.
+ */
+std::string RenderToastLine(const Notification::Options& toast) {
+    std::string line;
+    const std::string* const fields[] = { &toast.prefix, &toast.message, &toast.suffix };
+    for (const std::string* field : fields) {
+        if (field->empty()) {
+            continue;
+        }
+        if (!line.empty()) {
+            line += ' ';
+        }
+        line += *field;
+    }
+    return line;
 }
 
 /** The actual give. Precondition: MM_gPlayState != NULL and the id is real. */
@@ -444,10 +473,8 @@ void GiveNow(uint16_t riId) {
     // direction (OoT_AwardSharedItem), here on MM's side.
     //
     // PRESENTED AS AN ORDINARY MM PICKUP: MM's own toast, MM's own icon, MM's
-    // own "article + name" sentence, and no mention of where the item came from.
-    // Byte-for-byte the field arrangement of MM's native rando pickup toast, so
-    // it renders in the same colours — a bespoke layout would itself be the
-    // cross-game tell #510 removed everywhere else.
+    // own "article + name" sentence, and no mention of where the item came from
+    // (BuildArrivalToast, above).
     //
     // A toast rather than the get-item cutscene: this fires on a gameplay frame
     // the player did not initiate, where seizing the camera and the message
@@ -461,12 +488,7 @@ void GiveNow(uint16_t riId) {
     // (src/common/tests/test_foreign_award.c calls the real MM_ConsumeSharedItems
     // with no PlayState and no Gui), so a Notification::Emit there would put an
     // ImGui/audio call on a display-free CI path.
-    const ArrivalToast toast = BuildArrivalToast(randoItemId);
-    Notification::Emit({
-        .itemIcon = toast.icon,
-        .message = "You got",
-        .suffix = toast.text,
-    });
+    Notification::Emit(BuildArrivalToast(randoItemId));
 }
 
 } // namespace
@@ -606,15 +628,19 @@ extern "C" int MM_ForeignItem_TestIsJunkClassId(uint16_t riId) {
 }
 
 /**
- * The arrival toast's item text for `riId`, NUL-terminated into `out` (#494).
+ * The WHOLE arrival toast for `riId` as one line, NUL-terminated into `out`
+ * (#494) — every field the player can read, joined the way the overlay draws
+ * them.
  *
  * The SAME BuildArrivalToast the give emits, not a paraphrase of it — a lock
  * that rebuilt the string itself would keep passing after the toast changed.
  * What CI can honestly assert is the resolution surface: that MM's own item
- * table names every entry of MM's own pool, and names it with exactly the
- * article + name the pooled descriptor carries and nothing else. Extra prose —
- * "it came from Ocarina of Time", an origin badge — breaks that equality, which
- * is the no-tell contract (#510) stated as an assertion.
+ * table names every entry of MM's own pool, and that the toast is that name
+ * behind the native verb and NOTHING ELSE. Extra prose anywhere in the toast —
+ * "it came from Ocarina of Time" appended to the verb, an origin badge in the
+ * unused `.prefix` — breaks the equality, which is the no-tell contract (#510)
+ * stated as an assertion. Reporting only the item name would have left both of
+ * those regressions invisible to CI.
  *
  * @return the length written, or -1 if the id names no real MM item or `out` is
  *         too small (never a truncated string).
@@ -623,12 +649,12 @@ extern "C" int MM_ForeignItem_TestArrivalText(uint16_t riId, char* out, int cap)
     if (out == nullptr || cap <= 0 || !IsGiveableItemId(riId)) {
         return -1;
     }
-    const std::string text = BuildArrivalToast((RandoItemId)riId).text;
-    if ((int)text.size() >= cap) {
+    const std::string line = RenderToastLine(BuildArrivalToast((RandoItemId)riId));
+    if ((int)line.size() >= cap) {
         return -1;
     }
-    memcpy(out, text.c_str(), text.size() + 1);
-    return (int)text.size();
+    memcpy(out, line.c_str(), line.size() + 1);
+    return (int)line.size();
 }
 
 /** The arrival toast's icon path for `riId`, or nullptr — which is a text-only
@@ -637,7 +663,7 @@ extern "C" const char* MM_ForeignItem_TestArrivalIcon(uint16_t riId) {
     if (!IsGiveableItemId(riId)) {
         return nullptr;
     }
-    return BuildArrivalToast((RandoItemId)riId).icon;
+    return BuildArrivalToast((RandoItemId)riId).itemIcon;
 }
 
 #endif // RSBS_SINGLE_EXECUTABLE

--- a/games/mm/2s2h/Rando/ForeignItemsSingleExe.cpp
+++ b/games/mm/2s2h/Rando/ForeignItemsSingleExe.cpp
@@ -84,10 +84,17 @@
 #ifdef RSBS_SINGLE_EXECUTABLE
 
 #include <cstdio>
+#include <cstring>
+#include <string>
 
 #include "Rando/Rando.h"
 #include "Rando/Types.h"
 #include "Rando/StaticData/StaticData.h"
+// The arrival toast (#494). MM's own BenGui/Notification.cpp is excluded from
+// single-exe builds, so this Emit binds OoT's definition — the same deliberate
+// cross-bind MM's native rando pickup toast already uses, locked field-for-field
+// by mm_notification_binding_test.cpp (#427 item 1).
+#include "2s2h/BenGui/Notification.h"
 
 extern "C" {
 #include "variables.h" // MM_gPlayState
@@ -405,9 +412,61 @@ bool IsGiveableItemId(uint16_t riId) {
     return riId != (uint16_t)RI_UNKNOWN && riId != (uint16_t)RI_NONE && riId < (uint16_t)RI_MAX;
 }
 
+/**
+ * What the arrival toast shows for `riId`, read from MM's OWN item table.
+ *
+ * Split out from the emit so the ROM-free tier can assert what the player is
+ * shown without a Gui (MM_ForeignItem_TestArrivalText/Icon at the bottom of
+ * this file). Both fields come from the same two accessors MM's native rando
+ * pickup toast calls (Rando/MiscBehavior/CheckQueue.cpp) — this is an MM item
+ * being received in MM, so nothing here is cross-game and nothing needs an
+ * archive that is not mounted.
+ */
+struct ArrivalToast {
+    const char* icon; // may be nullptr; Emit then renders text-only
+    std::string text; // MM's article + name, e.g. "the Bunny Hood"
+};
+
+ArrivalToast BuildArrivalToast(RandoItemId randoItemId) {
+    return ArrivalToast{ Rando::StaticData::GetIconTexturePath(randoItemId),
+                         Rando::StaticData::GetItemName(randoItemId) };
+}
+
 /** The actual give. Precondition: MM_gPlayState != NULL and the id is real. */
 void GiveNow(uint16_t riId) {
-    Rando::GiveItem((RandoItemId)riId);
+    const RandoItemId randoItemId = (RandoItemId)riId;
+    Rando::GiveItem(randoItemId);
+
+    // #494: the arrival is the player's ONLY signal that this item landed.
+    // Until now it was silent — the item appeared in the inventory an arbitrary
+    // number of scenes after the OoT check that granted it, with no in-game
+    // feedback at all. That is the same gap the OoT arrival closed for the other
+    // direction (OoT_AwardSharedItem), here on MM's side.
+    //
+    // PRESENTED AS AN ORDINARY MM PICKUP: MM's own toast, MM's own icon, MM's
+    // own "article + name" sentence, and no mention of where the item came from.
+    // Byte-for-byte the field arrangement of MM's native rando pickup toast, so
+    // it renders in the same colours — a bespoke layout would itself be the
+    // cross-game tell #510 removed everywhere else.
+    //
+    // A toast rather than the get-item cutscene: this fires on a gameplay frame
+    // the player did not initiate, where seizing the camera and the message
+    // context would be a hijack. The toast is exactly what MM already falls back
+    // to for its own pickups when the cutscene is skipped.
+    //
+    // EMITTED HERE AND NOT IN MM_AwardSharedItem (GameExports_SingleExe.cpp)
+    // because this is the one point that is gameplay-gated by construction: both
+    // callers reach it only with a live MM_gPlayState. The award callback runs at
+    // the presence-gated arrival point, which the ROM-free rows drive headlessly
+    // (src/common/tests/test_foreign_award.c calls the real MM_ConsumeSharedItems
+    // with no PlayState and no Gui), so a Notification::Emit there would put an
+    // ImGui/audio call on a display-free CI path.
+    const ArrivalToast toast = BuildArrivalToast(randoItemId);
+    Notification::Emit({
+        .itemIcon = toast.icon,
+        .message = "You got",
+        .suffix = toast.text,
+    });
 }
 
 } // namespace
@@ -544,6 +603,41 @@ extern "C" int MM_ForeignItem_TestIsJunkClassId(uint16_t riId) {
         return -1;
     }
     return (it->second.randoItemType == RITYPE_JUNK) ? 1 : 0;
+}
+
+/**
+ * The arrival toast's item text for `riId`, NUL-terminated into `out` (#494).
+ *
+ * The SAME BuildArrivalToast the give emits, not a paraphrase of it — a lock
+ * that rebuilt the string itself would keep passing after the toast changed.
+ * What CI can honestly assert is the resolution surface: that MM's own item
+ * table names every entry of MM's own pool, and names it with exactly the
+ * article + name the pooled descriptor carries and nothing else. Extra prose —
+ * "it came from Ocarina of Time", an origin badge — breaks that equality, which
+ * is the no-tell contract (#510) stated as an assertion.
+ *
+ * @return the length written, or -1 if the id names no real MM item or `out` is
+ *         too small (never a truncated string).
+ */
+extern "C" int MM_ForeignItem_TestArrivalText(uint16_t riId, char* out, int cap) {
+    if (out == nullptr || cap <= 0 || !IsGiveableItemId(riId)) {
+        return -1;
+    }
+    const std::string text = BuildArrivalToast((RandoItemId)riId).text;
+    if ((int)text.size() >= cap) {
+        return -1;
+    }
+    memcpy(out, text.c_str(), text.size() + 1);
+    return (int)text.size();
+}
+
+/** The arrival toast's icon path for `riId`, or nullptr — which is a text-only
+ *  toast, not a defect (Notification::Emit skips a null icon). */
+extern "C" const char* MM_ForeignItem_TestArrivalIcon(uint16_t riId) {
+    if (!IsGiveableItemId(riId)) {
+        return nullptr;
+    }
+    return BuildArrivalToast((RandoItemId)riId).icon;
 }
 
 #endif // RSBS_SINGLE_EXECUTABLE

--- a/games/oot/soh/Enhancements/randomizer/hook_handlers.cpp
+++ b/games/oot/soh/Enhancements/randomizer/hook_handlers.cpp
@@ -401,12 +401,18 @@ void RandomizerOnPlayerUpdateForRCQueueHandler() {
         // class (#494/#507, OoT_AwardSharedItem), it takes an arbitrary string,
         // and it cannot interfere with the item-get queue. A fully native
         // textbox is a follow-up that needs that display-only path first.
+        //
+        // FIELD ARRANGEMENT (#494): verb in `.message`, item name in `.suffix`,
+        // matching the native rando pickup toasts further down this file.
+        // Options colours each field differently, so the earlier `.prefix` +
+        // `.message` form rendered this pickup in blue-then-grey where every
+        // ordinary one is grey-then-red.
         const char* foreignName = Combo_GetForeignItemName(*foreignItem);
         const char* foreignArticle = Combo_GetForeignItemArticle(*foreignItem);
         Notification::Emit({
-            .prefix = "You found",
-            .message = std::string(foreignArticle != nullptr ? foreignArticle : "") +
-                       (foreignName != nullptr ? foreignName : "a foreign item"),
+            .message = "You found ",
+            .suffix = std::string(foreignArticle != nullptr ? foreignArticle : "") +
+                      (foreignName != nullptr ? foreignName : "a foreign item"),
         });
 
         // RCSHOW_COLLECTED is what HasObtained() reads (status == RCSHOW_COLLECTED

--- a/games/oot/soh/GameExports_SingleExe.cpp
+++ b/games/oot/soh/GameExports_SingleExe.cpp
@@ -1077,12 +1077,20 @@ static void OoT_AwardSharedItem(const SharedItem* item, void* ctx) {
     // pinned pool via the origin-tagged SharedItem, so this never fabricates an
     // id-space crossing; both return NULL when that origin's pool is not linked
     // into this build, hence the fallbacks.
+    //
+    // FIELD ARRANGEMENT (#494): verb in `.message`, item name in `.suffix` —
+    // the arrangement every OTHER OoT rando pickup toast uses
+    // (Enhancements/randomizer/hook_handlers.cpp). Options colours each field
+    // differently, so the earlier `.prefix` + `.message` form rendered a foreign
+    // arrival in blue-then-grey where an ordinary pickup is grey-then-red. That
+    // difference is visible at a glance and reads as "this one is special",
+    // which is the class of tell #510 removed from the model and the text.
     const char* foreignName = Combo_GetForeignItemName(*item);
     const char* foreignArticle = Combo_GetForeignItemArticle(*item);
     Notification::Emit({
-        .prefix = "You got",
-        .message = std::string(foreignArticle != nullptr ? foreignArticle : "") +
-                   (foreignName != nullptr ? foreignName : "a foreign item"),
+        .message = "You got ",
+        .suffix = std::string(foreignArticle != nullptr ? foreignArticle : "") +
+                  (foreignName != nullptr ? foreignName : "a foreign item"),
     });
 }
 

--- a/src/common/tests/test_foreign_award.c
+++ b/src/common/tests/test_foreign_award.c
@@ -265,18 +265,24 @@ TestResult Test_ForeignAwardMM(void) {
     // pickup toast, and this is the honest lock on it — the pixels are the
     // operator's to verify, the RESOLUTION is CI's.
     //
-    // The assertion is an EQUALITY against the pooled descriptor, not a
-    // non-empty check, and that is what makes it falsifiable in both
-    // directions:
-    //   - a tell added back to the toast ("… from Ocarina of Time", an origin
-    //     badge) breaks the equality, because the descriptor carries the item's
-    //     name and nothing else;
+    // The assertion is an EQUALITY against the WHOLE toast — every field the
+    // overlay draws, joined the way it draws them — and not a non-empty check
+    // on the item name. That is what makes it falsifiable in both directions:
+    //   - any tell added back anywhere in the toast breaks the equality: "…
+    //     from Ocarina of Time" appended to the verb, an origin badge parked in
+    //     the unused `.prefix`, a changed verb. An item-name-only observable
+    //     would have missed all three, which is the whole point of asserting
+    //     the rendered line instead;
     //   - MM's item table drifting away from kForeignPoolMMV1's generated
     //     article/name columns also breaks it, and those columns are a
     //     persistence key (the spoiler-load inverse), so that drift matters
     //     beyond display.
     // Two independent tables have to agree; neither is derived from the other
     // at runtime.
+    //
+    // The expected line is "You got " + article + name because
+    // ComboForeignItemDef.article carries its own trailing space (foreign_items.h)
+    // while the verb is a separate Options field the overlay spaces itself.
     {
         const ComboForeignItemDef* mmPool = NULL;
         const int mmCount = Combo_GetForeignItemPoolFor((uint8_t)GAME_MM, &mmPool);
@@ -287,9 +293,9 @@ TestResult Test_ForeignAwardMM(void) {
             const int len = MM_ForeignItem_TestArrivalText(mmPool[i].item.id, shown, (int)sizeof(shown));
             FA_ASSERT(len > 0);
             FA_ASSERT(mmPool[i].article != NULL);
-            snprintf(expected, sizeof(expected), "%s%s", mmPool[i].article, mmPool[i].name);
+            snprintf(expected, sizeof(expected), "You got %s%s", mmPool[i].article, mmPool[i].name);
             if (strcmp(shown, expected) != 0) {
-                printf("[TEST] FAIL: arrival toast for pool entry %d shows '%s', pool says '%s'\n", i, shown, expected);
+                printf("[TEST] FAIL: arrival toast for pool entry %d shows '%s', expected '%s'\n", i, shown, expected);
                 return TEST_FAIL;
             }
             // The icon is allowed to be absent — Emit renders a text-only toast

--- a/src/common/tests/test_foreign_award.c
+++ b/src/common/tests/test_foreign_award.c
@@ -60,6 +60,11 @@ void MM_ForeignItem_TestResetPending(void);
 int MM_ForeignItem_TestItemIdMax(void);
 int MM_ForeignItem_TestIsGiveableId(uint16_t riId);
 
+// The arrival toast's payload, as the give builds it (#494). Same
+// BuildArrivalToast the Notification::Emit in GiveNow is handed.
+int MM_ForeignItem_TestArrivalText(uint16_t riId, char* out, int cap);
+const char* MM_ForeignItem_TestArrivalIcon(uint16_t riId);
+
 // The RandoItemId sentinels, from the #488 bridge block in Rando/Foreign.cpp.
 void MM_Rando_Foreign_TestItemSentinels(uint16_t* outJunk, uint16_t* outNone, uint16_t* outUnknown);
 }
@@ -229,11 +234,11 @@ TestResult Test_ForeignAwardMM(void) {
     //
     // Deliberately RED-able: this walks EVERY registered origin's pool, so an
     // entry added later without a name fails here rather than at whichever
-    // surface the player happens to reach first. It does NOT assert anything
-    // about the icon — that tier needs a per-item icon-name accessor that
-    // src/common does not have yet (see the report note on Lane 1), and
-    // asserting the current hardcoded RI_RUPEE_HUGE stand-in would lock in the
-    // placeholder rather than the contract.
+    // surface the player happens to reach first. It still asserts nothing about
+    // the icon: a foreign item is drawn model-less and toasted without an icon
+    // in the game that is NOT its own (#510), because reaching the other game's
+    // icon needs a cross-archive accessor src/common does not have. The one
+    // place an icon IS native — MM receiving an MM item — is locked in (8).
     for (uint8_t origin = 0; origin < (uint8_t)RSBS_FOREIGN_POOL_ORIGIN_COUNT; origin++) {
         const ComboForeignItemDef* originPool = NULL;
         const int n = Combo_GetForeignItemPoolFor(origin, &originPool);
@@ -251,12 +256,61 @@ TestResult Test_ForeignAwardMM(void) {
         }
     }
 
+    // ------------------------------------------------------------------
+    // (8) The MM ARRIVAL toast names the item, natively (#494).
+    // ------------------------------------------------------------------
+    // Until #494 the MM arrival was SILENT: MM_AwardSharedItem logged to stderr
+    // and the item simply appeared in the inventory, an arbitrary number of
+    // scenes after the OoT check that granted it. The give now emits MM's own
+    // pickup toast, and this is the honest lock on it — the pixels are the
+    // operator's to verify, the RESOLUTION is CI's.
+    //
+    // The assertion is an EQUALITY against the pooled descriptor, not a
+    // non-empty check, and that is what makes it falsifiable in both
+    // directions:
+    //   - a tell added back to the toast ("… from Ocarina of Time", an origin
+    //     badge) breaks the equality, because the descriptor carries the item's
+    //     name and nothing else;
+    //   - MM's item table drifting away from kForeignPoolMMV1's generated
+    //     article/name columns also breaks it, and those columns are a
+    //     persistence key (the spoiler-load inverse), so that drift matters
+    //     beyond display.
+    // Two independent tables have to agree; neither is derived from the other
+    // at runtime.
+    {
+        const ComboForeignItemDef* mmPool = NULL;
+        const int mmCount = Combo_GetForeignItemPoolFor((uint8_t)GAME_MM, &mmPool);
+        char shown[128];
+        char expected[128];
+        FA_ASSERT(mmCount > 0 && mmPool != NULL);
+        for (int i = 0; i < mmCount; i++) {
+            const int len = MM_ForeignItem_TestArrivalText(mmPool[i].item.id, shown, (int)sizeof(shown));
+            FA_ASSERT(len > 0);
+            FA_ASSERT(mmPool[i].article != NULL);
+            snprintf(expected, sizeof(expected), "%s%s", mmPool[i].article, mmPool[i].name);
+            if (strcmp(shown, expected) != 0) {
+                printf("[TEST] FAIL: arrival toast for pool entry %d shows '%s', pool says '%s'\n", i, shown, expected);
+                return TEST_FAIL;
+            }
+            // The icon is allowed to be absent — Emit renders a text-only toast
+            // for a null icon, which is a degradation, not a defect. What must
+            // not happen is an empty-but-present path, which would draw a blank
+            // 24x24 hole where the item icon belongs.
+            const char* icon = MM_ForeignItem_TestArrivalIcon(mmPool[i].item.id);
+            FA_ASSERT(icon == NULL || icon[0] != '\0');
+        }
+        // A sentinel id resolves to nothing rather than to a fabricated string:
+        // the toast is only ever built for an id the give accepted.
+        FA_ASSERT(MM_ForeignItem_TestArrivalText(riNone, shown, (int)sizeof(shown)) == -1);
+        FA_ASSERT(MM_ForeignItem_TestArrivalIcon(riUnknown) == NULL);
+    }
+
     // Leave global state clean for any subsequent row.
     MM_ForeignItem_TestResetPending();
     Combo_ClearSharedItemOutbox();
     ComboContext_Init();
 
     printf("[TEST] PASS: MM's real award reaches the real give once per crossing, defers safely, "
-           "preserves order, and filters by origin\n");
+           "preserves order, filters by origin, and names every arrival natively\n");
     return TEST_PASS;
 }


### PR DESCRIPTION
## Summary

Two presentation holes survived #524 in the cross-game item class, and this closes both.

1. **MM's arrival was completely silent.** `MM_AwardSharedItem` only wrote to stderr, so an MM item picked up in an OoT check appeared in the Termina inventory an arbitrary number of scenes later with zero in-game feedback. That is the "arrives silently" half of #494's title, which #507 fixed on the OoT side; MM never got the other half because its award callback was a log-only stub until #502.
2. **Both OoT foreign toasts rendered in non-native colours.** `Notification::Options` colours each field differently (prefix blue, message grey, suffix red). Every ordinary OoT rando pickup toast is `.message` + `.suffix`; the two foreign ones used `.prefix` + `.message`, so a foreign pickup or arrival was visibly a different colour pair from every other one — a residual "this one is special" tell of exactly the class #510 removed from the model and the text.

## Scope correction, please read

The lane brief said the OoT→MM direction "is keyed on `RI_RUPEE_HUGE`" and that #524 covered only MM→OoT. That is stale, and it was verified at source before any code was written:

- `grep -rn RI_RUPEE_HUGE games/ src/ rsbs/` finds it only in MM's own `Checks.cpp` / `Items.cpp` / `Types.h` rows — **no foreign path uses it at all**.
- `games/mm/2s2h/Rando/MiscBehavior/CheckQueue.cpp:81-131` already draws `Rando::DrawItem(RI_NONE)` with no actor (byte-identical to the native branch's draw), icons the textbox with `GetIconForZMessage(RI_NONE)`, and writes the native sentence `"You found " + article + name + "!"`.
- `Rando::DrawForeignCheckAura` is deleted; the OoT pool already carries articles.

5d612e1c (#524) converted **both** directions' pickup surfaces. That work was not redone.

## What changed

**MM arrival toast** (`games/mm/2s2h/Rando/ForeignItemsSingleExe.cpp`). `BuildArrivalToast` assembles MM's own pickup toast — MM's own icon (`Rando::StaticData::GetIconTexturePath`), MM's own article+name sentence (`GetItemName`), the same `.message` + `.suffix` arrangement MM's native rando pickup toast uses, and no mention of where the item came from. `GiveNow` emits it.

The placement is load-bearing twice, and both reasons are written into the code:

- `MM_AwardSharedItem` runs **before** `MM_gPlayState = this` (z_play.c:2406 vs :2468) — the item does not exist yet at the award point.
- The award point is driven headlessly by `test_foreign_award.c` with no Gui. An `Emit` there would put ImGui + `Audio_PlaySoundGeneral` on a display-free CI path, which is the SIGSEGV class this repo has already been bitten by. `GiveNow` is gameplay-gated by construction: both of its callers require a live `MM_gPlayState`.

A toast rather than the get-item cutscene, because this fires on a frame the player did not initiate — seizing the camera and the message context there would be a hijack.

**OoT toast field arrangement** (`GameExports_SingleExe.cpp` `OoT_AwardSharedItem`, `hook_handlers.cpp` foreign pickup). `.prefix`+`.message` → `.message`+`.suffix`, matching `hook_handlers.cpp:1213-1247`'s native `MOD_NONE` / `MOD_RANDOMIZER` toasts including the trailing space convention (`"You found "`, `"You got "` — the overlay `SameLine`s fields, it does not insert the space). Wording unchanged.

## Lock

`src/common/tests/test_foreign_award.c`, section (8) of the existing redship-tier row `foreign-award-mm` (`CMake/SingleExecutable.cmake:382`).

For **every** entry of MM's real `kForeignPoolMMV1` (128 rows), it drives `MM_ForeignItem_TestArrivalText` — which calls the *same* `BuildArrivalToast` the live `Notification::Emit` is handed, not a paraphrase — and asserts the toast **equals** `"You got " + article + name` from the pooled descriptor.

The review pass widened this. The bridge originally reported only the item-name field, so a tell re-added to the unused `.prefix`, or appended to the verb, would have rendered on screen and left the lock green. `BuildArrivalToast` now returns the whole `Notification::Options` and the bridge reports it joined the way `Notification::Window::Draw` lays it out (non-empty fields, one gap between neighbours), so prose added **anywhere** in the toast breaks the equality.

Falsifiable in both directions: any cross-game prose breaks it, and so does MM's `Items` table drifting from the pool's generated article/name columns — which are the spoiler-**load** persistence key (`Combo_GetForeignItemByNameFor`), so that drift matters well beyond display. Two independent tables must agree and neither is derived from the other at runtime. RED before this change because the bridges do not exist: the target does not link.

Also asserted: a sentinel id resolves to nothing rather than a fabricated string, and a present icon path is never the empty string (NULL stays legal — `Emit` renders text-only).

Pre-flight against a CI red on existing data: all 128 pool rows were parsed and compared offline against `games/mm/2s2h/Rando/StaticData/Items.cpp` — zero mismatches. (`GetItemName` appends `article + " "`, MM's table articles carry no trailing space, and `ComboForeignItemDef.article` carries one; the two conventions compose to the same string.) The icon walk was audited the same way: of the 128 rows, 87 fall through `GetIconTexturePath`'s switch to `MM_gItemIcons[Items[id].itemId]`, and every one of those item ids is below `ITEM_RECOVERY_HEART` (0x83) — none reaches the `D_801CFF94` re-lookup, and none is out of the 131-entry array. No new OOB on the headless path.

## Not done, deliberately

- **The OoT arrival toast still has no item icon**, so MM's arrival is now richer than OoT's. Closing that needs a new icon column on `ComboForeignItemDef` (a `src/common` surface plus a 134-row table touch) or the `Combo_GetForeignItemIconName` accessor of the issue's slice 4 — and the issue's proposed slice-4 lock cannot work as written, because `OoT_ForeignItem_Give` guards on OTRGlobals/`Rando::Context` being live, which is exactly what a headless row lacks. Its own slice.
- No cross-game model or cross-archive icon work (151 object-namespace collisions, `docs/resource-namespace-audit.md`).
- **#427 item 1 is NOT closed.** The MM toast adds a second call site on the deliberate MM→OoT `Notification::Emit` cross-bind. `games/mm/2s2h/mm_notification_binding_test.cpp` still covers the field layout, so the risk is unchanged in kind — but the blast radius is now slightly larger, and the issue explicitly parks "replace with an explicit `MM_Notify_Emit` bridge" on this work. Flagging for the operator rather than silently absorbing it.

Part of #494 — the OoT arrival icon asymmetry above is the remaining piece of the issue's presentation contract.

Not built locally (submodules absent, shared workstation). Every symbol called was read from its real declaration: `Notification::Options` field order/types in both ports' headers, `GetItemName(id, includeArticle = true)` and `GetIconTexturePath` at `Rando/StaticData/StaticData.h:56-57`, and the `MM_gItemIcons` / `D_801CFF94` bounds above. `git diff --stat origin/main...HEAD` is the five intended files; no submodule pointer or generated file is in either commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!--- section:artifacts:start -->
### Build Artifacts
  - [rsbs-windows.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/8735528203.zip)
  - [rsbs-linux.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/8735225666.zip)
<!--- section:artifacts:end -->