### PR TITLE
Encode one-game semantics in ADR 0009 D1/D2 and ADR 0004 §6, and retire two stale invariant comments (#564)

### DIFF
--- a/docs/adr/0004-menu-information-architecture.md
+++ b/docs/adr/0004-menu-information-architecture.md
@@ -1,10 +1,19 @@
 # ADR 0004: Menu information architecture — one shell, four tiers, capability-gated MM entries
 
-- Status: **Accepted** (2026-07-23, #497 step 1)
+- Status: **Accepted** (2026-07-23, #497 step 1); **§6 and §4.1a amended
+  2026-07-30** under the one-game-semantics ruling
 - For: #392 (Phase 3.0 tracker), #34 (settings migration), #497, #499
 - Amended on acceptance: §4.1 (scope and host of the MM randomizer pane — see
   §4.1a), §2d (the #454 disagreement, now ruled), and "What this ADR does not
   decide" (all five calls resolved).
+- Amended **2026-07-30 (#564**, ruling recorded on
+  [#500](https://github.com/spencerduncan/redshipblueship/issues/500#issuecomment-5126492334)**)**:
+  §6 gains a **fourth presentation state** — frozen-at-creation, read-only, with
+  the reason — and its "a player should be able to set MM options before
+  switching" clause is superseded; §4.1a's timing is restated as *reachable
+  before the combo file is created*, which strengthens rather than disturbs its
+  common-owned-window conclusion. The tier model, the capability-gating rule and
+  the section layout are untouched.
 - Depends on:
   - **[ADR 0003](0003-settings-namespace.md)** (settings namespace) — owns CVar key naming and
     the rename/migration rule; this ADR consumes its decisions rather than restating them.
@@ -240,8 +249,24 @@ arming condition is untouched (mechanized as the MM-side reader allowlist in
 
 **Consequence accepted: §4.2's shared-intent marker does not apply to this pane.** All 47 options
 are tier-3 (O) MM-only keys; none is in `kSharedIntentKeys`, so there is no "applies to both
-games" claim to mark. §6's three presentation states DO apply and are implemented: live,
-editable-but-not-active ("Majora's Mask — suspended"), and disabled-by-capability with a reason.
+games" claim to mark. §6's presentation states DO apply: live, editable-but-not-active
+("Majora's Mask — suspended"), and disabled-by-capability with a reason are implemented; §6's
+fourth state (frozen-at-creation, read-only) applies to this pane too and is **not** implemented
+— it is owed with the freeze work (#564 V5), and until it exists the pane is a live CVar editor
+at all times, including after the world it describes has been created.
+
+> **Amended 2026-07-30 (#564): the host conclusion survives and gets stronger; the deadline is
+> restated.** "Reachable while OoT is the running game, before the switch" was the right host
+> argument off the wrong deadline. Under one-game semantics the MM option profile freezes at the
+> **creation event** — OoT's file-create — not at the crossing, so the requirement restates as
+> **reachable before the combo file is created**: a strictly earlier window, and one in which OoT
+> is equally the running game. A `SohMenu` pane satisfies neither deadline, so ADR 0008's
+> common-owned window is confirmed rather than disturbed, and the precedent to copy for the gate
+> is OoT's own Generate button (file-select only, no save loaded — `SohMenuRandomizer.cpp`).
+> What changes is the pane's contract *after* that window closes: see §6 state 4. The shipped
+> copy that teaches the retired deadline — "These apply to the NEXT Majora's Mask file… set them
+> before you cross" (`ComboMmOptionsWindow.cpp:47-49`) — is superseded with it, and its
+> replacement must not describe a renegotiation window that no longer exists.
 
 **Consequence accepted: the options are a CHOICE, and the defaults do not change.** No raised
 profile ships. Every `RO_SHUFFLE_*` and `RO_HINTS_*` row keeps its `RO_GENERIC_OFF` default, so
@@ -293,12 +318,57 @@ now:
 1. **Tier 1 and tier 2 entries** apply to both games always — marked per §4.2.
 2. **Tier 3 entries** apply to one game. The inactive game's subsection must be visually
    de-emphasised and labelled with its state (e.g. "Majora's Mask — suspended"), while
-   remaining *readable and editable* (a player should be able to set MM options before
-   switching).
+   remaining *readable and editable* ~~(a player should be able to set MM options before
+   switching)~~ **for as long as they are still authorable at all — which, for any key that
+   is world identity, ends at the creation event. See state 4.**
 3. **Editable-but-not-active is a third state**, distinct from both "live" and "disabled by
    capability gating" (§5). Collapsing it into "disabled" would wrongly imply the setting is
-   broken; collapsing it into "live" would wrongly imply immediate effect. Three states, three
-   presentations.
+   broken; collapsing it into "live" would wrongly imply immediate effect.
+4. **Frozen-at-creation is a fourth state (added 2026-07-30, #564): read-only, labelled with
+   the reason and with the identity it is frozen to.** A world-identity key belonging to a
+   world that already exists is not editable, not suspended, and not broken — it was decided,
+   once, and the decision is part of the save. Rendering it live is the worst of the four
+   errors available here: the control accepts input, reports success, and changes nothing
+   about the world the player is in (§5's vacuous-gate class, in its most convincing form,
+   because this control *used* to work).
+
+   Four states, four presentations. The distinctions are what each one denies:
+
+   | State | Applies now? | Editable? | What the presentation must deny |
+   |---|---|---|---|
+   | Live | yes | yes | — |
+   | Editable-but-not-active | on resume | yes | "this takes effect now" |
+   | Disabled by capability (§5) | no | no | "this works" |
+   | Frozen at creation (#564) | it already did | **no** | "this is still a choice" |
+
+   The reason string is not optional and is not the capability reason: a capability gate says
+   *not yet available*, a freeze says *already decided*, and a player who reads the wrong one
+   goes looking for a bug in the right one. Where a frozen key's value is also shown, show the
+   frozen value from the save rather than the CVar — after creation the two may legitimately
+   differ, and the save is the one the world was built from.
+
+> **Why the fourth state exists (2026-07-30, ruling on #500, alignment plan #564).** *"This is
+> one game from a semantic standpoint"*: the paired OoT+MM world has ONE identity, fixed at ONE
+> creation event, and arrival-time divergence from it is corruption to detect and refuse rather
+> than a choice to honour. §6 as written assumed the opposite — that a suspended game's settings
+> stay negotiable until the player switches into it — which was true only because MM's half was
+> generated late, at first crossing. Once identity freezes at creation, a live editor over
+> world-identity keys is not a convenience; it is the mechanism by which a player silently
+> desynchronises the two halves of their own save.
+>
+> **Scope.** State 4 applies to a key when a world built from it exists — that is, to tier-3 and
+> tier-4 **world-identity** keys after creation. It does NOT apply to preference keys, which have
+> no identity role and stay live forever (Autosave and RememberSaveLocation are the named
+> examples; #539's missing MM driver is about those, not these). Classifying each key into one
+> bucket or the other is owed by the same work that ships the freeze — an unclassified key
+> defaults to identity, because guessing "preference" for an identity key is the failure this
+> state exists to prevent.
+>
+> **Enforcement is not the widget.** A read-only rendering that leaves the underlying writers
+> open is decorative: the pane is one caller of the `src/common` write choke points, and the gate
+> belongs on those (#564 V5). The predicate must be a `src/common` fact — the creation-stamped
+> `mmProfileDigest != 0` is what #564 prescribes — never a `gSaveContext` read, per ADR 0008 rule
+> 5 and the pane's game-agnosticism tripwire.
 
 ## Dependencies and sequencing
 
@@ -400,3 +470,9 @@ kept so the decision trail stays legible.
 - The rename list is generated from the classification table. A misclassification there becomes
   a wrong rename here — which is why every (S) row was verified by reading both
   implementations, and why the 7 (P) rows are called out explicitly as do-not-merge.
+- **Added 2026-07-30 (#564):** every world-identity key now needs a classification the
+  enhancement table does not currently carry — identity versus preference (§6 state 4). An
+  identity key misfiled as a preference stays editable after creation, which is the
+  desynchronisation the freeze exists to prevent; the safe default for an unclassified key is
+  therefore identity, and the cost of getting it wrong in that direction is a control that
+  refuses input a session too early.

--- a/docs/adr/0004-menu-information-architecture.md
+++ b/docs/adr/0004-menu-information-architecture.md
@@ -347,8 +347,9 @@ one goes looking for a bug in the right one. Where a frozen key's value is shown
 value from the save rather than the CVar — after creation the two may legitimately differ, and
 the save is the one the world was built from. **"From the save" names the authority, not the read
 site.** The host of every one of these keys is a common-owned window, which may not read
-`gSaveContext` at all (ADR 0008 rule 5, restated below), and D1's amendment puts the frozen MM
-profile in MM's own SaveContext — so a pane that rendered it directly would break the rule in the
+`gSaveContext` at all (ADR 0008 rule 5, restated below), and [ADR 0009](0009-combo-settings-and-reverse-pool.md)
+decision 1's 2026-07-30 amendment puts the frozen MM profile in MM's own SaveContext
+(`RANDO_SAVE_OPTIONS`, Tier-3) — so a pane that rendered it directly would break the rule in the
 same breath as obeying this one. The frozen value reaches the pane the way the digest already
 does: through a `src/common` accessor over `src/common`-owned storage
 (`Combo_MMProfileSummary`, `combo_mm_options_view.c:155`, reads `gComboCtx` and nothing else).

--- a/docs/adr/0004-menu-information-architecture.md
+++ b/docs/adr/0004-menu-information-architecture.md
@@ -345,7 +345,15 @@ A frozen entry's reason string is not optional and is not the capability reason:
 gate says *not yet available*, a freeze says *already decided*, and a player who reads the wrong
 one goes looking for a bug in the right one. Where a frozen key's value is shown at all, show the
 value from the save rather than the CVar — after creation the two may legitimately differ, and
-the save is the one the world was built from.
+the save is the one the world was built from. **"From the save" names the authority, not the read
+site.** The host of every one of these keys is a common-owned window, which may not read
+`gSaveContext` at all (ADR 0008 rule 5, restated below), and D1's amendment puts the frozen MM
+profile in MM's own SaveContext — so a pane that rendered it directly would break the rule in the
+same breath as obeying this one. The frozen value reaches the pane the way the digest already
+does: through a `src/common` accessor over `src/common`-owned storage
+(`Combo_MMProfileSummary`, `combo_mm_options_view.c:155`, reads `gComboCtx` and nothing else).
+Publishing the frozen profile into a `src/common` view is therefore part of the freeze work, not
+an afterthought of the presentation.
 
 > **Why the fourth state exists (2026-07-30, ruling on #500, alignment plan #564).** *"This is
 > one game from a semantic standpoint"*: the paired OoT+MM world has ONE identity, fixed at ONE

--- a/docs/adr/0004-menu-information-architecture.md
+++ b/docs/adr/0004-menu-information-architecture.md
@@ -6,8 +6,8 @@
 - Amended on acceptance: §4.1 (scope and host of the MM randomizer pane — see
   §4.1a), §2d (the #454 disagreement, now ruled), and "What this ADR does not
   decide" (all five calls resolved).
-- Amended **2026-07-30 (#564**, ruling recorded on
-  [#500](https://github.com/spencerduncan/redshipblueship/issues/500#issuecomment-5126492334)**)**:
+- Amended **2026-07-30, #564** (the one-game ruling is recorded on
+  [#500](https://github.com/spencerduncan/redshipblueship/issues/500#issuecomment-5126492334)):
   §6 gains a **fourth presentation state** — frozen-at-creation, read-only, with
   the reason — and its "a player should be able to set MM options before
   switching" clause is superseded; §4.1a's timing is restated as *reachable
@@ -332,20 +332,20 @@ now:
    about the world the player is in (§5's vacuous-gate class, in its most convincing form,
    because this control *used* to work).
 
-   Four states, four presentations. The distinctions are what each one denies:
+Four states, four presentations. The distinctions are what each one denies:
 
-   | State | Applies now? | Editable? | What the presentation must deny |
-   |---|---|---|---|
-   | Live | yes | yes | — |
-   | Editable-but-not-active | on resume | yes | "this takes effect now" |
-   | Disabled by capability (§5) | no | no | "this works" |
-   | Frozen at creation (#564) | it already did | **no** | "this is still a choice" |
+| State | Applies now? | Editable? | What the presentation must deny |
+|---|---|---|---|
+| Live | yes | yes | — |
+| Editable-but-not-active | on resume | yes | "this takes effect now" |
+| Disabled by capability (§5) | no | no | "this works" |
+| Frozen at creation (#564) | it already did | **no** | "this is still a choice" |
 
-   The reason string is not optional and is not the capability reason: a capability gate says
-   *not yet available*, a freeze says *already decided*, and a player who reads the wrong one
-   goes looking for a bug in the right one. Where a frozen key's value is also shown, show the
-   frozen value from the save rather than the CVar — after creation the two may legitimately
-   differ, and the save is the one the world was built from.
+A frozen entry's reason string is not optional and is not the capability reason: a capability
+gate says *not yet available*, a freeze says *already decided*, and a player who reads the wrong
+one goes looking for a bug in the right one. Where a frozen key's value is shown at all, show the
+value from the save rather than the CVar — after creation the two may legitimately differ, and
+the save is the one the world was built from.
 
 > **Why the fourth state exists (2026-07-30, ruling on #500, alignment plan #564).** *"This is
 > one game from a semantic standpoint"*: the paired OoT+MM world has ONE identity, fixed at ONE

--- a/docs/adr/0009-combo-settings-and-reverse-pool.md
+++ b/docs/adr/0009-combo-settings-and-reverse-pool.md
@@ -101,9 +101,16 @@ this ADR's.
 > The argument above ("a settings surface carved into the save would be a second
 > settings store") holds only while something *authors* there. Nothing does: such
 > a record is written once, by the creation event, and is read-only for the life
-> of the file — precisely the status `foreignPlacements` already has under ADR
-> 0002, and nobody calls the placement table a second item database. Rejecting a
-> profile record as a "second store" rejected the wrong thing. *Where* the record
+> of the file — precisely the status the REVERSE placement table
+> `foreignPlacementsOoT` already has (claim 1 of the budget below; #534's KEEP
+> snapshot exists because "nothing re-places the reverse table after
+> generation", `context.cpp`), and nobody calls that table a second item
+> database. Take the analogy from the reverse table specifically and not from
+> the forward `foreignPlacements`: the forward table is re-authored by MM at its
+> own `OnFileCreate` on each arrival, which is the deferred-generation behaviour
+> this amendment retires — it is the counter-example, not the precedent.
+> Rejecting a profile record as a "second store" rejected the wrong thing.
+> *Where* the record
 > lives stays a budget question, answered under claim 3 below: MM's own
 > `RANDO_SAVE_OPTIONS` in Tier-3 already IS a frozen per-save option record, so
 > the one game gets the storage for free and the digest stays a 4-byte

--- a/docs/adr/0009-combo-settings-and-reverse-pool.md
+++ b/docs/adr/0009-combo-settings-and-reverse-pool.md
@@ -417,10 +417,15 @@ Two constraints on anyone spending from this:
   scribble loop (`test_save_roundtrip.c:512-538`) iterates `sizeof(reserved)`; at
   zero it degenerates to zero iterations and passes vacuously, retiring the only
   test that proves headroom round-trips at all.
-- **Claim 3's size is a placeholder.** Lane 4 must confirm its digest size before
-  carving, not after. 4 B assumes a u32 digest by analogy with
+- ~~**Claim 3's size is a placeholder.** Lane 4 must confirm its digest size
+  before carving, not after. 4 B assumes a u32 digest by analogy with
   `sharedRandoSettingsHash`; a wider profile record changes the table and this
-  ADR should be amended rather than the floor quietly eaten.
+  ADR should be amended rather than the floor quietly eaten.~~ **Paid** — see
+  "Claim 3, settled" above (4 B, carved at offset 788) and, for why a wider
+  Tier-1 record is not the answer even under the freeze, "Claim 3's rationale
+  restated". Struck 2026-07-30 (#564) because the amendment two paragraphs
+  above re-opens the wider-record question and this bullet reads as though it
+  were still unanswered.
 
 Nothing here raises `RSBS_SAVE_VERSION`, `RSBS_COMBO_CONTEXT_RECORD_SIZE`, or
 `RSBS_COMBO_CONTEXT_PRECARVE_SIZE`. Every claim is a front-of-`reserved[]` carve

--- a/docs/adr/0009-combo-settings-and-reverse-pool.md
+++ b/docs/adr/0009-combo-settings-and-reverse-pool.md
@@ -4,8 +4,8 @@
   under the one-game-semantics ruling
 - For: #498 (combo-level settings), gating #493 (MM -> OoT foreign items); Phase
   3.1 tracker #492, Lane 1
-- Amended: **2026-07-30 (#564**, ruling recorded on
-  [#500](https://github.com/spencerduncan/redshipblueship/issues/500#issuecomment-5126492334)**)**
+- Amended: **2026-07-30, #564** (the one-game ruling is recorded on
+  [#500](https://github.com/spencerduncan/redshipblueship/issues/500#issuecomment-5126492334))
   — decision 1 (a frozen record on the save side is world identity, not a second
   settings store; the digest becomes a cross-check stamped before the act it
   validates) and decision 2 (identity is the post-condition of the WHOLE

--- a/docs/adr/0009-combo-settings-and-reverse-pool.md
+++ b/docs/adr/0009-combo-settings-and-reverse-pool.md
@@ -1,8 +1,19 @@
 # ADR 0009: Combo settings author in CVars and identify by digest; the reverse pool is a second origin-keyed table behind a pre-generation gate
 
-- Status: **Accepted** (2026-07-22)
+- Status: **Accepted** (2026-07-22); **decisions 1 and 2 amended 2026-07-30**
+  under the one-game-semantics ruling
 - For: #498 (combo-level settings), gating #493 (MM -> OoT foreign items); Phase
   3.1 tracker #492, Lane 1
+- Amended: **2026-07-30 (#564**, ruling recorded on
+  [#500](https://github.com/spencerduncan/redshipblueship/issues/500#issuecomment-5126492334)**)**
+  — decision 1 (a frozen record on the save side is world identity, not a second
+  settings store; the digest becomes a cross-check stamped before the act it
+  validates) and decision 2 (identity is the post-condition of the WHOLE
+  creation, and the MM option profile freezes ahead of OoT's `Fill()`). Decision
+  3, the reverse-pool rules and the `reserved[]` budget table are unchanged;
+  claim 3's *rationale* is restated where it leaned on decision 1. Each
+  amendment sits at the end of its decision, with the original reasoning kept
+  above it so the decision trail stays legible.
 - Depends on:
   - **[ADR 0002](0002-origin-tagged-shared-items.md)** (Accepted) — the origin-tag
     invariant and the `ComboContext` growth contract every carve below obeys.
@@ -38,6 +49,9 @@ Measured against `claude/lane5-tracker-visibility` on 2026-07-22 by direct read.
 The `.redsave` carries a single `uint32_t comboSettingsHash`, not the settings
 themselves.**
 
+> **Amended 2026-07-30 (#564) — read the amendment block at the end of this
+> section before acting on the reasoning below, which is kept for the trail.**
+
 The two framings in #498 were "per-save carve, so a `.redsave` carries its own
 pairing rules" versus "per-install CVars, per ADR 0003's one-store posture".
 They are not actually in tension, because they answer different questions:
@@ -69,11 +83,80 @@ point under the growth contract, and the digest becomes a checksum over them.
 setting changes the derived world" is unassertable. That is #498's lock, not
 this ADR's.
 
+### Amendment to decision 1 — one game, one identity, frozen at creation
+
+> **2026-07-30, operator ruling on #500, alignment plan #564.** *"Freezing at
+> creation is the correct semantics for sure. Keep that idea in mind with all
+> designs. This is one game from a semantic standpoint."* Decision 1 is amended,
+> not withdrawn: the CVar authoring surface survives with a boundary, and the
+> digest survives with a different job.
+>
+> **Survives — CVars author, and there is still no second settings store.** ADR
+> 0003's one-store posture is about *authoring*, and nothing here weakens it. It
+> gains a boundary: CVars author the one game's settings **only up to the
+> creation event**. After creation, no CVar describes a created world, and no
+> gameplay path may read one to decide world behaviour.
+>
+> **Changes — a frozen record on the save side is world identity, not a store.**
+> The argument above ("a settings surface carved into the save would be a second
+> settings store") holds only while something *authors* there. Nothing does: such
+> a record is written once, by the creation event, and is read-only for the life
+> of the file — precisely the status `foreignPlacements` already has under ADR
+> 0002, and nobody calls the placement table a second item database. Rejecting a
+> profile record as a "second store" rejected the wrong thing. *Where* the record
+> lives stays a budget question, answered under claim 3 below: MM's own
+> `RANDO_SAVE_OPTIONS` in Tier-3 already IS a frozen per-save option record, so
+> the one game gets the storage for free and the digest stays a 4-byte
+> cross-check rather than becoming the storage.
+>
+> **Changes — the digest is a cross-check, and it is stamped BEFORE the act it
+> validates.** Today `mmProfileDigest` has one writer, zero comparators, and is
+> produced *by* the resolution it should be validating (`Foreign.cpp:149`; every
+> consumer is display-only). Under one-game semantics it is stamped by the
+> creation event before either half generates, and every arrival and every load
+> recomputes it from the frozen record and compares. A mismatch is **corruption
+> to refuse, never a divergence to honour** — the ruling's second binding
+> consequence — so the comparison is semantics, not defensive plumbing.
+>
+> **Changes — "detects but cannot repair … that is accepted."** Detection stops
+> being merely sufficient and becomes mandatory; and repair stops being
+> impossible wherever the frozen record exists, because a record can say what the
+> original rules were and a digest never could. The un-repairable case shrinks to
+> a save whose record is itself gone — which is the refusal path, not a
+> degraded-play path.
+>
+> **Reinterpretation that must be written down loudly — `mmProfileDigest == 0`
+> changes meaning.** It reads today as "the MM half has not been generated yet",
+> and is rendered to the player as the *normal* state of a file still in OoT
+> (`ComboMmOptionsWindow.cpp:80-85`). Once identity freezes at creation, zero
+> means **identity not frozen**, a state no created combo file may be in. Any
+> reader carried across unchanged will report corruption as normal.
+>
+> **Coverage — the identity term must span the generator's whole input set.**
+> `gRando.ExcludedChecks`, the StartingItems block, spoiler policy, the RESOLVED
+> `RO_LOGIC` default (today decided at arrival by probing CVar *existence*,
+> `Foreign.cpp:125`), and every trap-type key classified as world identity all
+> shape the MM world and all sit outside `MMOptionsString()`. A digest narrower
+> than the input set is vacuous — same seed, same digest, different world — so a
+> guard built on it would pass while the thing it guards diverges. OoT's own
+> settings hash already folds excludes and tricks; that is the scope to copy
+> (#564 V4).
+>
+> **Sequencing.** This amendment lands before #498 carves any tier-4 key. No
+> identity-mismatch refusal may ship before #533's quarantine and armed-session
+> latch: while a refused file is indistinguishable from an absent one and the
+> next save overwrites it, every new detection converts into data loss (#564
+> V19).
+
 ## Decision 2 — an explicit pre-generation gate; the pairing stamp does NOT move
 
 **Add a pre-generation opt-in read before `Fill()`. Leave the
 `sourceIsRando`/`sharedRandoSeed`/`sharedRandoSettingsHash` stamp exactly where
 it is, at the end of `Playthrough_Init`.**
+
+> **Amended 2026-07-30 (#564) — restated, not reversed. The amendment block at
+> the end of this section widens the post-condition and adds one ordering
+> constraint; everything below it still holds.**
 
 The tempting move — hoist the stamp above `Fill()`, since `rsbsSettingsHash` is
 already in hand at `playthrough.cpp:71` and `seed` is a parameter — is
@@ -112,6 +195,66 @@ then fails. That is harmless and self-correcting — the placement table lives i
 `gComboCtx`, and `Context_InvalidateSessionState` / `ComboContext_Init` wipe it
 (`context.cpp:208-231`, `:273-310`); a failed generation never reaches the stamp,
 so `Combo_ForeignPairingActive()` stays false and nothing consumes the table.
+
+### Amendment to decision 2 — the post-condition is the whole creation
+
+> **2026-07-30, #564.** The core of this decision is unchanged and still
+> load-bearing: the stamp is a post-condition, and hoisting it above `Fill()`
+> would publish an identity for a world that was never generated. Three things
+> change around it.
+>
+> **The post-condition widens from OoT's fill to the WHOLE creation.** As
+> written, atomicity is scoped to one game's fill: the stamp says "OoT generated
+> successfully", and MM's half is authored later, at first arrival. One game
+> means one identity from one creation event, so identity is the post-condition
+> of *everything* the creation does — both option profiles frozen, both fills,
+> both crossing passes, pair validation, one spoiler — published atomically or
+> not at all (the ordered form is #564's target creation-event contract, steps
+> 1-8). "OoT's fill succeeded" is no longer a sufficient pre-condition for
+> publishing a paired identity, because a paired identity now claims things about
+> a Termina that must already exist.
+>
+> **New ordering constraint: the MM option profile freezes BEFORE OoT's
+> `Fill()`.** Freezing an *input* early is not the hoist this decision forbids,
+> and holding those two acts apart is what lets both rules stand at once — the
+> freeze snapshots what the player chose, the stamp publishes what generation
+> produced. The constraint is not tidiness: reverse-pool criterion 3
+> (`ForeignItemsSingleExe.cpp:139-157`) excludes the enemy/boss souls, the
+> ocarina buttons, `RI_ABILITY_SWIM` and the clock items solely because OoT's
+> placement pass "CANNOT read MM's option profile" — true only while the profile
+> resolves after that pass runs. With one frozen surface read by both directions,
+> criterion 3 becomes a profile-conditional predicate ("admissible when the
+> frozen profile arms its give") rather than a timing accident (#564 V24). It is
+> narrowed, not deleted: the promise it protects — never advertise a crossing in
+> OoT that Termina silently never delivers — is unaffected by the ruling.
+>
+> **The self-correcting consequence narrows to one attempt.** "A reverse pass can
+> run and place items into a world whose fill then fails … harmless and
+> self-correcting" holds *within* a creation attempt and no longer beyond it,
+> because there is no later generation to pick up the pieces: arrival becomes
+> hydrate-or-refuse, with no generation path reachable from it. A creation that
+> cannot produce both halves must therefore fail the creation, visibly, at the
+> file select where the player made the decision — never revert to a vanilla
+> Termina under an active pairing identity (`OnFileCreate.cpp:325`), which is a
+> divergence honoured forever (#564 V7).
+>
+> **A third tense joins the two predicates.** `Requested` (future) and `Active`
+> (past) do not cover the new question the option surfaces have to ask: *is this
+> world's identity already frozen?* (present). #564 V5 prescribes the
+> creation-stamped `mmProfileDigest != 0` as that fact, read from `src/common`
+> and never from a `gSaveContext` (ADR 0008 rule 5, and the pane's
+> game-agnosticism tripwire). The shape, names to be settled by the implementing
+> lane:
+>
+> ```
+> Combo_ForeignPairingRequested()  -- pre-condition, read before Fill()
+> <frozen predicate>               -- identity stamped; gates every authoring surface
+> Combo_ForeignPairingActive()     -- post-condition, read at give time
+> ```
+>
+> Reviewers must not collapse the three. They are three tenses of one noun, and
+> the same "simplify these into one" instinct that decision 2 was written against
+> applies unchanged to the third.
 
 ## Decision 3 — two independent origin-keyed pools; lookup keys on (origin, name)
 
@@ -249,6 +392,25 @@ the profile was rejected for decision 1's reason: the settings are authored in
 CVars, and storing them would be a second settings store that has to be
 re-versioned every time an option is added.
 
+**Claim 3's rationale restated (2026-07-30, #564).** The 4-byte carve is
+unchanged and the table still holds; the *reason* a wider Tier-1 record was
+rejected is not the one given above, which decision 1's amendment retires. Two
+reasons replace it, and both are arithmetic rather than posture:
+
+- **It does not fit.** After claims 1, 3, 5 and 6, `reserved[]` is 132 bytes;
+  claim 2 (4 B) and claim 4 (64 B) land it exactly on the 64-byte floor. A
+  47-option Tier-1 record fits in none of that, and could not be `u8` anyway —
+  `RO_CLOCK_TERMINAL_TIME` ranges to 359 (`OptionsUiSingleExe.cpp:339-342`).
+- **It is already stored, one tier down.** MM's `RANDO_SAVE_OPTIONS` lives in
+  the MM SaveContext the `.redsave` carries as Tier-3, is written once per file,
+  and is what every gameplay path already reads. The frozen record decision 1's
+  amendment calls for therefore costs zero new bytes; the digest stays a
+  cross-check over it, which is exactly the job the amendment gives it.
+
+Nothing here re-opens the floor or the table. It records that "a save-side record
+would be a second settings store" must not be re-used as an argument against
+freezing identity — it is the sentence #564 struck.
+
 Two constraints on anyone spending from this:
 
 - **Keep `reserved[]` at 64 bytes or more.** `Test_SaveComboRecordFixed`'s
@@ -284,3 +446,21 @@ leave nothing for claims 2-4.
   older one reads the new block as all-unset, which is correct.
 - ~~Lane 4 owes a digest size against claim 3 before it carves.~~ Paid: 4 B,
   carved as `ComboContext.mmProfileDigest` at offset 788 (see the budget table).
+
+Added by the 2026-07-30 amendments (#564):
+
+- **The identity terms this ADR names are creation-time state, so
+  `Context_InvalidateSessionState`'s KEEP policy must carry every one of them.**
+  A term stamped at or before file-create that KEEP drops is wiped by the
+  creation itself, which is a hole under any freeze design, not a preference
+  (#564 V9; the policy's contract lives at `src/common/context.h`).
+- **`mmProfileDigest` acquires comparators.** Every arrival and every load
+  recomputes and compares it; the display-only consumers stay, but a
+  display-only digest is no longer the whole of its use, and "digest 0 = not
+  generated yet" must be re-read as "identity not frozen" wherever it is
+  rendered.
+- **A creation-failure surface is owed on the OoT side.** Decision 2's amendment
+  makes "publish or fail" whole-creation, which leaves the silent
+  vanilla-Termina revert with nowhere to live; the refusal surface is shared
+  with #533's refused-load surface rather than invented per producer (#564's
+  one-authority persistence model, REFUSAL).

--- a/docs/adr/0009-combo-settings-and-reverse-pool.md
+++ b/docs/adr/0009-combo-settings-and-reverse-pool.md
@@ -226,7 +226,8 @@ so `Combo_ForeignPairingActive()` stays false and nothing consumes the table.
 > and holding those two acts apart is what lets both rules stand at once — the
 > freeze snapshots what the player chose, the stamp publishes what generation
 > produced. The constraint is not tidiness: reverse-pool criterion 3
-> (`ForeignItemsSingleExe.cpp:139-157`) excludes the enemy/boss souls, the
+> (`ForeignItemsSingleExe.cpp:144-157`; #564 V24 cites `:139-157`, which starts
+> five lines into criterion 2) excludes the enemy/boss souls, the
 > ocarina buttons, `RI_ABILITY_SWIM` and the clock items solely because OoT's
 > placement pass "CANNOT read MM's option profile" — true only while the profile
 > resolves after that pass runs. With one frozen surface read by both directions,

--- a/docs/adr/0009-combo-settings-and-reverse-pool.md
+++ b/docs/adr/0009-combo-settings-and-reverse-pool.md
@@ -110,8 +110,8 @@ this ADR's.
 > own `OnFileCreate` on each arrival, which is the deferred-generation behaviour
 > this amendment retires — it is the counter-example, not the precedent.
 > Rejecting a profile record as a "second store" rejected the wrong thing.
-> *Where* the record
-> lives stays a budget question, answered under claim 3 below: MM's own
+> *Where* the record lives stays a budget question, answered under claim 3
+> below: MM's own
 > `RANDO_SAVE_OPTIONS` in Tier-3 already IS a frozen per-save option record, so
 > the one game gets the storage for free and the digest stays a 4-byte
 > cross-check rather than becoming the storage.

--- a/docs/phase3-lane-prompts.md
+++ b/docs/phase3-lane-prompts.md
@@ -666,6 +666,29 @@ Deliverables:
    `rando` label (the existing three rows assert only generation-succeeds).
    Register in the `rando` pattern (xvfb, TIMEOUT 180, `SDL_AUDIODRIVER=dummy`,
    `RSBS_DISABLE_OTR_INIT=1`). Three verified pitfalls to design around:
+
+   > **CAVEAT ADDED 2026-07-30 (#560, PR #562) — do NOT copy the
+   > `RSBS_DISABLE_OTR_INIT=1` half of that pattern into a new row without
+   > justifying it in the row's own comment.** This brief is where the copying
+   > started. The flag began as a bisect knob for init crashes (#199), reached
+   > this tier as diagnostic scaffolding on the RandoGen row (#339), was
+   > repeated here as "the `rando` pattern", and ended up on 14 rows, none of
+   > which ever justified it independently. It skips the whole
+   > `OTRMessage_Init` / `OTRAudio_Init` / `OTRExtScanner` /
+   > `VanillaItemTable_Init` / `DebugConsole_Init` block
+   > (`games/oot/soh/OTRGlobals.cpp`), so every rando row was generating seeds
+   > with that subsystem masked — which is why CI never saw #560's archive-layer
+   > race. A coverage hole with the shape of a convention.
+   >
+   > At HEAD the flag is no longer load-bearing here: the port archives are now
+   > staged where the ctest rows actually look, so nothing in the block hangs
+   > (the long comment above `RandoGenFullInit` in
+   > `CMake/SingleExecutable.cmake` records the deadlock this masked and how it
+   > was fixed). `RandoGenFullInit` is the reference for a row whose bring-up
+   > matches a player's, and it asserts the un-masking before it generates so it
+   > cannot silently decay into a masked clone. Copy that row for anything that
+   > exercises resource loading; keep the mask only where a row states why it
+   > needs one.
    - **Same seed → same spoiler path** (`Randomizer/<hash>.json`,
      `spoiler_log.cpp:390-395`), so the second run OVERWRITES the first and a naive
      diff compares the file against itself. Snapshot/copy the first JSON (or capture

--- a/docs/phase3-lane-prompts.md
+++ b/docs/phase3-lane-prompts.md
@@ -665,7 +665,7 @@ Deliverables:
    (`extern "C"`, `3drando/menu.cpp:33`) — the first output-equality test in the
    `rando` label (the existing three rows assert only generation-succeeds).
    Register in the `rando` pattern (xvfb, TIMEOUT 180, `SDL_AUDIODRIVER=dummy`,
-   `RSBS_DISABLE_OTR_INIT=1`). Three verified pitfalls to design around:
+   `RSBS_DISABLE_OTR_INIT=1`).
 
    > **CAVEAT ADDED 2026-07-30 (#560, PR #562) — do NOT copy the
    > `RSBS_DISABLE_OTR_INIT=1` half of that pattern into a new row without
@@ -689,6 +689,9 @@ Deliverables:
    > cannot silently decay into a masked clone. Copy that row for anything that
    > exercises resource loading; keep the mask only where a row states why it
    > needs one.
+
+   Three verified pitfalls to design around:
+
    - **Same seed → same spoiler path** (`Randomizer/<hash>.json`,
      `spoiler_log.cpp:390-395`), so the second run OVERWRITES the first and a naive
      diff compares the file against itself. Snapshot/copy the first JSON (or capture

--- a/src/common/context.cpp
+++ b/src/common/context.cpp
@@ -338,11 +338,18 @@ void Context_InvalidateSessionState(ComboSeedStampPolicy seedPolicy) {
     // immediately derives these placements from it (OoT_PlaceForeignItems),
     // both BEFORE the file being created exists. Nothing re-places the
     // reverse table after generation — unlike the FORWARD table
-    // (foreignPlacements), which MM re-authors at its own OnFileCreate on the
-    // next arrival and is therefore deliberately NOT snapshotted (at this
-    // point it can only hold a dead session's rows). Wiping the reverse table
-    // here made #524 inert in every real playthrough: the new file's first
-    // .redsave write then persisted the zeroed table.
+    // (foreignPlacements), which is deliberately NOT snapshotted because at
+    // this point it can only hold a DEAD session's rows, so keeping it would
+    // resurrect them. That is the whole reason. "MM re-authors it at its own
+    // OnFileCreate on the next arrival" used to be given alongside it and is
+    // no longer a reason for anything: it describes the deferred-generation
+    // model #564 retires, in which arrival authors the MM half. Under
+    // one-game semantics arrival becomes hydrate-or-refuse, and when the
+    // creation event authors the forward table too it joins the KEEP set by
+    // the rule in ComboSeedStampPolicy (context.h) rather than by an
+    // exception written here. Wiping the reverse table here made #524 inert
+    // in every real playthrough: the new file's first .redsave write then
+    // persisted the zeroed table.
     ComboForeignPlacement savedPlacementsOoT[RSBS_FOREIGN_PLACEMENT_CAP];
     memcpy(savedPlacementsOoT, gComboCtx.foreignPlacementsOoT, sizeof(savedPlacementsOoT));
 

--- a/src/common/context.h
+++ b/src/common/context.h
@@ -880,13 +880,30 @@ typedef enum {
      */
     RSBS_SEED_STAMP_DROP = 0,
     /**
-     * Keep the stamp AND the reverse placement table (#534) — they were
-     * authored together and are only coherent together. Correct ONLY where
-     * generation has already authored them for the file now being created
-     * (OoT_Sram_InitSave on a randomizer file). The FORWARD table
-     * (foreignPlacements) is dropped even here: MM re-authors it at its own
-     * OnFileCreate on the next arrival, so at file-creation time it can only
-     * hold a dead session's rows.
+     * Keep what the creation event authored for the file now being created:
+     * the stamp, the reverse placement table (#534) — authored together and
+     * only coherent together — and every creation-stamped identity term.
+     * Correct ONLY where generation has already authored them for THIS file
+     * (OoT_Sram_InitSave on a randomizer file).
+     *
+     * THE RULE, NOT THE LIST, IS THE CONTRACT (#564 V9). Under one-game
+     * semantics the paired world's identity is frozen by the creation event,
+     * so any identity term stamped at or before file-create that KEEP does
+     * not carry is wiped by the creation itself — the stamping act destroying
+     * its own output. A new identity field carved into ComboContext must
+     * therefore join this policy's snapshot/restore pair in context.cpp in
+     * the same change that carves it. That pairing is the whole reason this
+     * is an explicit argument rather than a hidden policy.
+     *
+     * The FORWARD table (foreignPlacements) is dropped even here, and the
+     * reason is narrower than it used to read: at file-creation time it can
+     * only hold a DEAD session's rows, so keeping it would resurrect them.
+     * It is NOT dropped because "MM re-authors it at its own OnFileCreate on
+     * the next arrival" — that rationale belongs to the deferred-generation
+     * model #564 retires, in which arrival authors the MM half. Arrival
+     * becomes hydrate-or-refuse with no generation reachable from it; when
+     * the creation event authors the forward table too, it joins the KEEP
+     * set by the rule above rather than by an exception written here.
      */
     RSBS_SEED_STAMP_KEEP = 1,
 } ComboSeedStampPolicy;


### PR DESCRIPTION
Part of #564 (lane E — the doc set). Documentation and comments only; no behaviour changes.

The operator ruling recorded on [#500](https://github.com/spencerduncan/redshipblueship/issues/500#issuecomment-5126492334) — *"freezing at creation is the correct semantics for sure … this is one game from a semantic standpoint"* — leaves three written records saying the opposite of the contract. #564 V25 names two ADRs; the other two are stale invariant comments it flagged. This PR amends all four.

## ADR 0009 — decision 1 amended

`docs/adr/0009-combo-settings-and-reverse-pool.md`

- **A frozen record on the save side is world identity, not a second settings store.** The rejection above only holds while something *authors* in the save; nothing does. Such a record is written once by the creation event and is read-only for the life of the file — the status the *reverse* placement table `foreignPlacementsOoT` already has, and nobody calls that a second item database. (The forward `foreignPlacements` is named as the counter-example, not the precedent: MM re-authors it at every arrival.)
- **CVars keep the authoring surface, with a boundary:** they author the one game's settings *only up to the creation event*. ADR 0003's one-store posture is untouched — it is about authoring.
- **The digest becomes a cross-check, stamped before the act it validates.** `mmProfileDigest` today has one writer, zero comparators, and is produced *by* the resolution it should validate (`Foreign.cpp:149`). Amended: stamped at creation before either half generates, recomputed and compared at every arrival and load; mismatch = refuse.
- **`mmProfileDigest == 0` changes meaning** — from "MM hasn't generated yet" (rendered to the player as normal at `ComboMmOptionsWindow.cpp:80-85`) to "identity not frozen". Written down loudly because a reader carried over unchanged reports corruption as normal.
- **Coverage:** the identity term must span the generator's whole input set — `MMOptionsString()` folds only the 47 registered options, so ExcludedChecks, StartingItems, spoiler policy and the resolved `RO_LOGIC` default sit outside it and a guard built on it would pass while the world diverges (#564 V4).
- **Sequencing:** amend before #498 carves a tier-4 key; no mismatch refusal ships before #533, or every detection converts into data loss (#564 V19).

## ADR 0009 — decision 2 amended, and claim 3's rationale restated

- **Restated, not reversed.** The stamp stays a post-condition and must not be hoisted above `Fill()`. What widens is scope: identity is the post-condition of the WHOLE creation — both profiles frozen, both fills, both crossing passes, pair validation, one spoiler — published atomically or not at all.
- **New ordering constraint:** the MM option profile freezes *before* OoT's `Fill()`. Freezing an input is not hoisting the post-condition, and the distinction is what lets both rules stand. This is what turns reverse-pool criterion 3 (`ForeignItemsSingleExe.cpp:139-157`, "OoT's placement pass … CANNOT read MM's option profile") from a timing accident into a profile-conditional predicate — narrowed, not deleted.
- **"Harmless and self-correcting" narrows to one creation attempt**, because arrival becomes hydrate-or-refuse with no generation reachable from it; a creation that cannot produce both halves must fail visibly rather than revert to a vanilla Termina under an active pairing identity (`OnFileCreate.cpp:325`).
- **A third tense** joins `Requested` (future) and `Active` (past): a *frozen* predicate (present), prescribed by #564 V5 as the creation-stamped `mmProfileDigest != 0`, read from `src/common` and never from a `gSaveContext` (ADR 0008 rule 5).
- **Claim 3's carve and the byte table are unchanged**; only its *rationale* is restated. A wider Tier-1 record is still rejected — because it does not fit (`reserved[132]` minus claims 2 and 4 lands exactly on the 64-byte floor, and `RO_CLOCK_TERMINAL_TIME` ranges to 359 so it cannot be `u8`) and because the record already exists one tier down in `RANDO_SAVE_OPTIONS` — not because it would be a second settings store, which is the sentence #564 struck.

## ADR 0004 — §6 gains a fourth presentation state, §4.1a's deadline restated

`docs/adr/0004-menu-information-architecture.md`

- **State 4: frozen-at-creation** — read-only, labelled with the reason and the identity it is frozen to. Distinct from live, from editable-but-not-active, and from disabled-by-capability; the four are tabulated by what each presentation must deny. §6.2's "(a player should be able to set MM options before switching)" is struck.
- **Scoped:** world-identity keys only. Preference keys (Autosave, RememberSaveLocation — #539's territory) stay live forever; an unclassified key defaults to identity, because guessing "preference" for an identity key is the failure the state exists to prevent.
- **Enforcement is not the widget:** the gate belongs on the `src/common` write choke points the pane merely calls (#564 V5).
- **§4.1a:** the host conclusion survives and gets stronger — "reachable while OoT is the running game, before the switch" restates as **"reachable before the combo file is created"**, a strictly earlier window in which OoT is equally the running game, so ADR 0008's common-owned window is confirmed. The consequence paragraph now says the fourth state applies to that pane and is **not** implemented (owed with the freeze work), rather than claiming §6 is fully implemented.

## Two stale invariant comments

**`src/common/context.h` — `RSBS_SEED_STAMP_KEEP`.** Written to the POST-alignment contract, per the lane brief: KEEP carries the stamp, the reverse table, *and every creation-stamped identity term*, with the **rule** (not the list) as the contract, so a newly carved identity field must join the snapshot/restore pair in the same change that carves it (#564 V9). The forward table's drop keeps its narrow reason (at file-create it can only hold a dead session's rows) and loses the retired one — "MM re-authors it at its own OnFileCreate on the next arrival" is the deferred-generation model the ruling retires.

> **Merge-order note for the shepherd:** this hunk describes the contract as it stands *after* lane A's KEEP additions (#564 phase 0 step 2) land. Sequence this PR after that one *if it exists*. **Reviewer check: at the time of review no lane-A KEEP PR was open** (`gh pr list` showed only this PR and #543), so there is nothing to sequence behind and this PR can merge on its own. That is safe because the hunk is written as a rule plus a correction, not as a claim that `context.cpp` already carries a particular field list — and the rule is *already true at HEAD*: KEEP restores `sourceIsRando` / `sharedRandoSeed` / `sharedRandoSettingsHash` / `foreignPlacementsOoT` (`context.cpp:382-390`), and `mmProfileDigest` is not yet a *creation*-stamped term (it is stamped at arrival, `Foreign.cpp:149`), so "the stamp, the reverse table, and every creation-stamped identity term" describes exactly today's list. Lane A's change extends the list; it does not falsify the sentence.

**`docs/phase3-lane-prompts.md:668` — the `RSBS_DISABLE_OTR_INIT=1` recipe.** That brief is where the copying started: the flag began as a bisect knob (#199), reached the tier as scaffolding on one row (#339), was repeated there as "the `rando` pattern", and ended on 14 rows without one independent justification — which is exactly why CI never saw #560. The caveat records that, points at `RandoGenFullInit` (PR #562) as the reference row whose bring-up matches a player's, and says the mask stays only where a row states why it needs one.

## Verification

Doc/comment-only, so there is no runtime behaviour to lock. **What reverting breaks:** the documentary contract itself. ADR 0009 D1 would again be the newest written record saying a save-side profile record is a rejected "second settings store", ADR 0004 §6 would again mandate that MM options stay editable until the crossing, the KEEP comment would again justify dropping the forward table on the premise that arrival re-authors it, and the lane brief would again instruct new rando rows to mask OTR bring-up. Every one of those is a document a later lane would correctly follow into a violation of the ruling.

- No file touched is on the clang-format allowlist (`.github/clang-format-paths.txt`); `src/common/context.h` is not listed, and the change inside it is a doc comment.
- The `src/common/context.h` hunk makes this a mixed (non-docs-only) PR, so `docs-bypass` steps aside and the real `build-windows` / `build-linux` / `build-macos` / `clang-format` checks run — the change is a comment, so those are the compile proof.
- Local ctest tiers were **not** run for this branch: no compiled behaviour changes, and the workstation disk hit 0 bytes free mid-session (a concurrent heavy build), which made even `git add` fail until space freed. Flagging it because it will affect other lanes on this box.

## Adversarial review pass (commits 3-5)

Every anchor quoted in the amendments was re-read at source by the reviewer rather than trusted from #564 or from the implementer's report. All of them hold exactly: `Foreign.cpp:125` (`Combo_CVarIsExplicitInt` on `RO_LOGIC`), `Foreign.cpp:149` (sole `mmProfileDigest` writer), `Foreign.cpp:74-84` (`MMOptionsString()` loops `StaticData::Options` only), `ComboMmOptionsWindow.cpp:47-49` (the "set them before you cross" copy) and `:80` (digest-0 rendered as the normal state), `OptionsUiSingleExe.cpp:339-342` (`RO_CLOCK_TERMINAL_TIME` min 0 max 359), `OnFileCreate.cpp:325` (`saveType = SAVETYPE_VANILLA`), `ForeignItemsSingleExe.cpp:139-157` (criterion 3's "CANNOT read MM's option profile"), `SohMenuRandomizer.cpp` Generate `PreFunc` (`gameMode != GAMEMODE_FILE_SELECT || IsSaveLoaded()`), ADR 0008 rule 5 (`0008-common-owned-gui-registration.md:63`), and the `reserved[]` arithmetic (the ADR's own table: 132 B after claims 1/3/5/6, minus claim 2's 4 B and claim 4's 64 B = the 64-byte floor exactly). The `phase3-lane-prompts.md` caveat matches the in-tree record it summarises (`CMake/SingleExecutable.cmake:631-680`: #199 `e2a181c1`, #339 `8dc2786d`, "copied verbatim onto 13 more rows" = 14, `RandoGenFullInit` unmasked and asserting the un-masking).

**Counterfactuals re-run independently against `origin/main`,** not taken from the report:

- `git show origin/main:docs/adr/0009-…md | grep "second settings store"` → hit at line 249 — main does reject a save-side record for that reason.
- `git show origin/main:docs/adr/0004-…md | grep "Three states, three"` → hit at line 300 — main does close §6 at three states, with the "before switching" clause live.
- `git show origin/main:docs/phase3-lane-prompts.md`, lines 660-672 → main does instruct new `rando` rows to register with `RSBS_DISABLE_OTR_INIT=1` and nothing there qualifies it.

**One defect found and fixed** (commit 3 in this branch). The header hunk rewrote `RSBS_SEED_STAMP_KEEP` to say that "MM re-authors the forward table at its own OnFileCreate on the next arrival" is *not* the reason `foreignPlacements` is dropped — but the identical sentence still stood 40 lines away, in the snapshot comment inside `Context_InvalidateSessionState` (`context.cpp:340-343`). As pushed, the branch left the header asserting that the `.cpp`'s stated reason belongs to a retired model while the `.cpp` went on stating it: the same "newest written record says the opposite of the ruling" defect this lane exists to remove, reintroduced one file over. The `.cpp` comment now carries the narrowed reason (a dead session's rows would be resurrected), names the retired rationale as retired instead of deleting it silently, and defers to `ComboSeedStampPolicy` for the rule.

**A second defect found and fixed** (commit 4). D1's amendment argued that a frozen save-side record is world identity rather than a second store *by analogy* to a table already written once and read-only for the life of the file — and named `foreignPlacements`. That is the forward table, and at HEAD it is the one table in the pair that is **not** frozen: MM re-authors it at its own `OnFileCreate` on every arrival, which is exactly the deferred-generation behaviour the amendment retires. The analogy named its own counter-example, in the load-bearing sentence of the load-bearing amendment. Re-pointed at the *reverse* table `foreignPlacementsOoT` (#524/#534) — authored by `Playthrough_Init` before the file exists and never re-placed after generation, which is why #534 had to add it to the KEEP snapshot at all — with the forward table now called out explicitly as the counter-example so the substitution cannot be repeated. The "under ADR 0002" citation went with it: ADR 0002 establishes the `ComboContext` growth contract the tables are carved under (verified — it contains no occurrence of "placement"), while claim 1 of this ADR's own budget table is what actually describes the table.

**One reader trap fixed.** ADR 0009's budget constraint "Claim 3's size is a placeholder — Lane 4 must confirm its digest size before carving" was already superseded by the "Claim 3, settled" paragraph above it, and this branch's new "Claim 3's rationale restated" paragraph re-opens the wider-record question two paragraphs earlier — so an unstruck bullet saying the size is unconfirmed now reads as live. Struck with a pointer to both settled paragraphs.

**One rendering fix** (commit 5). The `#560` caveat blockquote had landed between "Three verified pitfalls to design around:" and the three bullets it introduces, so the caveat read as the list. Lead-in moved below the blockquote, blank lines on both sides so the list start cannot be taken as blockquote continuation under any renderer.

**Checked and clean:** branch is 0 commits behind `origin/main` (no stale-evidence rebase needed); five files touched, none a submodule pointer and none a generated stamp (`games/*/src/boot/build.c`, `properties.h`); `git diff --check` clean; no `src/` path appears anywhere in `.github/clang-format-paths.txt`, so neither `context.h` nor `context.cpp` is format-gated. Nothing in the amended text still honours post-creation divergence — §6 item 2's editability is now bounded by "ends at the creation event", D1 bounds CVar authoring at the creation event, and D2's "self-correcting" is bounded to one creation attempt.

**Not re-run locally:** the ROM-staged build and the two ctest tiers. The only compiled file this branch touches is `src/common/context.cpp`, and the only change in it is inside an existing `//` comment block; the PR's own `build-windows` / `build-linux` jobs compile that TU and are the proof. Disk on the workstation recovered to ~14 GB free but a cold build remains contended by another lane's build.

## Second adversarial review pass (commit 6)

An independent reviewer re-read the branch against `origin/main` at `ec510ec6` — every anchor re-derived at source, no claim carried over from #564, from the implementer's report, or from the first review pass. **One defect found and fixed; one citation corrected.** Everything else held.

**Defect: §6 state 4 prescribed the `gSaveContext` read the same amendment forbids.** The state-4 presentation rule said *"where a frozen key's value is shown at all, show the value from the save rather than the CVar"*, which reads as an instruction to the widget. Three paragraphs later, the same amendment says the predicate must be a `src/common` fact and **"never a `gSaveContext` read, per ADR 0008 rule 5"**. Those collide in practice, not just on paper: the only shipped host of these keys is a common-owned window (ADR 0008 rule 5 verified in tree at `0008-common-owned-gui-registration.md:63`), and ADR 0009 D1's amendment in this same PR deliberately places the frozen MM profile in MM's own SaveContext (`RANDO_SAVE_OPTIONS`, Tier-3) — so a pane rendering "the value from the save" directly would break rule 5 in the same breath as obeying §6. A lane implementing state 4 from this text either violates rule 5 or stalls. That is precisely the "a later lane correctly follows the written record into a violation" failure this PR exists to remove, reintroduced inside the fix.

Fixed: *"from the save"* now names the **authority, not the read site**, and the required mechanism is named rather than left to be rediscovered — the frozen value reaches the pane through a `src/common` accessor over `src/common`-owned storage, exactly as `Combo_MMProfileSummary` already surfaces the digest (verified: `combo_mm_options_view.c:155-170` reads `gComboCtx` and nothing else; `ComboMmOptionsWindow.cpp:66` is its only production caller). Publishing the frozen profile into a `src/common` view is therefore called out as part of the freeze work.

**Citation corrected.** D2's amendment cited reverse-pool criterion 3 as `ForeignItemsSingleExe.cpp:139-157`, copied from #564 V24. Criterion 3 actually begins at `:144` (`grep -n "Its give in Rando::GiveItem"` → 144; `"not the reason.)"` → 157); `:139` lands five lines into criterion 2's rupee/junk argument. Re-anchored to `:144-157` with the audit's own anchor noted in-line so the two records reconcile rather than silently disagree.

**Re-verified independently at `origin/main` / branch HEAD (nothing taken on trust):**

- `Foreign.cpp:125` — `Combo_CVarIsExplicitInt(Rando::StaticData::Options[RO_LOGIC].cvar)`, the arrival-time default probe. ✅
- `Foreign.cpp:149` — `gComboCtx.mmProfileDigest = digest;`. A tree-wide grep for `mmProfileDigest` confirms **one production writer and zero production comparators**: every other production site is display (`combo_mm_options_view.c:170`, `combo_tracker_view.c:235`, `ComboMmOptionsWindow.cpp:80,85`, `ComboTrackerWindow.cpp:142`) or a static_assert on the offset. The only comparisons in tree are in tests. ✅
- `MMOptionsString()` loops `Rando::StaticData::Options` only, so ExcludedChecks / StartingItems / spoiler policy really do sit outside the digest — D1's coverage paragraph is not overstated. ✅
- `ComboMmOptionsWindow.cpp:47-49` — "…so set them before you cross." ✅ `:80-85` — digest 0 rendered as "not resolved yet (no MM file generated)" with the comment "Zero is 'unset', not 'broken' … the normal state for a player still in OoT". ✅
- `OnFileCreate.cpp:325` — `gSaveContext.save.shipSaveInfo.saveType = SAVETYPE_VANILLA;` in the catch. ✅
- `OptionsUiSingleExe.cpp:339-342` — `RO_CLOCK_TERMINAL_TIME`, min `0`, max `359`. Cannot be `u8`. ✅
- `SohMenuRandomizer.cpp:605-606` — Generate's `PreFunc` disables on `(gSaveContext.gameMode != GAMEMODE_FILE_SELECT) || GameInteractor::IsSaveLoaded()`. The file-select-only precedent is real. ✅
- Budget arithmetic — ADR's own table: claim 1 is `foreignPlacementsOoT[8]` (so D1's "written once, read-only" analogy does point at the reverse table), and the in-tree claim-6 text already says `reserved[132]` "still clears the 64-byte floor once the outstanding claims 2 and 4 (4 B + 64 B) land". 132 − 4 − 64 = 64 exactly. ✅
- `context.cpp:376-390` — KEEP restores exactly `sourceIsRando` / `sharedRandoSeed` / `sharedRandoSettingsHash` / `foreignPlacementsOoT`, and the forward `foreignPlacements` is not snapshotted. The header's "the stamp, the reverse table, and every creation-stamped identity term" describes today's list exactly, so the hunk is true at HEAD with or without lane A. ✅

**Counterfactuals re-run by this reviewer, not copied:** `git show origin/main:docs/adr/0009-…md | sed -n '55,70p'` prints the "*cannot repair it — … That is accepted*" paragraph; `git show origin/main:docs/adr/0004-…md | sed -n '288,302p'` prints §6 closing at "Three states, three presentations" with "(a player should be able to set MM options before switching)" live; `git show origin/main:docs/phase3-lane-prompts.md | sed -n '663,672p'` prints `RSBS_DISABLE_OTR_INIT=1` registered with no qualification. All three revert targets are real, so the documentary lock is falsifiable.

**Hygiene re-checked at `acc5c9fa`:** branch base is `ec510ec6` = current `origin/main`, 0 behind. Five files, no submodule pointer, no generated stamp. `git diff --check` clean. `grep -c '^src/' .github/clang-format-paths.txt` → `0`, so neither `context.h` nor `context.cpp` is format-gated (and both changes are comments regardless). No markdown linter runs in CI; `link-check.yml` does, and this pass added no links. New prose stays under the files' ~100-col convention.

**Still not honouring post-creation divergence anywhere**, re-checked line by line after the fix: §6 item 2's editability is bounded at the creation event, §6 state 4 is read-only, D1 bounds CVar authoring at the creation event, D2's "self-correcting" is bounded to one creation attempt, and the KEEP comment's retired rationale is named as retired in both `.h` and `.cpp`.

**Out of scope, deliberately, and owed to whoever takes #564 Phase 0 step 4:** the two *overclaiming* comments V12 names are still live at HEAD and have drifted from the audit's anchors — `src/common/context.h:500` (audit said `:366`) still says "MM (Lane C) reads this to VERIFY both games were generated under the agreed pinned profile", and `playthrough.cpp:116-118` still says MM "verif[ies] the pinned settings profile matches". Nothing compares `sharedRandoSettingsHash` anywhere in tree. Those are a different plan item (Phase 0 step 4, which also owes "document OoT's Generate PreFunc as load-bearing for combo identity") and are not in this lane's brief; no lane currently owns them. Clean S-sized follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!--- section:artifacts:start -->
### Build Artifacts
  - [rsbs-windows.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/8782381662.zip)
  - [rsbs-linux.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/8782197211.zip)
<!--- section:artifacts:end -->
