### PR TITLE
Share the hookshot as a monotonic tier, not a cross-granted item (#525)

### DIFF
--- a/docs/adr/0009-combo-settings-and-reverse-pool.md
+++ b/docs/adr/0009-combo-settings-and-reverse-pool.md
@@ -221,11 +221,12 @@ addresses them through a single `SlotAt(logical)` resolver, and every scan — t
 duplicate lookup, the first-free claim, the occupancy count — spans both in one
 pass. That is not tidiness: a scan stopping at the first block's boundary would
 either split one kind across two slots or report the array full with twelve free
-slots behind it, silently dropping every resource past the eighth. Sixteen of
-the twenty are occupied (seven from v1 plus magic, nine from ammo); the block
-was sized for the whole class in one carve, because a third block would cost
-another literal offset, another span in every accessor, and another amendment
-here.
+slots behind it, silently dropping every resource past the eighth. Seventeen of
+the twenty are occupied (seven from v1 plus magic, nine from ammo, one for the
+shared hookshot); the block was sized for the whole class in one carve, because
+a third block would cost another literal offset, another span in every
+accessor, and another amendment here. The hookshot proved that out immediately:
+it landed in a spare slot with no format change at all.
 
 Twelve is the ceiling the floor below permits rather than a preference: 48 B
 leaves `reserved[132]`, which still clears the 64-byte floor once the

--- a/games/mm/2s2h/GameExports_SingleExe.cpp
+++ b/games/mm/2s2h/GameExports_SingleExe.cpp
@@ -2219,6 +2219,17 @@ static void MM_EnsureInventoryItem(uint8_t item) {
     }
 }
 
+// MM's hookshot ceiling. MM has no longshot: there is no RI_LONGSHOT at all,
+// and MM's ITEM_LONGSHOT id is an OoT leftover its give path repurposes into a
+// Red Potion. So MM tops out at tier 1, and the pool's tier 2 materializes here
+// as an ordinary hookshot — which is why only the abstract TIER crosses and
+// never an item id.
+#define MM_MAX_HOOKSHOT_TIER 1u
+
+static uint16_t MM_ReadHookshotTier(void) {
+    return INV_CONTENT(ITEM_HOOKSHOT) == ITEM_HOOKSHOT ? 1u : 0u;
+}
+
 static uint16_t MM_ReadHealthQuarters(void) {
     const uint16_t pieces =
         (uint16_t)((gSaveContext.save.saveInfo.inventory.questItems & MM_HEART_PIECE_MASK) >> MM_HEART_PIECE_SHIFT);
@@ -2333,6 +2344,11 @@ extern "C" void MM_HarvestSharedResources(void) {
         }
         Combo_HarvestSharedResource(GAME_MM, row->countKind, MM_ReadAmmo(row->item));
     }
+
+    // Harvesting MM's 1 can never demote a longshot the pool already holds:
+    // monotonic merges take the max, which is the whole reason a 2-vs-1 ceiling
+    // needs no special case here.
+    Combo_HarvestSharedResource(GAME_MM, RSBS_SHARED_RES_HOOKSHOT_TIER, MM_ReadHookshotTier());
 }
 
 /**
@@ -2481,6 +2497,16 @@ extern "C" void MM_ApplySharedResources(void) {
             }
             AMMO(row->item) = (s8)count;
         }
+    }
+
+    // --- Hookshot (monotonic). Clamped to MM's ceiling of 1, so an OoT
+    // longshot arrives as a plain hookshot; the pool keeps the 2 and OoT gets
+    // its longshot back. No C-button fixup is needed on this side, unlike
+    // OoT's: MM's id never changes, so an equipped hookshot stays correct.
+    uint16_t hookshotTier = MM_ReadHookshotTier();
+    if (Combo_ApplySharedResource(GAME_MM, RSBS_SHARED_RES_HOOKSHOT_TIER, MM_MAX_HOOKSHOT_TIER, &hookshotTier) &&
+        hookshotTier >= 1u) {
+        MM_EnsureInventoryItem(ITEM_HOOKSHOT);
     }
 }
 

--- a/games/mm/2s2h/Rando/ForeignItemsSingleExe.cpp
+++ b/games/mm/2s2h/Rando/ForeignItemsSingleExe.cpp
@@ -182,7 +182,11 @@ extern "C" {
 //      optional tier): RI_PROGRESSIVE_MAGIC, RI_SINGLE_MAGIC and
 //      RI_DOUBLE_MAGIC. Eight more left with shared ammo: RI_BOMB_BAG_20,
 //      RI_BOMB_BAG_30, RI_BOMB_BAG_40, RI_QUIVER_40, RI_QUIVER_50,
-//      RI_PROGRESSIVE_BOMB_BAG, RI_BOW and RI_PROGRESSIVE_BOW.
+//      RI_PROGRESSIVE_BOMB_BAG, RI_BOW and RI_PROGRESSIVE_BOW. And one more
+//      with the shared hookshot: RI_HOOKSHOT. Both games keep the hookshot in a
+//      single inventory byte, which makes it a monotonic TIER (0 none, 1
+//      hookshot, 2 longshot) rather than an item to hand over once — see
+//      RSBS_SHARED_RES_HOOKSHOT_TIER.
 //
 //      THE BOW ROWS LEAVE FOR A REASON WORTH SPELLING OUT, because "a bow is
 //      not ammo" is the obvious objection. MM does not separate the two: its
@@ -200,7 +204,7 @@ extern "C" {
 // the sword upgrades, the
 // progressives (which resolve against the LIVE MM save, so they are the single
 // best-behaved cross-game gift, and the OoT pool sets the precedent with
-// RG_PROGRESSIVE_HOOKSHOT / RG_PROGRESSIVE_STRENGTH), the boss remains, the
+// RG_PROGRESSIVE_STRENGTH), the boss remains, the
 // deeds and letters and other sidequest items, the owl statues, the Tingle maps,
 // and the dungeon keys/maps/compasses/stray fairies.
 //
@@ -214,7 +218,7 @@ extern "C" {
 // deferred to the first frame with a live MM_gPlayState (see the file header),
 // which is item-agnostic and O(1) in pool size — the #502 design note says in as
 // many words that an allowlist audited against today's pool would expire the
-// moment somebody added a row. This pool is that row, 117 times over, and it
+// moment somebody added a row. This pool is that row, 116 times over, and it
 // relies on the deferral instead of re-auditing it.
 //
 // Display names are MM's own (Rando::StaticData::Items) verbatim. They are a
@@ -233,7 +237,6 @@ static const ComboForeignItemDef kForeignPoolMMV1[] = {
     { { (uint8_t)GAME_MM, 0, (uint16_t)RI_PROGRESSIVE_LULLABY }, "Progressive Goron Lullaby", "" },
 
     // --- Core equipment, abilities and capacity upgrades.
-    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_HOOKSHOT }, "Hookshot", "the " },
     { { (uint8_t)GAME_MM, 0, (uint16_t)RI_LENS }, "Lens of Truth", "the " },
     { { (uint8_t)GAME_MM, 0, (uint16_t)RI_ARROW_FIRE }, "Fire Arrows", "" },
     { { (uint8_t)GAME_MM, 0, (uint16_t)RI_ARROW_ICE }, "Ice Arrows", "" },

--- a/games/oot/soh/Enhancements/randomizer/ForeignItemsSingleExe.cpp
+++ b/games/oot/soh/Enhancements/randomizer/ForeignItemsSingleExe.cpp
@@ -72,9 +72,12 @@ void GiveLinkRupees(int numOfRupees);
 // in this table and left with shared ammo: the quiver and bomb-bag capacity
 // tiers are now ONE quantity spanning both games (src/common/shared_resources.h),
 // and in MM owning the bow IS quiver tier 1, so either row would have crossed
-// as a mutation of the shared resource rather than as a new item. Nothing in
-// this pool may be a shared cross-game resource — no wallet, heart, magic or
-// ammo row.
+// as a mutation of the shared resource rather than as a new item.
+// "Progressive Hookshot" left the same way when the hookshot became
+// RSBS_SHARED_RES_HOOKSHOT_TIER — a progressive whose every step now moves a
+// shared quantity is the clearest case criterion 6 has. Nothing in this pool
+// may be a shared cross-game resource: no wallet, heart, magic, ammo or
+// hookshot row.
 //
 // "Lens of Truth" IS THE CROSS-POOL COLLISION, deliberately. Display names are
 // the spoiler-load persistence key, and the lookups are keyed on
@@ -86,13 +89,12 @@ void GiveLinkRupees(int numOfRupees);
 // strings must stay byte-identical.
 //
 // Boomerang and Megaton Hammer widen a pool that was down to three rows against
-// MM's 117, which made the forward direction ship nearly the same items every
+// MM's 116, which made the forward direction ship nearly the same items every
 // seed (a follow-up #525 lists in as many words). Both are plain MOD_NONE
 // inventory items whose give falls through OoT_Item_Give's generic tail — save
 // writes only, no PlayState deref — which is what makes them safe on the
 // NULL-play redemption path the pool is given through.
 static const ComboForeignItemDef kForeignPoolV1[] = {
-    { { (uint8_t)GAME_OOT, 0, (uint16_t)RG_PROGRESSIVE_HOOKSHOT }, "Progressive Hookshot", "a " },
     { { (uint8_t)GAME_OOT, 0, (uint16_t)RG_PROGRESSIVE_STRENGTH }, "Progressive Strength Upgrade", "a " },
     { { (uint8_t)GAME_OOT, 0, (uint16_t)RG_LENS_OF_TRUTH }, "Lens of Truth", "the " },
     { { (uint8_t)GAME_OOT, 0, (uint16_t)RG_BOOMERANG }, "Boomerang", "the " },

--- a/games/oot/soh/GameExports_SingleExe.cpp
+++ b/games/oot/soh/GameExports_SingleExe.cpp
@@ -1292,8 +1292,16 @@ static void OoT_WriteHookshotTier(uint16_t tier) {
         gSaveContext.adultEquips.buttonItems,
         gSaveContext.childEquips.buttonItems,
     };
+    // From index 1, never 0. Index 0 is the B button; every vanilla loop that
+    // matches a hookshot against buttonItems starts at 1 (the ITEM_LONGSHOT
+    // give and the button-restriction passes alike), and B is not a slot the
+    // hookshot is equippable to. It is also not inert storage: SoH's Bottle
+    // Adventure restoration deliberately stages arbitrary save bytes THROUGH
+    // buttonItems[0], so a byte there that happens to equal 0x0A or 0x0B is
+    // data, not an equipped hookshot, and rewriting it would corrupt the value
+    // that restoration exists to reproduce.
     for (size_t set = 0; set < ARRAY_COUNT(buttonSets); set++) {
-        for (size_t i = 0; i < ARRAY_COUNT(gSaveContext.equips.buttonItems); i++) {
+        for (size_t i = 1; i < ARRAY_COUNT(gSaveContext.equips.buttonItems); i++) {
             if (buttonSets[set][i] == ITEM_HOOKSHOT || buttonSets[set][i] == ITEM_LONGSHOT) {
                 buttonSets[set][i] = item;
             }

--- a/games/oot/soh/GameExports_SingleExe.cpp
+++ b/games/oot/soh/GameExports_SingleExe.cpp
@@ -1245,6 +1245,62 @@ static void OoT_EnsureInventoryItem(uint8_t item) {
     }
 }
 
+// OoT's hookshot ceiling: 0 none, 1 hookshot, 2 longshot.
+#define OOT_MAX_HOOKSHOT_TIER 2u
+
+// The hookshot as a tier. Both games keep it in ONE inventory byte, so the
+// "progressive item" is really a small monotonic number — which is why this is
+// a shared RESOURCE and not a shared item. Nothing crosses but the number: MM's
+// ITEM_LONGSHOT is a different id that its give path repurposes into a Red
+// Potion, so passing a raw item id over the boundary would hand MM a potion.
+static uint16_t OoT_ReadHookshotTier(void) {
+    const u8 held = INV_CONTENT(ITEM_HOOKSHOT);
+    if (held == ITEM_LONGSHOT) {
+        return 2u;
+    }
+    if (held == ITEM_HOOKSHOT) {
+        return 1u;
+    }
+    return 0u;
+}
+
+/**
+ * Author OoT's hookshot byte for `tier`, including the part a bare INV_CONTENT
+ * write would miss.
+ *
+ * OoT's own longshot give does more than swap the inventory byte: it rewrites
+ * every C-button (and both age-specific equip sets) that currently holds the
+ * hookshot, because the button stores the ITEM id rather than the slot
+ * (z_parameter.c's ITEM_LONGSHOT branch). Skip that and a player who had the
+ * hookshot equipped keeps firing the SHORT one after the pool hands them a
+ * longshot — the upgrade silently does nothing until they re-equip it.
+ *
+ * The icon reload that vanilla pairs with those writes is deliberately NOT
+ * copied: it needs a live PlayState and this runs from Play_Init before there
+ * is one. The arrival's own interface init loads the C-button icons after this
+ * point, so the texture follows the id without it.
+ */
+static void OoT_WriteHookshotTier(uint16_t tier) {
+    if (tier == 0u) {
+        return; // monotonic: never take one away
+    }
+    const u8 item = (tier >= 2u) ? (u8)ITEM_LONGSHOT : (u8)ITEM_HOOKSHOT;
+    INV_CONTENT(ITEM_HOOKSHOT) = item;
+
+    u8* const buttonSets[] = {
+        gSaveContext.equips.buttonItems,
+        gSaveContext.adultEquips.buttonItems,
+        gSaveContext.childEquips.buttonItems,
+    };
+    for (size_t set = 0; set < ARRAY_COUNT(buttonSets); set++) {
+        for (size_t i = 0; i < ARRAY_COUNT(gSaveContext.equips.buttonItems); i++) {
+            if (buttonSets[set][i] == ITEM_HOOKSHOT || buttonSets[set][i] == ITEM_LONGSHOT) {
+                buttonSets[set][i] = item;
+            }
+        }
+    }
+}
+
 /**
  * Would GRANTING this row's item be handing the player a shuffled CHECK the
  * seed placed elsewhere? Then the pool may not hand it over.
@@ -1416,6 +1472,8 @@ extern "C" void OoT_HarvestSharedResources(void) {
         }
         Combo_HarvestSharedResource(GAME_OOT, row->countKind, OoT_ReadAmmo(row->item));
     }
+
+    Combo_HarvestSharedResource(GAME_OOT, RSBS_SHARED_RES_HOOKSHOT_TIER, OoT_ReadHookshotTier());
 }
 
 /**
@@ -1567,6 +1625,15 @@ extern "C" void OoT_ApplySharedResources(void) {
             }
             AMMO(row->item) = (s8)count;
         }
+    }
+
+    // --- Hookshot (monotonic 0/1/2). Clamped to OoT's own ceiling of 2, which
+    // is the higher of the two: MM has no longshot, so a longshot earned here
+    // survives a Termina round trip untouched (max-merge cannot demote it) and
+    // materializes there as a plain hookshot.
+    uint16_t hookshotTier = OoT_ReadHookshotTier();
+    if (Combo_ApplySharedResource(GAME_OOT, RSBS_SHARED_RES_HOOKSHOT_TIER, OOT_MAX_HOOKSHOT_TIER, &hookshotTier)) {
+        OoT_WriteHookshotTier(hookshotTier);
     }
 }
 

--- a/src/common/context.h
+++ b/src/common/context.h
@@ -240,7 +240,7 @@ int Context_ArmShadowAsFrozen(GameId game, uint16_t returnEntrance);
  * value together ("current health is tracked as if OoT and MM were one game
  * with a single health bar"). All eight slots of THIS block are spoken for by
  * v1 plus magic; the ammo tier's nine kinds live in the second block below.
- * Together the two blocks hold twenty slots, sixteen of them occupied.
+ * Together the two blocks hold twenty slots, seventeen of them occupied.
  *
  * DO NOT BUMP THIS CONSTANT to get more capacity, for the reason
  * RSBS_GRANT_SOURCE_CAP spells out: the array is carved from the front of
@@ -264,10 +264,12 @@ int Context_ArmShadowAsFrozen(GameId game, uint16_t returnEntrance);
  * twelve free slots behind it.
  *
  * Sized for the whole class in ONE carve, deliberately. Today's set occupies
- * sixteen of the twenty slots (seven from v1 plus magic, nine from ammo), and a
- * carve is permanent: a third block would cost another literal offset, another
- * span in every accessor, and another ADR amendment. The four spare slots are
- * what keeps the next resource from needing any of that.
+ * seventeen of the twenty slots (seven from v1 plus magic, nine from ammo, one
+ * for the hookshot), and a carve is permanent: a third block would cost another
+ * literal offset, another span in every accessor, and another ADR amendment.
+ * The three spare slots are what keeps the next resource from needing any of
+ * that — the hookshot took one of them and needed no format change at all,
+ * which is the headroom doing its job.
  *
  * Bounded from above by ADR 0009's 64-byte reserved[] floor, not by taste:
  * twelve slots is 48 bytes, leaving reserved[132], which still clears the floor
@@ -404,6 +406,13 @@ enum {
     RSBS_SHARED_RES_BOMBCHU_COUNT = 14,   // CONSUMABLE: bombchus held; the CAP is per-game (see the shims), not a kind
     RSBS_SHARED_RES_STICK_COUNT = 15,     // CONSUMABLE: deku sticks held, clamped to the stick capacity
     RSBS_SHARED_RES_NUT_COUNT = 16,       // CONSUMABLE: deku nuts held, clamped to the nut capacity
+    // Hookshot (#525 optional tier). An ITEM in OoTMM's wording ("combines the
+    // Hookshots into two progressive items for both games") but a monotonic
+    // TIER in both saves: each game stores it as one inventory byte, so the
+    // shared quantity is 0 none / 1 hookshot / 2 longshot. OoT's ceiling is 2
+    // and MM's is 1 — MM has no longshot at all — which max-merge handles
+    // natively: an MM visit can never demote the pool's longshot.
+    RSBS_SHARED_RES_HOOKSHOT_TIER = 17,   // MONOTONIC: 0/1/2; each game clamps to its OWN ceiling
 };
 
 /**

--- a/src/common/foreign_items.h
+++ b/src/common/foreign_items.h
@@ -46,7 +46,7 @@ extern "C" {
  */
 typedef struct {
     SharedItem item;     // originGame == GAME_OOT, flags == 0, id == the RG_* value
-    const char* name;    // e.g. "Progressive Hookshot"
+    const char* name;    // e.g. "Megaton Hammer"
     const char* article; // "the ", "a ", "an " or "" — see below
 } ComboForeignItemDef;
 

--- a/src/common/shared_resources.c
+++ b/src/common/shared_resources.c
@@ -60,6 +60,7 @@ static bool IsMonotonicKind(uint8_t kind) {
         case RSBS_SHARED_RES_BOMB_BAG_TIER:
         case RSBS_SHARED_RES_STICK_TIER:
         case RSBS_SHARED_RES_NUT_TIER:
+        case RSBS_SHARED_RES_HOOKSHOT_TIER:
             return true;
         default:
             // The spent quantities — rupees, current health, current magic, and

--- a/src/common/shared_resources.h
+++ b/src/common/shared_resources.h
@@ -15,14 +15,28 @@
  *
  * v1 shares rupees and hearts; the #525 optional tier added magic — meter
  * level and current magic, "current magic is tracked as if OoT and MM were one
- * game with a single magic meter" — and then ammo: the quiver, bomb-bag, stick
- * and nut capacity TIERS plus the arrow, bomb, bombchu, stick and nut COUNTS.
+ * game with a single magic meter" — then ammo: the quiver, bomb-bag, stick
+ * and nut capacity TIERS plus the arrow, bomb, bombchu, stick and nut COUNTS —
+ * and finally the hookshot.
  * That is what justifies the matching pool shrink in `kForeignPoolMMV1`
- * (#525): with one wallet, one health bar, one magic meter and one quiver
- * spanning both games, MM's wallet/heart/double-defense/magic/ammo rows are no
- * longer separate items to cross — they ARE the shared resource, so shipping
- * them as foreign placements too would hand the player a second copy of a
- * quantity they already have.
+ * (#525): with one wallet, one health bar, one magic meter, one quiver and one
+ * hookshot spanning both games, MM's wallet/heart/double-defense/magic/ammo/
+ * hookshot rows are no longer separate items to cross — they ARE the shared
+ * resource, so shipping them as foreign placements too would hand the player a
+ * second copy of a quantity they already have.
+ *
+ * THE HOOKSHOT IS WHY "RESOURCE" IS ABOUT REPRESENTATION, NOT VOCABULARY.
+ * OoTMM calls it an item ("combines the Hookshots into two progressive items
+ * for both games") and #525 filed it as one, but both games store it in a
+ * single inventory byte, which is a monotonic tier: 0 none, 1 hookshot, 2
+ * longshot. Modelled that way it needs no new machinery and cannot loop.
+ * Modelled as a shared ITEM it would need a give-time producer in each game,
+ * and each redemption calls the far game's give — an unbounded ping-pong that
+ * `shared_items.h`'s content de-dup does NOT stop, because de-dup deliberately
+ * skips entries that are already redeemed and redemption is the step closing
+ * the cycle. (MM's OnItemGive is also a no-op stub, so that half would have
+ * been dead on arrival — the #512/#517 class.) Harvest-at-suspend /
+ * apply-at-arrival has no edge back to the producer at all.
  *
  * A CAPACITY TIER CARRIES THE ITEM WITH IT, copying OoTMM ("a Shared Bow
  * grants the ability to use the Hero's Bow in MM and the Fairy Bow in OoT").
@@ -38,8 +52,9 @@
  * ---------------------------------------------------------------------------
  * Picking the wrong one is a correctness bug, not a style choice.
  *
- *   MONOTONIC — wallet tier, health quarters, double defense, magic level, and
- *   the four ammo capacity tiers. A capacity that only ever grows. Harvest is
+ *   MONOTONIC — wallet tier, health quarters, double defense, magic level, the
+ *   four ammo capacity tiers, and the hookshot tier. A capacity that only ever
+ *   grows. Harvest is
  *   `shared = max(shared, live)`, apply is `live = max(live, shared)`.
  *   Idempotent in both directions; decay is impossible by construction, so no
  *   bookkeeping is needed.
@@ -118,7 +133,7 @@ extern "C" {
  * table, which is indexed by KIND (stable) rather than by slot (slots are found
  * by scan and a future compaction could move them).
  */
-#define RSBS_SHARED_RES_KIND_COUNT 17u
+#define RSBS_SHARED_RES_KIND_COUNT 18u
 
 /**
  * Canonical heart quantity ceiling, in health units (0x10 per heart, 4 per
@@ -180,7 +195,7 @@ void Combo_SplitHealthQuarters(uint16_t quarters, uint16_t* outCapacity, uint16_
  * No-op if `game` is not a real game or `kind` is not a real resource. If both
  * slot blocks are full of other resources the harvest is dropped — they are
  * sized with headroom for the whole class (twenty slots against today's
- * sixteen kinds), so this cannot happen without a new resource being added.
+ * seventeen kinds), so this cannot happen without three more being added.
  */
 void Combo_HarvestSharedResource(GameId game, uint8_t kind, uint16_t liveValue);
 

--- a/src/common/tests/test_foreign_items.c
+++ b/src/common/tests/test_foreign_items.c
@@ -879,6 +879,9 @@ TestResult Test_ForeignPoolMM(void) {
         "Bomb Bag",           "Big Bomb Bag",    "Biggest Bomb Bag",
         "Large Quiver",       "Largest Quiver",  "Progressive Bomb Bag",
         "Bow",                "Progressive Bow",
+        // Shared hookshot: one inventory byte in each game, so it crosses as a
+        // monotonic tier (0/1/2) rather than as an item handed over once.
+        "Hookshot",
     };
     for (size_t k = 0; k < sizeof(kSharedResourceNames) / sizeof(kSharedResourceNames[0]); k++) {
         for (int i = 0; i < poolCount; i++) {
@@ -903,9 +906,11 @@ TestResult Test_ForeignPoolMM(void) {
     static const char* const kOoTSharedResourceNames[] = {
         // Retired from kForeignPoolV1 by criterion 6 when shared ammo landed.
         // Byte-exact as that table spelled them, which is what makes the sweep
-        // non-vacuous: these two strings were really there.
+        // non-vacuous: these strings were really there.
         "Fairy Bow",
         "Bomb Bag",
+        // ...and this one when the hookshot became a shared tier.
+        "Progressive Hookshot",
     };
     for (size_t k = 0; k < sizeof(kSharedResourceNames) / sizeof(kSharedResourceNames[0]); k++) {
         for (int i = 0; i < ootPoolCount; i++) {
@@ -919,7 +924,7 @@ TestResult Test_ForeignPoolMM(void) {
         FI_ASSERT(!Combo_GetForeignItemByNameFor((uint8_t)GAME_OOT, kOoTSharedResourceNames[k], NULL));
     }
 
-    // The shrink is real, not a rename: seventeen rows have left across the
+    // The shrink is real, not a rename: eighteen rows have left across the
     // three tiers and nothing took their place. Bounded rather than exact for
     // the reason above — a future shared resource removes more, and unrelated
     // work may add.

--- a/src/common/tests/test_shared_resources.c
+++ b/src/common/tests/test_shared_resources.c
@@ -395,6 +395,11 @@ TestResult Test_SharedResources(void) {
 
     // MM harvesting its clamped 1 must NOT demote the pool — the whole 2-vs-1
     // asymmetry rests on max-merge, and a raw copy here would cost the longshot.
+    //
+    // Note this line alone does NOT pin the discipline: MM harvests back exactly
+    // what the apply above materialized, so a consumable misclassification would
+    // compute a zero delta and leave the pool at 2 as well. It is a round-trip
+    // assertion, and the discipline pin is the separate sequence below.
     Combo_HarvestSharedResource(GAME_MM, RSBS_SHARED_RES_HOOKSHOT_TIER, 1);
     SR_ASSERT(SR_Pool(RSBS_SHARED_RES_HOOKSHOT_TIER) == 2);
 
@@ -402,6 +407,15 @@ TestResult Test_SharedResources(void) {
     uint16_t ootHookshot = 0;
     SR_ASSERT(Combo_ApplySharedResource(GAME_OOT, RSBS_SHARED_RES_HOOKSHOT_TIER, 2, &ootHookshot));
     SR_ASSERT(ootHookshot == 2);
+
+    // THE DISCIPLINE PIN: a lower harvest after an apply that materialized the
+    // FULL value — the one sequence the two disciplines answer differently.
+    // The apply just above recorded a watermark of 2 for OoT, so a consumable
+    // misclassification computes delta 1 - 2 = -1 and decays the pool to 1;
+    // monotonic max-merges back to 2. Synthetic on purpose (a player cannot
+    // lose a hookshot) — what it pins is IsMonotonicKind, not a game state.
+    Combo_HarvestSharedResource(GAME_OOT, RSBS_SHARED_RES_HOOKSHOT_TIER, 1);
+    SR_ASSERT(SR_Pool(RSBS_SHARED_RES_HOOKSHOT_TIER) == 2);
 
     // And the other direction: MM finding the hookshot first arms OoT's.
     SR_FreshWorld();

--- a/src/common/tests/test_shared_resources.c
+++ b/src/common/tests/test_shared_resources.c
@@ -379,7 +379,39 @@ TestResult Test_SharedResources(void) {
     SR_ASSERT(arrows == 12);
 
     // ------------------------------------------------------------------
-    // THE SECOND BLOCK IS REACHABLE. Sixteen kinds do not fit the first
+    // The hookshot: a monotonic tier whose two ceilings DIFFER (OoT reaches 2
+    // for the longshot, MM only 1 — it has no longshot). This is the first
+    // shared tier where they diverge, and the property that matters is that a
+    // Termina round trip cannot cost the player their longshot.
+    // ------------------------------------------------------------------
+    SR_FreshWorld();
+    Combo_HarvestSharedResource(GAME_OOT, RSBS_SHARED_RES_HOOKSHOT_TIER, 2); // longshot in Hyrule
+
+    // MM shows what it can hold, which is a plain hookshot.
+    uint16_t mmHookshot = 0;
+    SR_ASSERT(Combo_ApplySharedResource(GAME_MM, RSBS_SHARED_RES_HOOKSHOT_TIER, 1, &mmHookshot));
+    SR_ASSERT(mmHookshot == 1);
+    SR_ASSERT(SR_Pool(RSBS_SHARED_RES_HOOKSHOT_TIER) == 2);
+
+    // MM harvesting its clamped 1 must NOT demote the pool — the whole 2-vs-1
+    // asymmetry rests on max-merge, and a raw copy here would cost the longshot.
+    Combo_HarvestSharedResource(GAME_MM, RSBS_SHARED_RES_HOOKSHOT_TIER, 1);
+    SR_ASSERT(SR_Pool(RSBS_SHARED_RES_HOOKSHOT_TIER) == 2);
+
+    // Home again with the longshot intact.
+    uint16_t ootHookshot = 0;
+    SR_ASSERT(Combo_ApplySharedResource(GAME_OOT, RSBS_SHARED_RES_HOOKSHOT_TIER, 2, &ootHookshot));
+    SR_ASSERT(ootHookshot == 2);
+
+    // And the other direction: MM finding the hookshot first arms OoT's.
+    SR_FreshWorld();
+    Combo_HarvestSharedResource(GAME_MM, RSBS_SHARED_RES_HOOKSHOT_TIER, 1);
+    uint16_t ootFromMM = 0;
+    SR_ASSERT(Combo_ApplySharedResource(GAME_OOT, RSBS_SHARED_RES_HOOKSHOT_TIER, 2, &ootFromMM));
+    SR_ASSERT(ootFromMM == 1); // a hookshot, not a free longshot
+
+    // ------------------------------------------------------------------
+    // THE SECOND BLOCK IS REACHABLE. Seventeen kinds do not fit the first
     // block's eight slots, so this is the assertion that fails outright if
     // sharedResourcesExt is never scanned — which is the whole hazard the
     // two-block carve introduces: a scan that stops at the first block's end
@@ -393,7 +425,7 @@ TestResult Test_SharedResources(void) {
         RSBS_SHARED_RES_MAGIC_CURRENT,   RSBS_SHARED_RES_QUIVER_TIER,   RSBS_SHARED_RES_BOMB_BAG_TIER,
         RSBS_SHARED_RES_STICK_TIER,      RSBS_SHARED_RES_NUT_TIER,      RSBS_SHARED_RES_ARROW_COUNT,
         RSBS_SHARED_RES_BOMB_COUNT,      RSBS_SHARED_RES_BOMBCHU_COUNT, RSBS_SHARED_RES_STICK_COUNT,
-        RSBS_SHARED_RES_NUT_COUNT,
+        RSBS_SHARED_RES_NUT_COUNT,       RSBS_SHARED_RES_HOOKSHOT_TIER,
     };
     const int kAllKindCount = (int)(sizeof(kAllKinds) / sizeof(kAllKinds[0]));
     SR_ASSERT(kAllKindCount > (int)RSBS_SHARED_RESOURCE_CAP); // or this proves nothing
@@ -424,7 +456,7 @@ TestResult Test_SharedResources(void) {
 
     // ------------------------------------------------------------------
     // The v1-plus-magic set still coexists inside the FIRST block alone. Kept
-    // as its own case beside the all-sixteen sweep above: this one pins that
+    // as its own case beside the all-kinds sweep above: this one pins that
     // those seven kinds have not drifted into the second block, which is the
     // shape every already-shipped .redsave stores them in.
     // ------------------------------------------------------------------


### PR DESCRIPTION
Final PR of #525's optional tier (magic ✅ → ammo ✅ → **hookshot**). Follows [#554](https://github.com/spencerduncan/redshipblueship/pull/554) and [#555](https://github.com/spencerduncan/redshipblueship/pull/555).

## The issue asked for a shared *item*. It should be a shared *resource*.

#525 files the hookshot under the shared-items side, quoting OoTMM: *"combines the Hookshots from OoT and MM into two progressive items for both games."* But both games store the hookshot in **a single inventory byte**, which is a monotonic tier — `0` none, `1` hookshot, `2` longshot. As a resource it's one more `RSBS_SHARED_RES_*` kind and needs no new machinery.

Three reasons the item model was the wrong call, all source-verified:

1. **`shared_items.h` structurally can't express "one find grants it in both."** Entries are tagged to one `originGame` and redeemed exactly once. What's needed is a quantity both games read and write for the whole run — the definition `shared_resources.h` opens with.
2. **A give-time producer would ping-pong without bound.** OoT's give records a crossing for MM; MM's redemption calls MM's give, which records one back for OoT; forever. Content de-dup does *not* stop it — de-dup deliberately skips already-redeemed entries, and redemption is the step that closes the cycle. Every switch would mint a fresh slot and re-fire the give, and OoT's progressive could escalate hookshot → longshot on the bounce. Breaking it needs a depth-counted suppression flag threaded into both games' give choke points, including MM's, which fires *frames after* the redeem call returned.
3. **MM's half would have been dead on arrival.** `GameInteractor_ExecuteOnItemGive` is a no-op stub in `src/common/mm_stubs.c` with no bridge and no dispatch test — a give-hook design works on the OoT leg and silently does nothing on MM's. That's the #512/#517 registered-but-never-dispatched class.

Harvest-at-suspend / apply-at-arrival has **no edge back to the producer**, so the loop cannot exist. The cost is latency: the hookshot appears in the other game at the next crossing rather than instantly — exactly how shared magic and shared ammo already behave.

## Two ceilings that differ — a first for a shared tier

OoT reaches 2 (longshot); MM reaches 1, having no longshot at all. Max-merge handles it natively: MM harvesting its clamped 1 **cannot demote** the pool's 2, so a longshot earned in Hyrule survives a Termina round trip and comes home intact.

## Only the abstract tier crosses

MM's `ITEM_LONGSHOT` (0x11) exists as an OoT leftover whose give path **repurposes it into a Red Potion**. Handing MM a raw OoT hookshot id would silently produce a bottle of potion. Each side's shim authors its own byte — the ADR 0002 boundary the ammo shims already respect.

OoT's apply also rewrites the **C-buttons**: vanilla's longshot give rewrites every button (and both age-specific equip sets) holding the hookshot, because buttons store the item id rather than the slot. Skipping that would leave a player who had the hookshot equipped still firing the short one after the upgrade. The icon reload vanilla pairs with those writes is deliberately not copied — it needs a live `PlayState` and the apply runs before there is one; the arrival's own interface init loads the icons afterwards.

## Pool shrink, both directions

`RG_PROGRESSIVE_HOOKSHOT` leaves OoT's pool (5 → 4, still clear of the 3-row floor thanks to the Boomerang and Megaton Hammer rows #555 added) and `RI_HOOKSHOT` leaves MM's (117 → 116). A progressive whose every step moves a shared quantity is the clearest case criterion 6 has. Both display names join their exclusion sweeps **in this commit** — each sweep asserts the name-keyed inverse resolves to nothing, so adding a name before deleting its row goes red.

## Tests

`shared-resources` gains the hookshot section: the 2-vs-1 round trip that must not cost the longshot, the max-merge no-demote pin, and MM-finds-it-first granting OoT a hookshot rather than a free longshot. The all-kinds sweep now covers seventeen kinds. ADR 0009 claim 6 restated at seventeen of twenty slots — the hookshot took a spare one with **no format change at all**, which is the headroom doing its job.

## Verification

Local compilation is paused on the operator's instruction, so CI is the build/test gate. Note the same `.redsave` caveat as the earlier tiers: a paired world generated before this change whose spoiler or placement table hosts a removed row won't resolve that name afterwards.

Also worth flagging for review: sharing the hookshot changes **logical access in both worlds** — MM's Pirate Fortress chest and OoT's progressive now feed one tier, and MM's logic checks `HAS_ITEM(ITEM_HOOKSHOT)` in ~40 places. That's inherent to the feature (the same is true of the shared bow), not a defect, but it is a real seed-logic change.

Closes the optional tier of #525.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!--- section:artifacts:start -->
### Build Artifacts
  - [rsbs-windows.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/8746496922.zip)
  - [rsbs-linux.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/8745955445.zip)
<!--- section:artifacts:end -->