### PR TITLE
Share ammo across both games, carving the second shared-resource block (#525)

### DIFF
--- a/docs/adr/0009-combo-settings-and-reverse-pool.md
+++ b/docs/adr/0009-combo-settings-and-reverse-pool.md
@@ -192,10 +192,11 @@ Publishing the allocation once beats five sequential re-versions:
 | 3 | MM option-profile digest (#497 step 7 / #499 step 4, Lane 4) | 4 B | **carved by Lane 4; size CONFIRMED at 4 B** |
 | 4 | Netplay grant fields (#460, ADR 0005/0007) | 64 B | reserved |
 | 5 | `sharedResources[8]` (#525, shared rupees + hearts + magic) | 32 B | **carved by #525** |
-| 6 | Unallocated floor | 132 B | must not drop below 64 |
+| 6 | `sharedResourcesExt[12]` (#525 optional tier, shared ammo) | 48 B | **carved by #525** |
+| 7 | Unallocated floor | 84 B | must not drop below 64 |
 
-Total reserved-against: 152 B of 284. After claims 1, 3 and 5 land, `reserved[]`
-is 180 bytes and 200 B of capacity remain.
+Total reserved-against: 152 B of 284. After claims 1, 3, 5 and 6 land, `reserved[]`
+is 132 bytes and 152 B of capacity remain.
 
 **Claim 5, settled (#525, 2026-07-29; amended for the optional tier).** Shared
 cross-game resources are eight kind-tagged 4-byte slots —
@@ -204,12 +205,32 @@ immediately after `mmProfileDigest`. Seven of the eight are occupied: five by
 v1 (rupees, wallet tier, health quarters, current health, double defense) and
 two by shared magic (meter level + current magic, kinds 6 and 7), which is why
 the claim is sized at the array rather than at any moment's resource count. The
-ammo upgrades — the queued remainder of the class — need ~10 more kinds and do
-NOT fit in the one remaining slot: per this ADR's own prescription they arrive
-as a SECOND block carved from the front of `reserved[]`, spanned together with
-this one by every accessor in `shared_resources.c`, never by bumping
-`RSBS_SHARED_RESOURCE_CAP` in place (the widen would move every field carved
-after the array off its shipped offset).
+ammo upgrades — the queued remainder of the class — needed nine more kinds and
+did NOT fit in the one remaining slot; see claim 6.
+
+**Claim 6, settled (#525 optional tier, 2026-07-29).** Shared ammo arrived
+exactly as claim 5's prescription requires: a SECOND block,
+`ComboSharedResource sharedResourcesExt[12]` at `.redsave` byte offset **824**,
+carved from the front of `reserved[]` and pinned by its own literal-offset
+static_assert. `RSBS_SHARED_RESOURCE_CAP` was **not** bumped — a widen in place
+would have moved this very block, and every field carved after it, off the
+offset every shipped save stored it at. `reserved[180]` becomes `reserved[132]`.
+
+The two blocks are ONE LOGICAL ARRAY of twenty slots. `shared_resources.c`
+addresses them through a single `SlotAt(logical)` resolver, and every scan — the
+duplicate lookup, the first-free claim, the occupancy count — spans both in one
+pass. That is not tidiness: a scan stopping at the first block's boundary would
+either split one kind across two slots or report the array full with twelve free
+slots behind it, silently dropping every resource past the eighth. Sixteen of
+the twenty are occupied (seven from v1 plus magic, nine from ammo); the block
+was sized for the whole class in one carve, because a third block would cost
+another literal offset, another span in every accessor, and another amendment
+here.
+
+Twelve is the ceiling the floor below permits rather than a preference: 48 B
+leaves `reserved[132]`, which still clears the 64-byte floor once the
+outstanding claims 2 and 4 (4 B + 64 B) land. Sixteen slots would have breached
+it.
 
 The tag is load-bearing, not bookkeeping. This ADR's growth contract is "zero
 means unset", and **0 rupees is a legal player state** — so a bare `uint16_t

--- a/games/mm/2s2h/GameExports_SingleExe.cpp
+++ b/games/mm/2s2h/GameExports_SingleExe.cpp
@@ -2159,6 +2159,8 @@ extern "C" void MM_Inventory_ChangeUpgrade(s16 upgrade, u32 value);
 extern "C" u32 MM_gUpgradeMasks[8];
 extern "C" u8 MM_gUpgradeShifts[8];
 extern "C" u16 MM_gUpgradeCapacities[][4];
+// Backs the SLOT/AMMO/INV_CONTENT macros (z64save.h) the ammo shim uses.
+extern "C" u8 MM_gItemSlots[77];
 
 // Heart pieces occupy the TOP NIBBLE of questItems in both games
 // (MM's QUEST_HEART_PIECE_COUNT is 0x1C; OoT writes 1 << (QUEST_HEART_PIECE+4)).
@@ -2169,6 +2171,53 @@ extern "C" u16 MM_gUpgradeCapacities[][4];
 // has 4 entries). Bounds the pool value so a tier authored by a future build
 // cannot index off the end of MM's capacity table.
 #define MM_MAX_WALLET_TIER 3u
+
+// Highest tier index in every ammo row of MM_gUpgradeCapacities, the twin of
+// OOT_MAX_AMMO_TIER. The rows themselves are identical across the two games —
+// quiver {0,30,40,50}, bomb bag {0,20,30,40}, sticks {0,10,20,30}, nuts
+// {0,20,30,40} — which is what lets a tier cross as one number with no
+// conversion, unlike the wallet.
+#define MM_MAX_AMMO_TIER 3u
+
+// See OoTSharedAmmo — same table, MM's ids. MM spells the stick and nut
+// upgrades UPG_DEKU_STICKS / UPG_DEKU_NUTS where OoT says UPG_STICKS /
+// UPG_NUTS, and its items ITEM_DEKU_STICK / ITEM_DEKU_NUT; the enum INDICES
+// agree, so the shared tier value means the same thing on both sides.
+typedef struct {
+    uint8_t tierKind;  // RSBS_SHARED_RES_*_TIER, or RSBS_SHARED_RES_NONE for the tier-less bombchu row
+    uint8_t countKind; // RSBS_SHARED_RES_*_COUNT
+    s16 upgrade;       // UPG_* row index, ignored when tierKind is NONE
+    uint8_t item;      // ITEM_* whose slot holds the count, and which a nonzero tier grants
+} MMSharedAmmo;
+
+static const MMSharedAmmo kMMSharedAmmo[] = {
+    { RSBS_SHARED_RES_QUIVER_TIER, RSBS_SHARED_RES_ARROW_COUNT, UPG_QUIVER, ITEM_BOW },
+    { RSBS_SHARED_RES_BOMB_BAG_TIER, RSBS_SHARED_RES_BOMB_COUNT, UPG_BOMB_BAG, ITEM_BOMB },
+    { RSBS_SHARED_RES_STICK_TIER, RSBS_SHARED_RES_STICK_COUNT, UPG_DEKU_STICKS, ITEM_DEKU_STICK },
+    { RSBS_SHARED_RES_NUT_TIER, RSBS_SHARED_RES_NUT_COUNT, UPG_DEKU_NUTS, ITEM_DEKU_NUT },
+    { RSBS_SHARED_RES_NONE, RSBS_SHARED_RES_BOMBCHU_COUNT, 0, ITEM_BOMBCHU },
+};
+
+static uint16_t MM_ReadAmmo(uint8_t item) {
+    const s8 held = AMMO(item);
+    return held < 0 ? 0u : (uint16_t)held;
+}
+
+// MM's bombchus have no upgrade row of their own — the bomb bag's capacity is
+// their ceiling, where OoT fixes it at 50. The pool holds the true count and
+// each side shows what it can hold, exactly as the 500-vs-999 wallet does.
+static uint16_t MM_AmmoCapacity(const MMSharedAmmo* row) {
+    if (row->tierKind == RSBS_SHARED_RES_NONE) {
+        return (uint16_t)CUR_CAPACITY(UPG_BOMB_BAG);
+    }
+    return (uint16_t)CUR_CAPACITY(row->upgrade);
+}
+
+static void MM_EnsureInventoryItem(uint8_t item) {
+    if (INV_CONTENT(item) == ITEM_NONE) {
+        INV_CONTENT(item) = item;
+    }
+}
 
 static uint16_t MM_ReadHealthQuarters(void) {
     const uint16_t pieces =
@@ -2274,6 +2323,16 @@ extern "C" void MM_HarvestSharedResources(void) {
                                 gSaveContext.save.saveInfo.playerData.doubleDefense ? 1u : 0u);
     Combo_HarvestSharedResource(GAME_MM, RSBS_SHARED_RES_MAGIC_LEVEL, MM_ReadMagicLevel());
     Combo_HarvestSharedResource(GAME_MM, RSBS_SHARED_RES_MAGIC_CURRENT, MM_ReadSettledMagic());
+
+    // Ammo, the twin of the OoT loop — no settle step, because ammo changes are
+    // immediate AMMO() writes in both games rather than accumulator drains.
+    for (int i = 0; i < ARRAY_COUNT(kMMSharedAmmo); i++) {
+        const MMSharedAmmo* row = &kMMSharedAmmo[i];
+        if (row->tierKind != RSBS_SHARED_RES_NONE) {
+            Combo_HarvestSharedResource(GAME_MM, row->tierKind, (uint16_t)CUR_UPG_VALUE(row->upgrade));
+        }
+        Combo_HarvestSharedResource(GAME_MM, row->countKind, MM_ReadAmmo(row->item));
+    }
 }
 
 /**
@@ -2395,6 +2454,34 @@ extern "C" void MM_ApplySharedResources(void) {
         gSaveContext.magicToAdd = 0;
         gSaveContext.magicToConsume = 0;
     }
+
+    // --- Ammo: tier before the count it bounds, per row. Deliberately does NOT
+    // copy MM's own rando bomb-bag give, which refills bombs AND bombchus to
+    // capacity — that is a give's semantics, and running it on every arrival
+    // would hand the player a free restock per switch. The apply authors an
+    // absolute count from the pool instead, which is what the watermark
+    // reconciles against.
+    for (int i = 0; i < ARRAY_COUNT(kMMSharedAmmo); i++) {
+        const MMSharedAmmo* row = &kMMSharedAmmo[i];
+
+        if (row->tierKind != RSBS_SHARED_RES_NONE) {
+            uint16_t tier = (uint16_t)CUR_UPG_VALUE(row->upgrade);
+            if (Combo_ApplySharedResource(GAME_MM, row->tierKind, MM_MAX_AMMO_TIER, &tier)) {
+                MM_Inventory_ChangeUpgrade(row->upgrade, (u32)tier);
+                if (tier >= 1u) {
+                    MM_EnsureInventoryItem(row->item);
+                }
+            }
+        }
+
+        uint16_t count = MM_ReadAmmo(row->item);
+        if (Combo_ApplySharedResource(GAME_MM, row->countKind, MM_AmmoCapacity(row), &count)) {
+            if (count > 0u) {
+                MM_EnsureInventoryItem(row->item);
+            }
+            AMMO(row->item) = (s8)count;
+        }
+    }
 }
 
 // ============================================================================
@@ -2434,8 +2521,24 @@ extern "C" void MM_ApplySharedResources(void) {
 // health at 0x30, and under one-health-bar semantics that is a Song of Time
 // healing the single shared bar — which is what "as if OoT and MM were one
 // game" means. It reads as a heal, not a bug.
+//
+// SHARED MAGIC deliberately has no equivalent hook either, and that is a fact
+// about MM rather than a policy call: Sram_SaveEndOfCycle never touches magic,
+// magicLevel or either acquired flag. A bracket there would be dead code
+// guarding a wipe that does not happen.
+//
+// SHARED AMMO, by contrast, needs one — the wipe zeroes AMMO() for every slot
+// in MM_gAmmoItems (arrows, bombs, bombchus, sticks, nuts, and MM-local beans
+// and powder keg) except the pictograph box. The five SHARED counts are
+// bracketed below for the same reason rupees are; the MM-local ones are left to
+// be wiped exactly as vanilla does, because restoring those would silently
+// reimplement 2S2H's DoNotResetConsumables enhancement for items that are not
+// part of the shared model and whose loss the player opted into by playing MM.
+// The capacity TIERS need no bracket: the wipe never touches inventory.upgrades,
+// and a monotonic resource could not decay through it anyway.
 
 static s16 sPreCycleRupees = 0;
+static s8 sPreCycleAmmo[ARRAY_COUNT(kMMSharedAmmo)];
 
 extern "C" void MM_RegisterSharedResourceCycleHooks(void) {
     S2H::GameHooks::Register<GameInteractor::BeforeEndOfCycleSave>([]() {
@@ -2453,6 +2556,15 @@ extern "C" void MM_RegisterSharedResourceCycleHooks(void) {
             settled = walletCap;
         }
         sPreCycleRupees = (s16)settled;
+
+        // Snapshot the shared ammo counts by SLOT, through the same AMMO()
+        // macro the wipe itself uses. Deliberately not by raw item id: the
+        // vanilla-reference restore in EndOfCycle.cpp indexes inventory arrays
+        // with item enumerators directly, which is correct only because a
+        // handful of MM's ids happen to equal their slot numbers.
+        for (int i = 0; i < ARRAY_COUNT(kMMSharedAmmo); i++) {
+            sPreCycleAmmo[i] = AMMO(kMMSharedAmmo[i].item);
+        }
     });
 
     S2H::GameHooks::Register<GameInteractor::AfterEndOfCycleSave>([]() {
@@ -2461,6 +2573,18 @@ extern "C" void MM_RegisterSharedResourceCycleHooks(void) {
         // The "you lost your rupees" notice would be a lie now, and it is the
         // same flag 2S2H's DoNotResetRupees clears for the same reason.
         CLEAR_EVENTINF(EVENTINF_THREEDAYRESET_LOST_RUPEES);
+
+        for (int i = 0; i < ARRAY_COUNT(kMMSharedAmmo); i++) {
+            AMMO(kMMSharedAmmo[i].item) = sPreCycleAmmo[i];
+        }
+        // Same reasoning as the rupee notice: four of the five shared counts
+        // have a "you lost it" flag that the cycle stamps before wiping, and
+        // leaving them set makes the game report a loss that no longer
+        // happened. Bombchus have no such flag in vanilla.
+        CLEAR_EVENTINF(EVENTINF_THREEDAYRESET_LOST_ARROW_AMMO);
+        CLEAR_EVENTINF(EVENTINF_THREEDAYRESET_LOST_BOMB_AMMO);
+        CLEAR_EVENTINF(EVENTINF_THREEDAYRESET_LOST_NUT_AMMO);
+        CLEAR_EVENTINF(EVENTINF_THREEDAYRESET_LOST_STICK_AMMO);
     });
 }
 

--- a/games/mm/2s2h/Rando/ForeignItemsSingleExe.cpp
+++ b/games/mm/2s2h/Rando/ForeignItemsSingleExe.cpp
@@ -169,31 +169,35 @@ extern "C" {
 //      pickup text promises an award in Termina; delivering MM's trap machinery
 //      instead would make that text a lie.
 //
-//  (6) It is NOT a shared cross-game resource (#525). Rupees, hearts and magic
-//      are one quantity spanning both games now — one wallet, one health bar,
-//      one magic meter, capacity AND current value
+//  (6) It is NOT a shared cross-game resource (#525). Rupees, hearts, magic and
+//      ammo are one quantity spanning both games now — one wallet, one health
+//      bar, one magic meter, one quiver, capacity AND current value
 //      (src/common/shared_resources.h) — so there is nothing left for a
-//      wallet, heart or magic item to CROSS. Shipping one anyway would hand
-//      the player a second copy of a capacity they already have, or worse, a
-//      rupee award that the next harvest reconciles straight back out. Six rows
-//      left with the sharing that replaced them: RI_PROGRESSIVE_WALLET,
+//      wallet, heart, magic or ammo item to CROSS. Shipping one anyway would
+//      hand the player a second copy of a capacity they already have, or worse,
+//      a rupee award that the next harvest reconciles straight back out. Six
+//      rows left with the sharing that replaced them: RI_PROGRESSIVE_WALLET,
 //      RI_WALLET_ADULT, RI_WALLET_GIANT, RI_DOUBLE_DEFENSE, RI_HEART_CONTAINER
 //      and RI_HEART_PIECE. Three more left when shared magic landed (#525's
 //      optional tier): RI_PROGRESSIVE_MAGIC, RI_SINGLE_MAGIC and
-//      RI_DOUBLE_MAGIC.
+//      RI_DOUBLE_MAGIC. Eight more left with shared ammo: RI_BOMB_BAG_20,
+//      RI_BOMB_BAG_30, RI_BOMB_BAG_40, RI_QUIVER_40, RI_QUIVER_50,
+//      RI_PROGRESSIVE_BOMB_BAG, RI_BOW and RI_PROGRESSIVE_BOW.
+//
+//      THE BOW ROWS LEAVE FOR A REASON WORTH SPELLING OUT, because "a bow is
+//      not ammo" is the obvious objection. MM does not separate the two: its
+//      own give for the bow sets UPG_QUIVER to 1 (z_parameter.c), so in MM
+//      owning the bow IS quiver tier 1 — and that tier is now the shared
+//      resource. A bow crossing would therefore mutate the shared quantity,
+//      which is precisely what this criterion excludes. The same logic retires
+//      OoT's RG_FAIRY_BOW from its own pool.
 //
 //      Note RI_DOUBLE_DEFENSE was NOT in the "Health" block — it sat under core
 //      equipment, so a block delete misses it. The block-shaped grouping below
 //      is presentational; criterion 6 is not.
 //
-//      This criterion grows with the shared-resource set. The ammo upgrades
-//      are the queued remainder of that class, and when they land the
-//      quiver/bomb-bag rows leave by this same rule — see the collision trap
-//      in #525's optional tier before deleting the bomb bags, since "Bomb Bag"
-//      is the only name shared with OoT's pool and a test depends on it.
-//
 // Everything else is IN — every mask, every song, every bottle, both shields,
-// the sword and quiver and bomb-bag upgrades, the
+// the sword upgrades, the
 // progressives (which resolve against the LIVE MM save, so they are the single
 // best-behaved cross-game gift, and the OoT pool sets the precedent with
 // RG_PROGRESSIVE_HOOKSHOT / RG_PROGRESSIVE_STRENGTH), the boss remains, the
@@ -210,35 +214,30 @@ extern "C" {
 // deferred to the first frame with a live MM_gPlayState (see the file header),
 // which is item-agnostic and O(1) in pool size — the #502 design note says in as
 // many words that an allowlist audited against today's pool would expire the
-// moment somebody added a row. This pool is that row, 125 times over, and it
+// moment somebody added a row. This pool is that row, 117 times over, and it
 // relies on the deferral instead of re-auditing it.
 //
 // Display names are MM's own (Rando::StaticData::Items) verbatim. They are a
 // PERSISTENCE KEY, not decoration: Combo_GetForeignItemByNameFor is the
 // spoiler-LOAD inverse, so renaming an entry breaks spoiler round-trips for
-// already-generated worlds. "Bomb Bag" is deliberately identical to the OoT
-// pool's row of the same name — that collision is real, is the reason the
+// already-generated worlds. "Lens of Truth" is deliberately identical to the
+// OoT pool's row of the same name — that collision is real, is the reason the
 // lookups are keyed on (originGame, name), and is asserted in
-// test_foreign_items.c rather than dodged.
+// test_foreign_items.c rather than dodged. It inherited that job from "Bomb
+// Bag", which was the colliding pair until shared ammo retired both halves;
+// OoT's pool gained its Lens row in the same commit that deleted them, because
+// the collision test goes red the instant one side exists without the other.
 static const ComboForeignItemDef kForeignPoolMMV1[] = {
     // --- Progressive upgrades: resolve against the live MM save at give time.
     { { (uint8_t)GAME_MM, 0, (uint16_t)RI_PROGRESSIVE_SWORD }, "Progressive Sword", "a " },
-    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_PROGRESSIVE_BOW }, "Progressive Bow", "a " },
-    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_PROGRESSIVE_BOMB_BAG }, "Progressive Bomb Bag", "a " },
     { { (uint8_t)GAME_MM, 0, (uint16_t)RI_PROGRESSIVE_LULLABY }, "Progressive Goron Lullaby", "" },
 
     // --- Core equipment, abilities and capacity upgrades.
-    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_BOW }, "Bow", "a " },
     { { (uint8_t)GAME_MM, 0, (uint16_t)RI_HOOKSHOT }, "Hookshot", "the " },
     { { (uint8_t)GAME_MM, 0, (uint16_t)RI_LENS }, "Lens of Truth", "the " },
     { { (uint8_t)GAME_MM, 0, (uint16_t)RI_ARROW_FIRE }, "Fire Arrows", "" },
     { { (uint8_t)GAME_MM, 0, (uint16_t)RI_ARROW_ICE }, "Ice Arrows", "" },
     { { (uint8_t)GAME_MM, 0, (uint16_t)RI_ARROW_LIGHT }, "Light Arrows", "" },
-    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_BOMB_BAG_20 }, "Bomb Bag", "a " },
-    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_BOMB_BAG_30 }, "Big Bomb Bag", "a " },
-    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_BOMB_BAG_40 }, "Biggest Bomb Bag", "the " },
-    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_QUIVER_40 }, "Large Quiver", "the " },
-    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_QUIVER_50 }, "Largest Quiver", "the " },
     { { (uint8_t)GAME_MM, 0, (uint16_t)RI_POWDER_KEG }, "Powder Keg", "a " },
     { { (uint8_t)GAME_MM, 0, (uint16_t)RI_PICTOGRAPH_BOX }, "Pictograph Box", "a " },
     { { (uint8_t)GAME_MM, 0, (uint16_t)RI_MAGIC_BEAN }, "Magic Bean", "a " },

--- a/games/oot/soh/Enhancements/randomizer/ForeignItemsSingleExe.cpp
+++ b/games/oot/soh/Enhancements/randomizer/ForeignItemsSingleExe.cpp
@@ -68,11 +68,35 @@ void GiveLinkRupees(int numOfRupees);
 // constant-expression enumerator that fits is not a narrowing conversion.
 // The article column matches OoT's own item table (Item::GetArticle), so MM's
 // pickup textbox reads exactly like an MM one: "You found the Fairy Bow!".
+// CRITERION 6 APPLIES HERE TOO (#525). "Fairy Bow" and "Bomb Bag" used to sit
+// in this table and left with shared ammo: the quiver and bomb-bag capacity
+// tiers are now ONE quantity spanning both games (src/common/shared_resources.h),
+// and in MM owning the bow IS quiver tier 1, so either row would have crossed
+// as a mutation of the shared resource rather than as a new item. Nothing in
+// this pool may be a shared cross-game resource — no wallet, heart, magic or
+// ammo row.
+//
+// "Lens of Truth" IS THE CROSS-POOL COLLISION, deliberately. Display names are
+// the spoiler-load persistence key, and the lookups are keyed on
+// (originGame, name) precisely because a bare name can appear in both pools;
+// "Bomb Bag" was that pair until shared ammo retired both halves, so this row
+// was added in the same commit that deleted them and inherits the job. The
+// collision is asserted on purpose in test_foreign_items.c — it must not be
+// "fixed" by renaming either side. MM's twin is the RI_LENS row, and the two
+// strings must stay byte-identical.
+//
+// Boomerang and Megaton Hammer widen a pool that was down to three rows against
+// MM's 117, which made the forward direction ship nearly the same items every
+// seed (a follow-up #525 lists in as many words). Both are plain MOD_NONE
+// inventory items whose give falls through OoT_Item_Give's generic tail — save
+// writes only, no PlayState deref — which is what makes them safe on the
+// NULL-play redemption path the pool is given through.
 static const ComboForeignItemDef kForeignPoolV1[] = {
     { { (uint8_t)GAME_OOT, 0, (uint16_t)RG_PROGRESSIVE_HOOKSHOT }, "Progressive Hookshot", "a " },
-    { { (uint8_t)GAME_OOT, 0, (uint16_t)RG_FAIRY_BOW }, "Fairy Bow", "the " },
-    { { (uint8_t)GAME_OOT, 0, (uint16_t)RG_BOMB_BAG }, "Bomb Bag", "a " },
     { { (uint8_t)GAME_OOT, 0, (uint16_t)RG_PROGRESSIVE_STRENGTH }, "Progressive Strength Upgrade", "a " },
+    { { (uint8_t)GAME_OOT, 0, (uint16_t)RG_LENS_OF_TRUTH }, "Lens of Truth", "the " },
+    { { (uint8_t)GAME_OOT, 0, (uint16_t)RG_BOOMERANG }, "Boomerang", "the " },
+    { { (uint8_t)GAME_OOT, 0, (uint16_t)RG_MEGATON_HAMMER }, "Megaton Hammer", "the " },
 };
 
 static constexpr int kForeignPoolCount = sizeof(kForeignPoolV1) / sizeof(kForeignPoolV1[0]);

--- a/games/oot/soh/GameExports_SingleExe.cpp
+++ b/games/oot/soh/GameExports_SingleExe.cpp
@@ -28,6 +28,10 @@
 #include "soh/Enhancements/game-interactor/GameInteractor.h"
 #include "soh/Enhancements/game-interactor/GameInteractor_Hooks.h"
 #include "soh/Notification/Notification.h" // Lane 6 (#494): the foreign-arrival toast
+// Rando::Context's definition, for GetBombchuCapacity() in the ammo shim.
+// OTRGlobals.h only forward-declares Rando::Context, which is enough to hold
+// the shared_ptr but not to call through it.
+#include "soh/Enhancements/randomizer/SeedContext.h"
 // SET_NEXT_GAMESTATE for the gameplay round-trip driver. Must come after
 // GameInteractor.h (-> z64.h): macros.h declares `extern GraphicsContext*`
 // and needs the type defined first.
@@ -1133,6 +1137,14 @@ extern "C" u16 OoT_gUpgradeCapacities[8][4];
 // Backs the SLOT/AMMO/INV_CONTENT macros (macros.h) the ammo shim uses.
 extern "C" u8 OoT_gItemSlots[56];
 
+// Declared locally because OTRGlobals.h only declares this inside its
+// `#ifndef __cplusplus` block — the C half of the header — so it is invisible
+// to every C++ TU. Redeclaring it here is the established pattern rather than a
+// workaround: draw.cpp, CosmeticsEditor.cpp, NoMasterSword.cpp and several
+// other C++ callers each do exactly this. The definition (OTRGlobals.cpp) is
+// extern "C", which is the linkage this must match.
+extern "C" u8 Randomizer_GetSettingValue(RandomizerSettingKey randoSettingKey);
+
 // Heart pieces live in the TOP NIBBLE of questItems in BOTH games (OoT writes
 // `1 << (QUEST_HEART_PIECE + 4)`, MM's QUEST_HEART_PIECE_COUNT is 0x1C), which
 // is what makes one canonical quantity possible at all.
@@ -1151,10 +1163,12 @@ extern "C" u8 OoT_gItemSlots[56];
 // off the end of the capacity table.
 #define OOT_MAX_AMMO_TIER 3u
 
-// OoT's bombchu ceiling. Unlike arrows and bombs, bombchus have no upgrade row
-// in either game — OoT fixes the cap at 50 while MM derives it from the bomb
-// bag — so the two ends of this shared count clamp against different numbers,
-// which is exactly the asymmetry the watermark discipline exists to absorb.
+// OoT's VANILLA bombchu ceiling. Unlike arrows and bombs, bombchus have no
+// upgrade row in either game — OoT fixes the cap at 50 while MM derives it from
+// the bomb bag — so the two ends of this shared count clamp against different
+// numbers, which is exactly the asymmetry the watermark discipline absorbs.
+//
+// Only half the story under rando: see OoT_BombchuCapacity.
 #define OOT_BOMBCHU_CAPACITY 50u
 
 // One shared ammo pair: the capacity tier, the count it bounds, and the
@@ -1181,11 +1195,37 @@ static uint16_t OoT_ReadAmmo(uint8_t item) {
     return held < 0 ? 0u : (uint16_t)held;
 }
 
+/**
+ * OoT's LIVE bombchu ceiling, which is 50 only outside the randomizer.
+ *
+ * With RSK_BOMBCHU_BAG set to progressive, SoH replaces the ceiling entirely:
+ * Bombchus.cpp registers a VB_CHECK_BOMBCHU_CAPACITY override that CLAMPS
+ * AMMO(ITEM_BOMBCHU) down to gRandoContext->GetBombchuCapacity() (0/20/30/50 by
+ * bag level) on the next capacity check. Applying the shared pool against a
+ * hardcoded 50 therefore does not just overfill — it stages a silent theft:
+ * the clamp fires on the very next bombchu thrown, the count drops to the real
+ * capacity, and the following harvest reads that as the player having SPENT the
+ * difference and debits the shared pool by it. With bag level 0 the pool is
+ * zeroed outright, so bombchus the player earned in Termina disappear from both
+ * games at once.
+ *
+ * Mirrors the capacity expression in Bombchus.cpp rather than paraphrasing it,
+ * including its restriction to the progressive option (the single-bag and
+ * vanilla options leave the 50 in place and register no clamp).
+ */
+static uint16_t OoT_BombchuCapacity(void) {
+    if (IS_RANDO && OTRGlobals::Instance != nullptr && OTRGlobals::Instance->gRandoContext != nullptr &&
+        Randomizer_GetSettingValue(RSK_BOMBCHU_BAG) == RO_BOMBCHU_BAG_PROGRESSIVE) {
+        return (uint16_t)OTRGlobals::Instance->gRandoContext->GetBombchuCapacity();
+    }
+    return (uint16_t)OOT_BOMBCHU_CAPACITY;
+}
+
 // The count's ceiling in OoT right now: the live capacity for a row that has an
-// upgrade, the fixed bombchu cap for the one that does not.
+// upgrade, the live bombchu capacity for the one that does not.
 static uint16_t OoT_AmmoCapacity(const OoTSharedAmmo* row) {
     if (row->tierKind == RSBS_SHARED_RES_NONE) {
-        return (uint16_t)OOT_BOMBCHU_CAPACITY;
+        return OoT_BombchuCapacity();
     }
     return (uint16_t)CUR_CAPACITY(row->upgrade);
 }
@@ -1205,34 +1245,34 @@ static void OoT_EnsureInventoryItem(uint8_t item) {
     }
 }
 
-// Declared locally because OTRGlobals.h only declares this inside its
-// `#ifndef __cplusplus` block — the C half of the header — so it is invisible
-// to every C++ TU. Redeclaring it here is the established pattern rather than a
-// workaround: draw.cpp, CosmeticsEditor.cpp, NoMasterSword.cpp and several
-// other C++ callers each do exactly this. The definition (OTRGlobals.cpp) is
-// extern "C", which is the linkage this must match.
-extern "C" u8 Randomizer_GetSettingValue(RandomizerSettingKey randoSettingKey);
-
 /**
- * Is this row's bag a shuffled CHECK in the live OoT seed that the player has
- * not found yet? Then the shared pool must not hand it over.
+ * Would GRANTING this row's item be handing the player a shuffled CHECK the
+ * seed placed elsewhere? Then the pool may not hand it over.
  *
- * OoT_Item_Give opens with exactly this refusal (z_parameter.c:1876-1885, "in
- * case something got missed"): with RSK_SHUFFLE_DEKU_STICK_BAG or
- * RSK_SHUFFLE_DEKU_NUT_BAG on, sticks and nuts are not obtainable at all until
- * their bag check is found. That gate matters HERE and not for the wallet or
- * the quiver because MM's side is not neutral: a fresh MM save is BORN at stick
- * and nut tier 1 (the Sram default table), so plain monotonic sharing would
- * push tier 1 into OoT on the very first crossing of every seed and quietly
- * satisfy a check the seed placed elsewhere.
+ * OoT_Item_Give opens with exactly this refusal for sticks and nuts
+ * (z_parameter.c:1876-1885, "in case something got missed"): with
+ * RSK_SHUFFLE_DEKU_STICK_BAG or RSK_SHUFFLE_DEKU_NUT_BAG on, neither is
+ * obtainable until its bag check is found. That gate matters HERE and not for
+ * the wallet or the quiver because MM's side is not neutral: a fresh MM save is
+ * BORN at stick and nut tier 1 (the Sram default table), so plain monotonic
+ * sharing would push tier 1 into OoT on the very first crossing of every seed.
  *
- * The whole row is skipped rather than just the tier. Applying the count alone
- * would clamp it against a capacity of zero and record that zero as
- * materialized, which is how a suppressed grant turns into a drained pool; with
- * no apply at all there is no watermark, and the harvest's own seed rule then
- * reads the occupied slot and contributes nothing.
+ * Bombchus are the same hazard wearing different clothes. When the seed shuffles
+ * them (RSK_BOMBCHU_BAG is not NONE) the player is meant to hold none until the
+ * check is found, and Bombchus.cpp keys shop eligibility on
+ * INV_CONTENT(ITEM_BOMBCHU) — so materializing the item here would open the
+ * bombchu shops too.
+ *
+ * ONLY THE GRANT IS SUPPRESSED, not the whole row. The count apply still runs,
+ * clamped to this game's real (often zero) capacity, and that is deliberate:
+ * the apply is what transfers WATERMARK OWNERSHIP to OoT. Skipping it leaves
+ * the watermark owned by MM, and then the first OoT harvest after the player
+ * legitimately finds the bag takes the "no watermark for this game" seed path,
+ * records the live count as already-counted, and silently discards the stock
+ * the bag just granted. Applying a zero costs nothing (the player has none) and
+ * keeps the pool's arithmetic honest across the moment the gate opens.
  */
-static bool OoT_SharedAmmoBlockedByShuffle(const OoTSharedAmmo* row) {
+static bool OoT_SharedAmmoGrantBlocked(const OoTSharedAmmo* row) {
     if (!IS_RANDO || OTRGlobals::Instance == nullptr || OTRGlobals::Instance->gRandoContext == nullptr) {
         return false;
     }
@@ -1241,6 +1281,10 @@ static bool OoT_SharedAmmoBlockedByShuffle(const OoTSharedAmmo* row) {
     }
     if (row->item == ITEM_NUT) {
         return Randomizer_GetSettingValue(RSK_SHUFFLE_DEKU_NUT_BAG) != 0 && CUR_UPG_VALUE(UPG_NUTS) == 0;
+    }
+    if (row->item == ITEM_BOMBCHU) {
+        return Randomizer_GetSettingValue(RSK_BOMBCHU_BAG) != RO_BOMBCHU_BAG_NONE &&
+               INV_CONTENT(ITEM_BOMBCHU) == ITEM_NONE;
     }
     return false;
 }
@@ -1498,12 +1542,9 @@ extern "C" void OoT_ApplySharedResources(void) {
     // materialized, quietly dropping the rest of the pool.
     for (int i = 0; i < ARRAY_COUNT(kOoTSharedAmmo); i++) {
         const OoTSharedAmmo* row = &kOoTSharedAmmo[i];
+        const bool grantBlocked = OoT_SharedAmmoGrantBlocked(row);
 
-        if (OoT_SharedAmmoBlockedByShuffle(row)) {
-            continue;
-        }
-
-        if (row->tierKind != RSBS_SHARED_RES_NONE) {
+        if (!grantBlocked && row->tierKind != RSBS_SHARED_RES_NONE) {
             uint16_t tier = (uint16_t)CUR_UPG_VALUE(row->upgrade);
             if (Combo_ApplySharedResource(GAME_OOT, row->tierKind, OOT_MAX_AMMO_TIER, &tier)) {
                 OoT_Inventory_ChangeUpgrade(row->upgrade, (s16)tier);
@@ -1513,11 +1554,15 @@ extern "C" void OoT_ApplySharedResources(void) {
             }
         }
 
+        // Runs even when the grant is blocked — see OoT_SharedAmmoGrantBlocked
+        // for why suppressing the apply entirely loses the player's stock the
+        // moment the gate opens. The cap does the suppressing: with no bag it
+        // is zero, so nothing materializes.
         uint16_t count = OoT_ReadAmmo(row->item);
         if (Combo_ApplySharedResource(GAME_OOT, row->countKind, OoT_AmmoCapacity(row), &count)) {
             // Bombchus have no tier to carry the item across, so a nonzero
             // shared count is what implies the item here.
-            if (count > 0u) {
+            if (!grantBlocked && count > 0u) {
                 OoT_EnsureInventoryItem(row->item);
             }
             AMMO(row->item) = (s8)count;

--- a/games/oot/soh/GameExports_SingleExe.cpp
+++ b/games/oot/soh/GameExports_SingleExe.cpp
@@ -1205,6 +1205,14 @@ static void OoT_EnsureInventoryItem(uint8_t item) {
     }
 }
 
+// Declared locally because OTRGlobals.h only declares this inside its
+// `#ifndef __cplusplus` block — the C half of the header — so it is invisible
+// to every C++ TU. Redeclaring it here is the established pattern rather than a
+// workaround: draw.cpp, CosmeticsEditor.cpp, NoMasterSword.cpp and several
+// other C++ callers each do exactly this. The definition (OTRGlobals.cpp) is
+// extern "C", which is the linkage this must match.
+extern "C" u8 Randomizer_GetSettingValue(RandomizerSettingKey randoSettingKey);
+
 /**
  * Is this row's bag a shuffled CHECK in the live OoT seed that the player has
  * not found yet? Then the shared pool must not hand it over.

--- a/games/oot/soh/GameExports_SingleExe.cpp
+++ b/games/oot/soh/GameExports_SingleExe.cpp
@@ -1130,6 +1130,8 @@ extern "C" void OoT_Inventory_ChangeUpgrade(s16 upgrade, s16 value);
 extern "C" u32 OoT_gUpgradeMasks[8];
 extern "C" u8 OoT_gUpgradeShifts[8];
 extern "C" u16 OoT_gUpgradeCapacities[8][4];
+// Backs the SLOT/AMMO/INV_CONTENT macros (macros.h) the ammo shim uses.
+extern "C" u8 OoT_gItemSlots[56];
 
 // Heart pieces live in the TOP NIBBLE of questItems in BOTH games (OoT writes
 // `1 << (QUEST_HEART_PIECE + 4)`, MM's QUEST_HEART_PIECE_COUNT is 0x1C), which
@@ -1142,6 +1144,98 @@ extern "C" u16 OoT_gUpgradeCapacities[8][4];
 // authored by a future build with more tiers cannot index off the end of OoT's
 // capacity table.
 #define OOT_MAX_WALLET_TIER 3u
+
+// Highest tier index in every ammo row of OoT_gUpgradeCapacities (each row has
+// 4 entries). Passed as the apply CAP for the same reason OOT_MAX_WALLET_TIER
+// is: a pool value authored by a future build with more tiers must not index
+// off the end of the capacity table.
+#define OOT_MAX_AMMO_TIER 3u
+
+// OoT's bombchu ceiling. Unlike arrows and bombs, bombchus have no upgrade row
+// in either game — OoT fixes the cap at 50 while MM derives it from the bomb
+// bag — so the two ends of this shared count clamp against different numbers,
+// which is exactly the asymmetry the watermark discipline exists to absorb.
+#define OOT_BOMBCHU_CAPACITY 50u
+
+// One shared ammo pair: the capacity tier, the count it bounds, and the
+// inventory item a tier of 1 or more implies. Table-driven because the five
+// rows differ only in these four values, and a copy-pasted block per row is
+// how one of them silently ends up reading another's slot.
+typedef struct {
+    uint8_t tierKind;  // RSBS_SHARED_RES_*_TIER, or RSBS_SHARED_RES_NONE when the count has no tier (bombchus)
+    uint8_t countKind; // RSBS_SHARED_RES_*_COUNT
+    s16 upgrade;       // UPG_* row index, ignored when tierKind is NONE
+    uint8_t item;      // ITEM_* whose slot holds the count, and which a nonzero tier grants
+} OoTSharedAmmo;
+
+static const OoTSharedAmmo kOoTSharedAmmo[] = {
+    { RSBS_SHARED_RES_QUIVER_TIER, RSBS_SHARED_RES_ARROW_COUNT, UPG_QUIVER, ITEM_BOW },
+    { RSBS_SHARED_RES_BOMB_BAG_TIER, RSBS_SHARED_RES_BOMB_COUNT, UPG_BOMB_BAG, ITEM_BOMB },
+    { RSBS_SHARED_RES_STICK_TIER, RSBS_SHARED_RES_STICK_COUNT, UPG_STICKS, ITEM_STICK },
+    { RSBS_SHARED_RES_NUT_TIER, RSBS_SHARED_RES_NUT_COUNT, UPG_NUTS, ITEM_NUT },
+    { RSBS_SHARED_RES_NONE, RSBS_SHARED_RES_BOMBCHU_COUNT, 0, ITEM_BOMBCHU },
+};
+
+static uint16_t OoT_ReadAmmo(uint8_t item) {
+    const s8 held = AMMO(item);
+    return held < 0 ? 0u : (uint16_t)held;
+}
+
+// The count's ceiling in OoT right now: the live capacity for a row that has an
+// upgrade, the fixed bombchu cap for the one that does not.
+static uint16_t OoT_AmmoCapacity(const OoTSharedAmmo* row) {
+    if (row->tierKind == RSBS_SHARED_RES_NONE) {
+        return (uint16_t)OOT_BOMBCHU_CAPACITY;
+    }
+    return (uint16_t)CUR_CAPACITY(row->upgrade);
+}
+
+// Put `item` in its own inventory slot if the slot is empty.
+//
+// This is the half of a tier grant OoT does NOT do for itself. Its tier-2 and
+// tier-3 gives (Bigger Quiver, Bigger Bomb Bag) only widen the capacity, on the
+// assumption that whatever granted tier 1 already put the bow or the bombs in
+// the inventory. A cross-game apply breaks that assumption — the pool can hand
+// OoT a quiver tier it never earned locally — so without this the player gets
+// capacity and ammo with no usable C-item. MM's own gives set INV_CONTENT
+// unconditionally, which is the behavior being matched.
+static void OoT_EnsureInventoryItem(uint8_t item) {
+    if (INV_CONTENT(item) == ITEM_NONE) {
+        INV_CONTENT(item) = item;
+    }
+}
+
+/**
+ * Is this row's bag a shuffled CHECK in the live OoT seed that the player has
+ * not found yet? Then the shared pool must not hand it over.
+ *
+ * OoT_Item_Give opens with exactly this refusal (z_parameter.c:1876-1885, "in
+ * case something got missed"): with RSK_SHUFFLE_DEKU_STICK_BAG or
+ * RSK_SHUFFLE_DEKU_NUT_BAG on, sticks and nuts are not obtainable at all until
+ * their bag check is found. That gate matters HERE and not for the wallet or
+ * the quiver because MM's side is not neutral: a fresh MM save is BORN at stick
+ * and nut tier 1 (the Sram default table), so plain monotonic sharing would
+ * push tier 1 into OoT on the very first crossing of every seed and quietly
+ * satisfy a check the seed placed elsewhere.
+ *
+ * The whole row is skipped rather than just the tier. Applying the count alone
+ * would clamp it against a capacity of zero and record that zero as
+ * materialized, which is how a suppressed grant turns into a drained pool; with
+ * no apply at all there is no watermark, and the harvest's own seed rule then
+ * reads the occupied slot and contributes nothing.
+ */
+static bool OoT_SharedAmmoBlockedByShuffle(const OoTSharedAmmo* row) {
+    if (!IS_RANDO || OTRGlobals::Instance == nullptr || OTRGlobals::Instance->gRandoContext == nullptr) {
+        return false;
+    }
+    if (row->item == ITEM_STICK) {
+        return Randomizer_GetSettingValue(RSK_SHUFFLE_DEKU_STICK_BAG) != 0 && CUR_UPG_VALUE(UPG_STICKS) == 0;
+    }
+    if (row->item == ITEM_NUT) {
+        return Randomizer_GetSettingValue(RSK_SHUFFLE_DEKU_NUT_BAG) != 0 && CUR_UPG_VALUE(UPG_NUTS) == 0;
+    }
+    return false;
+}
 
 static uint16_t OoT_ReadHealthQuarters(void) {
     const uint16_t pieces =
@@ -1258,6 +1352,18 @@ extern "C" void OoT_HarvestSharedResources(void) {
                                 gSaveContext.isDoubleDefenseAcquired ? 1u : 0u);
     Combo_HarvestSharedResource(GAME_OOT, RSBS_SHARED_RES_MAGIC_LEVEL, OoT_ReadMagicLevel());
     Combo_HarvestSharedResource(GAME_OOT, RSBS_SHARED_RES_MAGIC_CURRENT, OoT_ReadSettledMagic());
+
+    // Ammo. No settle step: unlike rupees and magic, neither game defers an
+    // ammo change through an accumulator — every give and every shot is an
+    // immediate AMMO() write with an inline clamp, so the live count is always
+    // already settled.
+    for (int i = 0; i < ARRAY_COUNT(kOoTSharedAmmo); i++) {
+        const OoTSharedAmmo* row = &kOoTSharedAmmo[i];
+        if (row->tierKind != RSBS_SHARED_RES_NONE) {
+            Combo_HarvestSharedResource(GAME_OOT, row->tierKind, (uint16_t)CUR_UPG_VALUE(row->upgrade));
+        }
+        Combo_HarvestSharedResource(GAME_OOT, row->countKind, OoT_ReadAmmo(row->item));
+    }
 }
 
 /**
@@ -1376,6 +1482,38 @@ extern "C" void OoT_ApplySharedResources(void) {
         gSaveContext.magicCapacity = 0;
         gSaveContext.magicState = MAGIC_STATE_IDLE;
         gSaveContext.prevMagicState = MAGIC_STATE_IDLE;
+    }
+
+    // --- Ammo: every tier BEFORE the count it bounds, in one pass per row, for
+    // the same reason wallet precedes rupees. A count applied against a
+    // capacity of zero clamps to zero and the watermark records that zero as
+    // materialized, quietly dropping the rest of the pool.
+    for (int i = 0; i < ARRAY_COUNT(kOoTSharedAmmo); i++) {
+        const OoTSharedAmmo* row = &kOoTSharedAmmo[i];
+
+        if (OoT_SharedAmmoBlockedByShuffle(row)) {
+            continue;
+        }
+
+        if (row->tierKind != RSBS_SHARED_RES_NONE) {
+            uint16_t tier = (uint16_t)CUR_UPG_VALUE(row->upgrade);
+            if (Combo_ApplySharedResource(GAME_OOT, row->tierKind, OOT_MAX_AMMO_TIER, &tier)) {
+                OoT_Inventory_ChangeUpgrade(row->upgrade, (s16)tier);
+                if (tier >= 1u) {
+                    OoT_EnsureInventoryItem(row->item);
+                }
+            }
+        }
+
+        uint16_t count = OoT_ReadAmmo(row->item);
+        if (Combo_ApplySharedResource(GAME_OOT, row->countKind, OoT_AmmoCapacity(row), &count)) {
+            // Bombchus have no tier to carry the item across, so a nonzero
+            // shared count is what implies the item here.
+            if (count > 0u) {
+                OoT_EnsureInventoryItem(row->item);
+            }
+            AMMO(row->item) = (s8)count;
+        }
     }
 }
 

--- a/src/common/context.h
+++ b/src/common/context.h
@@ -238,12 +238,9 @@ int Context_ArmShadowAsFrozen(GameId game, uint16_t returnEntrance);
  * RESOURCES can be tracked at once. A shared resource is not an item that
  * crosses once — it is ONE QUANTITY spanning both games, capacity and current
  * value together ("current health is tracked as if OoT and MM were one game
- * with a single health bar"). Seven of the eight slots are occupied — five by
- * v1 (rupees, wallet tier, health quarters, current health, double defense)
- * and two by shared magic (level + current, #525's optional tier) — leaving
- * ONE free. The ammo upgrades are the queued remainder of the class and need
- * ~10 slots, so they arrive with the second block prescribed below, not by
- * squeezing into this one.
+ * with a single health bar"). All eight slots of THIS block are spoken for by
+ * v1 plus magic; the ammo tier's nine kinds live in the second block below.
+ * Together the two blocks hold twenty slots, sixteen of them occupied.
  *
  * DO NOT BUMP THIS CONSTANT to get more capacity, for the reason
  * RSBS_GRANT_SOURCE_CAP spells out: the array is carved from the front of
@@ -253,6 +250,34 @@ int Context_ArmShadowAsFrozen(GameId game, uint16_t returnEntrance);
  * accessor instead. See ADR 0005 §1 for the identical hazard.
  */
 #define RSBS_SHARED_RESOURCE_CAP 8u
+
+/**
+ * Capacity of ComboContext.sharedResourcesExt (#525 optional tier): the SECOND
+ * shared-resource block, carved exactly as the comment above prescribes rather
+ * than by widening the first one in place.
+ *
+ * The two blocks are ONE LOGICAL ARRAY. shared_resources.c addresses them by a
+ * logical index — 0..RSBS_SHARED_RESOURCE_CAP-1 in the first block, the rest in
+ * this one — and every scan (duplicate lookup, first-free, count) must cover
+ * both in a single pass. A scan that stops at the first block's end silently
+ * splits a kind across blocks or drops a harvest on a "full" array that has
+ * twelve free slots behind it.
+ *
+ * Sized for the whole class in ONE carve, deliberately. Today's set occupies
+ * sixteen of the twenty slots (seven from v1 plus magic, nine from ammo), and a
+ * carve is permanent: a third block would cost another literal offset, another
+ * span in every accessor, and another ADR amendment. The four spare slots are
+ * what keeps the next resource from needing any of that.
+ *
+ * Bounded from above by ADR 0009's 64-byte reserved[] floor, not by taste:
+ * twelve slots is 48 bytes, leaving reserved[132], which still clears the floor
+ * after the ADR's outstanding claims 2 and 4 (4 + 64) land. Sixteen slots would
+ * not.
+ */
+#define RSBS_SHARED_RESOURCE_EXT_CAP 12u
+
+/** Logical slot count across BOTH shared-resource blocks. */
+#define RSBS_SHARED_RESOURCE_TOTAL_CAP (RSBS_SHARED_RESOURCE_CAP + RSBS_SHARED_RESOURCE_EXT_CAP)
 
 /**
  * One cross-game item, tagged with the game whose id-space `id` belongs to.
@@ -366,6 +391,19 @@ enum {
     RSBS_SHARED_RES_DOUBLE_DEFENSE = 5,   // MONOTONIC: 0/1 flag; each game sets its OWN differently-named field pair
     RSBS_SHARED_RES_MAGIC_LEVEL = 6,      // MONOTONIC: meter level 0/1/2 from the two acquired FLAGS, never magicLevel
     RSBS_SHARED_RES_MAGIC_CURRENT = 7,    // CONSUMABLE: the single shared magic meter, 0x30 per bar in both games
+    // Ammo (#525 optional tier). Both games pack the capacity tiers into
+    // inventory.upgrades with the SAME bit layout and the SAME capacity rows,
+    // so a tier is one number needing no conversion. The counts live in each
+    // game's own inventory.ammo[] and are spent, so they delta-harvest.
+    RSBS_SHARED_RES_QUIVER_TIER = 8,      // MONOTONIC: 0..3 ({0,30,40,50} arrows in both games)
+    RSBS_SHARED_RES_BOMB_BAG_TIER = 9,    // MONOTONIC: 0..3 ({0,20,30,40} bombs in both games)
+    RSBS_SHARED_RES_STICK_TIER = 10,      // MONOTONIC: 0..3 ({0,10,20,30} sticks in both games)
+    RSBS_SHARED_RES_NUT_TIER = 11,        // MONOTONIC: 0..3 ({0,20,30,40} nuts in both games)
+    RSBS_SHARED_RES_ARROW_COUNT = 12,     // CONSUMABLE: arrows held, clamped to the quiver capacity applied first
+    RSBS_SHARED_RES_BOMB_COUNT = 13,      // CONSUMABLE: bombs held, clamped to the bomb-bag capacity
+    RSBS_SHARED_RES_BOMBCHU_COUNT = 14,   // CONSUMABLE: bombchus held; the CAP is per-game (see the shims), not a kind
+    RSBS_SHARED_RES_STICK_COUNT = 15,     // CONSUMABLE: deku sticks held, clamped to the stick capacity
+    RSBS_SHARED_RES_NUT_COUNT = 16,       // CONSUMABLE: deku nuts held, clamped to the nut capacity
 };
 
 /**
@@ -554,6 +592,19 @@ typedef struct {
     // gSaveContext against it at the switch boundary.
     ComboSharedResource sharedResources[RSBS_SHARED_RESOURCE_CAP];
 
+    // #525 optional tier: the SECOND shared-resource block, carved from the
+    // front of the old reserved[180] under the growth contract — all-zero =
+    // every slot EMPTY, exactly what a zero-extended record written before the
+    // ammo tier must read as. This is the prescription in
+    // RSBS_SHARED_RESOURCE_CAP's own comment, followed literally: the first
+    // block was NOT widened, because anything carved after it (this array, and
+    // whatever follows) would have slid off the offset every shipped .redsave
+    // stored it at.
+    //
+    // Logically these twenty slots are ONE array; shared_resources.c spans both
+    // blocks in every scan. Physically they must stay two, forever.
+    ComboSharedResource sharedResourcesExt[RSBS_SHARED_RESOURCE_EXT_CAP];
+
     // Headroom. Carve new fields from the FRONT of this array (as
     // sharedItemsTagged, sharedRandoSettingsHash, foreignPlacements, the
     // grant cursors, and the reverse placement table were) so the struct
@@ -564,13 +615,14 @@ typedef struct {
     // a freshly-initialized one — every field carved from here must keep
     // "zero means unset".
     //
-    // 264 - 48 (foreignPlacementsOoT) - 4 (mmProfileDigest) - 32 (sharedResources).
+    // 264 - 48 (foreignPlacementsOoT) - 4 (mmProfileDigest) - 32 (sharedResources)
+    // - 48 (sharedResourcesExt).
     // ADR 0009 publishes the remaining
     // allocation across the other claimants and sets a 64-byte floor:
     // Test_SaveComboRecordFixed's scribble loop iterates sizeof(reserved), so
     // at zero it degenerates to zero iterations and passes vacuously, retiring
     // the only test that proves headroom round-trips at all.
-    uint8_t reserved[180];
+    uint8_t reserved[132];
 } ComboContext;
 
 /**
@@ -677,12 +729,27 @@ RSBS_CTX_STATIC_ASSERT(offsetof(ComboContext, sharedResources) ==
                            offsetof(ComboContext, mmProfileDigest) + sizeof(uint32_t),
                        "sharedResources must be carved from the FRONT of reserved[] (contiguous with "
                        "the MM profile digest); moving it changes .redsave format");
-RSBS_CTX_STATIC_ASSERT(offsetof(ComboContext, reserved) ==
+// The second shared-resource block is the next carve (#525 optional tier, 48
+// bytes). Pinned to the literal 824 for the same reason 672, 736, 740, 788 and
+// 792 are: anything carved after it inherits its position, so a field growing
+// in place ahead of it must break the build rather than slide it. In
+// particular, an in-place widen of the FIRST block would move this one — which
+// is exactly the break RSBS_SHARED_RESOURCE_CAP's comment forbids, and this is
+// the assert that catches it.
+RSBS_CTX_STATIC_ASSERT(offsetof(ComboContext, sharedResourcesExt) == 824u,
+                       "sharedResourcesExt lives at .redsave byte offset 824; if this fires, a field "
+                       "before it grew in place - carve from reserved[] instead");
+RSBS_CTX_STATIC_ASSERT(offsetof(ComboContext, sharedResourcesExt) ==
                            offsetof(ComboContext, sharedResources) +
                                RSBS_SHARED_RESOURCE_CAP * sizeof(ComboSharedResource),
+                       "sharedResourcesExt must be carved from the FRONT of reserved[] (contiguous "
+                       "with the first shared-resource block); moving it changes .redsave format");
+RSBS_CTX_STATIC_ASSERT(offsetof(ComboContext, reserved) ==
+                           offsetof(ComboContext, sharedResourcesExt) +
+                               RSBS_SHARED_RESOURCE_EXT_CAP * sizeof(ComboSharedResource),
                        "the tagged-item array, the settings digest, both foreign-placement tables, "
-                       "the grant cursors, the overflow count, the MM profile digest, the shared "
-                       "resource slots, and the remaining headroom must stay contiguous (no padding, "
+                       "the grant cursors, the overflow count, the MM profile digest, BOTH shared "
+                       "resource blocks, and the remaining headroom must stay contiguous (no padding, "
                        "no fields slipped between them)");
 // ADR 0009's floor. reserved[] is what Test_SaveComboRecordFixed scribbles to
 // prove Tier-1 headroom round-trips; at zero that loop runs zero times and the

--- a/src/common/foreign_items.c
+++ b/src/common/foreign_items.c
@@ -111,7 +111,7 @@ bool Combo_GetForeignItemByNameFor(uint8_t originGame, const char* name, SharedI
     // The spoiler-LOAD inverse. Reused (not re-derived) so reconstruction shares
     // one source of truth with generation, and so a raw RG_*/RI_* is never
     // fabricated on the far side (ADR 0002). Scoped to ONE origin's pool: the
-    // display names are not unique across pools ("Bomb Bag" is in both), so a
+    // display names are not unique across pools ("Lens of Truth" is in both), so a
     // merged scan would resolve to a wrong origin tag rather than to nothing.
     if (name == NULL) {
         return false;

--- a/src/common/foreign_items.h
+++ b/src/common/foreign_items.h
@@ -52,7 +52,7 @@ typedef struct {
 
 // WHY THE ARTICLE IS PART OF THE DESCRIPTOR (#510). A cross-game item is
 // presented as an ORDINARY pickup of whichever game the player found it in —
-// "You found the Bomb Bag!", never "it belongs to the other game". Both games
+// "You found the Lens of Truth!", never "it belongs to the other game". Both games
 // build that sentence by prepending a per-item article (MM:
 // Rando::StaticData::Items[].article; OoT: Item::GetArticle()), but the HOST
 // game cannot look up the FOREIGN game's item table — that is the whole ADR 0002
@@ -81,8 +81,10 @@ typedef struct {
 // pool linked resolves cleanly — the missing origin simply has no entries,
 // rather than failing to link.
 //
-// (originGame, name) IS THE KEY. Bare `name` is not: "Bomb Bag" is literally
-// present in BOTH pools (OoT's RG_BOMB_BAG row and MM's RI_BOMB_BAG_20 row), so
+// (originGame, name) IS THE KEY. Bare `name` is not: "Lens of Truth" is
+// literally present in BOTH pools (OoT's RG_LENS_OF_TRUTH row and MM's RI_LENS
+// row — it took the job over from "Bomb Bag", whose two halves both left when
+// shared ammo made the bomb-bag capacity a shared resource), so
 // a name-only inverse silently resolves to whichever pool it scans first and
 // writes a WRONG ORIGIN TAG into the placement table — the #356 aliasing class,
 // arriving through the one path that rebuilds state from untrusted text on
@@ -139,7 +141,7 @@ const char* Combo_GetForeignItemName(SharedItem item);
  *
  * Split from the name rather than baked into it because the two are consumed
  * separately: a spoiler line wants the bare name, a pickup textbox wants the
- * full "the Bomb Bag" phrase. See the note on ComboForeignItemDef.article.
+ * full "the Lens of Truth" phrase. See the note on ComboForeignItemDef.article.
  */
 const char* Combo_GetForeignItemArticle(SharedItem item);
 

--- a/src/common/shared_resources.c
+++ b/src/common/shared_resources.c
@@ -56,21 +56,50 @@ static bool IsMonotonicKind(uint8_t kind) {
         case RSBS_SHARED_RES_HEALTH_QUARTERS:
         case RSBS_SHARED_RES_DOUBLE_DEFENSE:
         case RSBS_SHARED_RES_MAGIC_LEVEL:
+        case RSBS_SHARED_RES_QUIVER_TIER:
+        case RSBS_SHARED_RES_BOMB_BAG_TIER:
+        case RSBS_SHARED_RES_STICK_TIER:
+        case RSBS_SHARED_RES_NUT_TIER:
             return true;
         default:
-            // RSBS_SHARED_RES_RUPEES, RSBS_SHARED_RES_HEALTH_CURRENT,
-            // RSBS_SHARED_RES_MAGIC_CURRENT: the player spends these, so they
-            // are delta-harvested.
+            // The spent quantities — rupees, current health, current magic, and
+            // the five ammo counts — are delta-harvested.
             return false;
     }
 }
 
+// ============================================================================
+// TWO PHYSICAL BLOCKS, ONE LOGICAL ARRAY.
+//
+// gComboCtx.sharedResources[8] and gComboCtx.sharedResourcesExt[12] are
+// separate fields at separate .redsave offsets — they must be, because
+// widening the first in place would move the second (and everything carved
+// after it) off the offset every shipped save stored it at. But nothing above
+// this line should have to know that: a "slot" here is a LOGICAL index into
+// the concatenation, and every scan below covers the whole range in one pass.
+//
+// This resolver is the only place the split is visible. Keeping it that way is
+// the point — a scan that stops at the first block's end would split a kind
+// across blocks (two slots claiming one resource) or report "full" with twelve
+// free slots behind it.
+// ============================================================================
+
+static ComboSharedResource* SlotAt(int logical) {
+    if (logical < 0 || logical >= (int)RSBS_SHARED_RESOURCE_TOTAL_CAP) {
+        return NULL;
+    }
+    if (logical < (int)RSBS_SHARED_RESOURCE_CAP) {
+        return &gComboCtx.sharedResources[logical];
+    }
+    return &gComboCtx.sharedResourcesExt[logical - (int)RSBS_SHARED_RESOURCE_CAP];
+}
+
 // Locate the occupied slot holding `kind`, or -1 when the resource has never
 // been shared. Slots are unordered; there is at most one per kind because
-// FindOrCreateSlot always looks first.
+// FindOrCreateSlot always looks first — across BOTH blocks.
 static int FindSlot(uint8_t kind) {
-    for (int i = 0; i < (int)RSBS_SHARED_RESOURCE_CAP; i++) {
-        if (gComboCtx.sharedResources[i].kind == kind) {
+    for (int i = 0; i < (int)RSBS_SHARED_RESOURCE_TOTAL_CAP; i++) {
+        if (SlotAt(i)->kind == kind) {
             return i;
         }
     }
@@ -81,22 +110,25 @@ static int FindSlot(uint8_t kind) {
 // -1 only when every slot is taken by some OTHER resource. Nothing is ever
 // evicted: unlike a shared ITEM, a shared resource has no "redeemed" state, so
 // there is no slot that is safe to reclaim — a full array means the resource
-// set outgrew RSBS_SHARED_RESOURCE_CAP, which is a carve-time bug, not a
-// runtime condition. The array is sized with room for the whole class.
+// set outgrew both blocks, which is a carve-time bug, not a runtime condition.
+// The blocks are sized with room for the whole class.
 static int FindOrCreateSlot(uint8_t kind) {
     int slot = FindSlot(kind);
     if (slot >= 0) {
         return slot;
     }
-    for (int i = 0; i < (int)RSBS_SHARED_RESOURCE_CAP; i++) {
-        if (gComboCtx.sharedResources[i].kind == RSBS_SHARED_RES_NONE) {
-            gComboCtx.sharedResources[i].kind = kind;
-            gComboCtx.sharedResources[i].flags = IsMonotonicKind(kind) ? RSBS_SHARED_RES_F_MONOTONIC : 0u;
-            gComboCtx.sharedResources[i].value = 0u;
+    for (int i = 0; i < (int)RSBS_SHARED_RESOURCE_TOTAL_CAP; i++) {
+        ComboSharedResource* entry = SlotAt(i);
+        if (entry->kind == RSBS_SHARED_RES_NONE) {
+            entry->kind = kind;
+            entry->flags = IsMonotonicKind(kind) ? RSBS_SHARED_RES_F_MONOTONIC : 0u;
+            entry->value = 0u;
             return i;
         }
     }
-    fprintf(stderr, "[combo] shared-resource slots full; dropping kind=%u (raise RSBS_SHARED_RESOURCE_CAP by carving a second block)\n",
+    fprintf(stderr,
+            "[combo] shared-resource slots full across both blocks; dropping kind=%u (carve a THIRD "
+            "block from reserved[] and span it too — never widen an existing block in place)\n",
             (unsigned)kind);
     return -1;
 }
@@ -149,8 +181,9 @@ void Combo_HarvestSharedResource(GameId game, uint8_t kind, uint16_t liveValue) 
         if (slot < 0) {
             return;
         }
-        if (liveValue > gComboCtx.sharedResources[slot].value) {
-            gComboCtx.sharedResources[slot].value = liveValue;
+        ComboSharedResource* entry = SlotAt(slot);
+        if (liveValue > entry->value) {
+            entry->value = liveValue;
         }
         return;
     }
@@ -181,14 +214,15 @@ void Combo_HarvestSharedResource(GameId game, uint8_t kind, uint16_t liveValue) 
     if (slot < 0) {
         return;
     }
-    int32_t next = (int32_t)gComboCtx.sharedResources[slot].value + delta;
+    ComboSharedResource* entry = SlotAt(slot);
+    int32_t next = (int32_t)entry->value + delta;
     if (next < 0) {
         next = 0;
     }
     if (next > 0xFFFF) {
         next = 0xFFFF;
     }
-    gComboCtx.sharedResources[slot].value = (uint16_t)next;
+    entry->value = (uint16_t)next;
 }
 
 bool Combo_ApplySharedResource(GameId game, uint8_t kind, uint16_t cap, uint16_t* liveValue) {
@@ -208,7 +242,7 @@ bool Combo_ApplySharedResource(GameId game, uint8_t kind, uint16_t cap, uint16_t
         return false;
     }
 
-    const uint16_t shared = gComboCtx.sharedResources[slot].value;
+    const uint16_t shared = SlotAt(slot)->value;
     const uint16_t applied = (shared > cap) ? cap : shared;
 
     if (IsMonotonicKind(kind)) {
@@ -237,14 +271,14 @@ bool Combo_GetSharedResource(uint8_t kind, uint16_t* outValue) {
     if (slot < 0) {
         return false;
     }
-    *outValue = gComboCtx.sharedResources[slot].value;
+    *outValue = SlotAt(slot)->value;
     return true;
 }
 
 int Combo_CountSharedResources(void) {
     int count = 0;
-    for (int i = 0; i < (int)RSBS_SHARED_RESOURCE_CAP; i++) {
-        if (gComboCtx.sharedResources[i].kind != RSBS_SHARED_RES_NONE) {
+    for (int i = 0; i < (int)RSBS_SHARED_RESOURCE_TOTAL_CAP; i++) {
+        if (SlotAt(i)->kind != RSBS_SHARED_RES_NONE) {
             count++;
         }
     }

--- a/src/common/shared_resources.h
+++ b/src/common/shared_resources.h
@@ -15,27 +15,38 @@
  *
  * v1 shares rupees and hearts; the #525 optional tier added magic — meter
  * level and current magic, "current magic is tracked as if OoT and MM were one
- * game with a single magic meter". That is what justifies the matching pool
- * shrink in `kForeignPoolMMV1` (#525): with one wallet, one health bar and one
- * magic meter spanning both games, MM's wallet/heart/double-defense/magic rows
- * are no longer separate items to cross — they ARE the shared resource, so
- * shipping them as foreign placements too would hand the player a second copy
- * of a quantity they already have. The ammo upgrades are the queued remainder
- * of the same class.
+ * game with a single magic meter" — and then ammo: the quiver, bomb-bag, stick
+ * and nut capacity TIERS plus the arrow, bomb, bombchu, stick and nut COUNTS.
+ * That is what justifies the matching pool shrink in `kForeignPoolMMV1`
+ * (#525): with one wallet, one health bar, one magic meter and one quiver
+ * spanning both games, MM's wallet/heart/double-defense/magic/ammo rows are no
+ * longer separate items to cross — they ARE the shared resource, so shipping
+ * them as foreign placements too would hand the player a second copy of a
+ * quantity they already have.
+ *
+ * A CAPACITY TIER CARRIES THE ITEM WITH IT, copying OoTMM ("a Shared Bow
+ * grants the ability to use the Hero's Bow in MM and the Fairy Bow in OoT").
+ * Each game's apply authors its own inventory slot when a tier rises from
+ * zero, because the two games disagree about who does that: MM's own tier
+ * gives set INV_CONTENT (it treats quiver tier 1 AS owning the bow), while
+ * OoT's tier-2/3 gives assume tier 1 already granted the item. That is also
+ * why the bow rows left both pools — a bow crossing would mutate the shared
+ * quiver tier, which criterion 6 forbids.
  *
  * ---------------------------------------------------------------------------
  * THE TWO MERGE DISCIPLINES
  * ---------------------------------------------------------------------------
  * Picking the wrong one is a correctness bug, not a style choice.
  *
- *   MONOTONIC — wallet tier, health quarters, double defense, magic level. A
- *   capacity that only ever grows. Harvest is `shared = max(shared, live)`,
- *   apply is `live = max(live, shared)`. Idempotent in both directions; decay
- *   is impossible by construction, so no bookkeeping is needed.
+ *   MONOTONIC — wallet tier, health quarters, double defense, magic level, and
+ *   the four ammo capacity tiers. A capacity that only ever grows. Harvest is
+ *   `shared = max(shared, live)`, apply is `live = max(live, shared)`.
+ *   Idempotent in both directions; decay is impossible by construction, so no
+ *   bookkeeping is needed.
  *
- *   CONSUMABLE — rupee count, current health, current magic. A quantity the
- *   player spends. Harvest takes a DELTA against a watermark recorded at apply
- *   time, never a raw copy.
+ *   CONSUMABLE — rupee count, current health, current magic, and the five ammo
+ *   counts. A quantity the player spends. Harvest takes a DELTA against a
+ *   watermark recorded at apply time, never a raw copy.
  *
  * THE WATERMARK IS MANDATORY. MM's tier-3 wallet holds 500 and OoT's holds 999
  * (`gUpgradeCapacities`, both games). Under a naive `shared = live` harvest,
@@ -107,7 +118,7 @@ extern "C" {
  * table, which is indexed by KIND (stable) rather than by slot (slots are found
  * by scan and a future compaction could move them).
  */
-#define RSBS_SHARED_RES_KIND_COUNT 8u
+#define RSBS_SHARED_RES_KIND_COUNT 17u
 
 /**
  * Canonical heart quantity ceiling, in health units (0x10 per heart, 4 per
@@ -166,10 +177,10 @@ void Combo_SplitHealthQuarters(uint16_t quarters, uint16_t* outCapacity, uint16_
  * is a no-op (monotonic re-maxes to the same number; consumable computes a zero
  * delta because the first call advanced the watermark).
  *
- * No-op if `game` is not a real game or `kind` is not a real resource. If the
- * slot array is full of other resources the harvest is dropped — the array is
- * sized with headroom for the whole class, so this cannot happen with today's
- * five resources.
+ * No-op if `game` is not a real game or `kind` is not a real resource. If both
+ * slot blocks are full of other resources the harvest is dropped — they are
+ * sized with headroom for the whole class (twenty slots against today's
+ * sixteen kinds), so this cannot happen without a new resource being added.
  */
 void Combo_HarvestSharedResource(GameId game, uint8_t kind, uint16_t liveValue);
 

--- a/src/common/tests/test_foreign_items.c
+++ b/src/common/tests/test_foreign_items.c
@@ -183,7 +183,7 @@ TestResult Test_ForeignItemGive(void) {
         FI_ASSERT(Combo_GetForeignItemByNameFor((uint8_t)GAME_OOT, pool[i].name, &back));
         FI_ASSERT(back.originGame == pool[i].item.originGame && back.id == pool[i].item.id);
         // NOT "the name must not exist in MM's pool": since #510 a real MM pool
-        // is registered and "Bomb Bag" is a genuine row in BOTH id-spaces, so
+        // is registered and "Lens of Truth" is a genuine row in BOTH id-spaces, so
         // that assertion would be false-by-design. The invariant that actually
         // matters is that the two id-spaces never bleed: if the name resolves
         // under GAME_MM at all, it comes back MM-tagged and is a DIFFERENT item
@@ -199,9 +199,9 @@ TestResult Test_ForeignItemGive(void) {
     // ------------------------------------------------------------------
     // ADR 0009 decision 3: (origin, name) is the key; bare name is NOT.
     // ------------------------------------------------------------------
-    // The reason the lookups take an origin at all. "Bomb Bag" is a real
-    // display name in BOTH id-spaces — OoT's RG_BOMB_BAG row and MM's
-    // RI_BOMB_BAG_20 row — so a name-only inverse resolves it to whichever
+    // The reason the lookups take an origin at all. "Lens of Truth" is a real
+    // display name in BOTH id-spaces — OoT's RG_LENS_OF_TRUTH row and MM's
+    // RI_LENS row — so a name-only inverse resolves it to whichever
     // pool it happens to scan first and writes a WRONG ORIGIN TAG into the
     // placement table. That is the #356 aliasing class arriving through the
     // spoiler-LOAD path, which rebuilds state from untrusted text on disk.
@@ -225,40 +225,48 @@ TestResult Test_ForeignItemGive(void) {
 
         // The collision this whole surface exists for must ACTUALLY be present in
         // the two real pools, or everything below passes for want of a conflict.
-        int ootBombBagIdx = -1;
+        //
+        // The colliding pair is "Lens of Truth" (OoT's RG_LENS_OF_TRUTH row
+        // against MM's RI_LENS row). It was "Bomb Bag" until shared ammo (#525)
+        // made the bomb-bag capacity one cross-game quantity and criterion 6
+        // retired BOTH halves of that pair at once — which is exactly why the
+        // OoT Lens row and these assertions landed in the same commit as the
+        // deletions. Renaming a row to dodge a collision is never the fix: the
+        // display name is the spoiler-load persistence key.
+        int ootCollisionIdx = -1;
         for (int k = 0; k < poolCount; k++) {
-            if (strcmp(pool[k].name, "Bomb Bag") == 0) {
-                ootBombBagIdx = k;
+            if (strcmp(pool[k].name, "Lens of Truth") == 0) {
+                ootCollisionIdx = k;
             }
         }
-        int mmBombBagIdx = -1;
+        int mmCollisionIdx = -1;
         for (int k = 0; k < mmPoolCount; k++) {
-            if (strcmp(mmPool[k].name, "Bomb Bag") == 0) {
-                mmBombBagIdx = k;
+            if (strcmp(mmPool[k].name, "Lens of Truth") == 0) {
+                mmCollisionIdx = k;
             }
         }
-        FI_ASSERT(ootBombBagIdx >= 0); // OoT's RG_BOMB_BAG row
-        FI_ASSERT(mmBombBagIdx >= 0);  // MM's RI_BOMB_BAG_20 row
+        FI_ASSERT(ootCollisionIdx >= 0); // OoT's RG_LENS_OF_TRUTH row
+        FI_ASSERT(mmCollisionIdx >= 0);  // MM's RI_LENS row
 
         // The colliding bare name resolves to a DIFFERENT item under each
         // origin — never to the same one, and never to nothing.
         SharedItem fromOoT, fromMM;
-        FI_ASSERT(Combo_GetForeignItemByNameFor((uint8_t)GAME_OOT, "Bomb Bag", &fromOoT));
-        FI_ASSERT(Combo_GetForeignItemByNameFor((uint8_t)GAME_MM, "Bomb Bag", &fromMM));
+        FI_ASSERT(Combo_GetForeignItemByNameFor((uint8_t)GAME_OOT, "Lens of Truth", &fromOoT));
+        FI_ASSERT(Combo_GetForeignItemByNameFor((uint8_t)GAME_MM, "Lens of Truth", &fromMM));
         FI_ASSERT(fromOoT.originGame == (uint8_t)GAME_OOT);
         FI_ASSERT(fromMM.originGame == (uint8_t)GAME_MM);
         // Pin BOTH sides to their real pool rows rather than asserting the two
         // results merely differ. Comparing (id, origin) pairs would be
         // tautological — the origins are already asserted distinct just above —
         // and would still pass if a lookup returned the wrong row of its own pool.
-        FI_ASSERT(fromOoT.id == pool[ootBombBagIdx].item.id);
-        FI_ASSERT(fromMM.id == mmPool[mmBombBagIdx].item.id);
+        FI_ASSERT(fromOoT.id == pool[ootCollisionIdx].item.id);
+        FI_ASSERT(fromMM.id == mmPool[mmCollisionIdx].item.id);
 
         // The legacy bare-name entry point keeps its exact previous meaning:
         // the OoT pool. Call sites that predate the origin dimension must not
         // have silently changed behavior when the MM pool appeared.
         SharedItem legacy;
-        FI_ASSERT(Combo_GetForeignItemByName("Bomb Bag", &legacy));
+        FI_ASSERT(Combo_GetForeignItemByName("Lens of Truth", &legacy));
         FI_ASSERT(legacy.originGame == (uint8_t)GAME_OOT && legacy.id == fromOoT.id);
 
         // Forward direction dispatches on the item's own tag: two items with the
@@ -786,7 +794,7 @@ TestResult Test_ForeignPoolMM(void) {
 
         // #510 presentation: OoT builds the pickup line as article + name, and
         // it cannot read MM's item table to get the article — so every row must
-        // carry one. NULL would print "You found Bomb Bag"; the empty string is
+        // carry one. NULL would print "You found Powder Keg"; the empty string is
         // legal and correct for the several MM items that take no article
         // ("Garo's Mask", "Epona's Song").
         FI_ASSERT(pool[i].article != NULL);
@@ -863,6 +871,14 @@ TestResult Test_ForeignPoolMM(void) {
         // names, spelled from the pool's own rows — a typo here passes
         // vacuously, because the assertion is a not-equal sweep.
         "Progressive Magic",  "Power of Magic",  "Magic Upgrade",
+        // Shared ammo: the capacity tiers are one cross-game quantity now, so
+        // every bag and quiver row left. The BOW rows are here for a reason
+        // that is easy to miss — MM's own bow give sets UPG_QUIVER to 1, so in
+        // MM owning the bow IS quiver tier 1, which makes a bow crossing a
+        // mutation of the shared resource rather than a new item.
+        "Bomb Bag",           "Big Bomb Bag",    "Biggest Bomb Bag",
+        "Large Quiver",       "Largest Quiver",  "Progressive Bomb Bag",
+        "Bow",                "Progressive Bow",
     };
     for (size_t k = 0; k < sizeof(kSharedResourceNames) / sizeof(kSharedResourceNames[0]); k++) {
         for (int i = 0; i < poolCount; i++) {
@@ -873,11 +889,49 @@ TestResult Test_ForeignPoolMM(void) {
         FI_ASSERT(!Combo_GetForeignItemByNameFor((uint8_t)GAME_MM, kSharedResourceNames[k], NULL));
     }
 
-    // The shrink is real, not a rename: those nine rows left and nothing took
-    // their place. Bounded rather than exact for the reason above — a future
-    // shared resource (ammo) removes more, and unrelated work may add.
+    // THE SAME SWEEP AGAINST OoT's POOL. Criterion 6 had no OoT twin until
+    // shared ammo, and that was a real hole rather than an omission worth
+    // leaving: OoT's own pool shipped "Fairy Bow" and "Bomb Bag" rows, and both
+    // became shared resources here, so nothing was watching the side that
+    // actually had to lose entries. Reusing the MM name list is meaningful
+    // wherever the two games spell a row identically — "Bomb Bag" collided
+    // across the pools for exactly that reason — and inert elsewhere, so the
+    // OoT-specific spellings are named separately below.
+    const ComboForeignItemDef* ootPool = NULL;
+    const int ootPoolCount = Combo_GetForeignItemPoolFor((uint8_t)GAME_OOT, &ootPool);
+    FI_ASSERT(ootPoolCount >= 1 && ootPool != NULL);
+    static const char* const kOoTSharedResourceNames[] = {
+        // Retired from kForeignPoolV1 by criterion 6 when shared ammo landed.
+        // Byte-exact as that table spelled them, which is what makes the sweep
+        // non-vacuous: these two strings were really there.
+        "Fairy Bow",
+        "Bomb Bag",
+    };
+    for (size_t k = 0; k < sizeof(kSharedResourceNames) / sizeof(kSharedResourceNames[0]); k++) {
+        for (int i = 0; i < ootPoolCount; i++) {
+            FI_ASSERT(strcmp(ootPool[i].name, kSharedResourceNames[k]) != 0);
+        }
+    }
+    for (size_t k = 0; k < sizeof(kOoTSharedResourceNames) / sizeof(kOoTSharedResourceNames[0]); k++) {
+        for (int i = 0; i < ootPoolCount; i++) {
+            FI_ASSERT(strcmp(ootPool[i].name, kOoTSharedResourceNames[k]) != 0);
+        }
+        FI_ASSERT(!Combo_GetForeignItemByNameFor((uint8_t)GAME_OOT, kOoTSharedResourceNames[k], NULL));
+    }
+
+    // The shrink is real, not a rename: seventeen rows have left across the
+    // three tiers and nothing took their place. Bounded rather than exact for
+    // the reason above — a future shared resource removes more, and unrelated
+    // work may add.
     printf("[TEST] foreign-pool-mm: %d entries after the #525 shared-resource shrink\n", poolCount);
     FI_ASSERT(poolCount <= 128);
+
+    // OoT's pool must stay clear of test_combo_spoiler_view.c's floor of 3,
+    // which it sat exactly on before shared ammo added the Lens, Boomerang and
+    // Megaton Hammer rows. Asserted here rather than left implicit because the
+    // ammo tier is what took two rows OUT of a four-row pool.
+    printf("[TEST] foreign-pool-oot: %d entries\n", ootPoolCount);
+    FI_ASSERT(ootPoolCount >= 3);
 
     printf("[TEST] PASS: MM source pool registered, well-formed, giveable, non-junk, name-invertible, "
            "no shared resources\n");

--- a/src/common/tests/test_save_roundtrip.c
+++ b/src/common/tests/test_save_roundtrip.c
@@ -525,6 +525,16 @@ TestResult Test_SaveComboLegacyRecord(void) {
     static const uint32_t kCraftedSourceKey = 0xC0FFEE01u;
     static const uint32_t kCraftedLastSeq = 0x00000205u;
     static const uint32_t kCraftedOverflow = 0x00BADBEDu;
+    // The SECOND shared-resource block (#525 optional tier). It is the newest
+    // carve and therefore the one most exposed to the hazard this case exists
+    // for: it sits directly behind sharedResources[8], so an in-place widen of
+    // THAT array — the one thing RSBS_SHARED_RESOURCE_CAP's comment forbids —
+    // slides this block off 824 while every other test stays green. Crafted as
+    // a whole 4-byte slot so the kind/flags/value member offsets are pinned too.
+    static const size_t kSharedResourcesExtOffset = 824u; // sharedResourcesExt[0]
+    static const uint8_t kCraftedExtKind = RSBS_SHARED_RES_QUIVER_TIER;
+    static const uint8_t kCraftedExtFlags = RSBS_SHARED_RES_F_MONOTONIC;
+    static const uint16_t kCraftedExtValue = 0x0003u;
 
     SaveTestSeed(tag);  // re-inits gComboCtx and restamps the magic/version
     {
@@ -536,6 +546,9 @@ TestResult Test_SaveComboLegacyRecord(void) {
         std::memcpy(image + kGrantCursorsOffset, &kCraftedSourceKey, sizeof(kCraftedSourceKey));
         std::memcpy(image + kGrantCursorsLastSeqOffset, &kCraftedLastSeq, sizeof(kCraftedLastSeq));
         std::memcpy(image + kOverflowCountOffset, &kCraftedOverflow, sizeof(kCraftedOverflow));
+        std::memcpy(image + kSharedResourcesExtOffset + 0, &kCraftedExtKind, sizeof(kCraftedExtKind));
+        std::memcpy(image + kSharedResourcesExtOffset + 1, &kCraftedExtFlags, sizeof(kCraftedExtFlags));
+        std::memcpy(image + kSharedResourcesExtOffset + 2, &kCraftedExtValue, sizeof(kCraftedExtValue));
     }
 
     mgr.DeleteSave(0);
@@ -547,6 +560,8 @@ TestResult Test_SaveComboLegacyRecord(void) {
     std::memset(gComboCtx.grantCursors, 0x5A, sizeof(gComboCtx.grantCursors));
     gComboCtx.sharedItemOverflowCount = 0x5A5A5A5Au;
     std::memset(gComboCtx.foreignPlacements, 0x5A, sizeof(gComboCtx.foreignPlacements));
+    std::memset(gComboCtx.sharedResources, 0x5A, sizeof(gComboCtx.sharedResources));
+    std::memset(gComboCtx.sharedResourcesExt, 0x5A, sizeof(gComboCtx.sharedResourcesExt));
 
     SAVE_ASSERT(mgr.Load(0), "Load refused a full-length v2 Tier-1 record");
 
@@ -566,9 +581,18 @@ TestResult Test_SaveComboLegacyRecord(void) {
     SAVE_ASSERT(offsetof(ComboContext, sharedItemOverflowCount) == kOverflowCountOffset,
                 "sharedItemOverflowCount moved off .redsave byte offset 736");
 
+    SAVE_ASSERT(gComboCtx.sharedResourcesExt[0].kind == kCraftedExtKind &&
+                    gComboCtx.sharedResourcesExt[0].flags == kCraftedExtFlags &&
+                    gComboCtx.sharedResourcesExt[0].value == kCraftedExtValue,
+                "byte 824 did not land in sharedResourcesExt[0] — the first shared-resource block grew "
+                "in place (which RSBS_SHARED_RESOURCE_CAP forbids) and orphaned every shipped save's "
+                "shared ammo");
+    SAVE_ASSERT(offsetof(ComboContext, sharedResourcesExt) == kSharedResourcesExtOffset,
+                "sharedResourcesExt moved off .redsave byte offset 824");
+
     mgr.DeleteSave(0);
     printf("[TEST] PASS: pre-headroom Tier-1 loads, added fields read as zero, "
-           "and bytes 672/676/736 still land in the ADR 0005 carve\n");
+           "and bytes 672/676/736/824 still land in their carves\n");
     return TEST_PASS;
 }
 

--- a/src/common/tests/test_shared_resources.c
+++ b/src/common/tests/test_shared_resources.c
@@ -445,9 +445,16 @@ TestResult Test_SharedResources(void) {
     SR_ASSERT(SR_Pool(RSBS_SHARED_RES_MAGIC_LEVEL) == 1);
     SR_ASSERT(SR_Pool(RSBS_SHARED_RES_MAGIC_CURRENT) == 0x30);
     // Seven of the first block's eight, so none of them needed the second block
-    // to exist. Anything that pushed one of these past the boundary would move
-    // it to a different .redsave offset than every shipped save wrote it to.
-    SR_ASSERT(Combo_CountSharedResources() <= (int)RSBS_SHARED_RESOURCE_CAP);
+    // to exist. Asserted as PLACEMENT, not as a count: Combo_CountSharedResources
+    // spans both blocks and would answer 7 wherever those seven sat, so a count
+    // here would be satisfied by the very drift it is meant to catch (and is
+    // already implied by the == 7 above). What actually matters is the .redsave
+    // offset — anything that pushed one of these into the ext block would move
+    // it from byte 792.. to byte 824.., where every build predating that carve
+    // reads it as reserved[] and zero-extends it away.
+    for (int i = 0; i < (int)RSBS_SHARED_RESOURCE_EXT_CAP; i++) {
+        SR_ASSERT(gComboCtx.sharedResourcesExt[i].kind == RSBS_SHARED_RES_NONE);
+    }
 
     // Session invalidation retires the pool AND the watermarks together — a
     // watermark surviving into a fresh world would measure a delta against a

--- a/src/common/tests/test_shared_resources.c
+++ b/src/common/tests/test_shared_resources.c
@@ -338,6 +338,78 @@ TestResult Test_SharedResources(void) {
     SR_ASSERT(magic == 0x30);
 
     // ------------------------------------------------------------------
+    // Ammo (#525's optional tier): four capacity TIERS that only grow and five
+    // COUNTS the player spends. Same two disciplines one more time, but this is
+    // the set that overflows the first slot block, so it is also what proves
+    // the second block is reachable at all.
+    // ------------------------------------------------------------------
+    SR_FreshWorld();
+
+    // A tier is monotonic, with the discipline pinned the only way that
+    // distinguishes it: a LOWER harvest AFTER an apply. Misclassified as
+    // consumable this decays to 1; monotonic holds 3.
+    Combo_HarvestSharedResource(GAME_OOT, RSBS_SHARED_RES_QUIVER_TIER, 3);
+    uint16_t quiver = 0;
+    SR_ASSERT(Combo_ApplySharedResource(GAME_MM, RSBS_SHARED_RES_QUIVER_TIER, 3, &quiver));
+    SR_ASSERT(quiver == 3);
+    Combo_HarvestSharedResource(GAME_MM, RSBS_SHARED_RES_QUIVER_TIER, 1);
+    SR_ASSERT(SR_Pool(RSBS_SHARED_RES_QUIVER_TIER) == 3);
+
+    // A count is consumable, and the two games' ceilings differ for bombchus
+    // exactly the way the wallets differ for rupees: OoT holds 50, MM holds
+    // whatever the bomb bag allows (40 at tier 3). The pool keeps the true
+    // total, MM shows what fits, and the overflow comes home intact.
+    Combo_HarvestSharedResource(GAME_OOT, RSBS_SHARED_RES_BOMBCHU_COUNT, 50);
+    uint16_t chus = 0;
+    SR_ASSERT(Combo_ApplySharedResource(GAME_MM, RSBS_SHARED_RES_BOMBCHU_COUNT, 40, &chus));
+    SR_ASSERT(chus == 40);
+    SR_ASSERT(SR_Pool(RSBS_SHARED_RES_BOMBCHU_COUNT) == 50);
+    Combo_HarvestSharedResource(GAME_MM, RSBS_SHARED_RES_BOMBCHU_COUNT, 40); // spent none
+    SR_ASSERT(SR_Pool(RSBS_SHARED_RES_BOMBCHU_COUNT) == 50);
+    SR_ASSERT(Combo_ApplySharedResource(GAME_OOT, RSBS_SHARED_RES_BOMBCHU_COUNT, 50, &chus));
+    SR_ASSERT(chus == 50);
+
+    // Arrows fired in Termina are gone from the one shared count OoT reads.
+    Combo_HarvestSharedResource(GAME_OOT, RSBS_SHARED_RES_ARROW_COUNT, 30);
+    uint16_t arrows = 0;
+    SR_ASSERT(Combo_ApplySharedResource(GAME_MM, RSBS_SHARED_RES_ARROW_COUNT, 30, &arrows));
+    SR_ASSERT(arrows == 30);
+    Combo_HarvestSharedResource(GAME_MM, RSBS_SHARED_RES_ARROW_COUNT, 12);
+    SR_ASSERT(Combo_ApplySharedResource(GAME_OOT, RSBS_SHARED_RES_ARROW_COUNT, 30, &arrows));
+    SR_ASSERT(arrows == 12);
+
+    // ------------------------------------------------------------------
+    // THE SECOND BLOCK IS REACHABLE. Sixteen kinds do not fit the first
+    // block's eight slots, so this is the assertion that fails outright if
+    // sharedResourcesExt is never scanned — which is the whole hazard the
+    // two-block carve introduces: a scan that stops at the first block's end
+    // reports "full" with twelve free slots behind it and silently drops every
+    // resource past the eighth.
+    // ------------------------------------------------------------------
+    SR_FreshWorld();
+    static const uint8_t kAllKinds[] = {
+        RSBS_SHARED_RES_RUPEES,          RSBS_SHARED_RES_WALLET_TIER,   RSBS_SHARED_RES_HEALTH_QUARTERS,
+        RSBS_SHARED_RES_HEALTH_CURRENT,  RSBS_SHARED_RES_DOUBLE_DEFENSE, RSBS_SHARED_RES_MAGIC_LEVEL,
+        RSBS_SHARED_RES_MAGIC_CURRENT,   RSBS_SHARED_RES_QUIVER_TIER,   RSBS_SHARED_RES_BOMB_BAG_TIER,
+        RSBS_SHARED_RES_STICK_TIER,      RSBS_SHARED_RES_NUT_TIER,      RSBS_SHARED_RES_ARROW_COUNT,
+        RSBS_SHARED_RES_BOMB_COUNT,      RSBS_SHARED_RES_BOMBCHU_COUNT, RSBS_SHARED_RES_STICK_COUNT,
+        RSBS_SHARED_RES_NUT_COUNT,
+    };
+    const int kAllKindCount = (int)(sizeof(kAllKinds) / sizeof(kAllKinds[0]));
+    SR_ASSERT(kAllKindCount > (int)RSBS_SHARED_RESOURCE_CAP); // or this proves nothing
+    for (int k = 0; k < kAllKindCount; k++) {
+        // Distinct nonzero values, so a slot collision shows up as a wrong
+        // number rather than as two kinds agreeing by luck.
+        Combo_HarvestSharedResource(GAME_OOT, kAllKinds[k], (uint16_t)(k + 1));
+    }
+    SR_ASSERT(Combo_CountSharedResources() == kAllKindCount);
+    for (int k = 0; k < kAllKindCount; k++) {
+        SR_ASSERT(SR_Pool(kAllKinds[k]) == (uint16_t)(k + 1));
+    }
+    // Still room left, across both blocks, for the next member of the class.
+    SR_ASSERT(Combo_CountSharedResources() < (int)RSBS_SHARED_RESOURCE_TOTAL_CAP);
+
+    // ------------------------------------------------------------------
     // Garbage in: a bogus game or kind must change nothing.
     // ------------------------------------------------------------------
     SR_FreshWorld();
@@ -351,8 +423,10 @@ TestResult Test_SharedResources(void) {
     SR_ASSERT(sink == 42);
 
     // ------------------------------------------------------------------
-    // All seven shared resources (v1 + magic) coexist: the slot array holds
-    // the whole set at once, with no kind overwriting another's slot.
+    // The v1-plus-magic set still coexists inside the FIRST block alone. Kept
+    // as its own case beside the all-sixteen sweep above: this one pins that
+    // those seven kinds have not drifted into the second block, which is the
+    // shape every already-shipped .redsave stores them in.
     // ------------------------------------------------------------------
     SR_FreshWorld();
     Combo_HarvestSharedResource(GAME_OOT, RSBS_SHARED_RES_RUPEES, 250);
@@ -370,11 +444,10 @@ TestResult Test_SharedResources(void) {
     SR_ASSERT(SR_Pool(RSBS_SHARED_RES_DOUBLE_DEFENSE) == 1);
     SR_ASSERT(SR_Pool(RSBS_SHARED_RES_MAGIC_LEVEL) == 1);
     SR_ASSERT(SR_Pool(RSBS_SHARED_RES_MAGIC_CURRENT) == 0x30);
-    // The set fits with exactly one slot to spare. The ammo upgrades — the
-    // queued remainder of the class — do NOT fit there; they arrive with the
-    // second reserved[] block carve (see RSBS_SHARED_RESOURCE_CAP's comment in
-    // context.h), not by squeezing into this array.
-    SR_ASSERT(Combo_CountSharedResources() < (int)RSBS_SHARED_RESOURCE_CAP);
+    // Seven of the first block's eight, so none of them needed the second block
+    // to exist. Anything that pushed one of these past the boundary would move
+    // it to a different .redsave offset than every shipped save wrote it to.
+    SR_ASSERT(Combo_CountSharedResources() <= (int)RSBS_SHARED_RESOURCE_CAP);
 
     // Session invalidation retires the pool AND the watermarks together — a
     // watermark surviving into a fresh world would measure a delta against a
@@ -384,6 +457,7 @@ TestResult Test_SharedResources(void) {
     Combo_HarvestSharedResource(GAME_OOT, RSBS_SHARED_RES_RUPEES, 700);
     SR_ASSERT(SR_Pool(RSBS_SHARED_RES_RUPEES) == 700);
 
-    printf("[TEST] PASS: watermark survives the 500/999 round trip, disciplines split, load cannot double-count\n");
+    printf("[TEST] PASS: watermark survives the 500/999 round trip, disciplines split, load cannot "
+           "double-count, both slot blocks reachable\n");
     return TEST_PASS;
 }


### PR DESCRIPTION
Second PR of #525's optional tier (magic ✅ → **ammo** → hookshot). Follows [#554](https://github.com/spencerduncan/redshipblueship/pull/554).

## The nine new kinds

Quiver / bomb-bag / deku-stick / deku-nut **capacity tiers** (monotonic) plus arrow / bomb / bombchu / stick / nut **counts** (consumable, delta-harvested). Both games pack the tiers into `inventory.upgrades` with the same bit layout *and* the same capacity rows, so a tier crosses as one number with no conversion — unlike the wallet.

## The second carve, done as prescribed

Sixteen kinds don't fit eight slots, and `RSBS_SHARED_RESOURCE_CAP`'s own comment forbids widening in place (it would move every field carved after the array off its shipped `.redsave` offset). So:

- `ComboSharedResource sharedResourcesExt[12]` at **literal offset 824**; `reserved[180]` → `reserved[132]`; new literal + contiguity asserts, and the "reserved begins after the last carve" assert retargeted.
- `shared_resources.c` now treats both blocks as **one logical array of twenty slots** behind a single `SlotAt()` resolver. Every scan spans both in one pass — a scan stopping at the first block's end would split a kind across blocks or report "full" with twelve free slots behind it.
- ADR 0009 gains claim 6. Twelve slots is what the 64-byte floor permits, not a preference: 48 B leaves `reserved[132]`, still clear once claims 2 and 4 land. Sixteen would breach it.

## Tier-implies-item, and why the bow rows leave

Copying OoTMM ("a Shared Bow grants the ability to use the Hero's Bow in MM and the Fairy Bow in OoT"), each apply authors its own inventory slot when a tier rises from zero — necessary because **MM's tier gives set `INV_CONTENT` while OoT's tier-2/3 gives assume tier 1 already granted the item**, an assumption a cross-game apply breaks (capacity and ammo, no usable C-item). Neither apply copies the accompanying *refill*: MM's rando bomb-bag give fills bombs and bombchus to capacity, which per-arrival would be a free restock every switch.

That's also why `RI_BOW` / `RI_PROGRESSIVE_BOW` / `RG_FAIRY_BOW` leave the pools — **MM's bow give sets `UPG_QUIVER = 1`, so in MM owning the bow *is* quiver tier 1**, making a bow crossing a mutation of the shared resource.

## Ordering and the cycle leg

Tier before count, per row, for the same reason wallet precedes rupees. Bombchus go last: their MM cap **is** the bomb-bag capacity (0 at tier 0, 40 at tier 3) where OoT fixes it at 50 — the 500-vs-999 asymmetry again, absorbed by the same watermark.

Unlike magic, **ammo genuinely needs the cycle bracket**: `Sram_SaveEndOfCycle` zeroes `AMMO()` for every slot in `MM_gAmmoItems`. The five shared counts are snapshotted and restored across the wipe via the same `Before`/`AfterEndOfCycleSave` pair the shared rupees use, clearing the four `LOST_*_AMMO` notices. **Slot-indexed**, not item-id-indexed — the vanilla reference in `EndOfCycle.cpp` indexes by item enumerator, which is correct only because a few MM ids coincide with their slot numbers. MM-local ammo (beans, powder keg) is left wiped as vanilla does; the tiers need no bracket (the wipe never touches `inventory.upgrades`).

Harvest needs **no settle step** (unlike rupees/magic): every ammo change in both games is an immediate `AMMO()` write with an inline clamp.

## OoT's shuffle gate is respected

`OoT_Item_Give` refuses sticks/nuts while `RSK_SHUFFLE_DEKU_STICK_BAG` / `..._NUT_BAG` is on and the tier is 0. A **fresh MM save is born at stick and nut tier 1**, so plain monotonic sharing would have pushed tier 1 into OoT on the first crossing of *every* seed and quietly satisfied a check the seed placed elsewhere. The whole row is skipped in that case — skipping only the tier would clamp the count against a zero capacity and drain the pool.

## Pool shrink + the collision trap

Eight MM rows leave (both quivers, all three bomb bags, `RI_PROGRESSIVE_BOMB_BAG`, `RI_BOW`, `RI_PROGRESSIVE_BOW`): **125 → 117**. OoT loses `RG_FAIRY_BOW` and `RG_BOMB_BAG`.

That deletes both halves of "Bomb Bag" — the only cross-pool colliding name, asserted on purpose. Renaming isn't an option (display names are the spoiler-load persistence key), so OoT's pool gains **`RG_LENS_OF_TRUTH`**, colliding byte-for-byte with MM's `RI_LENS`, **in this same commit** as the deletions, because the collision assertions go red the instant one side exists without the other.

OoT's pool would then sit at exactly 3 rows — `test_combo_spoiler_view.c`'s hard floor — so it also gains **Boomerang** and **Megaton Hammer**, the "expand `kForeignPoolV1` beyond 4 entries" follow-up #525 lists and the ammo tier forces. Both are plain `MOD_NONE` items whose give falls through `OoT_Item_Give`'s generic tail (save writes only, no `PlayState` deref), which is what makes them NULL-play safe on the redemption path.

## Tests

- `shared-resources`: ammo section (tier monotonicity pinned by a lower-harvest-after-apply, the 50-vs-40 bombchu round trip, arrow spend decay) plus a sweep harvesting **all sixteen kinds** at distinct values — which fails outright if the second block is never scanned.
- `save-combo-record-fixed`: crafts bytes at **literal offset 824** and reads them back from `sharedResourcesExt[0]` — the half a self-consistent wrong layout can't satisfy. Nothing pinned the new block with real bytes before.
- `foreign-pool-mm`: criterion-6 sweep gains the eight ammo/bow names **and an OoT-pool twin it never had** — a genuine hole, since OoT's pool was the side that had to lose rows this time.
- Collision block re-pointed to "Lens of Truth"; stale prose asserting the old pair corrected across `foreign_items.h/.c` and both pool headers.

## Verification

Local compilation is paused on the operator's instruction, so **CI is the build/test gate for this PR** (all tiers run there). Note the pre-existing `.redsave` compatibility caveat, unchanged from the earlier tiers: a paired world generated before this change whose spoiler or placement table hosts a now-removed row will not resolve that name afterwards — same accepted breakage as the wallet/heart/magic shrink.

Part of #525. Next: shared hookshot (a shared-items cross-grant, a different mechanism from these resources).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!--- section:artifacts:start -->
### Build Artifacts
  - [rsbs-windows.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/8743171593.zip)
  - [rsbs-linux.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/8742934896.zip)
<!--- section:artifacts:end -->