### PR TITLE
Share magic across both games as the sixth and seventh shared resources (#525)

### DIFF
--- a/docs/adr/0009-combo-settings-and-reverse-pool.md
+++ b/docs/adr/0009-combo-settings-and-reverse-pool.md
@@ -191,19 +191,25 @@ Publishing the allocation once beats five sequential re-versions:
 | 2 | `comboSettingsHash` (#498 decision 1, Lane 1) | 4 B | reserved |
 | 3 | MM option-profile digest (#497 step 7 / #499 step 4, Lane 4) | 4 B | **carved by Lane 4; size CONFIRMED at 4 B** |
 | 4 | Netplay grant fields (#460, ADR 0005/0007) | 64 B | reserved |
-| 5 | `sharedResources[8]` (#525, shared rupees + hearts) | 32 B | **carved by #525** |
+| 5 | `sharedResources[8]` (#525, shared rupees + hearts + magic) | 32 B | **carved by #525** |
 | 6 | Unallocated floor | 132 B | must not drop below 64 |
 
 Total reserved-against: 152 B of 284. After claims 1, 3 and 5 land, `reserved[]`
 is 180 bytes and 200 B of capacity remain.
 
-**Claim 5, settled (#525, 2026-07-29).** Shared cross-game resources are eight
-kind-tagged 4-byte slots — `ComboSharedResource sharedResources[8]` at `.redsave`
-byte offset **792**, immediately after `mmProfileDigest`. v1 occupies five of the
-eight (rupees, wallet tier, health quarters, current health, double defense);
-shared magic and the ammo upgrades are the queued members of the same class and
-fit in the remaining three without another carve, which is why the claim is sized
-at the array rather than at today's five resources.
+**Claim 5, settled (#525, 2026-07-29; amended for the optional tier).** Shared
+cross-game resources are eight kind-tagged 4-byte slots —
+`ComboSharedResource sharedResources[8]` at `.redsave` byte offset **792**,
+immediately after `mmProfileDigest`. Seven of the eight are occupied: five by
+v1 (rupees, wallet tier, health quarters, current health, double defense) and
+two by shared magic (meter level + current magic, kinds 6 and 7), which is why
+the claim is sized at the array rather than at any moment's resource count. The
+ammo upgrades — the queued remainder of the class — need ~10 more kinds and do
+NOT fit in the one remaining slot: per this ADR's own prescription they arrive
+as a SECOND block carved from the front of `reserved[]`, spanned together with
+this one by every accessor in `shared_resources.c`, never by bumping
+`RSBS_SHARED_RESOURCE_CAP` in place (the widen would move every field carved
+after the array off its shipped offset).
 
 The tag is load-bearing, not bookkeeping. This ADR's growth contract is "zero
 means unset", and **0 rupees is a legal player state** — so a bare `uint16_t

--- a/games/mm/2s2h/GameExports_SingleExe.cpp
+++ b/games/mm/2s2h/GameExports_SingleExe.cpp
@@ -2170,6 +2170,67 @@ static uint16_t MM_ReadHealthQuarters(void) {
     return Combo_MakeHealthQuarters(rawCapacity < 0 ? 0u : (uint16_t)rawCapacity, pieces);
 }
 
+// Magic meter level (0 none / 1 single / 2 double) from the two acquired
+// FLAGS — never from playerData.magicLevel, which Sram_OpenSave zeroes on
+// every file load as the meter-regrow trigger. See the OoT twin.
+static uint16_t MM_ReadMagicLevel(void) {
+    if (!gSaveContext.save.saveInfo.playerData.isMagicAcquired) {
+        return 0u;
+    }
+    return gSaveContext.save.saveInfo.playerData.isDoubleMagicAcquired ? 2u : 1u;
+}
+
+// Current magic with pending CREDITS settled in, the twin of
+// OoT_ReadSettledMagic. MM parks the true amount in magicFillTarget during the
+// meter regrow (MM_Interface_Update zeroes playerData.magic there — the same
+// window MM_Sram_OpenSave opens on every load) and carries magic-jar credit in
+// the magicToAdd accumulator that Magic_UpdateAddRequest drains a few units
+// per frame. Pending debits (the CONSUME_* family, including MM's
+// lens/Goron/Zora/Giant's Mask slow drains) are deliberately not settled, for
+// the reason the OoT twin gives. Nothing is written back here; the APPLY side
+// zeroes magicToAdd after authoring an authoritative amount, which is what
+// keeps a frozen accumulator from draining on top of an applied value and
+// being counted twice.
+static uint16_t MM_ReadSettledMagic(void) {
+    const uint16_t level = MM_ReadMagicLevel();
+    if (level == 0u) {
+        // A fresh MM save parks MAGIC_NORMAL_METER in playerData.magic before
+        // any meter exists (the Sram default-data table). Without a meter that
+        // is not magic, and it must not enter the pool as phantom credit.
+        return 0u;
+    }
+    const s8 rawMagic = gSaveContext.save.saveInfo.playerData.magic;
+    int32_t settled = rawMagic < 0 ? 0 : (int32_t)rawMagic;
+    switch (gSaveContext.magicState) {
+        case MAGIC_STATE_STEP_CAPACITY:
+        case MAGIC_STATE_FILL:
+            if ((int32_t)gSaveContext.magicFillTarget > settled) {
+                settled = (int32_t)gSaveContext.magicFillTarget;
+            }
+            break;
+        default:
+            break;
+    }
+    if (gSaveContext.magicToAdd > 0) {
+        settled += (int32_t)gSaveContext.magicToAdd;
+    }
+    // MM's parked PRE-regrow idiom, the twin of the OoT helper's last fold:
+    // the kaleido game-over continue parks the amount in magicFillTarget with
+    // magic == 0 and magicLevel == 0, machine IDLE, and the regrow that would
+    // move it back is transition-gated — an F10 harvest inside that fade would
+    // otherwise read 0 and debit the pool by the pre-death meter. Gated on
+    // magic == 0 as well as magicLevel == 0 because MM's plain file load
+    // (unlike OoT's) does NOT author magicFillTarget — it leaves the loaded
+    // amount in playerData.magic — so a stale RAM fillTarget must not outvote
+    // a genuine nonzero balance.
+    if (gSaveContext.save.saveInfo.playerData.magicLevel == 0 && rawMagic == 0 &&
+        (int32_t)gSaveContext.magicFillTarget > settled) {
+        settled = (int32_t)gSaveContext.magicFillTarget;
+    }
+    const int32_t cap = (int32_t)level * MAGIC_NORMAL_METER;
+    return (uint16_t)(settled > cap ? cap : settled);
+}
+
 /**
  * HARVEST (#525), the twin of OoT_HarvestSharedResources.
  *
@@ -2199,6 +2260,8 @@ extern "C" void MM_HarvestSharedResources(void) {
         gSaveContext.save.saveInfo.playerData.health < 0 ? 0u : (uint16_t)gSaveContext.save.saveInfo.playerData.health);
     Combo_HarvestSharedResource(GAME_MM, RSBS_SHARED_RES_DOUBLE_DEFENSE,
                                 gSaveContext.save.saveInfo.playerData.doubleDefense ? 1u : 0u);
+    Combo_HarvestSharedResource(GAME_MM, RSBS_SHARED_RES_MAGIC_LEVEL, MM_ReadMagicLevel());
+    Combo_HarvestSharedResource(GAME_MM, RSBS_SHARED_RES_MAGIC_CURRENT, MM_ReadSettledMagic());
 }
 
 /**
@@ -2266,6 +2329,59 @@ extern "C" void MM_ApplySharedResources(void) {
         // arrival lands in a death handler no arrival path has been tested
         // through.
         gSaveContext.save.saveInfo.playerData.health = (s16)(health < 0x10u ? 0x10u : health);
+    }
+
+    // --- Magic level (monotonic 0/1/2), then current magic clamped against it.
+    // The settled-current snapshot is taken BEFORE the level apply moves the
+    // acquired flags. This ordering is load-bearing on MM's side: a fresh MM
+    // save parks MAGIC_NORMAL_METER in playerData.magic with NO meter acquired
+    // (the Sram default-data table), and the settled read discards that
+    // residue only while the level is still 0. Reading it after the flag flip
+    // would promote the residue into a full phantom meter whenever the pool
+    // carries a level but no current slot (e.g. OoT earned the meter and spent
+    // it to exactly zero before crossing).
+    uint16_t magic = MM_ReadSettledMagic();
+    uint16_t magicLevel = MM_ReadMagicLevel();
+    const bool magicLevelShared = Combo_ApplySharedResource(GAME_MM, RSBS_SHARED_RES_MAGIC_LEVEL, 2u, &magicLevel);
+    if (magicLevelShared) {
+        if (magicLevel >= 1u) {
+            gSaveContext.save.saveInfo.playerData.isMagicAcquired = 1;
+        }
+        if (magicLevel >= 2u) {
+            gSaveContext.save.saveInfo.playerData.isDoubleMagicAcquired = 1;
+        }
+    }
+
+    // --- Current magic (consumable): one meter across both games. The cap is
+    // DERIVED from the level just applied, never read from live magicCapacity,
+    // which the boot chain leaves at 0 until the growth machine runs.
+    const uint16_t magicCap = (uint16_t)(magicLevel * MAGIC_NORMAL_METER);
+    const bool magicShared = Combo_ApplySharedResource(GAME_MM, RSBS_SHARED_RES_MAGIC_CURRENT, magicCap, &magic);
+
+    if ((magicLevelShared || magicShared) && magicLevel != 0u) {
+        // Re-author through MM's own file-load shape (MM_Sram_OpenSave): the
+        // amount stays in playerData.magic and only magicLevel is zeroed;
+        // MM_Interface_Update's regrow block then parks it in magicFillTarget
+        // ITSELF (magicFillTarget = playerData.magic; magic = 0) on its way
+        // into STEP_CAPACITY -> FILL. This is the one place MM's regrow
+        // differs from OoT's, and it is load-bearing: OoT's regrow leaves an
+        // externally-authored magicFillTarget alone, so OoT's apply parks the
+        // amount THERE — doing that here instead gets the target overwritten
+        // with the zeroed magic field and the meter refills to empty (caught
+        // by the int-gameplay-roundtrip probe, not by any ROM-free tier).
+        gSaveContext.magicState = MAGIC_STATE_IDLE;
+        gSaveContext.magicFlag = 0;
+        gSaveContext.magicCapacity = 0;
+        gSaveContext.save.saveInfo.playerData.magicLevel = 0;
+        gSaveContext.save.saveInfo.playerData.magic = (s8)(magic > magicCap ? magicCap : magic);
+        // The harvest that filled the pool already counted any pending
+        // magic-jar credit, so a frozen request draining on top of the amount
+        // just authored would be counted twice at the next harvest. Same rule
+        // as rupeeAccumulator, one accumulator further along; the stale consume
+        // request dies with it.
+        gSaveContext.isMagicRequested = 0;
+        gSaveContext.magicToAdd = 0;
+        gSaveContext.magicToConsume = 0;
     }
 }
 

--- a/games/mm/2s2h/Rando/ForeignItemsSingleExe.cpp
+++ b/games/mm/2s2h/Rando/ForeignItemsSingleExe.cpp
@@ -162,29 +162,31 @@ extern "C" {
 //      pickup text promises an award in Termina; delivering MM's trap machinery
 //      instead would make that text a lie.
 //
-//  (6) It is NOT a shared cross-game resource (#525). Rupees and hearts are one
-//      quantity spanning both games now — one wallet, one health bar, capacity
-//      AND current value (src/common/shared_resources.h) — so there is nothing
-//      left for a wallet or heart item to CROSS. Shipping one anyway would hand
+//  (6) It is NOT a shared cross-game resource (#525). Rupees, hearts and magic
+//      are one quantity spanning both games now — one wallet, one health bar,
+//      one magic meter, capacity AND current value
+//      (src/common/shared_resources.h) — so there is nothing left for a
+//      wallet, heart or magic item to CROSS. Shipping one anyway would hand
 //      the player a second copy of a capacity they already have, or worse, a
 //      rupee award that the next harvest reconciles straight back out. Six rows
 //      left with the sharing that replaced them: RI_PROGRESSIVE_WALLET,
 //      RI_WALLET_ADULT, RI_WALLET_GIANT, RI_DOUBLE_DEFENSE, RI_HEART_CONTAINER
-//      and RI_HEART_PIECE.
+//      and RI_HEART_PIECE. Three more left when shared magic landed (#525's
+//      optional tier): RI_PROGRESSIVE_MAGIC, RI_SINGLE_MAGIC and
+//      RI_DOUBLE_MAGIC.
 //
 //      Note RI_DOUBLE_DEFENSE was NOT in the "Health" block — it sat under core
 //      equipment, so a block delete misses it. The block-shaped grouping below
 //      is presentational; criterion 6 is not.
 //
-//      This criterion grows with the shared-resource set. Shared magic and the
-//      ammo upgrades are the queued members of that class, and when they land,
-//      RI_PROGRESSIVE_MAGIC / RI_SINGLE_MAGIC / RI_DOUBLE_MAGIC and the
-//      quiver/bomb-bag rows leave by this same rule — see the collision trap in
-//      #525's optional tier before deleting the bomb bags, since "Bomb Bag" is
-//      the only name shared with OoT's pool and a test depends on it.
+//      This criterion grows with the shared-resource set. The ammo upgrades
+//      are the queued remainder of that class, and when they land the
+//      quiver/bomb-bag rows leave by this same rule — see the collision trap
+//      in #525's optional tier before deleting the bomb bags, since "Bomb Bag"
+//      is the only name shared with OoT's pool and a test depends on it.
 //
 // Everything else is IN — every mask, every song, every bottle, both shields,
-// the sword and magic and quiver and bomb-bag upgrades, the
+// the sword and quiver and bomb-bag upgrades, the
 // progressives (which resolve against the LIVE MM save, so they are the single
 // best-behaved cross-game gift, and the OoT pool sets the precedent with
 // RG_PROGRESSIVE_HOOKSHOT / RG_PROGRESSIVE_STRENGTH), the boss remains, the
@@ -201,7 +203,7 @@ extern "C" {
 // deferred to the first frame with a live MM_gPlayState (see the file header),
 // which is item-agnostic and O(1) in pool size — the #502 design note says in as
 // many words that an allowlist audited against today's pool would expire the
-// moment somebody added a row. This pool is that row, 128 times over, and it
+// moment somebody added a row. This pool is that row, 125 times over, and it
 // relies on the deferral instead of re-auditing it.
 //
 // Display names are MM's own (Rando::StaticData::Items) verbatim. They are a
@@ -216,7 +218,6 @@ static const ComboForeignItemDef kForeignPoolMMV1[] = {
     { { (uint8_t)GAME_MM, 0, (uint16_t)RI_PROGRESSIVE_SWORD }, "Progressive Sword", "a " },
     { { (uint8_t)GAME_MM, 0, (uint16_t)RI_PROGRESSIVE_BOW }, "Progressive Bow", "a " },
     { { (uint8_t)GAME_MM, 0, (uint16_t)RI_PROGRESSIVE_BOMB_BAG }, "Progressive Bomb Bag", "a " },
-    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_PROGRESSIVE_MAGIC }, "Progressive Magic", "" },
     { { (uint8_t)GAME_MM, 0, (uint16_t)RI_PROGRESSIVE_LULLABY }, "Progressive Goron Lullaby", "" },
 
     // --- Core equipment, abilities and capacity upgrades.
@@ -242,8 +243,6 @@ static const ComboForeignItemDef kForeignPoolMMV1[] = {
     { { (uint8_t)GAME_MM, 0, (uint16_t)RI_SWORD_GILDED }, "Gilded Sword", "the " },
     { { (uint8_t)GAME_MM, 0, (uint16_t)RI_GREAT_FAIRY_SWORD }, "Great Fairy's Sword", "the " },
     { { (uint8_t)GAME_MM, 0, (uint16_t)RI_GREAT_SPIN_ATTACK }, "Great Spin Attack", "the " },
-    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_SINGLE_MAGIC }, "Power of Magic", "the " },
-    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_DOUBLE_MAGIC }, "Magic Upgrade", "a " },
 
     // --- Bottles (the bottle itself, not its refills).
     { { (uint8_t)GAME_MM, 0, (uint16_t)RI_BOTTLE_EMPTY }, "Empty Bottle", "an " },

--- a/games/oot/soh/GameExports_SingleExe.cpp
+++ b/games/oot/soh/GameExports_SingleExe.cpp
@@ -1145,6 +1145,76 @@ static uint16_t OoT_ReadHealthQuarters(void) {
     return Combo_MakeHealthQuarters(capacity, pieces);
 }
 
+// Magic meter level (0 none / 1 single / 2 double), derived from the two
+// acquired FLAGS. Never from magicLevel: Sram_OpenSave zeroes magicLevel on
+// every file load and the interface treats "acquired but level 0" as its
+// meter-regrow trigger, so magicLevel is transiently 0 on exactly the frames a
+// suspend or a mid-play save can land on.
+static uint16_t OoT_ReadMagicLevel(void) {
+    if (!gSaveContext.isMagicAcquired) {
+        return 0u;
+    }
+    return gSaveContext.isDoubleMagicAcquired ? 2u : 1u;
+}
+
+// Current magic with the state machine's pending CREDITS settled in — the
+// magic twin of the rupeeAccumulator fold, except nothing is written back:
+// advancing the watermark to the settled value is enough, because the machine
+// completing later brings the live field to exactly this number (delta zero),
+// and on a switch the arrival path wipes the machine to IDLE and the apply
+// re-authors the amount from the pool.
+//
+//   - STEP_CAPACITY / FILL: the true amount is parked in magicFillTarget and
+//     `magic` itself can read 0 — the file-load meter-regrow window
+//     (z_file_choose parks the saved amount there) and the tail of every
+//     magic-upgrade give.
+//   - ADD: a magic jar's credit is stepping toward magicTarget.
+//   - The CONSUME_* family is deliberately NOT settled: a staged debit dies
+//     with the machine on a switch (the spell never completed, so its cost is
+//     refunded), and on a mid-play save the machine finishes normally and the
+//     next harvest picks the decrement up as an ordinary spend.
+//
+// A game with no meter reports 0 regardless of the raw field, so a stale
+// `magic` value can never enter the pool as phantom credit.
+static uint16_t OoT_ReadSettledMagic(void) {
+    const uint16_t level = OoT_ReadMagicLevel();
+    if (level == 0u) {
+        return 0u;
+    }
+    int32_t settled = gSaveContext.magic < 0 ? 0 : (int32_t)gSaveContext.magic;
+    switch (gSaveContext.magicState) {
+        case MAGIC_STATE_STEP_CAPACITY:
+        case MAGIC_STATE_FILL:
+            if ((int32_t)gSaveContext.magicFillTarget > settled) {
+                settled = (int32_t)gSaveContext.magicFillTarget;
+            }
+            break;
+        case MAGIC_STATE_ADD:
+            if ((int32_t)gSaveContext.magicTarget > settled) {
+                settled = (int32_t)gSaveContext.magicTarget;
+            }
+            break;
+        default:
+            break;
+    }
+    // The parked PRE-regrow idiom is state-machine-invisible: a file load, the
+    // debug-save injection, and this file's own apply all leave the true
+    // amount in magicFillTarget with magic == 0, magicLevel == 0 and the
+    // machine IDLE — and it STAYS that way for the whole arrival fade, because
+    // the regrow trigger is transition-gated. A harvest landing inside that
+    // window (F10 is polled ungated every frame; the interval autosave's
+    // OnSaveFile also harvests) would otherwise read 0 against a watermark
+    // holding the applied amount and debit the pool by a full meter. The
+    // signature is exact — acquired flags set (level != 0 above) with
+    // magicLevel still 0 and magic still 0 — and every OoT path that produces
+    // it authors magicFillTarget, so the park is trustworthy here.
+    if (gSaveContext.magicLevel == 0 && gSaveContext.magic == 0 && (int32_t)gSaveContext.magicFillTarget > settled) {
+        settled = (int32_t)gSaveContext.magicFillTarget;
+    }
+    const int32_t cap = (int32_t)level * MAGIC_NORMAL_METER;
+    return (uint16_t)(settled > cap ? cap : settled);
+}
+
 /**
  * HARVEST (#525). Fold OoT's live resource values into the shared pool.
  *
@@ -1178,6 +1248,8 @@ extern "C" void OoT_HarvestSharedResources(void) {
                                 gSaveContext.health < 0 ? 0u : (uint16_t)gSaveContext.health);
     Combo_HarvestSharedResource(GAME_OOT, RSBS_SHARED_RES_DOUBLE_DEFENSE,
                                 gSaveContext.isDoubleDefenseAcquired ? 1u : 0u);
+    Combo_HarvestSharedResource(GAME_OOT, RSBS_SHARED_RES_MAGIC_LEVEL, OoT_ReadMagicLevel());
+    Combo_HarvestSharedResource(GAME_OOT, RSBS_SHARED_RES_MAGIC_CURRENT, OoT_ReadSettledMagic());
 }
 
 /**
@@ -1251,6 +1323,51 @@ extern "C" void OoT_ApplySharedResources(void) {
         // cross-game arrival lands in a death handler no arrival path has ever
         // been tested through.
         gSaveContext.health = (s16)(health < 0x10u ? 0x10u : health);
+    }
+
+    // --- Magic level (monotonic 0/1/2), then current magic clamped against it.
+    // The settled-current snapshot is taken BEFORE the level apply moves the
+    // acquired flags: the settled read gates on the game's own PRE-apply level,
+    // which is what keeps a magic-less half's residue (see the MM twin) from
+    // being promoted into real magic by the flag flip when the pool carries a
+    // level but no current slot.
+    uint16_t magic = OoT_ReadSettledMagic();
+    uint16_t magicLevel = OoT_ReadMagicLevel();
+    const bool magicLevelShared = Combo_ApplySharedResource(GAME_OOT, RSBS_SHARED_RES_MAGIC_LEVEL, 2u, &magicLevel);
+    if (magicLevelShared) {
+        if (magicLevel >= 1u) {
+            gSaveContext.isMagicAcquired = 1;
+        }
+        if (magicLevel >= 2u) {
+            gSaveContext.isDoubleMagicAcquired = 1;
+        }
+    }
+
+    // --- Current magic (consumable): one meter across both games, per OoTMM:
+    // "current magic is tracked as if OoT and MM were one game with a single
+    // magic meter". The cap is DERIVED from the level just applied, never read
+    // from live magicCapacity — at this point in the arrival the boot chain has
+    // not run the growth machine, so magicCapacity can be 0 or partial.
+    const uint16_t magicCap = (uint16_t)(magicLevel * MAGIC_NORMAL_METER);
+    const bool magicShared = Combo_ApplySharedResource(GAME_OOT, RSBS_SHARED_RES_MAGIC_CURRENT, magicCap, &magic);
+
+    if ((magicLevelShared || magicShared) && magicLevel != 0u) {
+        // Re-author through the vanilla file-load idiom (z_file_choose): park
+        // the amount in magicFillTarget, zero magic/magicLevel/magicCapacity,
+        // idle the machine, and let OoT_Interface_Update regrow the bar from
+        // the acquired flags (STEP_CAPACITY -> FILL) exactly as every file load
+        // does. Direct field writes would have to reproduce the
+        // level/capacity/HUD invariants by hand — and the idiom also repairs a
+        // blob frozen mid-regrow, whose magicCapacity is otherwise stranded at
+        // a partial value for the rest of the session (the regrow trigger
+        // requires magicLevel == 0, which only this and a real file load
+        // re-establish).
+        gSaveContext.magicFillTarget = (s16)(magic > magicCap ? magicCap : magic);
+        gSaveContext.magic = 0;
+        gSaveContext.magicLevel = 0;
+        gSaveContext.magicCapacity = 0;
+        gSaveContext.magicState = MAGIC_STATE_IDLE;
+        gSaveContext.prevMagicState = MAGIC_STATE_IDLE;
     }
 }
 

--- a/src/common/context.h
+++ b/src/common/context.h
@@ -238,9 +238,12 @@ int Context_ArmShadowAsFrozen(GameId game, uint16_t returnEntrance);
  * RESOURCES can be tracked at once. A shared resource is not an item that
  * crosses once — it is ONE QUANTITY spanning both games, capacity and current
  * value together ("current health is tracked as if OoT and MM were one game
- * with a single health bar"). v1 occupies five of the eight slots (rupees,
- * wallet tier, health quarters, current health, double defense); magic and the
- * ammo upgrades are the queued members of the same class.
+ * with a single health bar"). Seven of the eight slots are occupied — five by
+ * v1 (rupees, wallet tier, health quarters, current health, double defense)
+ * and two by shared magic (level + current, #525's optional tier) — leaving
+ * ONE free. The ammo upgrades are the queued remainder of the class and need
+ * ~10 slots, so they arrive with the second block prescribed below, not by
+ * squeezing into this one.
  *
  * DO NOT BUMP THIS CONSTANT to get more capacity, for the reason
  * RSBS_GRANT_SOURCE_CAP spells out: the array is carved from the front of
@@ -361,6 +364,8 @@ enum {
     RSBS_SHARED_RES_HEALTH_QUARTERS = 3,  // MONOTONIC: capacity + pieces*4, the canonical heart quantity
     RSBS_SHARED_RES_HEALTH_CURRENT = 4,   // CONSUMABLE: the single shared health bar, in 0x10-per-heart units
     RSBS_SHARED_RES_DOUBLE_DEFENSE = 5,   // MONOTONIC: 0/1 flag; each game sets its OWN differently-named field pair
+    RSBS_SHARED_RES_MAGIC_LEVEL = 6,      // MONOTONIC: meter level 0/1/2 from the two acquired FLAGS, never magicLevel
+    RSBS_SHARED_RES_MAGIC_CURRENT = 7,    // CONSUMABLE: the single shared magic meter, 0x30 per bar in both games
 };
 
 /**

--- a/src/common/shared_resources.c
+++ b/src/common/shared_resources.c
@@ -55,10 +55,12 @@ static bool IsMonotonicKind(uint8_t kind) {
         case RSBS_SHARED_RES_WALLET_TIER:
         case RSBS_SHARED_RES_HEALTH_QUARTERS:
         case RSBS_SHARED_RES_DOUBLE_DEFENSE:
+        case RSBS_SHARED_RES_MAGIC_LEVEL:
             return true;
         default:
-            // RSBS_SHARED_RES_RUPEES, RSBS_SHARED_RES_HEALTH_CURRENT: the
-            // player spends these, so they are delta-harvested.
+            // RSBS_SHARED_RES_RUPEES, RSBS_SHARED_RES_HEALTH_CURRENT,
+            // RSBS_SHARED_RES_MAGIC_CURRENT: the player spends these, so they
+            // are delta-harvested.
             return false;
     }
 }

--- a/src/common/shared_resources.h
+++ b/src/common/shared_resources.h
@@ -13,27 +13,29 @@
  *   "Current health is tracked as if OoT and MM were one game with a single
  *    health bar."
  *
- * v1 shares rupees and hearts. That is what justifies the matching pool shrink
- * in `kForeignPoolMMV1` (#525): with one wallet and one health bar spanning
- * both games, MM's wallet/heart/double-defense rows are no longer separate
- * items to cross — they ARE the shared resource, so shipping them as foreign
- * placements too would hand the player a second copy of a quantity they
- * already have. Shared magic and the ammo upgrades are the queued members of
- * the same class.
+ * v1 shares rupees and hearts; the #525 optional tier added magic — meter
+ * level and current magic, "current magic is tracked as if OoT and MM were one
+ * game with a single magic meter". That is what justifies the matching pool
+ * shrink in `kForeignPoolMMV1` (#525): with one wallet, one health bar and one
+ * magic meter spanning both games, MM's wallet/heart/double-defense/magic rows
+ * are no longer separate items to cross — they ARE the shared resource, so
+ * shipping them as foreign placements too would hand the player a second copy
+ * of a quantity they already have. The ammo upgrades are the queued remainder
+ * of the same class.
  *
  * ---------------------------------------------------------------------------
  * THE TWO MERGE DISCIPLINES
  * ---------------------------------------------------------------------------
  * Picking the wrong one is a correctness bug, not a style choice.
  *
- *   MONOTONIC — wallet tier, health quarters, double defense. A capacity that
- *   only ever grows. Harvest is `shared = max(shared, live)`, apply is
- *   `live = max(live, shared)`. Idempotent in both directions; decay is
- *   impossible by construction, so no bookkeeping is needed.
+ *   MONOTONIC — wallet tier, health quarters, double defense, magic level. A
+ *   capacity that only ever grows. Harvest is `shared = max(shared, live)`,
+ *   apply is `live = max(live, shared)`. Idempotent in both directions; decay
+ *   is impossible by construction, so no bookkeeping is needed.
  *
- *   CONSUMABLE — rupee count, current health. A quantity the player spends.
- *   Harvest takes a DELTA against a watermark recorded at apply time, never a
- *   raw copy.
+ *   CONSUMABLE — rupee count, current health, current magic. A quantity the
+ *   player spends. Harvest takes a DELTA against a watermark recorded at apply
+ *   time, never a raw copy.
  *
  * THE WATERMARK IS MANDATORY. MM's tier-3 wallet holds 500 and OoT's holds 999
  * (`gUpgradeCapacities`, both games). Under a naive `shared = live` harvest,
@@ -105,7 +107,7 @@ extern "C" {
  * table, which is indexed by KIND (stable) rather than by slot (slots are found
  * by scan and a future compaction could move them).
  */
-#define RSBS_SHARED_RES_KIND_COUNT 6u
+#define RSBS_SHARED_RES_KIND_COUNT 8u
 
 /**
  * Canonical heart quantity ceiling, in health units (0x10 per heart, 4 per

--- a/src/common/tests/test_foreign_items.c
+++ b/src/common/tests/test_foreign_items.c
@@ -858,6 +858,11 @@ TestResult Test_ForeignPoolMM(void) {
     static const char* const kSharedResourceNames[] = {
         "Progressive Wallet", "Adult's Wallet",  "Giant's Wallet",
         "Double Defense",     "Heart Container", "Heart Piece",
+        // Shared magic (#525's optional tier): one meter across both games, so
+        // the three MM magic rows left by the same criterion. Exact display
+        // names, spelled from the pool's own rows — a typo here passes
+        // vacuously, because the assertion is a not-equal sweep.
+        "Progressive Magic",  "Power of Magic",  "Magic Upgrade",
     };
     for (size_t k = 0; k < sizeof(kSharedResourceNames) / sizeof(kSharedResourceNames[0]); k++) {
         for (int i = 0; i < poolCount; i++) {
@@ -868,9 +873,9 @@ TestResult Test_ForeignPoolMM(void) {
         FI_ASSERT(!Combo_GetForeignItemByNameFor((uint8_t)GAME_MM, kSharedResourceNames[k], NULL));
     }
 
-    // The shrink is real, not a rename: those six rows left and nothing took
+    // The shrink is real, not a rename: those nine rows left and nothing took
     // their place. Bounded rather than exact for the reason above — a future
-    // shared resource (magic, ammo) removes more, and unrelated work may add.
+    // shared resource (ammo) removes more, and unrelated work may add.
     printf("[TEST] foreign-pool-mm: %d entries after the #525 shared-resource shrink\n", poolCount);
     FI_ASSERT(poolCount <= 128);
 

--- a/src/common/tests/test_shared_resources.c
+++ b/src/common/tests/test_shared_resources.c
@@ -292,6 +292,52 @@ TestResult Test_SharedResources(void) {
     SR_ASSERT(health == 0x20);
 
     // ------------------------------------------------------------------
+    // Magic (#525's optional tier): the meter level is a MONOTONIC capacity
+    // and current magic a CONSUMABLE — the wallet/rupee split, one resource
+    // over. Units are shared verbatim (0x30 per bar in both games), so the
+    // games' caps differ only by LEVEL: a single-magic game can display at
+    // most 0x30 of a double-magic pool.
+    // ------------------------------------------------------------------
+    SR_FreshWorld();
+    // OoT earned double magic; MM holds single. The level never downgrades.
+    Combo_HarvestSharedResource(GAME_OOT, RSBS_SHARED_RES_MAGIC_LEVEL, 2);
+    Combo_HarvestSharedResource(GAME_MM, RSBS_SHARED_RES_MAGIC_LEVEL, 1);
+    SR_ASSERT(SR_Pool(RSBS_SHARED_RES_MAGIC_LEVEL) == 2);
+    uint16_t magicLevel = 1;
+    SR_ASSERT(Combo_ApplySharedResource(GAME_MM, RSBS_SHARED_RES_MAGIC_LEVEL, 2, &magicLevel));
+    SR_ASSERT(magicLevel == 2);
+    // Discipline pin: a LOWER harvest AFTER an apply is the one sequence the
+    // two disciplines answer differently — misclassified as consumable this
+    // computes delta -1 against the apply's watermark and decays the pool to
+    // 1; monotonic max-merge holds 2. (The harvests above pass either way:
+    // before any apply, the consumable first-harvest seed makes them look
+    // monotonic. Verified by mutation — dropping MAGIC_LEVEL from
+    // IsMonotonicKind fails exactly here and nowhere else.)
+    Combo_HarvestSharedResource(GAME_MM, RSBS_SHARED_RES_MAGIC_LEVEL, 1);
+    SR_ASSERT(SR_Pool(RSBS_SHARED_RES_MAGIC_LEVEL) == 2);
+
+    // A full double meter (0x60) visits a game that displays a single bar
+    // (cap 0x30): the pool keeps the true amount, the arriving game shows what
+    // fits, and nothing is lost on the way home — the 500/999 wallet
+    // invariant, in magic units.
+    Combo_HarvestSharedResource(GAME_OOT, RSBS_SHARED_RES_MAGIC_CURRENT, 0x60);
+    uint16_t magic = 0;
+    SR_ASSERT(Combo_ApplySharedResource(GAME_MM, RSBS_SHARED_RES_MAGIC_CURRENT, 0x30, &magic));
+    SR_ASSERT(magic == 0x30);
+    SR_ASSERT(SR_Pool(RSBS_SHARED_RES_MAGIC_CURRENT) == 0x60);
+    Combo_HarvestSharedResource(GAME_MM, RSBS_SHARED_RES_MAGIC_CURRENT, 0x30); // spent nothing in Termina
+    SR_ASSERT(SR_Pool(RSBS_SHARED_RES_MAGIC_CURRENT) == 0x60);
+    SR_ASSERT(Combo_ApplySharedResource(GAME_OOT, RSBS_SHARED_RES_MAGIC_CURRENT, 0x60, &magic));
+    SR_ASSERT(magic == 0x60);
+
+    // Spending decays the shared meter: a 0x20 spell cast in Hyrule is gone
+    // from the one meter MM reads too.
+    Combo_HarvestSharedResource(GAME_OOT, RSBS_SHARED_RES_MAGIC_CURRENT, 0x40);
+    SR_ASSERT(SR_Pool(RSBS_SHARED_RES_MAGIC_CURRENT) == 0x40);
+    SR_ASSERT(Combo_ApplySharedResource(GAME_MM, RSBS_SHARED_RES_MAGIC_CURRENT, 0x30, &magic));
+    SR_ASSERT(magic == 0x30);
+
+    // ------------------------------------------------------------------
     // Garbage in: a bogus game or kind must change nothing.
     // ------------------------------------------------------------------
     SR_FreshWorld();
@@ -305,8 +351,8 @@ TestResult Test_SharedResources(void) {
     SR_ASSERT(sink == 42);
 
     // ------------------------------------------------------------------
-    // All five v1 resources coexist: the slot array holds the whole set at
-    // once, with no kind overwriting another's slot.
+    // All seven shared resources (v1 + magic) coexist: the slot array holds
+    // the whole set at once, with no kind overwriting another's slot.
     // ------------------------------------------------------------------
     SR_FreshWorld();
     Combo_HarvestSharedResource(GAME_OOT, RSBS_SHARED_RES_RUPEES, 250);
@@ -314,14 +360,20 @@ TestResult Test_SharedResources(void) {
     Combo_HarvestSharedResource(GAME_OOT, RSBS_SHARED_RES_HEALTH_QUARTERS, 0x60);
     Combo_HarvestSharedResource(GAME_OOT, RSBS_SHARED_RES_HEALTH_CURRENT, 0x40);
     Combo_HarvestSharedResource(GAME_OOT, RSBS_SHARED_RES_DOUBLE_DEFENSE, 1);
-    SR_ASSERT(Combo_CountSharedResources() == 5);
+    Combo_HarvestSharedResource(GAME_OOT, RSBS_SHARED_RES_MAGIC_LEVEL, 1);
+    Combo_HarvestSharedResource(GAME_OOT, RSBS_SHARED_RES_MAGIC_CURRENT, 0x30);
+    SR_ASSERT(Combo_CountSharedResources() == 7);
     SR_ASSERT(SR_Pool(RSBS_SHARED_RES_RUPEES) == 250);
     SR_ASSERT(SR_Pool(RSBS_SHARED_RES_WALLET_TIER) == 2);
     SR_ASSERT(SR_Pool(RSBS_SHARED_RES_HEALTH_QUARTERS) == 0x60);
     SR_ASSERT(SR_Pool(RSBS_SHARED_RES_HEALTH_CURRENT) == 0x40);
     SR_ASSERT(SR_Pool(RSBS_SHARED_RES_DOUBLE_DEFENSE) == 1);
-    // The set fits with headroom left for the queued members of the class
-    // (shared magic, the ammo upgrades) without another .redsave carve.
+    SR_ASSERT(SR_Pool(RSBS_SHARED_RES_MAGIC_LEVEL) == 1);
+    SR_ASSERT(SR_Pool(RSBS_SHARED_RES_MAGIC_CURRENT) == 0x30);
+    // The set fits with exactly one slot to spare. The ammo upgrades — the
+    // queued remainder of the class — do NOT fit there; they arrive with the
+    // second reserved[] block carve (see RSBS_SHARED_RESOURCE_CAP's comment in
+    // context.h), not by squeezing into this array.
     SR_ASSERT(Combo_CountSharedResources() < (int)RSBS_SHARED_RESOURCE_CAP);
 
     // Session invalidation retires the pool AND the watermarks together — a


### PR DESCRIPTION
First PR of #525's optional tier (magic → ammo → hookshot, landing as three sequential PRs). Copies OoTMM's shared magic at the user-facing level: *"receiving a magic upgrade affects the magic meter in both games"*, *"current magic is tracked as if OoT and MM were one game with a single magic meter."*

## What this adds

- **Kinds 6 + 7 in the existing 8-slot array** — no `.redsave` carve, enum is append-only format:
  - `RSBS_SHARED_RES_MAGIC_LEVEL` (MONOTONIC): meter level 0/1/2, derived from the two acquired flags — never from `magicLevel`, which both games zero on every file load as their meter-regrow trigger.
  - `RSBS_SHARED_RES_MAGIC_CURRENT` (CONSUMABLE): delta-harvested against the RAM watermark. Units are shared verbatim (0x30 per bar in both games).
- **Harvest settles pending credits without mutating** the live machine (regrow window parks the true amount in `magicFillTarget`; OoT's ADD state and MM's `magicToAdd` accumulator carry jar credit). Pending debits are deliberately refunded — a spell cancelled by the switch's IDLE wipe never completed.
- **Apply uses each game's own vanilla re-grow idiom** — and the two idioms genuinely differ: OoT's regrow honors an externally-authored `magicFillTarget` (park it there, z_file_choose shape); MM's regrow *overwrites* `magicFillTarget` from `playerData.magic` (leave the amount there, `MM_Sram_OpenSave` shape). The first probed roundtrip caught the MM side refilling to zero under the OoT idiom.
- **No cycle hook, deliberately**: MM's `Sram_SaveEndOfCycle` never touches magic (verified line-by-line), so the rupee-style Before/After pair would be dead code. Ammo *will* need it — its counts are wiped at lines 579-586.
- **Pool shrink by criterion 6**: `RI_PROGRESSIVE_MAGIC`, `RI_SINGLE_MAGIC`, `RI_DOUBLE_MAGIC` leave `kForeignPoolMMV1` (128 → 125); their display names join the exclusion sweep in `test_foreign_items.c`.
- **ADR 0009 claim 5 amended**: seven of eight slots occupied; ammo arrives via a second `reserved[]` block, never an in-place widen.

## Review-driven hardening (adversarial panel, all findings source-verified)

1. **Parked pre-regrow window** (blocker): after an apply/file-load parks the amount (`magicLevel == 0`, `magic == 0`, machine IDLE), the regrow is transition-gated for the whole arrival fade — an F10 or autosave harvest inside that window read 0 against a watermark holding the applied amount and drained the pool by a full meter. Both settled reads now trust the park in exactly that signature (gated on `magic == 0` so MM's un-authored load-path `fillTarget` can't outvote a real balance).
2. **Flag-flip residue promotion** (major): MM's fresh-save default parks 0x30 in `playerData.magic` with no meter acquired. Each apply now snapshots its settled current *before* the level apply moves the flags, so a pool carrying a level but no current slot can't mint a phantom full meter.
3. **Discipline pin** (major): a lower-harvest-after-apply assertion now pins `MAGIC_LEVEL` as monotonic — mutation-verified as the only sequence the two disciplines answer differently.

A pre-existing quirk the review surfaced (OoT `gameplayFrames` only reset on first `Play_Init`, voiding the autosave warm-up guard on re-arrivals) is out of scope and tracked separately.

## Verification (local, ROM-staged)

- `redship` tier: **63/63** · `rando` tier: **14/14** · `integration` tier: **5/6** — the one red is `IntSwitchOoTHmsToMm`, permanently red per #544 (pre-existing, needs a Start press no harness sends).
- Probed `int-gameplay-roundtrip`: level 1 + 48 units cross OoT → MM → OoT intact (probes reverted before commit).
- Both new test locks falsified: `KIND_COUNT` revert fails at the first magic assertion; a resurrected "Power of Magic" row fails the criterion-6 sweep; the monotonic pin fails when `MAGIC_LEVEL` is dropped from `IsMonotonicKind`.
- clang-format 14 clean on all gated files.

Part of #525. Next: ammo (second `reserved[]` block carve + the Bomb Bag collision-test subject swap), then hookshot (shared-items cross-grant).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!--- section:artifacts:start -->
### Build Artifacts
  - [rsbs-windows.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/8739451471.zip)
  - [rsbs-linux.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/8738605518.zip)
<!--- section:artifacts:end -->