### PR TITLE
Gate both games' shared-resource harvests on a real loaded file (#525)

### DIFF
--- a/games/mm/2s2h/GameExports_SingleExe.cpp
+++ b/games/mm/2s2h/GameExports_SingleExe.cpp
@@ -2292,13 +2292,71 @@ static uint16_t MM_ReadSettledMagic(void) {
     return (uint16_t)(settled > cap ? cap : settled);
 }
 
+// The harvest gate's game-mode contract (see Combo_SaveIsLiveFile), asserted
+// against MM's own enumerators for the same reason the OoT shim asserts its: a
+// renumber upstream would silently invert the gate. MM is the side that adds
+// GAMEMODE_OWL_SAVE, so this is the only TU that can pin it.
+static_assert(GAMEMODE_NORMAL == RSBS_GAMEMODE_NORMAL, "MM GAMEMODE_NORMAL must match RSBS_GAMEMODE_NORMAL");
+static_assert(GAMEMODE_TITLE_SCREEN == RSBS_GAMEMODE_TITLE_SCREEN,
+              "MM GAMEMODE_TITLE_SCREEN must match RSBS_GAMEMODE_TITLE_SCREEN");
+static_assert(GAMEMODE_FILE_SELECT == RSBS_GAMEMODE_FILE_SELECT,
+              "MM GAMEMODE_FILE_SELECT must match RSBS_GAMEMODE_FILE_SELECT");
+static_assert(GAMEMODE_END_CREDITS == RSBS_GAMEMODE_END_CREDITS,
+              "MM GAMEMODE_END_CREDITS must match RSBS_GAMEMODE_END_CREDITS");
+static_assert(GAMEMODE_OWL_SAVE == RSBS_GAMEMODE_OWL_SAVE, "MM GAMEMODE_OWL_SAVE must match RSBS_GAMEMODE_OWL_SAVE");
+
+/**
+ * Is MM's live gSaveContext a real loaded file being played (#525 follow-up)?
+ *
+ * The twin of OoT_SaveIsLiveFile. fileNum is not consulted on either side, and
+ * on THIS side it could not be: a legitimate cross-game MM session runs pinned
+ * to the 0xFF "no real slot" sentinel for its entire life. gameMode carries the
+ * whole test — TitleSetup_SetupTitleScreen (z_opening.c) leaves
+ * GAMEMODE_TITLE_SCREEN over MM_Sram_InitNewSave's bootstrap file, the
+ * file-select actor (z_en_mag.c) sets GAMEMODE_FILE_SELECT, and the cross-game
+ * arrival sets GAMEMODE_NORMAL in the same z_play.c block that calls
+ * MM_ApplySharedResources, so no frame can observe the bootstrap save under a
+ * NORMAL mode.
+ *
+ * NOTE, because it surprises: unlike OoT, MM runs real GAMEPLAY FRAMES under
+ * GAMEMODE_TITLE_SCREEN — its opening cutscene plays that way, and a harness
+ * force-boot straight into a scene never leaves it. So this gate genuinely fires
+ * in MM (visible as the skip line in IntSwitchMmClockTownSouthToOoT, which
+ * force-boots MM and fires the Clock Tower door without ever passing through
+ * file select). Every such frame has the bootstrap save resident, so suppressing
+ * is correct; a legitimate standalone session is unaffected because MM's real
+ * file-load path sets GAMEMODE_NORMAL (z_file_choose_NES.c FileSelect_LoadGame).
+ */
+static bool MM_SaveIsLiveFile(void) {
+    return Combo_SaveIsLiveFile(GAME_MM, (int32_t)gSaveContext.gameMode);
+}
+
 /**
  * HARVEST (#525), the twin of OoT_HarvestSharedResources.
  *
  * Called from MM_Game_Suspend and immediately before MM's `.redsave` writes.
  * Idempotent in both merge disciplines.
+ *
+ * GATED on a real loaded file, for the reason spelled out in
+ * Combo_SaveIsLiveFile. MM's own title screen is the milder half of the class
+ * — its bootstrap save is 3 hearts and no gear, so it cannot inflate a MONOTONIC
+ * kind the way OoT's debug save does — but its CONSUMABLE kinds are the same
+ * hazard in the other direction: harvesting a 3-heart bootstrap against a
+ * watermark left by a real session's apply computes a large negative delta and
+ * DEBITS the shared health bar. The gate closes both directions at once.
  */
 extern "C" void MM_HarvestSharedResources(void) {
+    if (!MM_SaveIsLiveFile()) {
+        // Early return before the accumulator settle and before the first
+        // Combo_HarvestSharedResource call — neither the pool nor the RAM
+        // watermark table is touched, so the next real harvest still meets the
+        // world its first-harvest seed rule was written for.
+        fprintf(stderr, "[MM] shared-resource harvest skipped: not a live file (gameMode=%d fileNum=%d)\n",
+                (int)gSaveContext.gameMode, (int)gSaveContext.fileNum);
+        fflush(stderr);
+        return;
+    }
+
     // Settle rupeeAccumulator into the count first — MM drains it one per frame
     // exactly as OoT does, so a pending accumulator would be harvested as
     // nothing now and then credited again later.

--- a/games/oot/soh/GameExports_SingleExe.cpp
+++ b/games/oot/soh/GameExports_SingleExe.cpp
@@ -1369,6 +1369,29 @@ static uint16_t OoT_ReadSettledMagic(void) {
     return (uint16_t)(settled > cap ? cap : settled);
 }
 
+// The harvest gate's game-mode contract (see Combo_SaveIsLiveFile). Asserted
+// rather than assumed: these are OoT's own enumerators, and a renumber upstream
+// would silently invert the gate — accepting the title screen and rejecting
+// gameplay, which is precisely the bug the gate exists to close.
+static_assert(GAMEMODE_NORMAL == RSBS_GAMEMODE_NORMAL, "OoT GAMEMODE_NORMAL must match RSBS_GAMEMODE_NORMAL");
+static_assert(GAMEMODE_TITLE_SCREEN == RSBS_GAMEMODE_TITLE_SCREEN,
+              "OoT GAMEMODE_TITLE_SCREEN must match RSBS_GAMEMODE_TITLE_SCREEN");
+static_assert(GAMEMODE_FILE_SELECT == RSBS_GAMEMODE_FILE_SELECT,
+              "OoT GAMEMODE_FILE_SELECT must match RSBS_GAMEMODE_FILE_SELECT");
+static_assert(GAMEMODE_END_CREDITS == RSBS_GAMEMODE_END_CREDITS,
+              "OoT GAMEMODE_END_CREDITS must match RSBS_GAMEMODE_END_CREDITS");
+
+/**
+ * Is OoT's live gSaveContext a real loaded file being played (#525 follow-up)?
+ *
+ * Thin adapter over the shared policy so the two games cannot drift; all of the
+ * reasoning — including why fileNum is deliberately NOT consulted, even though
+ * OoT's title save is the 0xFF sentinel — lives in Combo_SaveIsLiveFile.
+ */
+static bool OoT_SaveIsLiveFile(void) {
+    return Combo_SaveIsLiveFile(GAME_OOT, (int32_t)gSaveContext.gameMode);
+}
+
 /**
  * HARVEST (#525). Fold OoT's live resource values into the shared pool.
  *
@@ -1377,8 +1400,27 @@ static uint16_t OoT_ReadSettledMagic(void) {
  * before every `.redsave` write, so a file written mid-session carries a pool
  * that agrees with the OoT save stored beside it. Idempotent: a second call
  * with unchanged values is a no-op in both merge disciplines.
+ *
+ * GATED on a real loaded file. Without the gate, F10 on the title screen
+ * harvests the ATTRACT DEMO's debug save — 14 hearts, single magic, and tier 1
+ * of every ammo and wallet upgrade against a new file's zeroes — and because
+ * those kinds are MONOTONIC they can never leave the pool again. See
+ * Combo_SaveIsLiveFile.
  */
 extern "C" void OoT_HarvestSharedResources(void) {
+    if (!OoT_SaveIsLiveFile()) {
+        // Early return BEFORE the accumulator settle and before the first
+        // Combo_HarvestSharedResource call, so this touches neither the pool nor
+        // the RAM watermark table: the next real harvest must find the
+        // empty/occupied world its first-harvest seed rule expects. Skipping the
+        // settle is right too — a menu's save has no balance worth settling, and
+        // not writing gSaveContext leaves that save exactly as the menu left it.
+        fprintf(stderr, "[OoT] shared-resource harvest skipped: not a live file (gameMode=%d fileNum=%d)\n",
+                (int)gSaveContext.gameMode, (int)gSaveContext.fileNum);
+        fflush(stderr);
+        return;
+    }
+
     // SETTLE THE ACCUMULATOR FIRST. Both games write rupeeAccumulator, not the
     // count, and drain it one per frame. A pending accumulator would otherwise
     // ride the frozen blob and drain into OoT later — after an apply has

--- a/src/common/shared_resources.c
+++ b/src/common/shared_resources.c
@@ -157,6 +157,34 @@ void Combo_SplitHealthQuarters(uint16_t quarters, uint16_t* outCapacity, uint16_
     }
 }
 
+// ============================================================================
+// "IS THIS A REAL LOADED FILE" — the harvest gate. See the header for why this
+// is mandatory: the title screen's gSaveContext is the ATTRACT DEMO's debug
+// save, and F10 is polled ungated every frame.
+//
+// Kept here, in the game-header-free TU, so the POLICY is one testable function
+// rather than two hand-written conditions that can drift apart in two shims.
+// ============================================================================
+
+bool Combo_SaveIsLiveFile(GameId game, int32_t gameMode) {
+    if (!IsRealGame(game)) {
+        return false;
+    }
+
+    // Gameplay only, and SYMMETRICALLY for both games — see the header for why
+    // an OoT-only fileNum refinement would be worse than none. Every menu path
+    // in both games (title, attract demo, file select) leaves a synthetic save
+    // resident under a non-NORMAL mode, and both games set NORMAL at the
+    // cross-game arrival itself, in the same block that calls their apply.
+    //
+    // MM's OWL_SAVE is the one accepted mode that is not gameplay: it is a real
+    // file mid-save, entered from gameplay, and one of MM's two `.redsave`
+    // capture points fires inside it. END_CREDITS is excluded in both — the save
+    // is real but the session is terminal, so no later arrival can consume what
+    // a harvest there would contribute.
+    return gameMode == RSBS_GAMEMODE_NORMAL || (game == GAME_MM && gameMode == RSBS_GAMEMODE_OWL_SAVE);
+}
+
 void Combo_HarvestSharedResource(GameId game, uint8_t kind, uint16_t liveValue) {
     if (!IsRealGame(game) || !IsRealKind(kind)) {
         return;

--- a/src/common/shared_resources.h
+++ b/src/common/shared_resources.h
@@ -96,6 +96,10 @@
  *     before every `.redsave` write. Game_Suspend is the only point on BOTH the
  *     entrance and the F10 hot-swap path while the live `gSaveContext` still
  *     belongs to the departing game.
+ *   - Every harvest shim opens with `Combo_SaveIsLiveFile()` and returns early
+ *     when it is false. See that function for why the gate is mandatory rather
+ *     than defensive: without it, F10 on the title screen harvests the ATTRACT
+ *     DEMO's save.
  *   - Apply at each game's presence-gated startup-entrance point in `z_play.c`,
  *     beside the shared-item consumer — the first point after the boot chain's
  *     last `gSaveContext` wipe. NOT `Game_Resume`: both restores are
@@ -161,6 +165,93 @@ uint16_t Combo_MakeHealthQuarters(uint16_t capacity, uint16_t pieces);
  * drift. Either out-pointer may be NULL.
  */
 void Combo_SplitHealthQuarters(uint16_t quarters, uint16_t* outCapacity, uint16_t* outPieces);
+
+/**
+ * `gSaveContext.gameMode` values. BOTH ports spell this field and these
+ * enumerators identically (games/oot/include/z64save.h, games/mm/include/-
+ * z64save.h) and agree on 0..3; MM alone adds 4. Restated here as macros
+ * because this TU deliberately includes no game headers — each shim
+ * static_asserts its own enum against these, so a renumber upstream is a build
+ * error rather than a silently inverted gate.
+ */
+#define RSBS_GAMEMODE_NORMAL 0
+#define RSBS_GAMEMODE_TITLE_SCREEN 1
+#define RSBS_GAMEMODE_FILE_SELECT 2
+#define RSBS_GAMEMODE_END_CREDITS 3
+#define RSBS_GAMEMODE_OWL_SAVE 4 // MM only
+
+/**
+ * Is the live `gSaveContext` a REAL LOADED FILE being played — as opposed to the
+ * synthetic save a menu leaves resident?
+ *
+ * THIS GATE IS MANDATORY, AND IT IS NOT DEFENSIVE. While OoT sits on the title
+ * screen, `gSaveContext` holds the ATTRACT DEMO's save: `Opening_SetupTitle-
+ * Screen` (z_opening.c) calls `OoT_Sram_InitDebugSave`, and `SaveManager::-
+ * InitFileDebug` authors 14 hearts, single magic, 150 rupees and
+ * `inventory.upgrades == 0x125249` — which decodes to TIER 1 of all eight
+ * upgrade slots (quiver, bomb bag, wallet, sticks, nuts and the rest), against a
+ * new file's zeroes. `Combo_CheckHotSwap` is polled from graph.c EVERY FRAME
+ * with no gameplay gate, so F10 on the title screen runs a full harvest against
+ * that save. Every MONOTONIC kind it touches then sits in the pool permanently —
+ * max-merge cannot decay by construction — and since A CAPACITY TIER CARRIES ITS
+ * ITEM WITH IT (see above), the next arrival in either game materializes a bow, a
+ * bomb bag and an upgraded wallet the player never earned. OoT's file-select
+ * screen and MM's own title screen (`TitleSetup_SetupTitleScreen` ->
+ * `MM_Sram_InitNewSave`) are the same class.
+ *
+ * WHY `gameMode` IS THE WHOLE TEST. It is the one field both games set to
+ * GAMEMODE_NORMAL at the cross-game arrival itself — in z_play.c, inside the
+ * same block that calls each game's apply — and to TITLE_SCREEN / FILE_SELECT on
+ * every menu path. So no frame can observe a menu's save under a NORMAL mode.
+ * It is also exactly what SoH's own `GameInteractor::IsSaveLoaded` leans on, for
+ * this precise reason ("prevents debug saves from reporting true on title
+ * screen"). MM additionally accepts GAMEMODE_OWL_SAVE — a real file mid-save,
+ * reached from gameplay, and the mode one of MM's two `.redsave` capture points
+ * fires in. END_CREDITS is excluded in both: the save is real but the session is
+ * terminal, so there is nothing downstream for a harvest to serve.
+ *
+ * WHY `fileNum` IS DELIBERATELY NOT PART OF THIS. Two independent reasons, and
+ * the second is the surprising one:
+ *
+ *   1. 0xFF IS OVERLOADED. It is OoT's title/map-select "no file" marker AND
+ *      this project's mandatory cross-game sentinel, which MM's `fileNum` is
+ *      PINNED to for the entire life of a legitimate cross-game session (see
+ *      `Sram_FileNumHasFlashSlot` and the 0xFF gates in z_sram_NES.c). On the MM
+ *      side it therefore carries no information at all, and rejecting it would
+ *      suppress the whole feature in the direction it was written for.
+ *
+ *   2. AN OOT-ONLY fileNum RULE IS ACTIVELY WORSE THAN NONE. Gating OoT's
+ *      harvest on a real slot while MM's harvest (which cannot be so gated) and
+ *      BOTH applies stay live makes the flow one-way — and apply is not
+ *      symmetric with harvest: for a CONSUMABLE it ASSIGNS
+ *      (`*liveValue = applied`), so it can lower a live value. A slot-less OoT
+ *      session would stop contributing while still receiving, and MM's harvest
+ *      would walk OoT's 14-heart debug save down to MM's 3-heart bootstrap. That
+ *      is a new corruption introduced by the guard, in the exact session
+ *      `IntGameplayRoundtrip` runs in. Keeping the predicate symmetric across
+ *      the two games is what keeps harvest and apply paired.
+ *
+ * KNOWN RESIDUAL, accepted deliberately: OoT's map-select debug save (fileNum
+ * 0xFF) and Boss Rush (0xFE) do reach gameplay under GAMEMODE_NORMAL carrying
+ * synthetic inventories nobody earned, and this predicate admits both. They are
+ * admitted SYMMETRICALLY — both games harvest and both apply, which is the
+ * pre-existing
+ * behavior and cannot corrupt either live save — and neither can persist a pool
+ * on its own, because OoT's `.redsave` hooks reject any fileNum outside 0..2 and
+ * MM's capture needs an active slot only those hooks establish. Closing them
+ * needs the APPLY gated on the same predicate, which is a separate change.
+ *
+ * A suppressed harvest must be a clean no-op on BOTH stores: an early return
+ * taken BEFORE any `Combo_HarvestSharedResource` call, so neither the pool nor
+ * the RAM watermark table is touched. That is what keeps the first-harvest seed
+ * above intact — a skipped harvest leaves "has this game been applied to in this
+ * process" exactly as it was, so the next real harvest applies the
+ * empty/occupied rule to an unchanged world.
+ *
+ * @param game     the game whose gSaveContext this is
+ * @param gameMode `gSaveContext.gameMode` (RSBS_GAMEMODE_*)
+ */
+bool Combo_SaveIsLiveFile(GameId game, int32_t gameMode);
 
 /**
  * HARVEST. Fold `liveValue` — the departing game's live value for `kind` — into

--- a/src/common/tests/test_shared_resources.c
+++ b/src/common/tests/test_shared_resources.c
@@ -34,6 +34,14 @@
  *  (5) THE HEART QUANTITY round-trips through its split, and clamps at 20
  *      hearts. Neither game's give path clamps capacity.
  *
+ *  (6) THE LIVE-FILE GATE. A harvest may only read a gSaveContext that belongs to
+ *      a real loaded file. On the title screen OoT's holds the ATTRACT DEMO's
+ *      debug save, and F10 is polled every frame with no gameplay gate — so an
+ *      ungated harvest permanently installs every MONOTONIC capacity that save
+ *      carries, and a capacity tier carries its ITEM with it. Each case below is
+ *      paired with the UNGATED call that proves the gate is what prevented it;
+ *      without that pairing a gate stuck at "always true" would still pass.
+ *
  * Display-free, ROM-free and save-free: everything under test is gComboCtx plus
  * a RAM watermark table, so this runs in the plain `redship` tier.
  *
@@ -67,6 +75,33 @@
 static void SR_FreshWorld(void) {
     ComboContext_Init();
     Combo_ResetSharedResourceWatermarks();
+}
+
+// OoT's title-screen / attract-demo save, as authored by SaveManager::-
+// InitFileDebug (games/oot/soh/SaveManager.cpp) — the real numbers, and the
+// reason the gate exists. They sit in gSaveContext the whole time the player is
+// looking at the title screen, where InitFileDebug deliberately skips the
+// DebugSaveFileMode branch (so it is always this save, never InitFileMaxed).
+//
+// `inventory.upgrades = 0x125249` decodes against OoT_gUpgradeMasks/Shifts to
+// TIER 1 OF ALL EIGHT slots — quiver, bomb bag, strength, scale, wallet, bullet
+// bag, sticks, nuts — not maxed tiers. Tier 1 is the whole problem anyway: a
+// fresh file holds ZERO for every one of them, and a capacity tier carries its
+// ITEM with it (see shared_resources.h), so a tier-1 leak hands the other game a
+// bow, a bomb bag and an upgraded wallet out of nothing.
+#define SR_OOT_DEBUG_HEALTH_QUARTERS 0xE0u // 14 hearts, vs a new file's 3
+#define SR_OOT_DEBUG_WALLET_TIER 1u
+#define SR_OOT_DEBUG_QUIVER_TIER 1u
+#define SR_OOT_DEBUG_RUPEES 150u
+
+// Mirrors the shape of BOTH harvest shims: the live-file gate, then the harvest.
+// Whatever the gate rejects never reaches the pool OR the watermark table, which
+// is the property (6) below is about.
+static void SR_GatedHarvest(GameId game, int32_t gameMode, uint8_t kind, uint16_t liveValue) {
+    if (!Combo_SaveIsLiveFile(game, gameMode)) {
+        return;
+    }
+    Combo_HarvestSharedResource(game, kind, liveValue);
 }
 
 // Read a slot's value, or a sentinel that no test expects, so a "resource is
@@ -464,7 +499,138 @@ TestResult Test_SharedResources(void) {
     Combo_HarvestSharedResource(GAME_OOT, RSBS_SHARED_RES_RUPEES, 700);
     SR_ASSERT(SR_Pool(RSBS_SHARED_RES_RUPEES) == 700);
 
+    // ------------------------------------------------------------------
+    // (6) THE LIVE-FILE GATE, as a truth table first.
+    // ------------------------------------------------------------------
+    // Gameplay is the whole point of the feature, in both games. Note what is
+    // NOT a parameter here: fileNum. A legitimate cross-game MM session runs
+    // pinned to the 0xFF "no real slot" sentinel for its entire life
+    // (z_sram_NES.c's Sram_FileNumHasFlashSlot and every 0xFF gate around it),
+    // so on that side 0xFF means "cross-game", not "no file" — and gating only
+    // OoT on a real slot would leave MM's harvest feeding OoT's still-live
+    // apply, which ASSIGNS consumables and would walk OoT's save down. The
+    // predicate is symmetric so that harvest and apply stay paired.
+    SR_ASSERT(Combo_SaveIsLiveFile(GAME_OOT, RSBS_GAMEMODE_NORMAL));
+    SR_ASSERT(Combo_SaveIsLiveFile(GAME_MM, RSBS_GAMEMODE_NORMAL));
+    // MM mid-owl-save: a real file being written from gameplay, and the mode one
+    // of MM's two `.redsave` capture points fires in.
+    SR_ASSERT(Combo_SaveIsLiveFile(GAME_MM, RSBS_GAMEMODE_OWL_SAVE));
+
+    // The menus, in both games. OoT's title screen is the reported bug — its
+    // gSaveContext is the attract demo's debug save — and each of the rest holds
+    // some synthetic save the player never earned.
+    SR_ASSERT(!Combo_SaveIsLiveFile(GAME_OOT, RSBS_GAMEMODE_TITLE_SCREEN));
+    SR_ASSERT(!Combo_SaveIsLiveFile(GAME_OOT, RSBS_GAMEMODE_FILE_SELECT));
+    SR_ASSERT(!Combo_SaveIsLiveFile(GAME_MM, RSBS_GAMEMODE_TITLE_SCREEN));
+    SR_ASSERT(!Combo_SaveIsLiveFile(GAME_MM, RSBS_GAMEMODE_FILE_SELECT));
+
+    // Terminal and bogus states. END_CREDITS carries a real save but no later
+    // arrival can consume what a harvest there would contribute.
+    SR_ASSERT(!Combo_SaveIsLiveFile(GAME_OOT, RSBS_GAMEMODE_END_CREDITS));
+    SR_ASSERT(!Combo_SaveIsLiveFile(GAME_MM, RSBS_GAMEMODE_END_CREDITS));
+    SR_ASSERT(!Combo_SaveIsLiveFile(GAME_NONE, RSBS_GAMEMODE_NORMAL));
+    // GAMEMODE_OWL_SAVE is MM's alone — OoT's enum stops at END_CREDITS, so the
+    // value must not be accepted there just because the numbers are adjacent.
+    SR_ASSERT(!Combo_SaveIsLiveFile(GAME_OOT, RSBS_GAMEMODE_OWL_SAVE));
+
+    // ------------------------------------------------------------------
+    // (6a) THE REPORTED BUG. A real 3-heart session banks its hearts and its
+    // rupees — and NOTHING else: a new file holds tier 0 for every capacity, so
+    // the pool has no wallet or quiver slot at all. The player then quits to the
+    // title screen, where InitFileDebug re-authors gSaveContext with 14 hearts
+    // and tier 1 of everything, and presses F10.
+    //
+    // MONOTONIC is what makes it permanent: max-merge cannot decay, so one
+    // title-screen harvest is unrecoverable for the rest of the run. And because
+    // a capacity tier carries its item, a wallet/quiver slot CREATED here is gear
+    // conjured from a save nobody played.
+    // ------------------------------------------------------------------
+    SR_FreshWorld();
+    SR_GatedHarvest(GAME_OOT, RSBS_GAMEMODE_NORMAL, RSBS_SHARED_RES_HEALTH_QUARTERS, 0x30);
+    SR_GatedHarvest(GAME_OOT, RSBS_GAMEMODE_NORMAL, RSBS_SHARED_RES_RUPEES, 42);
+    SR_GatedHarvest(GAME_OOT, RSBS_GAMEMODE_NORMAL, RSBS_SHARED_RES_WALLET_TIER, 0);
+    SR_GatedHarvest(GAME_OOT, RSBS_GAMEMODE_NORMAL, RSBS_SHARED_RES_QUIVER_TIER, 0);
+    SR_ASSERT(SR_Pool(RSBS_SHARED_RES_HEALTH_QUARTERS) == 0x30);
+    SR_ASSERT(SR_Pool(RSBS_SHARED_RES_RUPEES) == 42);
+    SR_ASSERT(!Combo_GetSharedResource(RSBS_SHARED_RES_WALLET_TIER, &probe));
+    SR_ASSERT(!Combo_GetSharedResource(RSBS_SHARED_RES_QUIVER_TIER, &probe));
+    SR_ASSERT(Combo_CountSharedResources() == 2);
+
+    // F10 on the title screen, against the attract demo's save.
+    SR_GatedHarvest(GAME_OOT, RSBS_GAMEMODE_TITLE_SCREEN, RSBS_SHARED_RES_HEALTH_QUARTERS,
+                    SR_OOT_DEBUG_HEALTH_QUARTERS);
+    SR_GatedHarvest(GAME_OOT, RSBS_GAMEMODE_TITLE_SCREEN, RSBS_SHARED_RES_RUPEES, SR_OOT_DEBUG_RUPEES);
+    SR_GatedHarvest(GAME_OOT, RSBS_GAMEMODE_TITLE_SCREEN, RSBS_SHARED_RES_WALLET_TIER, SR_OOT_DEBUG_WALLET_TIER);
+    SR_GatedHarvest(GAME_OOT, RSBS_GAMEMODE_TITLE_SCREEN, RSBS_SHARED_RES_QUIVER_TIER, SR_OOT_DEBUG_QUIVER_TIER);
+    SR_ASSERT(SR_Pool(RSBS_SHARED_RES_HEALTH_QUARTERS) == 0x30);
+    SR_ASSERT(SR_Pool(RSBS_SHARED_RES_RUPEES) == 42);
+    SR_ASSERT(!Combo_GetSharedResource(RSBS_SHARED_RES_WALLET_TIER, &probe));
+    SR_ASSERT(!Combo_GetSharedResource(RSBS_SHARED_RES_QUIVER_TIER, &probe));
+    SR_ASSERT(Combo_CountSharedResources() == 2);
+
+    // NOT VACUOUS: the same reads UNGATED do land — 11 extra hearts, and two
+    // capacity slots created from nothing. So the block above is testing the gate
+    // and not some incidental property of the merge rules. A gate stuck at
+    // "always true" fails above; one stuck at "always false" fails the truth
+    // table's positive cases.
+    Combo_HarvestSharedResource(GAME_OOT, RSBS_SHARED_RES_HEALTH_QUARTERS, SR_OOT_DEBUG_HEALTH_QUARTERS);
+    Combo_HarvestSharedResource(GAME_OOT, RSBS_SHARED_RES_WALLET_TIER, SR_OOT_DEBUG_WALLET_TIER);
+    Combo_HarvestSharedResource(GAME_OOT, RSBS_SHARED_RES_QUIVER_TIER, SR_OOT_DEBUG_QUIVER_TIER);
+    SR_ASSERT(SR_Pool(RSBS_SHARED_RES_HEALTH_QUARTERS) == SR_OOT_DEBUG_HEALTH_QUARTERS);
+    SR_ASSERT(SR_Pool(RSBS_SHARED_RES_WALLET_TIER) == SR_OOT_DEBUG_WALLET_TIER);
+    SR_ASSERT(SR_Pool(RSBS_SHARED_RES_QUIVER_TIER) == SR_OOT_DEBUG_QUIVER_TIER);
+    SR_ASSERT(Combo_CountSharedResources() == 4);
+
+    // ------------------------------------------------------------------
+    // (6b) THE CONSUMABLE HALF, which runs the other way. MM's title-screen
+    // bootstrap save (MM_Sram_InitNewSave: 3 hearts, no gear) cannot inflate a
+    // monotonic kind — but harvested against the watermark a real apply left
+    // behind, its 3 hearts read as a large NEGATIVE delta and debit the shared
+    // health bar. Same gate, opposite direction.
+    // ------------------------------------------------------------------
+    SR_FreshWorld();
+    Combo_HarvestSharedResource(GAME_OOT, RSBS_SHARED_RES_HEALTH_CURRENT, 0xE0); // 14 hearts banked in OoT
+    uint16_t mmHealth = 0x30;
+    SR_ASSERT(Combo_ApplySharedResource(GAME_MM, RSBS_SHARED_RES_HEALTH_CURRENT, 0x140, &mmHealth));
+    SR_ASSERT(mmHealth == 0xE0); // ...and materialized in MM, watermark 0xE0
+
+    // MM's title screen, holding the bootstrap file's 3 hearts.
+    SR_GatedHarvest(GAME_MM, RSBS_GAMEMODE_TITLE_SCREEN, RSBS_SHARED_RES_HEALTH_CURRENT, 0x30);
+    SR_ASSERT(SR_Pool(RSBS_SHARED_RES_HEALTH_CURRENT) == 0xE0);
+
+    // Not vacuous: ungated, that same 3-heart read debits eleven hearts.
+    Combo_HarvestSharedResource(GAME_MM, RSBS_SHARED_RES_HEALTH_CURRENT, 0x30);
+    SR_ASSERT(SR_Pool(RSBS_SHARED_RES_HEALTH_CURRENT) == 0x30);
+
+    // ------------------------------------------------------------------
+    // (6c) A SUPPRESSED HARVEST MUST NOT DISTURB THE WATERMARK CONTRACT. The
+    // first-harvest seed rule (3) reads "has this game been applied to in this
+    // process" — so a gated-out harvest has to leave that answer exactly as it
+    // was, which is why the shims return BEFORE the first
+    // Combo_HarvestSharedResource call rather than harvesting into a discard.
+    // Getting this wrong reintroduces the .redsave double-count through a new
+    // door: a suppressed harvest that still seeded a watermark at 150 would make
+    // the next real harvest of 300 look like +150 of new money.
+    // ------------------------------------------------------------------
+    SR_FreshWorld();
+    SR_GatedHarvest(GAME_OOT, RSBS_GAMEMODE_NORMAL, RSBS_SHARED_RES_RUPEES, 300);
+    SR_ASSERT(SR_Pool(RSBS_SHARED_RES_RUPEES) == 300);
+    Combo_ResetSharedResourceWatermarks(); // the .redsave load
+
+    // Quit to title, F10 twice against the debug save's 150 rupees.
+    SR_GatedHarvest(GAME_OOT, RSBS_GAMEMODE_TITLE_SCREEN, RSBS_SHARED_RES_RUPEES, SR_OOT_DEBUG_RUPEES);
+    SR_GatedHarvest(GAME_OOT, RSBS_GAMEMODE_TITLE_SCREEN, RSBS_SHARED_RES_RUPEES, SR_OOT_DEBUG_RUPEES);
+    SR_ASSERT(SR_Pool(RSBS_SHARED_RES_RUPEES) == 300);
+
+    // Load the file back and switch: the seed still sees an occupied slot and no
+    // watermark, so the restored 300 is money the pool already counted.
+    SR_GatedHarvest(GAME_OOT, RSBS_GAMEMODE_NORMAL, RSBS_SHARED_RES_RUPEES, 300);
+    SR_ASSERT(SR_Pool(RSBS_SHARED_RES_RUPEES) == 300);
+    // ...and money earned after it still counts, exactly as in (3).
+    SR_GatedHarvest(GAME_OOT, RSBS_GAMEMODE_NORMAL, RSBS_SHARED_RES_RUPEES, 450);
+    SR_ASSERT(SR_Pool(RSBS_SHARED_RES_RUPEES) == 450);
+
     printf("[TEST] PASS: watermark survives the 500/999 round trip, disciplines split, load cannot "
-           "double-count, both slot blocks reachable\n");
+           "double-count, both slot blocks reachable, title-screen saves cannot enter the pool\n");
     return TEST_PASS;
 }


### PR DESCRIPTION
## The bug

`OoT_HarvestSharedResources` / `MM_HarvestSharedResources` were called with no "is a real save file loaded" guard.

While OoT sits on the **title screen**, `gSaveContext` holds the **attract demo's** save — `Opening_SetupTitleScreen` → `OoT_Sram_InitDebugSave` → `SaveManager::InitFileDebug`: 14 hearts, single magic, 150 rupees, and `inventory.upgrades = 0x125249`. `Combo_CheckHotSwap` is polled from `graph.c` **every frame with no gameplay gate**, so pressing F10 on the title screen ran a full harvest against that save.

Every MONOTONIC kind it touched then sat in the pool **permanently** — max-merge cannot decay by construction — and because *a capacity tier carries its item*, the next arrival in either game materialized a bow, a bomb bag and an upgraded wallet the player never earned.

**Pre-existing.** Introduced with the v1 resources (#540), widened by magic (#554) and ammo (#555). Not a regression from any one of them.

> One correction to the original report: `0x125249` decodes against `OoT_gUpgradeMasks`/`OoT_gUpgradeShifts` to **tier 1 of all eight upgrade slots**, not maxed tiers (the shift table is not a uniform 3-bit stride — wallet is a 2-bit field at shift 12). Tier 1 is still the bug: a new file holds tier 0 everywhere.

## The fix

`Combo_SaveIsLiveFile(game, gameMode)` in `src/common/shared_resources.c`, with both harvest shims gated on it.

`gameMode` carries the whole test: both games set `GAMEMODE_NORMAL` at the cross-game arrival **in the same `z_play.c` block that calls their apply**, and `TITLE_SCREEN`/`FILE_SELECT` on every menu path — so no frame can observe a menu's save under a NORMAL mode. It is also exactly what SoH's own `GameInteractor::IsSaveLoaded` leans on, with the same rationale in its comment. MM additionally accepts `GAMEMODE_OWL_SAVE` (a real file mid-save, and the mode one of MM's two `.redsave` capture points fires in). Each game's TU `static_assert`s its own `GAMEMODE_*` enum against the shared macros, so an upstream renumber is a build error rather than a silently inverted gate.

### Why `fileNum` is deliberately not part of the predicate

1. **0xFF is overloaded** — OoT's title/map-select "no file" marker *and* this project's cross-game sentinel, which MM's `fileNum` is pinned to for the entire life of a legitimate session (`Sram_FileNumHasFlashSlot` + the 0xFF gates in `z_sram_NES.c`). On the MM side it carries no information at all.
2. **An OoT-only `fileNum` rule would be actively worse than none.** Apply is *not* symmetric with harvest — for a CONSUMABLE it **assigns** (`*liveValue = applied`), so it can lower a live value. Gating only OoT's harvest while both applies stay live makes the flow one-way: MM's harvest would walk OoT's 14-heart debug save down to MM's 3-heart bootstrap. I started down that path, caught it, and made the predicate symmetric instead.

### Watermark contract

Both gates are early returns taken **before** the accumulator settle and before the first `Combo_HarvestSharedResource` call, so a suppressed harvest touches neither the pool nor the RAM watermark table. The first-harvest seed rule still meets the empty/occupied world it was written for — locked by case (6c) in the test.

## Known residual (documented, deliberate)

OoT's map-select debug save (`0xFF`) and Boss Rush (`0xFE`) reach gameplay under `NORMAL` and are still admitted — but **symmetrically** (pre-existing behavior, cannot corrupt either live save), and neither can persist a pool alone because OoT's `.redsave` hooks reject any `fileNum` outside 0..2. Closing them requires gating the **apply** on the same predicate: a separate change.

## Verification

Full ROM-staged local build (fresh worktree: submodules, ROMs, extraction, `assets/`, OpenGL config).

| Tier | Result |
|---|---|
| `redship` | **65/65 pass** |
| `rando` | **14/14 pass** |
| `integration` | **5/6** — only `IntSwitchOoTHmsToMm` (permanently red, #544) |

**Mutation-tested three ways**, each failing at a distinct assertion:
- always-true → truth table (line 522); **and** with the truth table disabled, the scenario block catches it at line 567
- always-false → scenario block (line 555) with the truth table disabled
- `OWL_SAVE` clause dropped → line 517

The gate is observable end-to-end: `IntSwitchMmClockTownSouthToOoT` logs `[MM] shared-resource harvest skipped: not a live file (gameMode=1 fileNum=255)`. That test force-boots MM without passing through file select, so `gameMode` stays `TITLE_SCREEN` over the bootstrap save — **MM runs real gameplay frames under `TITLE_SCREEN`** (its opening cutscene does too), which is worth knowing and is now documented in the shim. A legitimate standalone MM session is unaffected: `FileSelect_LoadGame` sets `GAMEMODE_NORMAL`.

`IntGameplayRoundtripSoak` is **pre-existing red** — `0xc0000005` READ AV in `mm-play` cycle 1/3. Confirmed by stashing this change, rebuilding, and reproducing the identical crash at the identical phase and continuity checkpoint. It is in the `integration-soak` label, outside the tiers this change was scoped to.

## Noted in passing, not fixed here

The `OnSaveFile` harvest runs on a **thread-pool thread** (`SaveManager::SaveSection` → `detach_task` → `SaveFileThreaded`) while reading the live `gSaveContext`, which contradicts `shared_resources.h`'s "game thread only" threading note. Pre-existing; this gate inherits the same race, conservatively (a stale read can only suppress, never over-harvest).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!--- section:artifacts:start -->
### Build Artifacts
  - [rsbs-windows.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/8747150347.zip)
  - [rsbs-linux.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/8746286152.zip)
<!--- section:artifacts:end -->