### PR TITLE
Serialize the shared archive handle and the resource cache, and lock the race in-tier (#560)

### DIFF
--- a/CMake/SingleExecutable.cmake
+++ b/CMake/SingleExecutable.cmake
@@ -453,6 +453,22 @@ if(BUILD_TESTING)
         redship_add_test(NAME RelaySuspendLatch COMMAND redship --test relay-suspend-latch)
     endif()
     redship_add_test(NAME ArchiveHotswapLogic COMMAND redship --test archive-hotswap-logic)
+    # #560 archive-handle contention lock: 4 loader threads + 1 hot reader
+    # through the REAL ResourceManager against the soh.o2r that #562 mounts
+    # in-tier, asserting no concurrent cold load ever returns null / init-data
+    # type 0 / bytes differing from a single-threaded read. Deterministic
+    # regression tripwire for the per-archive mutex in the libultraship fork —
+    # on the unfixed archive layer (one shared, unlocked zip_t) it fails within
+    # a few hundred loads. Display-free: the test's own threads are the
+    # concurrency, so it needs no Fast3dWindow and runs in this tier.
+    #
+    # SKIP_RETURN_CODE: the netplay-relay job re-runs this label WITHOUT
+    # archives on purpose (the tier's archive-less control, #562); there the
+    # row self-skips (exit 77) instead of going red. That skip cannot mask a
+    # staging regression — RandoGenFullInit hard-fails on exactly that
+    # condition in the rando tier.
+    redship_add_test(NAME ZipContention COMMAND redship --test zip-contention)
+    set_tests_properties(ZipContention PROPERTIES SKIP_RETURN_CODE 77)
     # Unified save (.redsave) headless tests — Phase 2 T6 (#35)
     redship_add_test(NAME SaveRoundtripTiers COMMAND redship --test save-roundtrip-tiers)
     redship_add_test(NAME SaveHeader COMMAND redship --test save-header)

--- a/src/common/test_runner.cpp
+++ b/src/common/test_runner.cpp
@@ -17,6 +17,14 @@
 
 #include <ship/Context.h>
 #include <ship/resource/ResourceManager.h>
+// For Test_ZipContention's headless factory registration (#560): both games
+// register these only inside their display-bound Initialize paths.
+#include <ship/resource/File.h>
+#include <ship/resource/ResourceLoader.h>
+#include <ship/resource/ResourceType.h>
+#include <ship/resource/factory/BlobFactory.h>
+#include <fast/resource/ResourceType.h>
+#include <fast/resource/factory/TextureFactory.h>
 
 // Shared-context bring-up entries for the boot regression tests (#329/#330).
 // Defined in games/oot/soh/OTRGlobals.cpp and
@@ -279,6 +287,14 @@ extern "C" {
 // included above), proving the budget is wall-clock and can fire before the
 // CTest timeout. No display, no ROM archives, no game loop.
 #include "tests/test_gp_watchdog.c"
+
+// #560 root-cause contention lock over the shared per-archive handle. FILE
+// SCOPE (compiled as C++): it drives the C++-linkage Ship::Context /
+// ResourceManager / ArchiveManager APIs directly. The wrapper
+// (Test_ZipContention below) performs the display-free shared bring-up and the
+// soh.o2r resolvability check (#562) before this body spins its loader
+// threads.
+#include "tests/test_zip_contention.c"
 
 // MM scene-command EXECUTE regression (issue #344). Unlike the parse test, the
 // body runs the parsed commands against a PlayState, so it needs MM's global.h
@@ -1068,6 +1084,79 @@ TestResult Test_BootMM(void) {
     return TEST_PASS;
 }
 
+// #560 root-cause lock: libultraship's O2rArchive reads ONE shared zip_t with
+// no synchronization anywhere (ResourceManager::mMutex guards only the cache
+// map). During menu-triggered seed generation, a resource-pool worker and the
+// render thread zip_fread the same handle concurrently; both reads come back
+// zeroed ("type 0x0, Format 0, Version 0" — the exact logged pair from the
+// field crash), both loads return nullptr, and one unchecked consumer AVs. The
+// fix is a per-archive-object mutex in the libultraship fork; this row is its
+// deterministic regression tripwire. Body in
+// src/common/tests/test_zip_contention.c: 4 loader threads over disjoint cold
+// slices of real soh.o2r entries + 1 hot reader over cached ones, all through
+// the REAL ResourceManager against the archive #562 now mounts in-tier, with a
+// single-threaded calibration pass first so a contention failure can only mean
+// concurrency.
+//
+// Display-free (no Fast3dWindow needed): the loads run on this test's own
+// threads via LoadResourceProcess — the render thread's exact call shape — so
+// concurrency never depends on the resource pool's sizing, and the row runs in
+// the display-free redship tier and inside `--test all`.
+//
+// SKIP (not FAIL) when soh.o2r is unresolvable: the netplay-relay CI job
+// re-runs the redship label archive-less ON PURPOSE, as the tier's
+// archive-less control (#562). This does not reopen the silent-staging hole —
+// the rando-tier RandoGenFullInit row hard-fails on exactly that condition, so
+// a staging regression stays loud there while this row reports an honest CTest
+// "Skipped" (SKIP_RETURN_CODE 77) instead of a false red.
+TestResult Test_ZipContention(void) {
+    printf("[TEST] zip-contention: concurrent cold loads from one o2r return intact resources (#560)\n");
+
+    auto ctx = CreateHarnessStyleContext();
+    if (!ctx) {
+        printf("[TEST] FAIL: could not create Ship::Context singleton\n");
+        return TEST_FAIL;
+    }
+
+    const std::string sohArchive = Ship::Context::LocateFileAcrossAppDirs("soh.o2r");
+    if (!std::filesystem::exists(sohArchive)) {
+        printf("[TEST] SKIP: no soh.o2r resolvable (tried '%s') — the archive-less redship control run keeps "
+               "this row skipped by design; RandoGenFullInit is the loud tripwire for a staging regression "
+               "(#560/#562)\n",
+               sohArchive.c_str());
+        return TEST_SKIP;
+    }
+
+    if (OoT_InitSharedContextSubsystems() != 0) {
+        printf("[TEST] FAIL: shared bring-up reported failure\n");
+        return TEST_FAIL;
+    }
+
+    // Give the calibration pass the factory surface the real bring-up would
+    // have. MM's headless registrar (the same call Test_BootMM makes) brings
+    // the Path/Room/Cutscene per-archive dispatchers and MM's own types; the
+    // Texture/Blob factories below are otherwise registered only inside the
+    // games' display-bound Initialize paths. Texture matters here: the
+    // OTR-format textures in soh.o2r are the largest factory-parseable
+    // entries, and a cold glyph texture load is the render-thread arm of the
+    // #560 race.
+    if (MM_RegisterResourceFactoriesHeadless() != 0) {
+        printf("[TEST] FAIL: MM resource factory registration failed\n");
+        return TEST_FAIL;
+    }
+    auto loader = ctx->GetResourceManager()->GetResourceLoader();
+    loader->RegisterResourceFactory(std::make_shared<Fast::ResourceFactoryBinaryTextureV0>(), RESOURCE_FORMAT_BINARY,
+                                    "Texture", static_cast<uint32_t>(Fast::ResourceType::Texture), 0);
+    loader->RegisterResourceFactory(std::make_shared<Fast::ResourceFactoryBinaryTextureV1>(), RESOURCE_FORMAT_BINARY,
+                                    "Texture", static_cast<uint32_t>(Fast::ResourceType::Texture), 1);
+    loader->RegisterResourceFactory(std::make_shared<Ship::ResourceFactoryBinaryBlobV0>(), RESOURCE_FORMAT_BINARY,
+                                    "Blob", static_cast<uint32_t>(Ship::ResourceType::Blob), 0);
+
+    int rc = ZipContention_RunHeadless();
+    printf("[TEST] %s: zip contention rc=%d\n", rc == 0 ? "PASS" : "FAIL", rc);
+    return rc == 0 ? TEST_PASS : TEST_FAIL;
+}
+
 TestResult Test_SwitchOoTMM(void) {
     printf("[TEST] switch-oot-mm: Test game switch OoT -> MM\n");
 
@@ -1779,6 +1868,10 @@ const TestDescriptor gTests[] = {
      Test_MMOwlSaveArmState},
     {"boot-oot", "Shared-context bring-up leaves no null subsystems (#329)", Test_BootOoT},
     {"boot-mm", "MM-first bring-up prerequisites on the shared context (#330)", Test_BootMM},
+    // #560: the archive-handle contention lock. Display-free — its own threads
+    // ARE the concurrency — so `--test all` runs it; it SKIPs itself when no
+    // soh.o2r is mounted (the netplay-relay archive-less control tier).
+    {"zip-contention", "Concurrent cold o2r loads return intact resources (#560)", Test_ZipContention},
     {"switch-oot-mm", "Test game switch OoT -> MM", Test_SwitchOoTMM},
     {"switch-mm-oot", "Test game switch MM -> OoT", Test_SwitchMMOoT},
     {"midos-house", "Test Mido's House entrance (test mode)", Test_MidosHouse},
@@ -2011,6 +2104,7 @@ int TestRunner_Run(const char* testName) {
     if (strcmp(testName, "all") == 0) {
         int failures = 0;
         int passed = 0;
+        int skipped = 0;
         int total = 0;
 
         for (int i = 0; gTests[i].name != nullptr; i++) {
@@ -2038,19 +2132,30 @@ int TestRunner_Run(const char* testName) {
 
             if (result == TEST_PASS) {
                 passed++;
+            } else if (result == TEST_SKIP) {
+                // Environment-gated (e.g. zip-contention with no archive
+                // mounted): counted and reported, never a failure.
+                skipped++;
             } else if (result == TEST_FAIL || result == TEST_ERROR) {
                 failures++;
             }
         }
 
         printf("\n=== Test Summary ===\n");
-        printf("Total: %d, Passed: %d, Failed: %d\n", total, passed, failures);
+        printf("Total: %d, Passed: %d, Skipped: %d, Failed: %d\n", total, passed, skipped, failures);
 
         return failures;
     }
 
     // Run single test
     TestResult result = RunSingleTest(testName);
+    if (result == TEST_SKIP) {
+        // Rows that can self-skip declare SKIP_RETURN_CODE 77 in
+        // CMake/SingleExecutable.cmake, so ctest reports "Skipped" rather than
+        // a false red (the netplay-relay job re-runs the redship label
+        // archive-less as a control; see Test_ZipContention).
+        return 77;
+    }
     return (result == TEST_PASS) ? 0 : 1;
 }
 

--- a/src/common/tests/test_zip_contention.c
+++ b/src/common/tests/test_zip_contention.c
@@ -1,0 +1,349 @@
+/**
+ * @file test_zip_contention.c
+ * @brief Deterministic concurrent-load contention lock over the shared archive
+ *        handle (#560).
+ *
+ * The #560 field crash: libultraship's archive layer reads ONE shared zip_t per
+ * o2r with no synchronization anywhere (O2rArchive::LoadFile does
+ * zip_name_locate / zip_stat_index / zip_fopen_index / zip_fread / zip_fclose
+ * on it; ResourceManager::mMutex guards only the resource cache map). During
+ * menu-triggered seed generation, a resource-pool worker (scene sub-load in the
+ * fill) and the render thread (direct LoadResourceProcess for a cold glyph
+ * texture) zip_fread the same handle concurrently; libzip documents zip_t as
+ * not thread-safe, both buffers come back zeroed, ReadResourceInitDataBinary
+ * sees ByteOrder/Type/Version = 0, and both loads return nullptr — one
+ * unchecked consumer then AVs. The root fix is a per-archive-object mutex in
+ * the libultraship fork (spencerduncan/libultraship); this lock is the
+ * regression tripwire for it, made possible by #562 mounting soh.o2r where the
+ * ctest rows look.
+ *
+ * Shape — deliberately deterministic rather than probabilistic:
+ *
+ *   1. CALIBRATION (single-threaded): enumerate soh.o2r entries (textures/ and
+ *      objects/ first — the largest, widest-window entries), keep every entry
+ *      whose RAW archive read succeeds at >= 64 bytes, and record its size and
+ *      FNV-1a64 content hash. Each kept entry is also probed once through
+ *      LoadResourceProcess: entries a registered factory parses cleanly are
+ *      flagged `resLoadable` and additionally exercise the factory pipeline
+ *      below. (Most soh.o2r entries are RAW files — .png/.json/shader text —
+ *      with no OTR header, so the RAW read is the universal detector; the
+ *      factory leg mirrors the field crash's exact null/type-0 signature on
+ *      the subset that parses. An entry that cannot load single-threaded is
+ *      excluded from the corresponding assertion, so a contention failure can
+ *      only mean concurrency.)
+ *
+ *   2. CONTENTION: kZcLoaderThreads threads each own a DISJOINT slice of the
+ *      cold entries and tight-loop { raw load + byte-exact size/hash compare
+ *      against calibration; for resLoadable entries also resource load +
+ *      null/type-0 check + unload so the next pass is cold }. One more thread
+ *      re-reads a small HOT set of resLoadable entries through the resource
+ *      cache throughout — the glyph-side access pattern, exercising the cache
+ *      map concurrently with the writers.
+ *
+ * Determinism note: the loader threads call LoadFileProcess /
+ * LoadResourceProcess DIRECTLY (the render thread's call shape in
+ * gfx_set_timg_otr_filepath_handler_custom), so N-way concurrency over the one
+ * zip_t is guaranteed by this test's own threads on every machine — it does
+ * not depend on the resource pool's sizing, which collapses to a single worker
+ * on small CI runners. Through-pool loads execute the identical
+ * LoadResourceProcess body, so the code under contention is the same either
+ * way.
+ *
+ * On the UNFIXED libultraship this fails (or crashes — the harness's headless
+ * crash handler converts that into a fast failure) within the first few
+ * hundred concurrent loads; the pass count is sized well past ten times that
+ * horizon. Stop-on-first-failure keeps the red run short and reports a crisp
+ * loads-to-failure number.
+ *
+ * Env knob: RSBS_ZIP_CONTENTION_PASSES overrides the per-thread pass count
+ * (used for calibration/soak runs; the default is the shipped lock).
+ *
+ * Included at FILE SCOPE by test_runner.cpp (compiled as C++): it drives the
+ * C++-linkage Ship::Context / ResourceManager / ArchiveManager APIs. The
+ * caller (Test_ZipContention) performs the display-free shared bring-up, the
+ * soh.o2r resolvability check, and the factory registration first; with no
+ * archive this body is never reached.
+ */
+
+#include <ship/Context.h>
+#include <ship/resource/File.h>
+#include <ship/resource/Resource.h>
+#include <ship/resource/ResourceManager.h>
+#include <ship/resource/archive/ArchiveManager.h>
+
+#include <algorithm>
+#include <atomic>
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <mutex>
+#include <string>
+#include <thread>
+#include <vector>
+
+namespace {
+
+constexpr int kZcLoaderThreads = 4;
+constexpr int kZcMaxHotEntries = 4;
+constexpr int kZcMaxColdEntries = 48;
+// Minimum RAW-verified entries to stage real contention: at least two cold
+// entries per loader thread. Below that the lock FAILS (loudly): a contention
+// lock that silently degrades to fewer threads than it claims is the vacuity
+// #560 documents.
+constexpr int kZcMinColdEntries = kZcLoaderThreads * 2;
+// Skip near-empty entries: a 4-byte read has no meaningful race window.
+constexpr size_t kZcMinEntryBytes = 64;
+// Per-thread passes over its cold slice. Sized from the measured unfixed
+// failure horizon (see the pointer-bump PR's counterfactual evidence): the
+// unfixed archive layer fails within the first few hundred concurrent cold
+// loads, and this default drives well over ten times that many.
+constexpr int kZcDefaultPasses = 400;
+
+struct ZcEntry {
+    std::string path;
+    size_t size;
+    uint64_t hash;
+    bool resLoadable;
+};
+
+uint64_t ZcFnv1a64(const char* data, size_t len) {
+    uint64_t hash = 0xCBF29CE484222325ull;
+    for (size_t i = 0; i < len; i++) {
+        hash ^= (uint8_t)data[i];
+        hash *= 0x100000001B3ull;
+    }
+    return hash;
+}
+
+int ZcPassCount(void) {
+    const char* env = getenv("RSBS_ZIP_CONTENTION_PASSES");
+    if (env != nullptr && env[0] != '\0') {
+        long parsed = strtol(env, nullptr, 10);
+        if (parsed > 0) {
+            return (int)parsed;
+        }
+    }
+    return kZcDefaultPasses;
+}
+
+} // namespace
+
+extern "C" int ZipContention_RunHeadless(void) {
+    auto ctx = Ship::Context::GetInstance();
+    if (ctx == nullptr || ctx->GetResourceManager() == nullptr ||
+        ctx->GetResourceManager()->GetArchiveManager() == nullptr) {
+        fprintf(stderr, "[zip-contention] FAIL: resource manager not initialized (caller must run the shared "
+                        "bring-up first)\n");
+        return 1;
+    }
+    auto rm = ctx->GetResourceManager();
+    auto am = rm->GetArchiveManager();
+    if (!am->IsLoaded()) {
+        fprintf(stderr, "[zip-contention] FAIL: no archive mounted; the caller's soh.o2r resolvability check "
+                        "should have skipped this body (#562 staging)\n");
+        return 1;
+    }
+
+    // ---- Calibration (single-threaded) ------------------------------------
+    // Candidate order: the big binary namespaces first (widest zip_fread
+    // windows), then everything else, alphabetical within each group so the
+    // verified set is deterministic for a given archive.
+    std::vector<std::string> candidates;
+    for (const char* mask : { "textures/*", "objects/*", "*" }) {
+        auto names = am->ListFiles(mask);
+        if (names == nullptr) {
+            continue;
+        }
+        std::vector<std::string> group(names->begin(), names->end());
+        std::sort(group.begin(), group.end());
+        for (auto& name : group) {
+            if (std::find(candidates.begin(), candidates.end(), name) == candidates.end()) {
+                candidates.push_back(name);
+            }
+        }
+    }
+
+    const int targetEntries = kZcMaxHotEntries + kZcMaxColdEntries;
+    std::vector<ZcEntry> verified;
+    int resLoadableCount = 0;
+    for (const auto& name : candidates) {
+        if ((int)verified.size() >= targetEntries) {
+            break;
+        }
+        auto file = rm->LoadFileProcess(name);
+        if (file == nullptr || file->Buffer == nullptr || file->Buffer->size() < kZcMinEntryBytes) {
+            continue;
+        }
+        // Factory probe. Most soh.o2r entries are raw files with no OTR
+        // header, so a null here is expected and only excludes the entry from
+        // the FACTORY leg — the raw-read leg still hammers and checks it.
+        auto res = rm->LoadResourceProcess(name, /*loadExact*/ true, nullptr);
+        bool resLoadable = res != nullptr && res->GetInitData() != nullptr && res->GetInitData()->Type != 0;
+        rm->UnloadResource(name);
+        if (resLoadable) {
+            resLoadableCount++;
+        }
+        verified.push_back(
+            { name, file->Buffer->size(), ZcFnv1a64(file->Buffer->data(), file->Buffer->size()), resLoadable });
+    }
+
+    // Hot set: the first kZcMaxHotEntries factory-loadable entries, read
+    // through the resource cache by the hot thread. The factory leg going
+    // completely vacuous is a loud failure, not a quiet degradation — it means
+    // the harness's factory surface changed and the null/type-0 arm of this
+    // lock no longer runs.
+    if (resLoadableCount < 1) {
+        fprintf(stderr,
+                "[zip-contention] FAIL: no factory-loadable entries at all (%d raw-verified candidates). The "
+                "factory arm of this lock is vacuous — re-check the factory registrations in "
+                "Test_ZipContention.\n",
+                (int)verified.size());
+        return 1;
+    }
+
+    std::vector<ZcEntry> hot;
+    std::vector<ZcEntry> cold;
+    for (const auto& e : verified) {
+        if ((int)hot.size() < kZcMaxHotEntries && e.resLoadable) {
+            hot.push_back(e);
+        } else {
+            cold.push_back(e);
+        }
+    }
+
+    if ((int)cold.size() < kZcMinColdEntries) {
+        fprintf(stderr,
+                "[zip-contention] FAIL: only %d cold entries survived calibration (need >= %d to stage %d "
+                "loader threads). The lock refuses to run degraded — if the archive shrank this much, "
+                "re-inventory the candidate masks.\n",
+                (int)cold.size(), kZcMinColdEntries, kZcLoaderThreads);
+        return 1;
+    }
+
+    printf("[zip-contention] calibration: %d candidates, %d raw-verified (%d factory-loadable), %d hot + %d "
+           "cold staged\n",
+           (int)candidates.size(), (int)verified.size(), resLoadableCount, (int)hot.size(), (int)cold.size());
+
+    // Warm the hot set into the resource cache.
+    for (const auto& e : hot) {
+        auto res = rm->LoadResourceProcess(e.path, /*loadExact*/ true, nullptr);
+        if (res == nullptr) {
+            fprintf(stderr, "[zip-contention] FAIL: hot warm-up load of '%s' failed single-threaded\n",
+                    e.path.c_str());
+            return 1;
+        }
+    }
+
+    const int passes = ZcPassCount();
+
+    std::atomic<bool> go{ false };
+    std::atomic<bool> stop{ false };
+    std::atomic<long long> coldLoads{ 0 };
+    std::atomic<long long> hotReads{ 0 };
+    std::atomic<long long> failures{ 0 };
+    std::mutex failMutex;
+    std::string firstFailure;
+
+    auto recordFailure = [&](long long loadOrdinal, int pass, const std::string& path, const char* what) {
+        failures.fetch_add(1);
+        {
+            const std::lock_guard<std::mutex> lock(failMutex);
+            if (firstFailure.empty()) {
+                char buf[512];
+                snprintf(buf, sizeof(buf), "cold load #%lld (pass %d, entry '%s'): %s", loadOrdinal, pass,
+                         path.c_str(), what);
+                firstFailure = buf;
+            }
+        }
+        stop.store(true);
+    };
+
+    auto loaderBody = [&](int tid) {
+        while (!go.load()) {
+            std::this_thread::yield();
+        }
+        for (int pass = 0; pass < passes && !stop.load(); pass++) {
+            for (size_t i = tid; i < cold.size() && !stop.load(); i += kZcLoaderThreads) {
+                const ZcEntry& e = cold[i];
+                long long ordinal = coldLoads.fetch_add(1) + 1;
+
+                // Leg (a): the raw archive read — byte-exactness against the
+                // single-threaded calibration hash catches silent corruption,
+                // not just the null/type-0 signature.
+                auto file = rm->LoadFileProcess(e.path);
+                if (file == nullptr || file->Buffer == nullptr) {
+                    recordFailure(ordinal, pass, e.path, "raw file load returned null");
+                    return;
+                }
+                if (file->Buffer->size() != e.size) {
+                    recordFailure(ordinal, pass, e.path, "raw file size differs from single-threaded read");
+                    return;
+                }
+                if (ZcFnv1a64(file->Buffer->data(), file->Buffer->size()) != e.hash) {
+                    recordFailure(ordinal, pass, e.path, "raw file bytes corrupted vs single-threaded read");
+                    return;
+                }
+
+                // Leg (b): the factory pipeline — the exact consumer path the
+                // field crash took (null resource / init data type 0). Only for
+                // entries a registered factory parses cleanly single-threaded.
+                if (e.resLoadable) {
+                    auto res = rm->LoadResourceProcess(e.path, /*loadExact*/ true, nullptr);
+                    if (res == nullptr) {
+                        recordFailure(ordinal, pass, e.path, "resource load returned null (the #560 signature)");
+                        return;
+                    }
+                    if (res->GetInitData() == nullptr || res->GetInitData()->Type == 0) {
+                        recordFailure(ordinal, pass, e.path,
+                                      "resource init data read as type 0 (the #560 signature)");
+                        return;
+                    }
+                    rm->UnloadResource(e.path); // Cold again for the next pass.
+                }
+            }
+        }
+    };
+
+    auto hotBody = [&]() {
+        while (!go.load()) {
+            std::this_thread::yield();
+        }
+        size_t idx = 0;
+        while (!stop.load()) {
+            const ZcEntry& e = hot[idx % hot.size()];
+            idx++;
+            auto res = rm->LoadResourceProcess(e.path, /*loadExact*/ true, nullptr);
+            hotReads.fetch_add(1);
+            if (res == nullptr || res->GetInitData() == nullptr || res->GetInitData()->Type == 0) {
+                recordFailure(-1, -1, e.path, "HOT cached entry read back null/type-0");
+                return;
+            }
+        }
+    };
+
+    std::vector<std::thread> loaders;
+    loaders.reserve(kZcLoaderThreads);
+    for (int t = 0; t < kZcLoaderThreads; t++) {
+        loaders.emplace_back(loaderBody, t);
+    }
+    std::thread hotThread(hotBody);
+
+    go.store(true);
+    for (auto& th : loaders) {
+        th.join();
+    }
+    stop.store(true); // Cold work complete (or failed): release the hot reader.
+    hotThread.join();
+
+    printf("[zip-contention] %d loader threads x %d passes over %d cold entries (+%d hot): %lld cold loads, "
+           "%lld hot reads, %lld failure(s)\n",
+           kZcLoaderThreads, passes, (int)cold.size(), (int)hot.size(), coldLoads.load(), hotReads.load(),
+           failures.load());
+    if (failures.load() != 0) {
+        const std::lock_guard<std::mutex> lock(failMutex);
+        fprintf(stderr, "[zip-contention] FAIL: first failure at %s\n", firstFailure.c_str());
+        return 1;
+    }
+    return 0;
+}


### PR DESCRIPTION
## Mechanism

libultraship's archive layer reads **one shared `zip_t` per o2r with no synchronization anywhere**. `O2rArchive::LoadFile` runs `zip_name_locate` / `zip_stat_index` / `zip_fopen_index` / `zip_fread` / `zip_fclose` on that handle, and `ResourceManager::mMutex` guards only the resource cache map — nothing serializes the handle itself. libzip documents `zip_t` as not thread-safe.

During menu-triggered seed generation two threads reach it at once: a resource-pool worker sub-loading a dungeon scene during the fill (`SetPathwaysFactory`), and the render thread resolving a cold glyph texture through a direct `LoadResourceProcess` while it draws "Generating…" every frame. Both buffers come back zeroed, `ReadResourceInitDataBinary` sees ByteOrder/Type/Version = 0 — the exact logged pair from the field crash, twice, 0ms apart — both loads return `nullptr`, and an unchecked consumer AVs. #561 closed the consumers; this is the root.

## What changes here

**One submodule pointer, one new test row.** No other submodule moves; no generated build stamps.

`libultraship` 3a3e0251 → **8a8b20a** (fork PR: spencerduncan/libultraship#3, left open — not merged):

1. A **per-archive-object `std::mutex`** over every access to the shared archive handle — `O2rArchive`'s `zip_t` (`LoadFile`, `Open`, `Close`, `WriteFile`) and `OtrArchive`'s StormLib handle, which has the same hazard at source. `FolderArchive` opens a fresh stream per read and correctly takes no lock. Lock scope is raw archive I/O only: parsing and factory work still run in parallel on the pool.
2. **Null-guards on the two unchecked S2DEX texture derefs** (`Gfxs2dexBgCopy`, `Gfxs2dexBg1cyc`), in the SETTIMG handlers' style — every other SETTIMG handler checks its `LoadResourceProcess` result; these two called `tex->Flags` unchecked.
3. **The resource-cache races the archive mutex leaves behind** (added during review of 1–2, see below).

Plus `ZipContention` (`--test zip-contention`), a deterministic redship-tier lock: single-threaded calibration first (raw read + FNV-1a64 hash per entry), then 4 loader threads over disjoint cold slices of real `soh.o2r` entries plus one hot reader, all through the real `ResourceManager`, asserting no concurrent load returns null, type-0, or bytes differing from the single-threaded read. Anything that cannot load single-threaded is excluded, so a failure can only mean concurrency.

## Adversarial review of the fork diff

Checked against the hazard rather than the description:

- **Coverage is total.** `git grep -c 'zip_[a-z_]*('` over `src/` + `include/` returns exactly one file (`O2rArchive.cpp`, 19 sites); `SFile[A-Za-z]*(` returns exactly one (`OtrArchive.cpp`, 7 sites). Every site is inside the four methods that now take the archive mutex.
- **No recursive acquisition.** Both `LoadFile(uint64_t)` overloads resolve the hash *before* delegating; `OtrArchive::Open` scopes its lock and releases it before the `(listfile)` `LoadFile` re-acquires.
- **No lock-order inversion is reachable.** The archive mutex is a strict leaf: `ArchiveManager` has no mutex at all, and the only thing called under the archive lock is `Archive::IndexFile`, which touches nothing but the archive's own `mHashes`.
- **Parsing stays parallel.** `LoadResourceProcess` calls the factory only after `LoadFileProcess` has returned and released the lock.
- Side benefit worth naming: this also closes an archive-**hotswap** use-after-free on the o2r side, since `Close()` nulls `mZipArchive` under the same lock `LoadFile` checks it under.

**What the review found that the mutex did not cover**, fixed in the second fork commit (8a8b20a):

- `ResourceManager::LoadResourceProcess` wrote `mResourceCache[identifier] = ResourceLoadError::NotFound` on the failed-load branch **with no lock held**, while every other access to that `unordered_map` takes `mMutex`. Two threads failing a load simultaneously — precisely the observed field condition — is a concurrent insert against another thread's locked `find`: undefined behaviour, not a duplicated cache line. Live regardless of the archive fix, since any two threads probing the same genuinely-missing path reach it.
- `UnloadResource` tested `mResourceCache.contains()` **outside** the lock, same rehash exposure. Not hypothetical here: the new `ZipContention` row's loader threads call `UnloadResource` every pass while the hot thread inserts through `LoadResourceProcess`, so the *previous* pin's green result was green over live UB. Lookup and erase are now one critical section, and the cache line is moved out and destructed after the lock releases — which is what that function's own unused `value` local always claimed to be for, and which removes a latent deadlock when a resource destructor loads another resource.
- `OtrArchive::Open` dereferenced the `(listfile)` result unchecked (the unchecked-sub-load pattern #561 closed across both games), and `OtrArchive::Close` never cleared `mHandle`, so the "archive not open" guard the mutex commit relies on could never fire after an `Unload`.

Reported, not changed (want their own reasoning): `mResourceCache[identifier] = resource` on the *success* path also destructs a pre-existing cache line under `mMutex`, same latent destructor-deadlock shape but not reachable from a failed load; and `OtrArchive` has no destructor-side `Close` at all.

## Counterfactual

Run twice — the implementer's, and again from scratch by the reviewer on a freshly configured worktree (Windows MSVC Release, Ninja, build capped to 4 jobs at low priority).

**RED** — tree at `52e733be`, submodule at the unfixed `3a3e0251`. Every run red, every one by **silent byte corruption**, the mode a null check alone would miss:

| | first failure at cold load | entry |
|---|---|---|
| reviewer run 1 | **#5** | `textures/buttons/CUp.png` |
| reviewer run 2 | **#7** | `textures/buttons/CLeftOutline.png` |
| reviewer run 3 | **#10** | `textures/buttons/AnalogStick.png` |
| reviewer run 4 | **#4** | `textures/buttons/CLeftOutline.png` |
| implementer runs 1–4 | #13, #877, #803, #684 | `nintendo_rogo_static` textures |

All eight: `raw file bytes corrupted vs single-threaded read`. The reviewer's horizons are far tighter because the workstation was under other load — more interleaving, faster detection. Same failure mode either way.

**GREEN** — same tree, only the submodule pointer moved. 3/3 runs complete the full **19,200 cold loads** (4 threads × 400 passes × 12 entries) plus 2.1–2.2M hot cache reads, **0 failures**, 0.36–2.9 s per run. That is 1,920× the worst reviewer red horizon and 21.9× the worst horizon observed anywhere.

Calibration was byte-identical across all runs — 1280 candidates, 52 raw-verified, 5 factory-loadable, 4 hot + 48 cold — so red and green staged the same work and the pin is the only variable.

## Tiers (reviewer's own build, at the pushed pin)

```
ctest -L "^redship$"   100% tests passed out of 66   (14.18 s)   [ZipContention live and passing]
ctest -L "^rando$"     100% tests passed out of 15   (24.81 s)
```

Archive-less control re-verified: with the archives moved aside the row reports `SKIP` (exit 77) and CTest shows `ZipContention (Skipped)` in 0.09 s, so the netplay-relay job stays green by an honest skip. That skip cannot mask a staging regression — `RandoGenFullInit` hard-fails on exactly that condition in the rando tier.

## Known tradeoff

A render-thread cold load can now block behind a pool worker's large archive read, where before it silently corrupted. A brief frame hitch replaces data corruption; the alternative (per-thread handles) is a much larger change. `ZipContention` at 60 s timeout finishes in under 3 s locally, with the tier's `AllTests` row running it a second time and still landing at 1.68 s.

Closes #560. The fork PR (spencerduncan/libultraship#3) is deliberately left open — merge order is the shepherd's call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!--- section:artifacts:start -->
### Build Artifacts
  - [rsbs-windows.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/8783553935.zip)
  - [rsbs-linux.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/8783431989.zip)
<!--- section:artifacts:end -->