### PR TITLE
Null-guard the resource consumers that turned a failed load into an AV, in both games (#560)

### DIFF
--- a/games/mm/2s2h/resource/importer/AnimationFactory.cpp
+++ b/games/mm/2s2h/resource/importer/AnimationFactory.cpp
@@ -88,6 +88,14 @@ ResourceFactoryBinaryAnimationV0::ReadResource(std::shared_ptr<Ship::File> file,
         const auto animData = std::static_pointer_cast<Animation>(
             Ship::Context::GetInstance()->GetResourceManager()->LoadResourceProcess(path.c_str()));
 
+        // #560: a failed sub-load returns null. Fail the whole animation rather than
+        // dereferencing it or handing the animation player an uninitialized segment.
+        // Mirrors the same site in OoT's AnimationFactory.
+        if (animData == nullptr) {
+            SPDLOG_ERROR("Animation {}: failed to load link animation segment \"{}\"", initData->Path, path);
+            return nullptr;
+        }
+
         animation->animationData.linkAnimationHeader.segment = animData->GetPointer();
     } else if (animType == AnimationType::Legacy) {
         SPDLOG_DEBUG("BEYTAH ANIMATION?!");

--- a/games/mm/2s2h/resource/importer/scenecommand/SetAnimatedMaterialListFactory.cpp
+++ b/games/mm/2s2h/resource/importer/scenecommand/SetAnimatedMaterialListFactory.cpp
@@ -3,6 +3,7 @@
 #include "2s2h/resource/type/TextureAnimation.h"
 #include <ship/Context.h>
 #include <ship/resource/ResourceManager.h>
+#include <spdlog/spdlog.h>
 
 namespace S2H {
 
@@ -16,6 +17,16 @@ SetAnimatedMaterialListFactory::ReadResource(std::shared_ptr<Ship::ResourceInitD
     std::string str = reader->ReadString();
     const auto data = std::static_pointer_cast<TextureAnimation>(
         Ship::Context::GetInstance()->GetResourceManager()->LoadResourceProcess(str.c_str()));
+
+    // #560: a failed sub-load returns null. play->sceneMaterialAnims is null in a
+    // scene that has no SetAnimatedMaterialList at all and its consumers handle that,
+    // so store null rather than dereferencing.
+    if (data == nullptr) {
+        SPDLOG_ERROR("SetAnimatedMaterialList: failed to load texture animation \"{}\" for {}; leaving it unset", str,
+                     initData->Path);
+        setAnimatedMat->mat = nullptr;
+        return setAnimatedMat;
+    }
 
     AnimatedMaterial* res = data->GetPointer();
     setAnimatedMat->mat = res;

--- a/games/mm/2s2h/resource/importer/scenecommand/SetPathwaysFactory.cpp
+++ b/games/mm/2s2h/resource/importer/scenecommand/SetPathwaysFactory.cpp
@@ -2,6 +2,7 @@
 #include "2s2h/resource/type/scenecommand/SetPathways.h"
 #include <ship/Context.h>
 #include <ship/resource/ResourceManager.h>
+#include <spdlog/spdlog.h>
 
 namespace S2H {
 std::shared_ptr<Ship::IResource> SetPathwaysMMFactory::ReadResource(std::shared_ptr<Ship::ResourceInitData> initData,
@@ -10,14 +11,30 @@ std::shared_ptr<Ship::IResource> SetPathwaysMMFactory::ReadResource(std::shared_
 
     ReadCommandId(setPathways, reader);
 
-    setPathways->numPaths = reader->ReadUInt32();
-    setPathways->paths.reserve(setPathways->numPaths);
-    for (uint32_t i = 0; i < setPathways->numPaths; i++) {
+    uint32_t declaredPaths = reader->ReadUInt32();
+    setPathways->paths.reserve(declaredPaths);
+    for (uint32_t i = 0; i < declaredPaths; i++) {
         std::string pathFileName = reader->ReadString();
         auto path = std::static_pointer_cast<PathMM>(
             Ship::Context::GetInstance()->GetResourceManager()->LoadResourceProcess(pathFileName.c_str()));
+        // #560: this sub-load can come back null — the archive layer reads one shared
+        // zip_t with no synchronization, so a concurrent read can leave the buffer
+        // zeroed and ReadResourceInitData then rejects it. Skip the entry instead of
+        // calling GetPointer() through the null. Mirrors the guard the sibling
+        // SetCutscenesFactory in this directory already has, and OoT's
+        // SetPathwaysFactory. Every read above stays consumed, so the binary reader
+        // does not desync for the scene's remaining commands.
+        if (path == nullptr) {
+            SPDLOG_ERROR("SetPathwaysMM: failed to load pathway resource \"{}\" for {}; skipping it", pathFileName,
+                         initData->Path);
+            continue;
+        }
         setPathways->paths.push_back(path->GetPointer());
     }
+
+    // Report what actually loaded, not what the file claimed.
+    setPathways->numPaths = static_cast<uint32_t>(setPathways->paths.size());
+
     return setPathways;
 }
 } // namespace S2H

--- a/games/mm/2s2h/z_scene_2SH.cpp
+++ b/games/mm/2s2h/z_scene_2SH.cpp
@@ -37,6 +37,7 @@
 #include "2s2h/resource/type/scenecommand/SetMinimapList.h"
 #include "2s2h/resource/type/scenecommand/SetMinimapChests.h"
 #include "2s2h/resource/type/scenecommand/SetCsCamera.h"
+#include <spdlog/spdlog.h>
 
 s32 MM_OTRScene_ExecuteCommands(PlayState* play, S2H::Scene* scene);
 
@@ -273,6 +274,16 @@ void MM_Scene_CommandLightList(PlayState* play, S2H::ISceneCommand* cmd) {
 
 void MM_Scene_CommandPathList(PlayState* play, S2H::ISceneCommand* cmd) {
     S2H::SetPathwaysMM* paths = (S2H::SetPathwaysMM*)cmd;
+
+    // GetPointer() is paths.data(), so indexing [0] on an empty list dereferences
+    // what data() returns for an empty vector (nullptr in practice). Same guard as
+    // OoT's OoT_Scene_CommandPathList: a scene with no usable pathway is equivalent
+    // to one with no SetPathways command at all, i.e. a null setupPathList.
+    if (paths->paths.empty()) {
+        SPDLOG_ERROR("MM scene command SetPathways has no usable pathway list; leaving setupPathList null");
+        play->setupPathList = nullptr;
+        return;
+    }
 
     play->setupPathList = (Path*)paths->GetPointer()[0];
 }
@@ -537,6 +548,17 @@ s32 MM_OTRScene_ExecuteCommands(PlayState* play, S2H::Scene* scene) {
 
     for (int i = 0; i < scene->commands.size(); i++) {
         auto sceneCmd = scene->commands[i];
+
+        // #560: ParseSceneCommand pushes a null entry for every command it could not
+        // build — an unknown command id, or a factory whose sub-load failed — and
+        // logs it there. OoT's OTRScene_ExecuteCommands has always skipped those;
+        // this loop read ->cmdId straight through the null, so any logged
+        // scene-command load failure became an access violation on the next MM scene
+        // load. Skip it and run the rest of the scene's commands.
+        if (sceneCmd == nullptr) {
+            continue;
+        }
+
         cmdId = sceneCmd->cmdId;
 
         // 2S2H [Port] This opcode is not in the original game. Its a special command for OTRs, for supporting multiple

--- a/games/oot/soh/Enhancements/Restorations/GraveHoleJumps.cpp
+++ b/games/oot/soh/Enhancements/Restorations/GraveHoleJumps.cpp
@@ -7,6 +7,7 @@
 #include "soh/resource/type/Scene.h"
 #include "soh/resource/type/scenecommand/SceneCommand.h"
 #include "soh/resource/type/scenecommand/SetCollisionHeader.h"
+#include "spdlog/spdlog.h"
 
 #define CVAR_GRAVE_HOLE_NAME CVAR_ENHANCEMENT("GraveHoles")
 #define GRAVE_HOLES_DEFAULT 0
@@ -32,15 +33,32 @@ CollisionHeader* getGraveyardCollisionHeader() {
      */
     SOH::Scene* scene =
         (SOH::Scene*)Ship::Context::GetInstance()->GetResourceManager()->LoadResource(GRAVEYARD_SCENE_FILEPATH).get();
+    // Any of these can be null after a failed archive read (#560): the scene itself,
+    // an individual command ParseSceneCommand could not build, and the collision
+    // header sub-load SetCollisionHeaderFactory stores without checking. Bail out
+    // instead of patching through a null — the patch re-runs on the next ShipInit or
+    // CVar change, so skipping one attempt is recoverable.
+    if (scene == nullptr) {
+        SPDLOG_ERROR("GraveHoleJumps: failed to load the graveyard scene; skipping the geometry patch");
+        return nullptr;
+    }
     SOH::SetCollisionHeader* sceneCmd = nullptr;
     for (size_t i = 0; i < scene->commands.size(); i++) {
         auto cmd = scene->commands[i];
-        if (cmd->cmdId == SOH::SceneCommandID::SetCollisionHeader) {
+        if (cmd != nullptr && cmd->cmdId == SOH::SceneCommandID::SetCollisionHeader) {
             sceneCmd = static_cast<SOH::SetCollisionHeader*>(cmd.get());
             break;
         }
     }
+    if (sceneCmd == nullptr || sceneCmd->collisionHeader == nullptr) {
+        SPDLOG_ERROR("GraveHoleJumps: graveyard scene has no usable collision header; skipping the geometry patch");
+        return nullptr;
+    }
     CollisionHeader* graveyardColHeader = (CollisionHeader*)sceneCmd->GetRawPointer();
+    if (graveyardColHeader == nullptr) {
+        SPDLOG_ERROR("GraveHoleJumps: graveyard collision header has no data; skipping the geometry patch");
+        return nullptr;
+    }
     uint32_t surfaceTypesCount = sceneCmd->collisionHeader->surfaceTypesCount;
 
     /*
@@ -76,6 +94,9 @@ void ApplyGraveyardGeometryPatches() {
     // ShipInit/CVar-change re-run was a use-after-free. LoadResource is a cache hit while the resource
     // is loaded, so re-fetching is cheap, and it also re-applies the patch to a freshly reloaded scene.
     CollisionHeader* graveyardColHeader = getGraveyardCollisionHeader();
+    if (graveyardColHeader == nullptr) {
+        return;
+    }
     for (auto& mappingPatch : graveyardGeometryPatches) {
         for (int i = mappingPatch.first.first; i <= mappingPatch.first.second; i++) {
             CollisionPoly* poly = &graveyardColHeader->polyList[i];

--- a/games/oot/soh/Enhancements/randomizer/3drando/fill.cpp
+++ b/games/oot/soh/Enhancements/randomizer/3drando/fill.cpp
@@ -1278,7 +1278,15 @@ int Fill() {
                         RandomizerCheck rc =
                             Rando::StaticData::GetShopLocations()[i * LOCATIONS_PER_SHOP + itemindex - 1];
                         Rando::ItemLocation* itemLoc = ctx->GetItemLocation(rc);
-                        uint16_t shopsanityPrice = GetRandomPrice(Rando::StaticData::GetLocation(rc), shopsanityPrices);
+                        Rando::Location* loc = Rando::StaticData::GetLocation(rc);
+                        // GetRandomPrice reads loc->GetName()/GetRCType(), so a null
+                        // here is a deref inside the price roll, mid-generation.
+                        if (itemLoc == nullptr || loc == nullptr) {
+                            SPDLOG_ERROR("Shopsanity: no location entry for check {}; leaving its price vanilla",
+                                         static_cast<int>(rc));
+                            continue;
+                        }
+                        uint16_t shopsanityPrice = GetRandomPrice(loc, shopsanityPrices);
                         itemLoc->SetCustomPrice(shopsanityPrice);
                     }
                 }
@@ -1301,42 +1309,48 @@ int Fill() {
 
         // Add prices to scrubs
         auto scrubLoc = Rando::StaticData::GetScrubLocations();
-        if (ctx->GetOption(RSK_SHUFFLE_SCRUBS).Is(RO_SCRUBS_ALL)) {
-            for (size_t i = 0; i < scrubLoc.size(); i++) {
-                ctx->GetItemLocation(scrubLoc[i])
-                    ->SetCustomPrice(GetRandomPrice(Rando::StaticData::GetLocation(scrubLoc[i]), scrubPrices));
+        const bool randomScrubPrices = ctx->GetOption(RSK_SHUFFLE_SCRUBS).Is(RO_SCRUBS_ALL);
+        for (size_t i = 0; i < scrubLoc.size(); i++) {
+            Rando::ItemLocation* itemLoc = ctx->GetItemLocation(scrubLoc[i]);
+            Rando::Location* loc = Rando::StaticData::GetLocation(scrubLoc[i]);
+            if (itemLoc == nullptr || loc == nullptr) {
+                SPDLOG_ERROR("Scrub prices: no location entry for check {}; skipping it",
+                             static_cast<int>(scrubLoc[i]));
+                continue;
             }
-        } else {
-            for (size_t i = 0; i < scrubLoc.size(); i++) {
-                ctx->GetItemLocation(scrubLoc[i])
-                    ->SetCustomPrice(Rando::StaticData::GetLocation(scrubLoc[i])->GetVanillaPrice());
-            }
+            // GetVanillaPrice is int16_t and GetRandomPrice is uint16_t; make the
+            // narrowing to SetCustomPrice's uint16_t explicit rather than implicit.
+            itemLoc->SetCustomPrice(
+                static_cast<uint16_t>(randomScrubPrices ? GetRandomPrice(loc, scrubPrices) : loc->GetVanillaPrice()));
         }
 
         // set merchant prices
-        if (ctx->GetOption(RSK_SHUFFLE_MERCHANTS).Is(RO_SHUFFLE_MERCHANTS_BEANS_ONLY) ||
-            ctx->GetOption(RSK_SHUFFLE_MERCHANTS).Is(RO_SHUFFLE_MERCHANTS_ALL)) {
-            ctx->GetItemLocation(RC_ZR_MAGIC_BEAN_SALESMAN)
-                ->SetCustomPrice(
-                    GetRandomPrice(Rando::StaticData::GetLocation(RC_ZR_MAGIC_BEAN_SALESMAN), merchantPrices));
+        const bool randomBeanPrice = ctx->GetOption(RSK_SHUFFLE_MERCHANTS).Is(RO_SHUFFLE_MERCHANTS_BEANS_ONLY) ||
+                                     ctx->GetOption(RSK_SHUFFLE_MERCHANTS).Is(RO_SHUFFLE_MERCHANTS_ALL);
+        Rando::ItemLocation* beanItemLoc = ctx->GetItemLocation(RC_ZR_MAGIC_BEAN_SALESMAN);
+        Rando::Location* beanLoc = Rando::StaticData::GetLocation(RC_ZR_MAGIC_BEAN_SALESMAN);
+        if (beanItemLoc == nullptr || beanLoc == nullptr) {
+            SPDLOG_ERROR("Merchant prices: no location entry for the magic bean salesman; skipping its price");
         } else {
-            ctx->GetItemLocation(RC_ZR_MAGIC_BEAN_SALESMAN)
-                ->SetCustomPrice(Rando::StaticData::GetLocation(RC_ZR_MAGIC_BEAN_SALESMAN)->GetVanillaPrice());
+            beanItemLoc->SetCustomPrice(static_cast<uint16_t>(randomBeanPrice ? GetRandomPrice(beanLoc, merchantPrices)
+                                                                              : beanLoc->GetVanillaPrice()));
         }
 
         auto merchantLoc = Rando::StaticData::GetMerchantLocations();
 
-        if (ctx->GetOption(RSK_SHUFFLE_MERCHANTS).Is(RO_SHUFFLE_MERCHANTS_ALL_BUT_BEANS) ||
-            ctx->GetOption(RSK_SHUFFLE_MERCHANTS).Is(RO_SHUFFLE_MERCHANTS_ALL)) {
-            for (size_t i = 0; i < merchantLoc.size(); i++) {
-                ctx->GetItemLocation(merchantLoc[i])
-                    ->SetCustomPrice(GetRandomPrice(Rando::StaticData::GetLocation(merchantLoc[i]), merchantPrices));
+        const bool randomMerchantPrices =
+            ctx->GetOption(RSK_SHUFFLE_MERCHANTS).Is(RO_SHUFFLE_MERCHANTS_ALL_BUT_BEANS) ||
+            ctx->GetOption(RSK_SHUFFLE_MERCHANTS).Is(RO_SHUFFLE_MERCHANTS_ALL);
+        for (size_t i = 0; i < merchantLoc.size(); i++) {
+            Rando::ItemLocation* itemLoc = ctx->GetItemLocation(merchantLoc[i]);
+            Rando::Location* loc = Rando::StaticData::GetLocation(merchantLoc[i]);
+            if (itemLoc == nullptr || loc == nullptr) {
+                SPDLOG_ERROR("Merchant prices: no location entry for check {}; skipping it",
+                             static_cast<int>(merchantLoc[i]));
+                continue;
             }
-        } else {
-            for (size_t i = 0; i < merchantLoc.size(); i++) {
-                ctx->GetItemLocation(merchantLoc[i])
-                    ->SetCustomPrice(Rando::StaticData::GetLocation(merchantLoc[i])->GetVanillaPrice());
-            }
+            itemLoc->SetCustomPrice(static_cast<uint16_t>(randomMerchantPrices ? GetRandomPrice(loc, merchantPrices)
+                                                                               : loc->GetVanillaPrice()));
         }
         StopPerformanceTimer(PT_SHOPSANITY);
 

--- a/games/oot/soh/Enhancements/randomizer/location_list.cpp
+++ b/games/oot/soh/Enhancements/randomizer/location_list.cpp
@@ -1060,6 +1060,14 @@ void Rando::StaticData::InitHashMaps() {
 }
 
 Location* Rando::StaticData::GetLocation(RandomizerCheck locKey) {
+    // NOTE: this cannot currently return null — callers all over the tree
+    // (menu.cpp, hook_handlers.cpp, TrackerAdapterSingleExe.cpp, fill.cpp)
+    // null-check the result, and those checks are defensive rather than live. The
+    // real hazard for an out-of-range key is a pointer past the end of the array,
+    // not null. Bounding it here would make every one of those guards meaningful,
+    // but it would also turn today's out-of-range reads into hard null derefs in
+    // the many callers that do NOT check, so it needs its own change with its own
+    // audit of the unguarded callers.
     return &(locationTable[locKey]);
 }
 

--- a/games/oot/soh/Enhancements/randomizer/logic.cpp
+++ b/games/oot/soh/Enhancements/randomizer/logic.cpp
@@ -2402,6 +2402,14 @@ const std::vector<uint8_t>& GetDungeonSmallKeyDoors(SceneID sceneId) {
     // Find the SetTransitionActorList command
     std::shared_ptr<SOH::SetTransitionActorList> transitionActorListCommand = nullptr;
     for (auto& command : scene->commands) {
+        // ParseSceneCommand pushes a null entry for any command it could not build
+        // (unknown id, or a factory that failed a sub-load — #560) and logs it there.
+        // The engine's own walk in OTRScene_ExecuteCommands skips nulls; this one
+        // must too, or a partially loaded scene turns a logged load failure into an
+        // access violation in the middle of fill.
+        if (command == nullptr) {
+            continue;
+        }
         if (command->cmdId == SOH::SceneCommandID::SetTransitionActorList) {
             transitionActorListCommand = std::dynamic_pointer_cast<SOH::SetTransitionActorList>(command);
             break;

--- a/games/oot/soh/Enhancements/randomizer/randomizer.cpp
+++ b/games/oot/soh/Enhancements/randomizer/randomizer.cpp
@@ -3466,44 +3466,49 @@ void GenerateRandomizerImgui(std::string seed = "") {
     CVarSetInteger(CVAR_GENERAL("RandoGenerating"), 1);
     Ship::Context::GetInstance()->GetWindow()->GetGui()->SaveConsoleVariablesNextFrame();
     auto ctx = Rando::Context::GetInstance();
-    // RANDOTODO proper UI for selecting if a spoiler loaded should be used for settings
-    Rando::Settings::GetInstance()->SetAllToContext();
 
-    // todo: this efficently when we build out cvar array support
-    std::set<RandomizerCheck> excludedLocations;
-    std::stringstream excludedLocationStringStream(CVarGetString(CVAR_RANDOMIZER_SETTING("ExcludedLocations"), ""));
-    std::string excludedLocationString;
-    while (getline(excludedLocationStringStream, excludedLocationString, ',')) {
-        excludedLocations.insert((RandomizerCheck)std::stoi(excludedLocationString));
-    }
-
-    // todo: better way to sort out linking tricks rather than name
-
-    std::set<RandomizerTrick> enabledTricks;
-    std::stringstream enabledTrickStringStream(CVarGetString(CVAR_RANDOMIZER_SETTING("EnabledTricks"), ""));
-    std::string enabledTrickString;
-    while (getline(enabledTrickStringStream, enabledTrickString, ',')) {
-        enabledTricks.insert((RandomizerTrick)std::stoi(enabledTrickString));
-    }
-
-    // Update the visibilitiy before removing conflicting excludes (in case the locations tab wasn't viewed)
-    RandomizerCheckObjects::UpdateImGuiVisibility();
-
-    // Remove excludes for locations that are no longer allowed to be excluded
-    for (auto& location : Rando::StaticData::GetLocationTable()) {
-        auto elfound = excludedLocations.find(location.GetRandomizerCheck());
-        if (!ctx->GetItemLocation(location.GetRandomizerCheck())->IsVisible() && elfound != excludedLocations.end()) {
-            excludedLocations.erase(elfound);
-        }
-    }
-
-    // #560: this runs on its own thread with nothing above it that catches. An
-    // exception escaping GenerateRando therefore std::terminate'd the process, and
-    // because RandoGenerating was already persisted as 1 by the
-    // SaveConsoleVariablesNextFrame above, the menu and the file-select screen were
-    // left believing a generation was still in flight. A failed attempt has to clear
-    // the flag and hand the thread back joinable, exactly like a successful one.
+    // #560: this function IS the thread entry, and nothing above it catches, so any
+    // exception escaping it std::terminate'd the process — with RandoGenerating
+    // already persisted as 1 by the SaveConsoleVariablesNextFrame above, leaving the
+    // menu and the file-select screen believing a generation was still in flight and
+    // the thread never joinable. The whole body has to be covered, not just the
+    // GenerateRando call: the std::stoi calls below parse persisted CVar strings and
+    // throw std::invalid_argument on any token that is not a number. A failed attempt
+    // must clear the flag and hand the thread back exactly like a successful one, so
+    // the fall-through below runs in every case.
     try {
+        // RANDOTODO proper UI for selecting if a spoiler loaded should be used for settings
+        Rando::Settings::GetInstance()->SetAllToContext();
+
+        // todo: this efficently when we build out cvar array support
+        std::set<RandomizerCheck> excludedLocations;
+        std::stringstream excludedLocationStringStream(CVarGetString(CVAR_RANDOMIZER_SETTING("ExcludedLocations"), ""));
+        std::string excludedLocationString;
+        while (getline(excludedLocationStringStream, excludedLocationString, ',')) {
+            excludedLocations.insert((RandomizerCheck)std::stoi(excludedLocationString));
+        }
+
+        // todo: better way to sort out linking tricks rather than name
+
+        std::set<RandomizerTrick> enabledTricks;
+        std::stringstream enabledTrickStringStream(CVarGetString(CVAR_RANDOMIZER_SETTING("EnabledTricks"), ""));
+        std::string enabledTrickString;
+        while (getline(enabledTrickStringStream, enabledTrickString, ',')) {
+            enabledTricks.insert((RandomizerTrick)std::stoi(enabledTrickString));
+        }
+
+        // Update the visibilitiy before removing conflicting excludes (in case the locations tab wasn't viewed)
+        RandomizerCheckObjects::UpdateImGuiVisibility();
+
+        // Remove excludes for locations that are no longer allowed to be excluded
+        for (auto& location : Rando::StaticData::GetLocationTable()) {
+            auto elfound = excludedLocations.find(location.GetRandomizerCheck());
+            if (!ctx->GetItemLocation(location.GetRandomizerCheck())->IsVisible() &&
+                elfound != excludedLocations.end()) {
+                excludedLocations.erase(elfound);
+            }
+        }
+
         RandoMain::GenerateRando(excludedLocations, enabledTricks, seed);
     } catch (const std::exception& e) {
         SPDLOG_ERROR("Seed generation threw: {}", e.what());

--- a/games/oot/soh/Enhancements/randomizer/randomizer.cpp
+++ b/games/oot/soh/Enhancements/randomizer/randomizer.cpp
@@ -3497,7 +3497,21 @@ void GenerateRandomizerImgui(std::string seed = "") {
         }
     }
 
-    RandoMain::GenerateRando(excludedLocations, enabledTricks, seed);
+    // #560: this runs on its own thread with nothing above it that catches. An
+    // exception escaping GenerateRando therefore std::terminate'd the process, and
+    // because RandoGenerating was already persisted as 1 by the
+    // SaveConsoleVariablesNextFrame above, the menu and the file-select screen were
+    // left believing a generation was still in flight. A failed attempt has to clear
+    // the flag and hand the thread back joinable, exactly like a successful one.
+    try {
+        RandoMain::GenerateRando(excludedLocations, enabledTricks, seed);
+    } catch (const std::exception& e) {
+        SPDLOG_ERROR("Seed generation threw: {}", e.what());
+        ctx->SetSeedGenerated(false);
+    } catch (...) {
+        SPDLOG_ERROR("Seed generation threw an unknown exception");
+        ctx->SetSeedGenerated(false);
+    }
 
     CVarSetInteger(CVAR_GENERAL("RandoGenerating"), 0);
     Ship::Context::GetInstance()->GetWindow()->GetGui()->SaveConsoleVariablesNextFrame();

--- a/games/oot/soh/resource/importer/AnimationFactory.cpp
+++ b/games/oot/soh/resource/importer/AnimationFactory.cpp
@@ -86,6 +86,15 @@ ResourceFactoryBinaryAnimationV0::ReadResource(std::shared_ptr<Ship::File> file,
         const auto animData = std::static_pointer_cast<Animation>(
             Ship::Context::GetInstance()->GetResourceManager()->LoadResourceProcess(path.c_str()));
 
+        // #560: a sub-load can fail (a concurrent read on the unsynchronized shared
+        // zip_t zeroes the buffer, so ReadResourceInitData rejects it). Fail the
+        // whole animation rather than dereferencing the null or handing the animation
+        // player a header with an uninitialized segment.
+        if (animData == nullptr) {
+            SPDLOG_ERROR("Animation {}: failed to load link animation segment \"{}\"", initData->Path, path);
+            return nullptr;
+        }
+
         animation->animationData.linkAnimationHeader.segment = animData->GetPointer();
     } else if (animType == AnimationType::Legacy) {
         SPDLOG_DEBUG("BEYTAH ANIMATION?!");

--- a/games/oot/soh/resource/importer/AudioSampleFactory.cpp
+++ b/games/oot/soh/resource/importer/AudioSampleFactory.cpp
@@ -289,8 +289,20 @@ ResourceFactoryXMLAudioSampleV0::ReadResource(std::shared_ptr<Ship::File> file,
     audioSample->sample.size = size;
 
     const char* path = child->Attribute("Path");
+    // Attribute() yields nullptr for a missing attribute, and LoadFile takes a
+    // std::string — constructing one from nullptr is undefined, so check first.
+    if (path == nullptr) {
+        SPDLOG_ERROR("AudioSample {}: sample element has no Path attribute", initData->Path);
+        return nullptr;
+    }
 
     auto sampleFile = Ship::Context::GetInstance()->GetResourceManager()->GetArchiveManager()->LoadFile(path);
+    // LoadFile returns null when the entry is absent or the archive read fails
+    // (#560); every branch below reads through Buffer.
+    if (sampleFile == nullptr || sampleFile->Buffer == nullptr) {
+        SPDLOG_ERROR("AudioSample {}: failed to load sample data \"{}\"", initData->Path, path);
+        return nullptr;
+    }
     audioSample->sample.fileSize = sampleFile->Buffer.get()->size();
     if (customFormatStr != nullptr) {
         // Compressed files can take a really long time to decode (~250ms per).

--- a/games/oot/soh/resource/importer/AudioSequenceFactory.cpp
+++ b/games/oot/soh/resource/importer/AudioSequenceFactory.cpp
@@ -343,6 +343,16 @@ ResourceFactoryXMLAudioSequenceV0::ReadResource(std::shared_ptr<Ship::File> file
     std::shared_ptr<Ship::File> seqFile;
     if (path != nullptr) {
         seqFile = Ship::Context::GetInstance()->GetResourceManager()->GetArchiveManager()->LoadFile(path);
+        // LoadFile returns null when the entry is absent or the archive read fails
+        // (#560); both users of seqFile below read straight through Buffer.
+        if (seqFile == nullptr || seqFile->Buffer == nullptr) {
+            SPDLOG_ERROR("AudioSequence {}: failed to load sequence data \"{}\"", initData->Path, path);
+            return nullptr;
+        }
+    } else if (!streamed) {
+        // A non-streamed sequence has nowhere to get its data from without a Path.
+        SPDLOG_ERROR("AudioSequence {}: non-streamed sequence has no Path attribute", initData->Path);
+        return nullptr;
     }
 
     if (!streamed) {

--- a/games/oot/soh/resource/importer/AudioSoundFontFactory.cpp
+++ b/games/oot/soh/resource/importer/AudioSoundFontFactory.cpp
@@ -6,6 +6,7 @@
 #include <ship/Context.h>
 #include <ship/resource/archive/Archive.h>
 #include <ship/resource/ResourceManager.h>
+#include "spdlog/spdlog.h"
 
 namespace SOH {
 std::shared_ptr<Ship::IResource>
@@ -309,10 +310,19 @@ void ResourceFactoryXMLSoundFontV0::ParseInstruments(AudioSoundFont* soundFont, 
             if (sampleStr != nullptr && sampleStr[0] != 0) {
                 std::shared_ptr<SOH::AudioSample> res = static_pointer_cast<SOH::AudioSample>(
                     Ship::Context::GetInstance()->GetResourceManager()->LoadResourceProcess(sampleStr));
-                if (res->tuning != -1.0f) {
-                    instrument->lowNotesSound.tuning = res->tuning;
+                // The sample assignment below already tolerates a failed sub-load
+                // (#560); the tuning read above it did not. Keep both inside the
+                // same check.
+                if (res == nullptr) {
+                    SPDLOG_ERROR("SoundFont: failed to load LowNotesSound sample \"{}\"; leaving the sound unbound",
+                                 sampleStr);
+                    instrument->lowNotesSound.sample = nullptr;
+                } else {
+                    if (res->tuning != -1.0f) {
+                        instrument->lowNotesSound.tuning = res->tuning;
+                    }
+                    instrument->lowNotesSound.sample = static_cast<Sample*>(res->GetRawPointer());
                 }
-                instrument->lowNotesSound.sample = static_cast<Sample*>(res ? res->GetRawPointer() : nullptr);
             }
             instrumentElement = instrumentElement->NextSiblingElement();
         }
@@ -323,10 +333,16 @@ void ResourceFactoryXMLSoundFontV0::ParseInstruments(AudioSoundFont* soundFont, 
             if (sampleStr != nullptr && sampleStr[0] != 0) {
                 std::shared_ptr<SOH::AudioSample> res = static_pointer_cast<SOH::AudioSample>(
                     Ship::Context::GetInstance()->GetResourceManager()->LoadResourceProcess(sampleStr));
-                if (res->tuning != -1.0f) {
-                    instrument->normalNotesSound.tuning = res->tuning;
+                if (res == nullptr) {
+                    SPDLOG_ERROR("SoundFont: failed to load NormalNotesSound sample \"{}\"; leaving the sound unbound",
+                                 sampleStr);
+                    instrument->normalNotesSound.sample = nullptr;
+                } else {
+                    if (res->tuning != -1.0f) {
+                        instrument->normalNotesSound.tuning = res->tuning;
+                    }
+                    instrument->normalNotesSound.sample = static_cast<Sample*>(res->GetRawPointer());
                 }
-                instrument->normalNotesSound.sample = static_cast<Sample*>(res ? res->GetRawPointer() : nullptr);
             }
             instrumentElement = instrumentElement->NextSiblingElement();
         }
@@ -337,10 +353,16 @@ void ResourceFactoryXMLSoundFontV0::ParseInstruments(AudioSoundFont* soundFont, 
             if (sampleStr != nullptr && sampleStr[0] != 0) {
                 std::shared_ptr<SOH::AudioSample> res = static_pointer_cast<SOH::AudioSample>(
                     Ship::Context::GetInstance()->GetResourceManager()->LoadResourceProcess(sampleStr));
-                if (res->tuning != -1.0f) {
-                    instrument->highNotesSound.tuning = res->tuning;
+                if (res == nullptr) {
+                    SPDLOG_ERROR("SoundFont: failed to load HighNotesSound sample \"{}\"; leaving the sound unbound",
+                                 sampleStr);
+                    instrument->highNotesSound.sample = nullptr;
+                } else {
+                    if (res->tuning != -1.0f) {
+                        instrument->highNotesSound.tuning = res->tuning;
+                    }
+                    instrument->highNotesSound.sample = static_cast<Sample*>(res->GetRawPointer());
                 }
-                instrument->highNotesSound.sample = static_cast<Sample*>(res ? res->GetRawPointer() : nullptr);
             }
             instrumentElement = instrumentElement->NextSiblingElement();
         }
@@ -377,10 +399,16 @@ void ResourceFactoryXMLSoundFontV0::ParseSfxTable(AudioSoundFont* soundFont, tin
         if (sampleStr[0] != 0) {
             auto res = static_pointer_cast<SOH::AudioSample>(
                 Ship::Context::GetInstance()->GetResourceManager()->LoadResourceProcess(sampleStr));
-            if (res->tuning != -1.0f) {
-                sound.tuning = res->tuning;
+            if (res == nullptr) {
+                SPDLOG_ERROR("SoundFont: failed to load sfx sample \"{}\"; leaving the sound effect unbound",
+                             sampleStr);
+                sound.sample = nullptr;
+            } else {
+                if (res->tuning != -1.0f) {
+                    sound.tuning = res->tuning;
+                }
+                sound.sample = static_cast<Sample*>(res->GetRawPointer());
             }
-            sound.sample = static_cast<Sample*>(res ? res->GetRawPointer() : nullptr);
         }
     skip:
         element = element->NextSiblingElement();
@@ -432,6 +460,13 @@ ResourceFactoryXMLSoundFontV0::ReadResource(std::shared_ptr<Ship::File> file,
         origName += patch;
         audioSoundFont = dynamic_pointer_cast<AudioSoundFont>(
             Ship::Context::GetInstance()->GetResourceManager()->LoadResourceProcess(origName));
+        // Every field write below goes through this pointer. If the base font this
+        // patch extends failed to load (#560), fail the patch too rather than
+        // dereferencing null.
+        if (audioSoundFont == nullptr) {
+            SPDLOG_ERROR("SoundFont {}: failed to load the base font \"{}\" it patches", initData->Path, origName);
+            return nullptr;
+        }
     } else {
         audioSoundFont = std::make_shared<AudioSoundFont>(initData);
         memset(&audioSoundFont->soundFont, 0, sizeof(audioSoundFont->soundFont));

--- a/games/oot/soh/resource/importer/scenecommand/SetPathwaysFactory.cpp
+++ b/games/oot/soh/resource/importer/scenecommand/SetPathwaysFactory.cpp
@@ -12,15 +12,30 @@ std::shared_ptr<Ship::IResource> SetPathwaysFactory::ReadResource(std::shared_pt
 
     ReadCommandId(setPathways, reader);
 
-    setPathways->numPaths = reader->ReadUInt32();
-    setPathways->paths.reserve(setPathways->numPaths);
-    for (uint32_t i = 0; i < setPathways->numPaths; i++) {
+    uint32_t declaredPaths = reader->ReadUInt32();
+    setPathways->paths.reserve(declaredPaths);
+    for (uint32_t i = 0; i < declaredPaths; i++) {
         std::string pathFileName = reader->ReadString();
         auto path = std::static_pointer_cast<Path>(
             Ship::Context::GetInstance()->GetResourceManager()->LoadResourceProcess(pathFileName.c_str()));
+        // #560: this sub-load can legitimately come back null. The archive layer
+        // reads one shared zip_t with no synchronization, so a concurrent read on
+        // another thread can leave this buffer zeroed, and ReadResourceInitData
+        // then rejects it (type/format/version 0). Calling GetPointer() through
+        // that null shared_ptr was the operator's access violation. Skip the entry
+        // instead so the scene loads with a short pathway list.
+        if (path == nullptr) {
+            SPDLOG_ERROR("SetPathways: failed to load pathway resource \"{}\" for {}; skipping it", pathFileName,
+                         initData->Path);
+            continue;
+        }
         setPathways->paths.push_back(path->GetPointer());
         setPathways->pathFileNames.push_back(pathFileName);
     }
+
+    // Report what actually loaded, not what the file claimed, so nothing walks off
+    // the end of a list that lost entries above.
+    setPathways->numPaths = static_cast<uint32_t>(setPathways->paths.size());
 
     if (CVarGetInteger(CVAR_DEVELOPER_TOOLS("ResourceLogging"), 0)) {
         LogPathwaysAsXML(setPathways);
@@ -43,6 +58,13 @@ std::shared_ptr<Ship::IResource> SetPathwaysFactoryXML::ReadResource(std::shared
             std::string pathFileName = child->Attribute("FilePath");
             auto path = std::static_pointer_cast<Path>(
                 Ship::Context::GetInstance()->GetResourceManager()->LoadResourceProcess(pathFileName.c_str()));
+            // Same guard as the binary reader above (#560).
+            if (path == nullptr) {
+                SPDLOG_ERROR("SetPathways: failed to load pathway resource \"{}\" for {}; skipping it", pathFileName,
+                             initData->Path);
+                child = child->NextSiblingElement();
+                continue;
+            }
             setPathways->paths.push_back(path->GetPointer());
             setPathways->pathFileNames.push_back(pathFileName);
         }
@@ -50,7 +72,7 @@ std::shared_ptr<Ship::IResource> SetPathwaysFactoryXML::ReadResource(std::shared
         child = child->NextSiblingElement();
     }
 
-    setPathways->numPaths = setPathways->paths.size();
+    setPathways->numPaths = static_cast<uint32_t>(setPathways->paths.size());
 
     return setPathways;
 }

--- a/games/oot/soh/z_scene_otr.cpp
+++ b/games/oot/soh/z_scene_otr.cpp
@@ -196,6 +196,17 @@ bool OoT_Scene_CommandLightList(PlayState* play, SOH::ISceneCommand* cmd) {
 bool OoT_Scene_CommandPathList(PlayState* play, SOH::ISceneCommand* cmd) {
     // SOH::SetPathways* cmdPath = static_pointer_cast<SOH::SetPathways>(cmd);
     SOH::SetPathways* cmdPath = (SOH::SetPathways*)cmd;
+    // GetPointer() is paths.data(), so indexing [0] on an empty list dereferences
+    // whatever data() returns for an empty vector (nullptr in practice). Reachable
+    // two ways: an authored scene whose SetPathways command lists no pathway, and
+    // #560, where SetPathwaysFactory drops a pathway whose sub-load failed. A scene
+    // with no usable pathway is vanilla-equivalent to one with no SetPathways
+    // command at all, i.e. a null setupPathList.
+    if (cmdPath->paths.empty()) {
+        SPDLOG_ERROR("Scene command SetPathways has no usable pathway list; leaving setupPathList null");
+        play->setupPathList = NULL;
+        return false;
+    }
     play->setupPathList = (Path*)(cmdPath->GetPointer()[0]);
 
     return false;
@@ -402,7 +413,14 @@ bool Scene_CommandCutsceneData(PlayState* play, SOH::ISceneCommand* cmd) {
     // SOH::SetCutscenes* cmdCS = std::static_pointer_cast<SOH::SetCutscenes>(cmd);
     SOH::SetCutscenes* cmdCS = (SOH::SetCutscenes*)cmd;
 
-    play->csCtx.segment = cmdCS->cutscene->commands.data();
+    // Reach the data through GetPointer rather than cutscene->commands directly:
+    // SetCutscenesFactory stores the cutscene sub-load without checking it, and
+    // SetCutscenes::GetPointer is the accessor that already handles a null one
+    // (#560). Going straight through ->cutscene skipped that check.
+    play->csCtx.segment = cmdCS->GetPointer();
+    if (play->csCtx.segment == NULL) {
+        SPDLOG_ERROR("Scene command SetCutscenes has no usable cutscene data; leaving csCtx.segment null");
+    }
 
     // osSyncPrintf("\ngame_play->demo_play.data=[%x]", play->csCtx.segment);
     return false;


### PR DESCRIPTION
Part of #560 (consumer hardening; root fix is the archive mutex).

#560's race only became a crash because consumers dereferenced unchecked resource
loads. This makes any resource-load failure — from that race or anything else —
degrade to a logged failure instead of an access violation, on both halves of the
combo.

## Primary crash site

`games/oot/soh/resource/importer/scenecommand/SetPathwaysFactory.cpp:21` called
`path->GetPointer()` on an unchecked `LoadResourceProcess` result. Both the binary
and XML readers now log the pathway name plus the owning scene at error level, skip
the entry, and recompute `numPaths` from what actually loaded.

Skip rather than fail the whole command, deliberately: `ParseSceneCommand`
(`SceneFactory.cpp:92-97`) pushes a null into `scene->commands` and continues, so
returning null would relocate the deref into the lists that get walked later. It
also matters that every `reader->ReadUInt32()`/`ReadString()` in the loop stays
consumed — bailing mid-loop would desync the binary reader for the scene's
remaining commands.

## Factory audit (item 2)

All 40 factory `.cpp` files under `games/oot/soh/resource/importer/` were checked.
Nine perform sub-loads; the other 31 have none.

| Factory | Sub-load | Verdict |
| --- | --- | --- |
| `scenecommand/SetPathwaysFactory.cpp` | `LoadResourceProcess` ×2 (binary + XML) | **fixed** — log + skip entry, recompute `numPaths` |
| `AnimationFactory.cpp` | `LoadResourceProcess` (link-animation segment) | **fixed** — fail the animation |
| `AudioSoundFontFactory.cpp` | `LoadResourceProcess` ×12 | **fixed** at 5 sites (3 instrument note-sounds, sfx table, base font for a patch); the other 7 already used `res ? res->GetRawPointer() : nullptr` |
| `AudioSampleFactory.cpp` | `ArchiveManager::LoadFile` | **fixed** — plus a missing-`Path`-attribute check, since `LoadFile` takes a `std::string` |
| `AudioSequenceFactory.cpp` | `ArchiveManager::LoadFile` | **fixed** — plus the `!streamed && Path == nullptr` case, which dereferenced a null `seqFile` at line 359 |
| `SkeletonFactory.cpp` | `LoadResourceProcess` ×2 | already safe — `limb ? limb->GetRawPointer() : nullptr` |
| `scenecommand/SetAlternateHeadersFactory.cpp` | `LoadResourceProcess` ×2 | already safe — pushes a possibly-null header; consumers null-check |
| `scenecommand/SetCollisionHeaderFactory.cpp` | `LoadResourceProcess` ×2 | already safe — stores unchecked, but `SetCollisionHeader::GetPointer` null-checks `collisionHeader` |
| `scenecommand/SetCutscenesFactory.cpp` | `LoadResourceProcess` ×2 | already safe — same shape, `SetCutscenes::GetPointer` null-checks |

The audit's real payoff was the last two rows: they are safe **only** because the
accessor guards, and four consumers went around it.

- `z_scene_otr.cpp` `OoT_Scene_CommandPathList` — `GetPointer()[0]` is
  `paths.data()[0]`, a null deref on an empty list. Now leaves `setupPathList`
  null, which is what a scene with no `SetPathways` command produces anyway
  (`z_play.c:2106`).
- `z_scene_otr.cpp` `Scene_CommandCutsceneData` — reached the data via
  `->cutscene->commands.data()`, going around the guarded `GetPointer()`. Now uses
  the accessor.
- `logic.cpp` `GetDungeonSmallKeyDoors` — walked `scene->commands` reading
  `command->cmdId` unchecked, on the exact scene load in #560's generation chain.
  The engine's own `OTRScene_ExecuteCommands` already skips nulls; this walk now
  does too.
- `GraveHoleJumps.cpp` — scene, command, `sceneCmd`, and `GetRawPointer()` all
  unchecked.

## MM half — same class, one hole worse

The audit was repeated on `games/mm/2s2h/`.

| Site | Verdict |
| --- | --- |
| `z_scene_2SH.cpp` `MM_OTRScene_ExecuteCommands` | **fixed** — read `sceneCmd->cmdId` straight through the null entries `ParseSceneCommand` pushes (`SceneFactory.cpp:102` logs each one). OoT's equivalent loop has always had `if (sceneCmd == nullptr) continue;`; MM's did not, so **any** logged scene-command load failure was an immediate AV on the next MM scene load |
| `scenecommand/SetPathwaysFactory.cpp` | **fixed** — verbatim the same `path->GetPointer()` deref as OoT's primary crash site |
| `z_scene_2SH.cpp` `MM_Scene_CommandPathList` | **fixed** — same `GetPointer()[0]`-on-empty guard as OoT |
| `AnimationFactory.cpp` | **fixed** — same link-animation segment site as OoT's |
| `scenecommand/SetAnimatedMaterialListFactory.cpp` | **fixed** — stores null; `play->sceneMaterialAnims` is null in a scene without this command and its consumers handle that |
| `scenecommand/SetCutscenesFactory.cpp` | already safe — already had exactly this guard, which is why the pattern above matches it |
| `scenecommand/SetCollisionHeaderFactory.cpp` | already safe — accessor null-checks |
| `SkeletonFactory.cpp`, `AudioSoundFontFactory.cpp` | already safe — ternary-guarded |
| `KeyFrameFactory.cpp`, `AudioSampleFactory.cpp`, `AudioSequenceFactory.cpp`, `SetAlternateHeadersFactory.cpp` | not touched — see follow-ups |

The `MM_OTRScene_ExecuteCommands` row is the load-bearing one: it is a strictly
worse version of the hole guarded on the OoT side, and it is plausibly the same
class as #557 (wild-pointer AV on MM's second resume), which #560 already flags as
a candidate.

## fill.cpp shop shuffle (item 3)

Guarded the four `Rando::StaticData::GetLocation()` results, matching the
surrounding style. Three of them fed `GetRandomPrice`, which dereferences its
argument inside `GetPriceFromSettings`. The scrub and merchant `if`/`else` pairs
were folded into one loop each so the guard is written once; `GetRandomPrice` is
still called in exactly the same cases and in the same order, so the RNG stream is
untouched — `RandoDeterminism` and `SeedDeterminism` are the evidence.

## Failed generation no longer wedges the menu (item 4)

`logic.cpp:2396` is the only resource load in the whole generation path. A null
scene already returned the empty key-door list gracefully; the null-command walk
was the remaining AV.

The stuck-flag consequence the operator hit came from an exception escaping the
generation thread. `GenerateRandomizerImgui` **is** the thread entry
(`randomizer.cpp:3530`) and nothing above it catches, so a throw `std::terminate`'d
the process with `RandoGenerating` already persisted as 1 by the
`SaveConsoleVariablesNextFrame` at the top — leaving the menu and file-select
screen believing a generation was still in flight, and the thread never joinable.
The whole body is now inside the try, not just the `GenerateRando` call: the two
`std::stoi` loops above it parse persisted CVar strings and throw
`std::invalid_argument` on any non-numeric token, so a narrower try left the same
hole. Failure logs, marks the seed not-generated, and falls through to the existing
flag reset.

Note this catches C++ exceptions only. An access violation on Windows is SEH and
is not caught by `catch (...)`; the null guards above are what remove that.

## Verification

**Local build** — MSVC / Ninja / Release, `REDSHIP_BUILD_SHARED=ON`, rebased onto
`a1dc22ab`:

```
[491/492] Linking CXX executable redship.exe
BUILD_OK
```

**Warnings** — the full build log was grepped for every touched filename; zero
`warning`/`error` lines from any of them. (An earlier pass did surface one new
`C4267 size_t -> uint32_t` in `SetPathwaysFactory.cpp`, fixed with an explicit
`static_cast` — and the identical pre-existing one in the XML reader with it.)

**Both ROM-free ctest tiers**, on the rebased binary:

```
100% tests passed out of 65
redship    =  11.11 sec*proc (65 tests)

100% tests passed out of 14
rando    =  22.30 sec*proc (14 tests)
```

**Counterfactual** for the engine-side guard, compiled and run on this toolchain —
the factory fix alone would have moved the AV, not removed it:

```
empty vector: size=0 data()=0000000000000000 data()==nullptr: YES
one-element vector: size=1 data()=0000015001320180 data()[0]=0000000000000000
```

**clang-format** — verified with the repo's pinned 14.0.6. The two touched files on
`.github/clang-format-paths.txt` (`games/oot/soh/z_scene_otr.cpp`,
`games/mm/2s2h/z_scene_2SH.cpp`) are clean, as are the other 13. The only violation
anywhere in the touched set is `fill.cpp:402`, a pre-existing `assert` block that is
untouched and not on the allowlist.

**Remote CI**, all green at `eebcba34`: build-linux 2m57s, build-windows 13m9s,
netplay-relay 3m27s, clang-format, clang-tidy, test, generate-rsbs-otr,
odr-declaration-gate, link-check 2m55s. build-macos and create-release skipped.
`link-check` was red before the rebase; it is the #550 self-test fixture bug that
`a1dc22ab` (#563) fixed on main, not anything in this change — rebasing onto it
turned the check green with no source change here.

No submodule pointer or generated-stamp changes: the diff is 15 source files.

## Residual risk

A scene whose pathway list fails to load now gets a null `setupPathList` instead of
an AV at load time — but an actor in that scene that indexes `setupPathList[i]`
will still fault later. That is the same exposure vanilla has for a scene with no
`SetPathways` command, and it is strictly better than crashing during the load, but
it is a deferred fault rather than no fault. The archive mutex is what makes the
state unreachable.

## Follow-ups, deliberately not in this change

1. `ResourceManager` still negative-caches a transient read failure identically to a
   genuine not-found (#560 fix plan item 2) — belongs with the libultraship change.
2. The XML scene-command factories build a `std::string` from
   `XMLElement::Attribute(...)` with no null check
   (`SetPathwaysFactoryXML` "FilePath", `SetCollisionHeaderFactoryXML` /
   `SetCutscenesFactoryXML` "FileName", `SetAlternateHeadersFactoryXML` "Path") —
   missing-attribute UB, a different class from the archive race.
3. MM's `KeyFrameFactory`, `AudioSampleFactory`, `AudioSequenceFactory` and
   `SetAlternateHeadersFactory` sub-loads are enumerated above but unguarded; they
   are the audio/keyframe tail of the same sweep, not on the crash path.
4. `Rando::StaticData::GetLocation` and `Context::GetItemLocation` return
   `&table[key]` unconditionally, so they can never return null — the ~6 existing
   `loc == nullptr` guards in the tree, and the four added here, are defensive
   rather than live; the real hazard for a bad key is a pointer past the end of the
   array. Bounds-checking both accessors was implemented and then reverted: it would
   make every guard meaningful but would convert today's out-of-range reads into hard
   null derefs in the many callers that do *not* check, which works against this
   change's goal. A `NOTE` in `location_list.cpp` records this; it needs its own
   change with an audit of the unguarded callers.
5. No ROM-free ctest locks the `SetPathwaysFactory` guard, because writing one means
   pulling OoT `soh/resource/` headers into `test_runner.cpp`, which already includes
   MM's `2s2h/resource/` headers in the same TU. That OoT/MM header collision
   deserves its own change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
