### PR TITLE
Stage the port archives where ctest looks, and add the one rando row that runs the full OTR bring-up (#560)

### DIFF
--- a/.github/workflows/generate-builds.yml
+++ b/.github/workflows/generate-builds.yml
@@ -290,6 +290,29 @@ jobs:
       with:
         name: 2ship.o2r
         path: build-cmake/mm
+    # Stage the port archives where the ctest tiers actually look (#560).
+    # The downloads above land them where the INSTALL rules read them
+    # (${CMAKE_BINARY_DIR}/soh, .../mm). Test rows resolve archives through
+    # Ship::Context::LocateFileAcrossAppDirs, whose last resort is "./<name>"
+    # relative to the row's cwd — and `ctest --test-dir build-cmake` runs rows
+    # with cwd = build-cmake. So every row in the redship and rando tiers has
+    # been booting with ZERO archives mounted. The rando log says so out loud:
+    #   "The archive at path .../build-cmake/./soh.o2r does not exist"
+    #
+    # Not cosmetic. libultraship PAUSES the ResourceManager thread pool forever
+    # when no archive is loaded (ResourceManager.cpp:58-61, "Nothing ever
+    # unpauses the thread pool"), so any synchronous resource load in that state
+    # deadlocks on .get(). That is the real, undocumented reason the rando rows
+    # need RSBS_DISABLE_OTR_INIT=1: OTRAudio_Init performs exactly such a load.
+    #
+    # A copy, not a move, so Package still finds its originals. netplay-relay is
+    # deliberately left archive-less: it re-runs the redship tier, so it keeps an
+    # archive-less control over the same rows.
+    - name: Stage port archives for the ctest tiers (#560)
+      run: |
+        cp build-cmake/soh/soh.o2r build-cmake/soh.o2r
+        cp build-cmake/mm/2ship.o2r build-cmake/2ship.o2r
+        ls -l build-cmake/soh.o2r build-cmake/2ship.o2r
     - name: Build SoH
       run: |
         export PATH="/usr/lib/ccache:/usr/local/opt/ccache/libexec:$PATH"

--- a/.github/workflows/generate-builds.yml
+++ b/.github/workflows/generate-builds.yml
@@ -293,10 +293,11 @@ jobs:
     # Stage the port archives where the ctest tiers actually look (#560).
     # The downloads above land them where the INSTALL rules read them
     # (${CMAKE_BINARY_DIR}/soh, .../mm). Test rows resolve archives through
-    # Ship::Context::LocateFileAcrossAppDirs, whose last resort is "./<name>"
-    # relative to the row's cwd — and `ctest --test-dir build-cmake` runs rows
-    # with cwd = build-cmake. So every row in the redship and rando tiers has
-    # been booting with ZERO archives mounted. The rando log says so out loud:
+    # Ship::Context::LocateFileAcrossAppDirs, which probes the app-config dir,
+    # then the running binary's OWN directory, then "./" — and for a row started
+    # by `ctest --test-dir build-cmake` all three of those are build-cmake, never
+    # build-cmake/soh. So every row in the redship and rando tiers has been
+    # booting with ZERO archives mounted. The rando log says so out loud:
     #   "The archive at path .../build-cmake/./soh.o2r does not exist"
     #
     # Not cosmetic. libultraship PAUSES the ResourceManager thread pool forever

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -154,7 +154,8 @@ jobs:
 
     # Same staging fix as generate-builds' build-linux (#560): the redship and
     # rando ctest rows below run with cwd = build-cmake and resolve archives
-    # through LocateFileAcrossAppDirs, whose last resort is "./<name>" — so
+    # through LocateFileAcrossAppDirs, which probes the app-config dir, then the
+    # binary's own directory, then "./" — all of which are build-cmake, so
     # build-cmake/soh/soh.o2r is invisible to them and both tiers have been
     # booting with no archives mounted. With none loaded libultraship pauses the
     # ResourceManager thread pool permanently (ResourceManager.cpp:58-61), so any

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -152,6 +152,19 @@ jobs:
         name: 2ship.o2r
         path: .
 
+    # Same staging fix as generate-builds' build-linux (#560): the redship and
+    # rando ctest rows below run with cwd = build-cmake and resolve archives
+    # through LocateFileAcrossAppDirs, whose last resort is "./<name>" — so
+    # build-cmake/soh/soh.o2r is invisible to them and both tiers have been
+    # booting with no archives mounted. With none loaded libultraship pauses the
+    # ResourceManager thread pool permanently (ResourceManager.cpp:58-61), so any
+    # synchronous resource load deadlocks. Copies, so nothing else moves.
+    - name: Stage port archives for the ctest tiers (#560)
+      run: |
+        cp build-cmake/soh/soh.o2r build-cmake/soh.o2r
+        cp 2ship.o2r build-cmake/2ship.o2r
+        ls -l build-cmake/soh.o2r build-cmake/2ship.o2r
+
     - name: Build SoH
       run: |
         export PATH="/usr/lib/ccache:/usr/local/opt/ccache/libexec:$PATH"

--- a/CMake/SingleExecutable.cmake
+++ b/CMake/SingleExecutable.cmake
@@ -628,6 +628,39 @@ if(BUILD_TESTING)
         TIMEOUT 180
         ENVIRONMENT "SDL_AUDIODRIVER=dummy;RSBS_DISABLE_OTR_INIT=1")
 
+    # #560 ("Why CI never saw it"): every OTHER row in this tier sets
+    # RSBS_DISABLE_OTR_INIT=1, which skips the whole OTRMessage_Init /
+    # OTRAudio_Init / OTRExtScanner / VanillaItemTable_Init / DebugConsole_Init
+    # block (games/oot/soh/OTRGlobals.cpp:1811-1823). The flag started life as a
+    # bisect knob for init crashes (#199, e2a181c1) and reached this tier as
+    # diagnostic scaffolding in the row above (#339, 8dc2786d) — it was then
+    # copied verbatim onto 13 more rows. No row ever justified it independently,
+    # and nothing in the block needs it here. soh.o2r is the only archive CI
+    # mounts and it carries no `audio/` entries, so OTRAudio_Init's precache is a
+    # no-op and its thread parks on audio.cv_to_thread (no frame loop signals it);
+    # OTRExtScanner / VanillaItemTable_Init / DebugConsole_Init are pure
+    # in-process work; and OTRMessage_Init self-skips on its inner hasGameArchive
+    # gate, which is false wherever oot.o2r is absent. The bridge additionally
+    # pairs OTRAudio_Init with OTRAudio_Exit — defensively, since `--test` mode
+    # ends at _Exit and never runs static destructors today.
+    #
+    # This is the ONE row whose bring-up matches a player's, and the only one
+    # whose fill runs on a worker thread (the 1-arg GenerateRandomizer overload
+    # that z_file_choose.c:824 reaches, not the synchronous 3-arg one). It
+    # asserts the un-masking before it generates, so re-adding the flag here
+    # fails the row instead of quietly turning it into a RandoGen clone.
+    #
+    # It does NOT reproduce #560's crash and is not meant to: both sides of that
+    # race read oot.o2r-only entries and one of them is the render thread, so a
+    # ROM-free display-only tier structurally cannot host it. See #560.
+    #
+    # Deliberately NOT folded into RandoGen: that row's masked configuration is
+    # the one 13 siblings share, so it stays as-is and this row is the diff.
+    redship_add_test(NAME RandoGenFullInit COMMAND redship --test rando-gen-full-init
+        LABEL rando
+        TIMEOUT 300
+        ENVIRONMENT "SDL_AUDIODRIVER=dummy")
+
     # Hint validity (#441): a gossip stone read "catching Big Poes leads to No
     # Item" while that seed's spoiler named a real item, so the fill was fine
     # and only hint-side resolution was broken. Locks that no generated hint

--- a/CMake/SingleExecutable.cmake
+++ b/CMake/SingleExecutable.cmake
@@ -634,15 +634,30 @@ if(BUILD_TESTING)
     # block (games/oot/soh/OTRGlobals.cpp:1811-1823). The flag started life as a
     # bisect knob for init crashes (#199, e2a181c1) and reached this tier as
     # diagnostic scaffolding in the row above (#339, 8dc2786d) — it was then
-    # copied verbatim onto 13 more rows. No row ever justified it independently,
-    # and nothing in the block needs it here. soh.o2r is the only archive CI
-    # mounts and it carries no `audio/` entries, so OTRAudio_Init's precache is a
-    # no-op and its thread parks on audio.cv_to_thread (no frame loop signals it);
-    # OTRExtScanner / VanillaItemTable_Init / DebugConsole_Init are pure
-    # in-process work; and OTRMessage_Init self-skips on its inner hasGameArchive
-    # gate, which is false wherever oot.o2r is absent. The bridge additionally
-    # pairs OTRAudio_Init with OTRAudio_Exit — defensively, since `--test` mode
-    # ends at _Exit and never runs static destructors today.
+    # copied verbatim onto 13 more rows. No row ever justified it independently —
+    # but it turned out to be load-bearing for a reason nobody had written down,
+    # found by adding this row and watching it hang for 300s on Linux CI:
+    #
+    #   CI staged soh.o2r where only the install rules look
+    #   (${CMAKE_BINARY_DIR}/soh), while ctest rows run with cwd =
+    #   ${CMAKE_BINARY_DIR} and resolve archives via LocateFileAcrossAppDirs,
+    #   whose last resort is "./<name>". So every row in this tier was booting
+    #   with ZERO archives mounted. With none loaded, libultraship PAUSES the
+    #   ResourceManager thread pool forever (ResourceManager.cpp:58-61, "Nothing
+    #   ever unpauses the thread pool"), and OTRAudio_Init's synchronous
+    #   ResourceMgr_LoadDirectory("audio") then deadlocks on .get().
+    #
+    # Both workflows now stage the archives where the rows look, so the tier runs
+    # with soh.o2r mounted and the pool live. With that fixed nothing in the block
+    # needs the flag: soh.o2r carries no `audio/` entries so the precache is a
+    # no-op and the audio thread parks on audio.cv_to_thread (no frame loop
+    # signals it); OTRExtScanner / VanillaItemTable_Init / DebugConsole_Init are
+    # pure in-process work; and OTRMessage_Init self-skips on its inner
+    # hasGameArchive gate, which is false wherever oot.o2r is absent. The row
+    # additionally asserts a mounted archive BEFORE bring-up, so a staging
+    # regression fails in a second instead of hanging, and pairs OTRAudio_Init
+    # with OTRAudio_Exit (defensively — `--test` mode ends at _Exit and never runs
+    # static destructors today).
     #
     # This is the ONE row whose bring-up matches a player's, and the only one
     # whose fill runs on a worker thread (the 1-arg GenerateRandomizer overload

--- a/CMake/SingleExecutable.cmake
+++ b/CMake/SingleExecutable.cmake
@@ -641,14 +641,21 @@ if(BUILD_TESTING)
     #   CI staged soh.o2r where only the install rules look
     #   (${CMAKE_BINARY_DIR}/soh), while ctest rows run with cwd =
     #   ${CMAKE_BINARY_DIR} and resolve archives via LocateFileAcrossAppDirs,
-    #   whose last resort is "./<name>". So every row in this tier was booting
+    #   which probes the app-config dir, then the binary's own directory, then
+    #   "./" — all three being ${CMAKE_BINARY_DIR} for a ctest row, and none of
+    #   them ${CMAKE_BINARY_DIR}/soh. So every row in this tier was booting
     #   with ZERO archives mounted. With none loaded, libultraship PAUSES the
     #   ResourceManager thread pool forever (ResourceManager.cpp:58-61, "Nothing
     #   ever unpauses the thread pool"), and OTRAudio_Init's synchronous
     #   ResourceMgr_LoadDirectory("audio") then deadlocks on .get().
     #
-    # Both workflows now stage the archives where the rows look, so the tier runs
-    # with soh.o2r mounted and the pool live. With that fixed nothing in the block
+    # The archives are now staged where the rows look, in both places they can
+    # come from: the build itself (copy-existing-otrs.cmake and the Generate*Otr
+    # targets also copy into ${CMAKE_BINARY_DIR}, which is what makes a plain
+    # local `ctest --test-dir <dir>` work), and a staging step in each workflow
+    # (CI downloads the archives as artifacts and never runs those targets in the
+    # test job). So the tier runs with soh.o2r mounted and the pool live —
+    # locally and on CI alike. With that fixed nothing in the block
     # needs the flag: soh.o2r carries no `audio/` entries so the precache is a
     # no-op and the audio thread parks on audio.cv_to_thread (no frame loop
     # signals it); OTRExtScanner / VanillaItemTable_Init / DebugConsole_Init are

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -396,10 +396,14 @@ add_custom_target(
     # Land 2ship.o2r where the install rules read it (${CMAKE_BINARY_DIR}/mm/)
     # and at the source root, mirroring what copy-existing-otrs.cmake does for
     # soh.o2r. Extraction writes into WORKING_DIRECTORY (games/mm), which
-    # nothing installs from.
+    # nothing installs from. The third copy is the build root, which is where
+    # the CTest rows can actually see it (#560 — LocateFileAcrossAppDirs probes
+    # the app-config dir, then the exe's own dir, then "./"; all three are
+    # ${CMAKE_BINARY_DIR} for a ctest row, never ${CMAKE_BINARY_DIR}/mm).
     COMMAND ${CMAKE_COMMAND} -E copy 2ship.o2r ${CMAKE_SOURCE_DIR}
     COMMAND ${CMAKE_COMMAND} -E make_directory ${CMAKE_BINARY_DIR}/mm
     COMMAND ${CMAKE_COMMAND} -E copy 2ship.o2r ${CMAKE_BINARY_DIR}/mm/
+    COMMAND ${CMAKE_COMMAND} -E copy 2ship.o2r ${CMAKE_BINARY_DIR}/
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/games/mm
     COMMENT "Running MM asset extraction..."
     DEPENDS ZAPD_MM
@@ -420,10 +424,13 @@ add_custom_target(
     COMMAND ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/OTRExporter/extract_assets.py -z "$<TARGET_FILE:ZAPD_MM>" --norom --custom-otr-file 2ship.o2r "--custom-assets-path" ${CMAKE_CURRENT_SOURCE_DIR}/games/mm/assets/custom --port-ver "${CMAKE_PROJECT_VERSION}"
     # Land 2ship.o2r where the install rules read it (${CMAKE_BINARY_DIR}/mm/)
     # and at the source root (which CI uploads as the 2ship.o2r artifact),
-    # mirroring what copy-existing-otrs.cmake does for GenerateSohOtr.
+    # mirroring what copy-existing-otrs.cmake does for GenerateSohOtr. The third
+    # copy is the build root — the only place a CTest row can see it (#560; the
+    # rows run with cwd = ${CMAKE_BINARY_DIR} and the binary lives there too).
     COMMAND ${CMAKE_COMMAND} -E copy 2ship.o2r ${CMAKE_SOURCE_DIR}
     COMMAND ${CMAKE_COMMAND} -E make_directory ${CMAKE_BINARY_DIR}/mm
     COMMAND ${CMAKE_COMMAND} -E copy 2ship.o2r ${CMAKE_BINARY_DIR}/mm/
+    COMMAND ${CMAKE_COMMAND} -E copy 2ship.o2r ${CMAKE_BINARY_DIR}/
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/games/mm
     COMMENT "Generating 2ship.o2r..."
     DEPENDS ZAPD_MM

--- a/copy-existing-otrs.cmake
+++ b/copy-existing-otrs.cmake
@@ -1,5 +1,13 @@
 message(STATUS "Copying otr files...")
 
+# `cmake -E copy <file> <dir>/` fails with "Invalid argument" when <dir> does not
+# exist, and nothing else creates ${BINARY_DIR}/soh — so every copy below into it
+# printed an error and silently did nothing on a fresh tree (the MM side already
+# does this, via `-E make_directory ${CMAKE_BINARY_DIR}/mm` in its own targets).
+# Noticed while fixing #560's archive staging; the install rules read this
+# directory, so the failure was not harmless.
+execute_process(COMMAND ${CMAKE_COMMAND} -E make_directory ${BINARY_DIR}/soh)
+
 if(NOT ONLYSOHOTR AND EXISTS ${SOURCE_DIR}/games/oot/oot.o2r)
     execute_process(COMMAND ${CMAKE_COMMAND} -E copy oot.o2r ${SOURCE_DIR})
     execute_process(COMMAND ${CMAKE_COMMAND} -E copy oot.o2r ${BINARY_DIR}/soh/)
@@ -13,6 +21,18 @@ endif()
 if(EXISTS ${SOURCE_DIR}/games/oot/soh.o2r)
     execute_process(COMMAND ${CMAKE_COMMAND} -E copy soh.o2r ${SOURCE_DIR})
     execute_process(COMMAND ${CMAKE_COMMAND} -E copy soh.o2r ${BINARY_DIR}/soh/)
+    # And the build root (#560). ${BINARY_DIR}/soh above is where only the
+    # install rules look; the CTest rows run with cwd = ${BINARY_DIR} and the
+    # binary they run lives there too, so Ship::Context::LocateFileAcrossAppDirs
+    # (app-config dir -> exe dir -> "./<name>") only ever finds a port archive
+    # sitting directly in ${BINARY_DIR}. Without this copy every row in the
+    # redship and rando tiers boots with ZERO archives mounted, which pauses
+    # libultraship's resource thread pool for the life of the process
+    # (ResourceManager.cpp: "Nothing ever unpauses the thread pool") and
+    # deadlocks any synchronous load. CI stages the same file the same way in
+    # its own workflows, because there it is DOWNLOADED as an artifact rather
+    # than produced by this script.
+    execute_process(COMMAND ${CMAKE_COMMAND} -E copy soh.o2r ${BINARY_DIR}/)
     message(STATUS "Copied soh.o2r")
 endif()
 

--- a/games/oot/soh/Enhancements/randomizer/randomizer.cpp
+++ b/games/oot/soh/Enhancements/randomizer/randomizer.cpp
@@ -3604,22 +3604,35 @@ static int RunFullInitSeedTest(const char* seedStr) {
     }
 
     // GenerateRandomizerImgui sets `generated` as its last act; poll it the way
-    // the file-select gamestate does. Bounded so a hung fill fails with an
-    // attributable message instead of burning the whole CTest timeout.
+    // the file-select gamestate does.
     const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(150);
     while (!generated && std::chrono::steady_clock::now() < deadline) {
         std::this_thread::sleep_for(std::chrono::milliseconds(50));
     }
     const bool completed = generated != 0;
-    // Join unconditionally: a joinable std::thread left alive would std::terminate
-    // in randoThread's destructor at static-destruction time and turn any failure
-    // here into an abort with no diagnostic.
-    generated = 0;
+
+    // Say WHY before the join, not after. The join below is mandatory — a
+    // joinable std::thread left alive would std::terminate in randoThread's
+    // destructor at static-destruction time and turn any failure here into an
+    // abort with no diagnostic — but it is also UNBOUNDED, so on a genuinely
+    // hung fill it never returns and anything printed after it is never
+    // printed. So the deadline buys a DIAGNOSED hang, not a bounded one: the
+    // row still dies on its CTest timeout, but the log names the fill instead
+    // of showing nothing at all.
+    if (!completed) {
+        fprintf(stderr, "[rando-full-init] generation worker did not finish within 150s; joining it anyway — if "
+                        "this is the last line before the CTest timeout, the fill itself is hung\n");
+        fflush(stderr);
+    }
     if (randoThread.joinable()) {
         randoThread.join();
     }
+    // Cleared only AFTER the join: while the worker is alive it can still store
+    // 1 here, and a store racing ours would leave a stale 1 behind — which is
+    // exactly what makes a later GenerateRandomizer() join an already-joined
+    // thread.
+    generated = 0;
     if (!completed) {
-        fprintf(stderr, "[rando-full-init] generation worker did not finish within 150s\n");
         return 21;
     }
     if (!randoCtx->IsSeedGenerated()) {

--- a/games/oot/soh/Enhancements/randomizer/randomizer.cpp
+++ b/games/oot/soh/Enhancements/randomizer/randomizer.cpp
@@ -40,6 +40,12 @@
 #include "randomizerTypes.h"
 #include "soh/Notification/Notification.h"
 #include "soh/ObjectExtension/ObjectExtension.h"
+// Rando_HeadlessFullInitSeedTest (#560) asserts DebugConsole_Init registered its
+// commands; Context.h only forward-declares Ship::Console, so HasCommand needs
+// the complete type. <chrono>/<thread> are for that bridge's bounded worker wait.
+#include <ship/debug/Console.h>
+#include <chrono>
+#include <thread>
 
 static ObjectExtension::Register<CheckIdentity> RegisterIdentity;
 
@@ -3528,6 +3534,160 @@ void JoinRandoGenerationThread() {
         generated = 0;
         randoThread.join();
     }
+}
+
+// OTRGlobals.h puts most of its C entry points inside `#ifndef __cplusplus`, so a
+// C++ TU has to redeclare the ones it wants. Both of these are defined in
+// games/oot/soh/OTRGlobals.cpp.
+extern "C" int OoT_OtrInitRan(void);
+extern "C" void OTRAudio_Exit(void);
+
+// Body of Rando_HeadlessFullInitSeedTest; see the wrapper below for what the row
+// is for. Split out only so the wrapper owns the audio-thread teardown on every
+// exit path, including the early failures.
+static int RunFullInitSeedTest(const char* seedStr) {
+    // ---- (1) anti-vacuity: the RSBS_DISABLE_OTR_INIT block must have run ----
+    if (!OoT_OtrInitRan()) {
+        fprintf(stderr, "[rando-full-init] InitOTRImpl skipped its OTR-init block — RSBS_DISABLE_OTR_INIT is set "
+                        "for this row, so it would only re-run what RandoGen already covers\n");
+        return 10;
+    }
+    // Block-entered is necessary but not sufficient: assert what three of the
+    // inits actually produced, so moving one out of the block is caught too.
+    if (ExtensionCache.empty()) {
+        fprintf(stderr, "[rando-full-init] ExtensionCache is empty — OTRExtScanner produced nothing\n");
+        return 11;
+    }
+    if (ItemTableManager::Instance == nullptr) {
+        fprintf(stderr, "[rando-full-init] ItemTableManager::Instance is null\n");
+        return 12;
+    }
+    // RetrieveItemEntry swallows a missing table and returns GET_ITEM_NONE, so
+    // an un-populated table reads as a real-looking answer rather than an error
+    // — check the returned itemId, not just that the call succeeded.
+    const GetItemEntry vanillaBombs = ItemTableManager::Instance->RetrieveItemEntry(MOD_NONE, GI_BOMBS_5);
+    if (vanillaBombs.itemId != ITEM_BOMBS_5) {
+        fprintf(stderr,
+                "[rando-full-init] vanilla item table not populated (GI_BOMBS_5 -> itemId %d, expected %d) — "
+                "VanillaItemTable_Init never ran\n",
+                (int)vanillaBombs.itemId, (int)ITEM_BOMBS_5);
+        return 13;
+    }
+    auto console = Ship::Context::GetInstance()->GetConsole();
+    if (console == nullptr || !console->HasCommand("gen_rando")) {
+        fprintf(stderr, "[rando-full-init] console command `gen_rando` is not registered — DebugConsole_Init "
+                        "never ran\n");
+        return 14;
+    }
+    fprintf(stderr,
+            "[rando-full-init] full OTR bring-up verified: %zu ExtensionCache entries, vanilla item table "
+            "populated, debug console registered\n",
+            ExtensionCache.size());
+
+    // ---- (2) settings, as the headless bridge does ----
+    // The ROM-free bring-up skips SohGui::SetupMenuElements (gated on
+    // hasGameArchive), so nothing has created the Settings Options yet and
+    // SetAllToContext inside the worker would feed all-zero settings into the
+    // fill. Create them here for the same reason Rando_HeadlessSeedTest does.
+    auto randoCtx = Rando::Context::GetInstance();
+    if (randoCtx == nullptr) {
+        fprintf(stderr, "[rando-full-init] no Rando::Context after bring-up\n");
+        return 15;
+    }
+    Rando::Settings::GetInstance()->CreateOptions();
+    randoCtx->SetSeedGenerated(false);
+
+    // ---- (3) generate on a worker thread, the way the file select does ----
+    if (!GenerateRandomizer(seedStr ? seedStr : "")) {
+        fprintf(stderr, "[rando-full-init] GenerateRandomizer refused to start a worker\n");
+        return 20;
+    }
+
+    // GenerateRandomizerImgui sets `generated` as its last act; poll it the way
+    // the file-select gamestate does. Bounded so a hung fill fails with an
+    // attributable message instead of burning the whole CTest timeout.
+    const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(150);
+    while (!generated && std::chrono::steady_clock::now() < deadline) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(50));
+    }
+    const bool completed = generated != 0;
+    // Join unconditionally: a joinable std::thread left alive would std::terminate
+    // in randoThread's destructor at static-destruction time and turn any failure
+    // here into an abort with no diagnostic.
+    generated = 0;
+    if (randoThread.joinable()) {
+        randoThread.join();
+    }
+    if (!completed) {
+        fprintf(stderr, "[rando-full-init] generation worker did not finish within 150s\n");
+        return 21;
+    }
+    if (!randoCtx->IsSeedGenerated()) {
+        fprintf(stderr, "[rando-full-init] worker finished but the seed is not marked generated\n");
+        return 22;
+    }
+
+    fprintf(stderr, "[rando-full-init] seed generated on a worker thread with the full OTR bring-up live\n");
+    return 0;
+}
+
+/**
+ * Part of #560 — the "Why CI never saw it" coverage hole. Driven by the
+ * RandoGenFullInit CTest row (CMake/SingleExecutable.cmake).
+ *
+ * Every OTHER rando-label row sets RSBS_DISABLE_OTR_INIT=1, which skips the
+ * whole OTRMessage_Init / OTRAudio_Init / OTRExtScanner / VanillaItemTable_Init /
+ * DebugConsole_Init block at OTRGlobals.cpp:1811-1823, and then generates via
+ * the SYNCHRONOUS 3-arg GenerateRandomizer on the test's own thread
+ * (Rando_HeadlessSeedTest, 3drando/menu.cpp:35-69). That is a bring-up AND a
+ * call shape no player ever runs. This entry point differs in exactly two ways:
+ *
+ *   1. It PROVES the un-masking happened before generating anything, so
+ *      re-adding the env flag to the row fails it instead of silently turning it
+ *      into a RandoGen duplicate — precisely the vacuity #560 is about.
+ *      (OTRMessage_Init is deliberately NOT asserted: it carries its own inner
+ *      `hasGameArchive` gate at OTRGlobals.cpp:1815, and hasGameArchive is false
+ *      in every ROM-free environment because hasMasterQuest/hasOriginal are only
+ *      set from GetGameVersions(), OTRGlobals.cpp:1018-1063.)
+ *   2. It generates through GenerateRandomizer(seed) — the 1-arg overload that
+ *      spawns randoThread — i.e. the path a player's file select takes
+ *      (z_file_choose.c:824 -> Randomizer_GenerateRandomizer, OTRGlobals.cpp:
+ *      2730 -> here), so the fill runs on a WORKER thread with the main thread
+ *      live rather than inline.
+ *
+ * Scope honesty: this does NOT reproduce #560's crash and is not trying to. That
+ * race needs oot.o2r-only entries on both sides (scenes/nonmq/HIDAN_scene/... on
+ * the fill side, textures/nes_font_static/... on the render side) plus a running
+ * frame loop; a ROM-free row has neither, and a probabilistic concurrent-read
+ * stress loop would be a flaky row, not a lock. What this closes is the part of
+ * the hole that IS closable ROM-free: the masked bring-up, and
+ * generation-on-a-worker-thread.
+ *
+ * Returns 0 on success, non-zero with a distinct code per failure mode.
+ */
+extern "C" int Rando_HeadlessFullInitSeedTest(const char* seedStr) {
+    const bool otrInitRan = OoT_OtrInitRan() != 0;
+    const int rc = RunFullInitSeedTest(seedStr);
+
+    // This row is the first test to run OTRAudio_Init, which starts a REAL
+    // std::thread against a file-static `audio` (soh/OTRAudio.h) whose ~thread()
+    // would std::terminate on a still-joinable thread. The app pairs the init
+    // with OTRAudio_Exit inside DeinitOTR; do the same here rather than leaving
+    // the thread live at exit.
+    //
+    // Measured, so the comment does not overclaim: today this is DEFENSIVE, not
+    // load-bearing. `--test` mode ends at _Exit (rsbs/src/main.cpp:288, chosen
+    // deliberately so a teardown fault cannot clobber a decided verdict), which
+    // skips static destruction entirely — verified by temporarily suppressing
+    // this call, which still exited 0. Keeping the pairing means the row does not
+    // regress into an abort the day that _Exit becomes a normal return.
+    //
+    // Gated on the block having run because OTRAudio_Exit joins unconditionally,
+    // and joining a never-started thread throws.
+    if (otrInitRan) {
+        OTRAudio_Exit();
+    }
+    return rc;
 }
 
 class ExtendedVanillaTableInvalidItemIdException : public std::exception {

--- a/games/oot/soh/OTRGlobals.cpp
+++ b/games/oot/soh/OTRGlobals.cpp
@@ -1709,6 +1709,24 @@ bool VerifyArchiveVersion(OTRVersion version) {
     return false;
 }
 
+// Whether InitOTRImpl ran the RSBS_DISABLE_OTR_INIT block below (OTRAudio_Init /
+// OTRExtScanner / VanillaItemTable_Init / DebugConsole_Init, plus
+// archive-gated OTRMessage_Init). Two consumers, both in the #560 full-init
+// CTest row (rando-gen-full-init):
+//   - it is the row's un-masking assertion: every OTHER rando row sets
+//     RSBS_DISABLE_OTR_INIT=1, and without a direct signal a re-added flag would
+//     turn that row into a silent duplicate of RandoGen;
+//   - it tells the row whether it must tear the audio thread down before
+//     returning. OTRAudio_Init starts a real std::thread against the file-static
+//     `audio` (soh/OTRAudio.h); the app pairs it with OTRAudio_Exit inside
+//     DeinitOTR, and OTRAudio_Exit joins unconditionally, so a test may only
+//     call it when the block actually ran.
+static bool sOtrInitRan = false;
+
+extern "C" int OoT_OtrInitRan(void) {
+    return sOtrInitRan ? 1 : 0;
+}
+
 static void InitOTRImpl(int argc, char* argv[], bool runExtract) {
     OTRGlobals::Instance = new OTRGlobals();
     if (runExtract) {
@@ -1801,6 +1819,7 @@ static void InitOTRImpl(int argc, char* argv[], bool runExtract) {
         OTRExtScanner();
         VanillaItemTable_Init();
         DebugConsole_Init();
+        sOtrInitRan = true;
     }
 
     if (RsbsFeatureEnabled("RSBS_DISABLE_MODS")) {

--- a/src/common/test_runner.cpp
+++ b/src/common/test_runner.cpp
@@ -549,6 +549,28 @@ TestResult Test_RandoGenFullInit(void) {
         return TEST_FAIL;
     }
 
+    // Hard precondition, checked before bring-up because the failure mode is a
+    // 300-second HANG rather than a crash. With no archive loaded libultraship
+    // pauses the ResourceManager thread pool permanently (libultraship
+    // ResourceManager.cpp:58-61, "Nothing ever unpauses the thread pool"), and
+    // OTRAudio_Init inside the un-masked block does a synchronous
+    // ResourceMgr_LoadDirectory("audio") whose .get() then never returns. That is
+    // the real, previously-undocumented reason this tier carries
+    // RSBS_DISABLE_OTR_INIT=1 — and it is why CI's rando rows had been running
+    // with zero archives mounted for as long as the tier has existed (they were
+    // staged where only the install rules look; see the staging step added to
+    // both workflows for #560). Resolve exactly the way the
+    // bring-up will (OTRGlobals.cpp: LocateFileAcrossAppDirs("soh.o2r")) and fail
+    // in a second with a readable reason instead of burning the row's timeout.
+    const std::string sohArchive = Ship::Context::LocateFileAcrossAppDirs("soh.o2r");
+    if (!std::filesystem::exists(sohArchive)) {
+        printf("[TEST] FAIL: no soh.o2r resolvable (tried '%s'). This row needs a mounted archive: with none, "
+               "libultraship pauses the resource thread pool and OTRAudio_Init's synchronous load never "
+               "returns. Stage soh.o2r next to the ctest working directory (#560).\n",
+               sohArchive.c_str());
+        return TEST_FAIL;
+    }
+
     static char arg0[] = "redship";
     static char* fakeArgv[] = { arg0, nullptr };
     InitOTRForMMFirstBoot(1, fakeArgv);

--- a/src/common/test_runner.cpp
+++ b/src/common/test_runner.cpp
@@ -455,6 +455,14 @@ TestResult Test_BootOoT(void) {
 }
 
 extern "C" int Rando_HeadlessSeedTest(const char* seedStr);
+// Full-bring-up generation lock (#560 "Why CI never saw it"; body in
+// games/oot/soh/Enhancements/randomizer/randomizer.cpp). Driven by the ONE rando
+// row that does not set RSBS_DISABLE_OTR_INIT=1: it first proves the normally
+// masked init block actually ran (populated ExtensionCache + vanilla item table +
+// registered debug console — the anti-vacuity guard), then generates through the
+// THREADED entry a player's file select takes rather than the synchronous
+// overload every other row uses.
+extern "C" int Rando_HeadlessFullInitSeedTest(const char* seedStr);
 // Lane B unified-seed determinism bridge (body in
 // games/oot/soh/Enhancements/randomizer/3drando/menu.cpp). Runs ONE seed
 // generation, asserts the live producer stamped gComboCtx, and writes a
@@ -519,6 +527,34 @@ TestResult Test_RandoGen(void) {
 
     int rc = Rando_HeadlessSeedTest("RSBSDIAG1");
     printf("[TEST] %s: seed generation rc=%d\n", rc == 0 ? "PASS" : "FAIL", rc);
+    return rc == 0 ? TEST_PASS : TEST_FAIL;
+}
+
+// #560 coverage hole. rando-gen above, and all 13 of its siblings, run under
+// RSBS_DISABLE_OTR_INIT=1, so CI's only seed-generation coverage runs a bring-up
+// with OTRAudio_Init / OTRExtScanner / VanillaItemTable_Init / DebugConsole_Init
+// all skipped (OTRGlobals.cpp:1811-1823), and drives the synchronous 3-arg
+// GenerateRandomizer inline. This entry is the same generation with none of that
+// masked and with the fill on a worker thread, which is what a player gets. It
+// asserts the un-masking BEFORE generating so the row cannot pass vacuously if
+// the env flag is ever re-added to it. Needs a display (Fast3dWindow) like
+// rando-gen, so `--test all` skips it.
+TestResult Test_RandoGenFullInit(void) {
+    printf("[TEST] rando-gen-full-init: seed generation with the full OTR bring-up live, on a worker thread "
+           "(#560)\n");
+
+    auto ctx = CreateHarnessStyleContext();
+    if (!ctx) {
+        printf("[TEST] FAIL: could not create Ship::Context singleton\n");
+        return TEST_FAIL;
+    }
+
+    static char arg0[] = "redship";
+    static char* fakeArgv[] = { arg0, nullptr };
+    InitOTRForMMFirstBoot(1, fakeArgv);
+
+    int rc = Rando_HeadlessFullInitSeedTest("RSBSFULL1");
+    printf("[TEST] %s: full-init seed generation rc=%d\n", rc == 0 ? "PASS" : "FAIL", rc);
     return rc == 0 ? TEST_PASS : TEST_FAIL;
 }
 
@@ -1657,6 +1693,11 @@ TestResult Test_Context(void) {
 
 const TestDescriptor gTests[] = {
     {"rando-gen", "Seed generation succeeds with default settings (#337)", Test_RandoGen},
+    // #560: the same generation with the RSBS_DISABLE_OTR_INIT mask OFF and the
+    // fill on a worker thread — the bring-up and call shape a player actually
+    // gets. Needs a display like rando-gen, so `--test all` skips it (below).
+    {"rando-gen-full-init", "Seed generation with the full OTR bring-up live, on a worker thread (#560)",
+     Test_RandoGenFullInit},
     // #441: no generated hint may resolve to the no-item sentinel. Needs a
     // display like rando-gen, so `--test all` skips it (below).
     {"rando-hint-validity", "Every generated hint names a real item (#441)", Test_RandoHintValidity},
@@ -1948,7 +1989,8 @@ int TestRunner_Run(const char* testName) {
             // bring-up) and the RSBS_DISABLE_OTR_INIT environment; they run as
             // their own CTests ("rando" label, under xvfb-run) rather than in
             // this display-free suite, where they would hang the 60s timeout.
-            if (strcmp(gTests[i].name, "rando-gen") == 0 || strcmp(gTests[i].name, "rando-determinism") == 0 ||
+            if (strcmp(gTests[i].name, "rando-gen") == 0 || strcmp(gTests[i].name, "rando-gen-full-init") == 0 ||
+                strcmp(gTests[i].name, "rando-determinism") == 0 ||
                 strcmp(gTests[i].name, "rando-hint-validity") == 0 ||
                 strcmp(gTests[i].name, "rando-hint-reload") == 0 ||
                 strcmp(gTests[i].name, "rando-hint-crossgame") == 0 ||

--- a/src/common/test_runner.cpp
+++ b/src/common/test_runner.cpp
@@ -558,15 +558,22 @@ TestResult Test_RandoGenFullInit(void) {
     // the real, previously-undocumented reason this tier carries
     // RSBS_DISABLE_OTR_INIT=1 — and it is why CI's rando rows had been running
     // with zero archives mounted for as long as the tier has existed (they were
-    // staged where only the install rules look; see the staging step added to
-    // both workflows for #560). Resolve exactly the way the
-    // bring-up will (OTRGlobals.cpp: LocateFileAcrossAppDirs("soh.o2r")) and fail
-    // in a second with a readable reason instead of burning the row's timeout.
+    // staged where only the install rules look; #560 fixes that in BOTH places
+    // the archive can come from — copy-existing-otrs.cmake / the Generate*Otr
+    // targets for a locally built archive, and a staging step in each workflow
+    // for the CI case where it arrives as a downloaded artifact instead).
+    // Resolve exactly the way the bring-up will (OTRGlobals.cpp:
+    // LocateFileAcrossAppDirs("soh.o2r")) and fail in a second with a readable
+    // reason instead of burning the row's timeout. Deliberately a FAIL and not a
+    // CTest SKIP: a staging regression must be loud, since the symptom it
+    // otherwise produces is a silently masked subsystem.
     const std::string sohArchive = Ship::Context::LocateFileAcrossAppDirs("soh.o2r");
     if (!std::filesystem::exists(sohArchive)) {
         printf("[TEST] FAIL: no soh.o2r resolvable (tried '%s'). This row needs a mounted archive: with none, "
                "libultraship pauses the resource thread pool and OTRAudio_Init's synchronous load never "
-               "returns. Stage soh.o2r next to the ctest working directory (#560).\n",
+               "returns. Build the port archives once ('cmake --build <dir> --target GenerateSohOtr "
+               "Generate2ShipOtr'), which now also lands them in the build root where the ctest rows look "
+               "(#560).\n",
                sohArchive.c_str());
         return TEST_FAIL;
     }


### PR DESCRIPTION
Part of #560 — closes the part of the "Why CI never saw it" coverage hole that is closable ROM-free, and fixes the archive-staging bug found underneath it.

## What this changes

**1. One new rando row: `RandoGenFullInit` (`--test rando-gen-full-init`).**

All 14 existing `rando`-label rows set `RSBS_DISABLE_OTR_INIT=1`, which skips the whole `OTRMessage_Init` / `OTRAudio_Init` / `OTRExtScanner` / `VanillaItemTable_Init` / `DebugConsole_Init` block (`games/oot/soh/OTRGlobals.cpp:1811-1823`), and they generate through the synchronous 3-arg `GenerateRandomizer` on the test's own thread. That is a bring-up *and* a call shape no player ever runs.

The new row differs in exactly two ways:

- it **proves the un-masking happened before it generates anything** (populated `ExtensionCache`, vanilla item table returning a real `itemId` for `GI_BOMBS_5`, `gen_rando` registered on the console), so re-adding the env flag fails the row instead of silently turning it into a `RandoGen` clone;
- it generates through the **1-arg `GenerateRandomizer` overload that spawns `randoThread`** (`randomizer.cpp:3516`) — the path `z_file_choose.c:824` reaches. That overload previously had no CTest caller at all.

Scope honesty: this does **not** reproduce #560's crash and is not trying to. That race needs `oot.o2r`-only entries on both sides plus a live frame loop; a ROM-free display-only tier structurally cannot host it.

**2. Provenance of the flag (issue question 1).** It was never a display or asset constraint. It is a bisect knob from `e2a181c1` (#199, "useful for bisecting crashes during initialization"; `RsbsFeatureEnabled` at `OTRGlobals.cpp:143` inverts the name, so `=1` **skips**). It entered the test tier in `8dc2786d` (#339) inside a commit whose own message says "Diagnostic scaffolding… Not intended to merge as-is", then was copied verbatim onto 13 more rows. No row ever justified it independently.

**3. The real finding: every CTest row has been booting with zero archives mounted.**

The new row passed in 2s locally and **timed out at 300s on Linux CI**. Cause: the archives are staged where only the *install* rules read them (`${CMAKE_BINARY_DIR}/soh`, `.../mm`), but a ctest row resolves archives through `Ship::Context::LocateFileAcrossAppDirs`, which probes the app-config dir, then the running binary's own directory, then `./` — all three of which are `${CMAKE_BINARY_DIR}` for a row started by `ctest --test-dir build-cmake`, and none of which is `${CMAKE_BINARY_DIR}/soh`. So **all 65 `redship` rows and all 15 `rando` rows** have been running archive-less. The log has said so all along:

```
[warning] [ArchiveManager.cpp:225] The archive at path .../build-cmake/./soh.o2r does not exist
```

Not benign: libultraship **pauses the ResourceManager thread pool permanently** when no archive is loaded (`ResourceManager.cpp:58-61`, *"Nothing ever unpauses the thread pool"*), so any synchronous load deadlocks on `.get()`. `OTRAudio_Init` does exactly one (`ResourceMgr_LoadDirectory("audio")`). **So the flag was load-bearing — as an accidental workaround for an archive-staging bug.** Same deadlock #339 already papered over at the other call site (`logic.cpp:2385-2387` bails before `LoadResource` when `!IsLoaded()`).

Fixed in **both** places an archive can come from, because neither subsumes the other:

- **the build** — `copy-existing-otrs.cmake` (soh.o2r) and the two MM targets (2ship.o2r) now also copy into `${CMAKE_BINARY_DIR}`, so a plain local `ctest --test-dir <dir>` works with no manual staging;
- **CI** — a staging step in each workflow, since CI *downloads* the archives as artifacts and never runs those targets in the test job.

The row additionally asserts a resolvable `soh.o2r` **before** bring-up, so a staging regression fails in ~0.1s with the diagnosis instead of hanging for 300s. Deliberately a FAIL and not a CTest SKIP: the symptom it otherwise produces is a silently masked subsystem. `netplay-relay` is left archive-less on purpose, so one archive-less run of the `redship` tier survives as a control.

**4. Pre-existing bug found alongside.** `cmake -E copy <file> ${BINARY_DIR}/soh/` fails with *"Invalid argument"* because nothing ever creates that directory — so on a fresh tree every soh-side copy in `copy-existing-otrs.cmake` printed an error and did nothing, including the one the install rules read. The MM side already guards this with `-E make_directory`; this does the same.

**5. Cross-reference (issue question 3).** Posted on #177: a Windows rando tier would *not* have caught #560 (the reasons are tier properties, not OS properties), and the tier now has 15 rows, inheriting #177's status — gates on Linux under xvfb, no Windows ctest yet.

## Verification

Local: Windows MSVC, Release, `REDSHIP_BUILD_SHARED=ON`, ROM-free (only `soh.o2r`/`2ship.o2r`, produced by `GenerateSohOtr`/`Generate2ShipOtr`; no ROMs staged). Re-run after merging `origin/main` (a1dc22ab / #563, which brought in source changes from #559).

```
ctest -L "^redship$"    100% tests passed out of 65    (10.93 s)
ctest -L "^rando$"      100% tests passed out of 15    (24.51 s)
  1/15 RandoGen ...............  Passed   1.49 s
  2/15 RandoGenFullInit .......  Passed   2.04 s
```

The new row's own assertions, verbatim from `ctest -V`:

```
67: [rando-full-init] full OTR bring-up verified: 1278 ExtensionCache entries, vanilla item table populated, debug console registered
67: [rando-full-init] seed generated on a worker thread with the full OTR bring-up live
67: [TEST] PASS: full-init seed generation rc=0
```

The 1278 `ExtensionCache` entries are themselves proof the archive is mounted — `OTRExtScanner` populates it purely from `ArchiveManager::ListFiles`.

Archives land in all three places from a plain build, no manual copy: `build-cmake/soh.o2r`, `build-cmake/soh/soh.o2r`, `build-cmake/2ship.o2r`, `build-cmake/mm/2ship.o2r`.

`clang-format` 14.0.6 clean on `games/oot/soh/OTRGlobals.cpp` — the only touched file listed in `.github/clang-format-paths.txt`.

### Counterfactuals

**Anti-vacuity guard bites.** Re-add the flag the other 14 rows carry:

```
$ RSBS_DISABLE_OTR_INIT=1 ./redship --test rando-gen-full-init
[rando-full-init] InitOTRImpl skipped its OTR-init block — RSBS_DISABLE_OTR_INIT is set for this
                  row, so it would only re-run what RandoGen already covers
[TEST] FAIL: full-init seed generation rc=10                                       EXITCODE=1
```

**The old archive layout, reproduced locally** (archives moved aside, same binary):

```
$ ./redship --test rando-gen-full-init
[TEST] FAIL: no soh.o2r resolvable (tried './soh.o2r'). This row needs a mounted archive: with
none, libultraship pauses the resource thread pool and OTRAudio_Init's synchronous load never
returns. Build the port archives once ('cmake --build <dir> --target GenerateSohOtr
Generate2ShipOtr'), which now also lands them in the build root where the ctest rows look (#560).
EXITCODE=1        ... in 0.13 sec, versus the 300.08 sec ***Timeout the same row produced on CI.
```

**The load-bearing claim, tested directly rather than argued.** `--test rando-gen` has no precondition guard, so it can be run with the flag *unset* and no archives present:

```
$ ./redship --test rando-gen          # RSBS_DISABLE_OTR_INIT unset, archives moved aside
[OoT] No OoT game archive loaded - skipping SoH GUI setup
   ... STILL RUNNING AFTER 90s -> HUNG (killed)
```

It stops dead exactly where `OTRAudio_Init` sits. The flag really was an accidental workaround for the staging bug, and the row's precondition guard is not decorative.

**Audio-teardown claim checked, not assumed.** Temporarily suppressing the `OTRAudio_Exit()` call still exits 0, because `--test` mode ends at `_Exit` (`rsbs/src/main.cpp:288`) and skips static destruction. The pairing is kept and the in-tree comment says "defensive, not load-bearing" rather than claiming an abort that does not happen.

### CI evidence

The 300s hang, from the first push (run 30513498436, job 90778372440), **before** the staging fix:

```
2/15 Test #67: RandoGenFullInit .................***Timeout 300.08 sec
[warning] [ArchiveManager.cpp:225] The archive at path .../build-cmake/./soh.o2r does not exist
(none of the bridge's stderr assertions printed -> the hang was inside the flag-masked block)
```

**After** the staging fix (run 30514545098, job 90781459142), build-linux PASS in 2m59s:

```
Run cp build-cmake/soh/soh.o2r build-cmake/soh.o2r
100% tests passed, 0 tests failed out of 65      (redship tier)
2/15 Test #67: RandoGenFullInit .................   Passed    2.02 sec
100% tests passed, 0 tests failed out of 15      (rando tier)
```

## Review notes

Reviewed adversarially against the real declarations; every counterfactual above was re-run rather than taken on trust. Findings fixed in the review commit:

- **The staging fix did not cover a local build**, leaving the new row red by default for every developer. Now fixed in CMake as well as CI (item 3 above).
- **The 150s worker deadline printed its diagnostic *after* an unbounded `randoThread.join()`**, so on a real hang the message never appeared. It now prints before the join (which remains mandatory — a live joinable thread would `std::terminate` in the destructor) and says plainly that the deadline buys a *diagnosed* hang, not a bounded one.
- **`generated` was cleared before the join**, so a worker store could race and leave a stale 1 — exactly what makes a later `GenerateRandomizer()` join an already-joined thread. Cleared after the join now.
- **Comment accuracy**: `LocateFileAcrossAppDirs` was described in four places as falling back to `./<name>`. It probes app-config dir → exe dir → `./`, and it is the exe-dir probe the observed CI log line resolves through. Conclusion was right, mechanism was not.
- Also **resolves the one oddity the implementer flagged as unexplained**: the rando tier does *not* slow from 25s to 88s once archives are mounted. Built in place it is 24.5s here, matching Linux CI; the 88s was an artifact of the hand-staged archive, not of the extra archive work.

No submodule-pointer or generated-stamp changes are included (`build.c` / `properties.h` touched by the build were reverted).

### Blast radius, called out explicitly

The staging fix changes the runtime environment of **80 existing CTest rows** (65 `redship` + 15 `rando`) from archive-less to archive-mounted. That exact configuration is verified green both locally and on Linux CI, so it is evidence-backed rather than hopeful — but it is a bigger change than "add one row", and a reviewer may reasonably want it split. It cannot be split *away* from the row, though: without it the row hangs for 300s on CI.

### Deliberately not done

- **No concurrent-load stress row.** #560's race window is microseconds and probabilistic; such a row would be flaky before the mutex lands and a permanent pass after. It belongs in the libultraship fork next to the mutex as a deterministic contention test. Worth noting: the staging fix makes it *possible* for the first time — before it, a ROM-free row could not read a single archive byte.
- **No touching of the 14 existing rows' `RSBS_DISABLE_OTR_INIT`.** Now that the deadlock cause is fixed the flag can probably come off all of them, but that should be measured row by row in its own change.
- **No edit to `docs/phase3-lane-prompts.md:668`**, the "Register in the rando pattern (… `RSBS_DISABLE_OTR_INIT=1`)" recipe that is how the flag reached 14 rows. It is a historical record of a completed lane's prompt; editing it would falsify history. Raised as follow-up on #560 instead.

Still open on #560 (documented there, not attempted): reproducing the actual crash needs a ROM-equipped runner with a live frame loop driving menu-triggered generation — i.e. a new `int-*` row on `integration-tests.yml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

### CI on this revision (8f29fe3a) — all green

```
build-linux            pass   3m16s   (staging step + both tiers: 65/65 and 15/15, incl. the new row)
netplay-relay          pass   3m23s   (the deliberately archive-less control, still green)
build-windows          pass  13m42s
link-check             pass   2m38s   (was red on every branch based on pre-#563 main; the merge fixes it)
clang-format           pass     20s
clang-tidy             pass   1m14s
generate-rsbs-otr      pass   5m12s
odr-declaration-gate   pass      9s
test                   pass     41s
build-macos / create-release   skipping (if: false)
```

Not merged — the session shepherds merges.
