### PR TITLE
Reset OoT's gameplay frame counter on every cross-game arrival

### DIFF
--- a/games/oot/soh/GameExports_SingleExe.cpp
+++ b/games/oot/soh/GameExports_SingleExe.cpp
@@ -519,6 +519,29 @@ static void OoT_RegisterIntegrationTestHooks(void) {
                 IntegrationTest_GameplayFail(ageMsg);
                 return;
             }
+            // Frame-counter reset lock. The scene build runs after the
+            // frame-counter block in OoT_Play_Init, so an arrival must land
+            // here with a counter that was just zeroed. Left stale, the
+            // suspended session's value (or MM's arena leftovers) rides into
+            // the arrival and voids the interval autosave's `gameplayFrames <
+            // 60` warm-up guard (soh/Enhancements/QoL/Autosave.cpp) — a save
+            // can then fire during the arrival fade. Return leg only: the warp
+            // and exit phases are ordinary in-game door transitions, where a
+            // large counter is the correct session-long value.
+            if (phase == GP_PHASE_OOT_RETURN && OoT_gPlayState != NULL) {
+                fprintf(stderr, "[GP-TEST] return leg gameplayFrames=%u (expect 0)\n",
+                        (unsigned)OoT_gPlayState->gameplayFrames);
+                fflush(stderr);
+                if (OoT_gPlayState->gameplayFrames != 0) {
+                    char frameMsg[176];
+                    snprintf(frameMsg, sizeof(frameMsg),
+                             "return leg arrived with gameplayFrames=%u, expected 0 — the arrival frame-counter "
+                             "reset regressed, so the autosave warm-up guard is void on re-arrivals",
+                             (unsigned)OoT_gPlayState->gameplayFrames);
+                    IntegrationTest_GameplayFail(frameMsg);
+                    return;
+                }
+            }
             // Demo-state leakage asserts (the bug 1a/1b/1c common-cause
             // class): every cross-game arrival and post-return load must be a
             // plain gameplay spawn. A title/attract gameMode, a live cutscene

--- a/games/oot/src/code/z_play.c
+++ b/games/oot/src/code/z_play.c
@@ -411,6 +411,7 @@ void OoT_Play_Init(GameState* thisx) {
     s32 playerStartBgCamIndex;
     s32 i;
     u8 baseSceneLayer;
+    s32 crossGameArrival = 0;
     s32 pad[2];
 
     enableBetaQuest();
@@ -427,6 +428,12 @@ void OoT_Play_Init(GameState* thisx) {
         // continuity point, so value-gating would drop a legitimate restore.
         if (Combo_HasStartupEntranceForGame("oot")) {
             uint16_t startupEntrance = Combo_GetStartupEntranceForGame("oot");
+            // Latched for the frame-counter reset below. Set from the presence
+            // check rather than inside the consuming branch on purpose: an
+            // out-of-range id is still an arrival that was routed here after a
+            // stint in the other game, so its Play_Init inherits an equally
+            // stale gameplayFrames and wants the same reset.
+            crossGameArrival = 1;
             if (startupEntrance >= ENTR_MAX) {
                 // Defense in depth: never index gEntranceTable out of range,
                 // even if a bogus value slips past the game-affinity check.
@@ -584,8 +591,39 @@ void OoT_Play_Init(GameState* thisx) {
         }
     }
 
-    // Properly initialize the frame counter so it doesn't use garbage data
-    if (!firstInit) {
+    // Properly initialize the frame counter so it doesn't use garbage data.
+    //
+    // Two distinct reasons to zero it here:
+    //
+    // 1. !firstInit — the process's very first Play_Init. The gamestate arena
+    //    is still fill-pattern garbage, so the counter has never been a count.
+    //    Once past that, gameplayFrames is deliberately session-long: it
+    //    survives ordinary scene transitions (each of which re-runs Play_Init)
+    //    because actors use it as a shared animation/behaviour phase.
+    //
+    // 2. crossGameArrival — a cross-game arrival into OoT. The single-exe
+    //    process keeps running across a switch, so firstInit stays latched and
+    //    the counter carries the SUSPENDED session's value into the arrival
+    //    (or MM's arena leftovers, if the gamestate memory was recycled while
+    //    OoT was away). An arrival is not a scene transition: it is a fresh
+    //    spawn from a save that was just restored and neutralized above —
+    //    exactly the situation a file load authors, and a file load starts the
+    //    counter at 0 (ResetGameplayFrames.cpp zeroes it on the way through the
+    //    title screen, so FileChoose_LoadGame enters gameplay at zero).
+    //
+    // Zero is also how the port already signals "a load just happened, hold off
+    // the autosave": z_kaleido_scope_PAL.c does the same assignment on a
+    // pause-menu save-and-respawn ("Reset frame counter to prevent autosave on
+    // respawn"). Without it on the return leg the interval autosave's warm-up
+    // guard (`gameplayFrames < 60`, soh/Enhancements/QoL/Autosave.cpp) is void
+    // on every re-arrival and a save can land during the arrival fade, before
+    // the restored save has settled on screen.
+    //
+    // Every other consumer reads gameplayFrames as a free-running phase
+    // (texture scroll, enemy attack cadence, effect spawn cadence), so an
+    // arrival-time reset is at most a one-frame phase jump for them — the same
+    // discontinuity they already take on a file load.
+    if (!firstInit || crossGameArrival) {
         play->gameplayFrames = 0;
         firstInit = 1;
     }


### PR DESCRIPTION
Closes a pre-existing `!firstInit` quirk in `games/oot/src/code/z_play.c` that made the interval autosave's warm-up guard vacuous on every cross-game return leg.

## The quirk

`OoT_Play_Init` zeroed `play->gameplayFrames` behind a **process-static** `!firstInit` latch, so only the very first `Play_Init` of the process ever reset it. In the single exe the process survives an OoT→MM→OoT round trip, so `firstInit` stays latched and every **re-arrival** into OoT inherited either the suspended session's counter or — when the gamestate arena was recycled while OoT was away — raw arena fill.

The counter's one *semantic* consumer is the interval autosave's warm-up guard:

```c
OoT_gPlayState->gameplayFrames < 60 || ...   // soh/Enhancements/QoL/Autosave.cpp:34
```

which exists so a save cannot be taken while a freshly loaded file is still settling. A stale counter makes that guard **void on re-arrivals**, so an autosave can fire during the arrival fade, before the restored save has settled on screen.

The counterfactual run below shows the inherited value is literally **`0xABABABAB` (2880154539)** — MSVC's uninitialized-heap fill. Not merely "large": the counter had never been a count at all on the return leg.

## The change

**1. `z_play.c`** — `crossGameArrival` is latched at the **startup-entrance presence check**, not inside the consuming branch, so the out-of-range-id fallback (still an arrival, still a stale counter) gets the reset too. The guard widens to `if (!firstInit || crossGameArrival)`.

Ordinary scene transitions keep the vanilla **session-long** counter, which is what the ~617 other readers want — they treat `gameplayFrames` as a free-running animation/behaviour phase (texture scroll, enemy attack cadence, effect spawn cadence), for which an arrival-time reset is at most a one-frame phase jump: the same discontinuity a file load already causes. The single static-vs-counter comparison (`z_en_item00.c`'s `D_80157D90` once-per-frame dyna-scan latch) degrades to skipping one frame's scan at worst.

Zero is also how the port **already** signals "a load just happened, hold off the autosave": `ResetGameplayFrames.cpp` zeroes the counter on the way through the title screen so `FileChoose_LoadGame` enters gameplay at zero, and `z_kaleido_scope_PAL.c` does the same assignment on a pause-menu save-and-respawn for the same stated reason ("Reset frame counter to prevent autosave on respawn"). An arrival is not a scene transition — it is a fresh spawn from a save that was just restored and neutralized.

**MM is deliberately untouched**: 2Ship's autosave has no frame-count warm-up guard, so MM's counter has no semantic consumer to protect, and its one static-vs-counter reader (`Rando/ConvertItem.cpp`) has no driver for the change.

**2. `GameExports_SingleExe.cpp`** — regression lock in the round-trip integration test's `OnSceneInit` arrival hook: `GP_PHASE_OOT_RETURN` must land with `gameplayFrames == 0`, alongside the existing entrance / forced-child / demo-state asserts. The scene build runs *after* the frame-counter block in `OoT_Play_Init`, so an arrival must observe a counter that was just zeroed. **Return leg only** — the warp and exit phases are ordinary in-game door transitions where a large session-long counter is the correct value.

## Verification

Release build on Windows (MSVC, Ninja), ROM-staged with `oot.o2r`/`mm.o2r`/`soh.o2r`/`2ship.o2r` and an OpenGL backend. Verified against **current `main`** (`origin/main` merged in as `6e6bcb0f`; the cloud run predated #554/#555).

**`IntGameplayRoundtrip` — PASS.** The new line is on the path:

```
[GP-TEST] OoT scene init #2: scene 32, entrance 0x01D1 (return leg)
[GP-TEST] return leg gameplayFrames=0 (expect 0)
[GP-TEST] door check: 6 door actors in scene 32 (baseline 6)
[GP-TEST] round-trip 1/1 complete
[GP-TEST] PASS: 1 round trip(s), warp, and door transition survived 120 live frames per phase
1/1 Test #85: IntGameplayRoundtrip .............   Passed   37.85 sec
```

**Counterfactual — the lock is non-vacuous.** Temporarily reverting *just* the `|| crossGameArrival` term (assert kept) turns the row RED with the intended message:

```
[GP-TEST] return leg gameplayFrames=2880154539 (expect 0)
[GP-TEST] FAIL: return leg arrived with gameplayFrames=2880154539, expected 0 — the arrival
          frame-counter reset regressed, so the autosave warm-up guard is void on re-arrivals
1/1 Test #85: IntGameplayRoundtrip .............***Failed   18.76 sec
```

Restored and re-run green. No trace of the revert is committed.

Also clean from the earlier cloud container run at `659c60cd`: redship tier 65/65, rando tier 14/14, clang-format.

### Multi-cycle soak: known-red row, baselined as unchanged

`IntGameplayRoundtripSoak` (`RSBS_GP_CYCLES=3`) is a **known-red row for ROM-staged local verification** — red here is expected and is not by itself a verdict on a branch, the same standing exemption [#544](https://github.com/spencerduncan/redshipblueship/issues/544) carries for `IntSwitchOoTHmsToMm`. It **cannot** reach return legs 2 and 3: it dies with an access violation on **MM's second resume**, immediately after `mm-stabilize → mm-play` on cycle 2.

Per convention the row was run anyway and then **baselined**, so that "pre-existing" is a measurement rather than an assumption. With this branch's behaviour change reverted to `main`'s (and the new assert neutralized so the run could get that far), the soak crashes at the **same point with the same signature and the same code offset** — i.e. it does *not* fail differently on this branch:

| Build | Cycle-1 return leg | Soak outcome |
|---|---|---|
| This branch | `gameplayFrames=0` | crash, cycle 2 `mm-play`, `exe_offset=0x16db4e2` |
| This branch (rerun) | `gameplayFrames=0` | crash, cycle 2 `mm-play`, `exe_offset=0x16dc62e` |
| `main` behaviour | `gameplayFrames=2880154539` | crash, cycle 2 `mm-play`, `exe_offset=0x16db4c2` |

Fault addresses vary run to run (`0x178fd2fb6be`, `0x23d8eb0cec4`, `0x29fc74acde2`) while the faulting code offset stays put — a wild-pointer/corruption signature in MM re-entry, unrelated to a frame counter. Now tracked as [#557](https://github.com/spencerduncan/redshipblueship/issues/557), which had no issue of its own before. The soak row is also not a PR check: `integration-tests.yml` is `workflow_dispatch`-only and needs a ROM runner that is currently unset.

Note this also means the cycle-1 return leg is the *only* leg the assert can currently observe. That is sufficient here — the mechanism is per-arrival and cycle-independent, and the counterfactual pins it — but the "stale counter compounds across cycles" half of the original motivation stays unverifiable until #557 is fixed.

**Merge basis**, therefore: `IntGameplayRoundtrip` green with the new line printed, the counterfactual RED proof, and full CI green — not the known-red soak row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!--- section:artifacts:start -->
### Build Artifacts
  - [rsbs-windows.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/8746529750.zip)
  - [rsbs-linux.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/8745998305.zip)
<!--- section:artifacts:end -->