### PR TITLE
Re-apply MM's sound mode from the restored save at the arrival (#483)

### DIFF
--- a/games/mm/2s2h/mm_resume_state_test.cpp
+++ b/games/mm/2s2h/mm_resume_state_test.cpp
@@ -47,6 +47,18 @@ void Combo_ClearFrozenState(const char* gameId);
 void Combo_SetStartupEntrance(uint16_t entrance);
 bool Combo_HasStartupEntrance(void);
 void Combo_ClearStartupEntrance(void);
+// games/mm/src/audio/code_8019AF00.c — the derived sound-mode global the
+// arrival must re-apply from the restored save (#483). Not declared in any
+// header; Audio_SetFileSelectSettings (declared in sequence.h, reached through
+// global.h) is its only writer.
+extern s8 sSoundMode;
+// games/mm/src/audio/sequence.c — write cursor into MM_sAudioSeqCmds (declared
+// in sequence.h). Nothing drains the queue in a headless run, so the delta
+// across a call is exactly what that call handed the audio thread. Needed
+// because sSoundMode alone cannot see the second half of the #483 write:
+// Audio_SetFileSelectSettings' default branch leaves sSoundMode untouched but
+// still queues SEQCMD_SET_SOUND_MODE with an unassigned soundMode.
+extern u8 sSeqCmdWritePos;
 }
 
 extern "C" u8* MM_gSystemHeap;
@@ -60,6 +72,45 @@ namespace {
             return 1;                                                     \
         }                                                                 \
     } while (0)
+
+/**
+ * How many seq commands were queued since write cursor `from`.
+ *
+ * This is the half of the sound-mode write sSoundMode cannot report.
+ * Audio_SetFileSelectSettings has no `default` case that assigns soundMode, so
+ * an out-of-range audioSetting leaves sSoundMode standing — indistinguishable
+ * from not calling it at all — while still queueing a command whose payload the
+ * audio thread uses to index sSoundModeList[5]. A DEPTH check is what catches
+ * that, and it is deliberately payload-blind: the queued word is
+ * `... | (soundMode)` on an `s8`, so an unassigned NEGATIVE soundMode
+ * sign-extends over the opcode nibble and an opcode-matched probe would miss
+ * the very command it exists to catch.
+ */
+u8 SeqCmdsQueuedSince(u8 from) {
+    return (u8)(sSeqCmdWritePos - from);
+}
+
+/**
+ * The SoundMode payload of the last SEQCMD_SET_SOUND_MODE queued since write
+ * cursor `from`, or -1 if none was queued. Sound only for in-range values (see
+ * SeqCmdsQueuedSince) — used to check WHICH mode a good call asked for.
+ */
+int LastQueuedSoundModeSince(u8 from) {
+    // Same op/sub-op mask-and-value shape AudioSeq_IsSeqCmdNotQueued uses:
+    // op in bits 31..28, sub-op in bits 11..8, payload in bits 7..0.
+    const u32 kMask = 0xF0000F00;
+    const u32 kSetSoundMode = ((u32)SEQCMD_OP_GLOBAL_CMD << 28) | ((u32)SEQCMD_SUB_OP_GLOBAL_SET_SOUND_MODE << 8);
+    int found = -1;
+
+    for (u8 i = from; i != sSeqCmdWritePos; i++) {
+        u32 cmd = MM_sAudioSeqCmds[i];
+
+        if ((cmd & kMask) == kSetSoundMode) {
+            found = (int)(cmd & 0xFF);
+        }
+    }
+    return found;
+}
 
 } // namespace
 
@@ -113,8 +164,11 @@ extern "C" int MM_ResumeArena_RunHeadless(void) {
 /**
  * mm-startup-restore: MM_Play_ConsumeStartupEntrance must (a) restore the
  * frozen save over a boot-chain wipe, (b) spawn at the startup entrance with
- * cutscene/game-mode state reset, (c) clear the startup slot, and (d) leave
- * a wiped save alone when there is no frozen state (first entry).
+ * cutscene/game-mode state reset, (c) clear the startup slot, (d) leave
+ * a wiped save alone when there is no frozen state (first entry), and (e)
+ * re-apply the sound mode DERIVED from the restored save's
+ * options.audioSetting, which lives outside gSaveContext and so cannot ride
+ * the restore memcpy (#483, audit #482 row M5).
  */
 extern "C" int MM_StartupRestore_RunHeadless(void) {
     printf("[TEST] mm-startup-restore: startup consumption restores the frozen save post-wipe\n");
@@ -126,17 +180,29 @@ extern "C" int MM_StartupRestore_RunHeadless(void) {
     memset(&gSaveContext, kPattern, sizeof(gSaveContext));
     gSaveContext.save.day = 3;
     gSaveContext.save.time = 0x4321;
+    // A NON-DEFAULT sound preference in the frozen save. The 0x5A fill would
+    // otherwise leave audioSetting out of range, which is a separate case
+    // (locked at the end of this function).
+    gSaveContext.options.audioSetting = SAVE_AUDIO_HEADSET;
     ((uint8_t*)&gSaveContext)[sizeof(gSaveContext) - 1] = 0x77;
     Combo_FreezeState("mm", kArrival, &gSaveContext, sizeof(gSaveContext));
 
     // The boot chain's wipe (Setup_InitImpl -> MM_SaveContext_Init).
     memset(&gSaveContext, 0, sizeof(gSaveContext));
 
+    // ...and the boot chain's derived sound mode, taken from the VANILLA
+    // BOOTSTRAP options the wipe just left behind (ConsoleLogo_Destroy ->
+    // MM_Sram_InitSram -> Audio_SetFileSelectSettings, z_sram_NES.c). This
+    // runs BEFORE the restore below — which is the whole bug.
+    Audio_SetFileSelectSettings(gSaveContext.options.audioSetting);
+    RESUME_ASSERT(sSoundMode == SOUNDMODE_STEREO, "bootstrap-derived sound mode not the STEREO default");
+
     // The switch path's pending startup entrance (wildcard tag — visible to
     // MM, same visibility rule the game-scoped setter grants).
     Combo_SetStartupEntrance(kArrival);
 
     // Act: the consumption point in MM_Play_Init.
+    const u8 seqCmdPosBeforeArrival = sSeqCmdWritePos;
     MM_Play_ConsumeStartupEntrance();
 
     // Assert: frozen save is back...
@@ -160,6 +226,30 @@ extern "C" int MM_StartupRestore_RunHeadless(void) {
     RESUME_ASSERT(gSaveContext.magicState == MAGIC_STATE_IDLE, "frozen magicState not reset on MM arrival (#373)");
     RESUME_ASSERT(gSaveContext.forcedSeqId == NA_BGM_GENERAL_SFX, "frozen forcedSeqId not reset on MM arrival (#373)");
     RESUME_ASSERT(gSaveContext.powderKegTimer == 0, "frozen powder-keg timer not cleared on MM arrival (#373)");
+    // ...the sound mode DERIVED from the restored options is live (#483). This
+    // is the assertion the fix exists for: options.audioSetting rides the
+    // restore memcpy, but sSoundMode and the audio thread's copy do not, and
+    // nothing downstream of an arrival re-derives them —
+    // Audio_SetFileSelectSettings is sSoundMode's only writer and its other
+    // call sites are file-select-only. Without the re-apply in
+    // MM_Play_ConsumeStartupEntrance this still reads SOUNDMODE_STEREO, the
+    // bootstrap's value, for the rest of the MM session.
+    RESUME_ASSERT(gSaveContext.options.audioSetting == SAVE_AUDIO_HEADSET,
+                  "frozen options.audioSetting not restored after wipe");
+    RESUME_ASSERT(sSoundMode == SOUNDMODE_HEADSET, "restored options.audioSetting not re-applied to sSoundMode (#483)");
+    // ...and the audio thread was told, not just the CPU-side global: sSoundMode
+    // gates SFX panning/distance on the game thread, the queued command is what
+    // reaches AUDIOCMD_GLOBAL_SET_SOUND_MODE. Both halves or the mode is only
+    // half live.
+    //
+    // Exactly one command, not "at least one": that is what licenses the
+    // out-of-range leg below to assert a queue depth of ZERO. If the consume
+    // ever legitimately queues other audio work, this assertion fails loudly
+    // here instead of quietly making that leg vacuous.
+    RESUME_ASSERT(SeqCmdsQueuedSince(seqCmdPosBeforeArrival) == 1,
+                  "arrival queued something other than exactly one seq command (#483)");
+    RESUME_ASSERT(LastQueuedSoundModeSince(seqCmdPosBeforeArrival) == SOUNDMODE_HEADSET,
+                  "arrival queued no SET_SOUND_MODE for the restored audioSetting (#483)");
     // ...and the slot is consumed.
     RESUME_ASSERT(!Combo_HasStartupEntrance(), "startup entrance not cleared after consumption");
 
@@ -181,11 +271,44 @@ extern "C" int MM_StartupRestore_RunHeadless(void) {
                   "SCT tower-exit intro flag (WEEKEVENTREG_59_04) not pre-set on arrival");
     RESUME_ASSERT(CHECK_WEEKEVENTREG(WEEKEVENTREG_31_04),
                   "Tatl interrupt flag (WEEKEVENTREG_31_04) not pre-set on arrival");
+    // First entry re-derives from the bootstrap options, i.e. the same value
+    // the boot chain already applied — the re-apply is a no-op, never an
+    // invention. (Non-vacuous: the previous leg left sSoundMode at
+    // SOUNDMODE_HEADSET.)
+    RESUME_ASSERT(sSoundMode == SOUNDMODE_STEREO, "first-entry consumption did not track the bootstrap sound mode");
+
+    // Out-of-range guard: a restored blob — unlike the freshly-initialised
+    // options block MM_Sram_InitSram sees — can carry any byte, and
+    // Audio_SetFileSelectSettings has no case for one: its default branch
+    // leaves sSoundMode alone but still runs SEQCMD_SET_SOUND_MODE(soundMode)
+    // with soundMode never assigned, and the audio thread indexes
+    // sSoundModeList[5] (sequence.c) with that payload. So the arrival must
+    // leave the boot chain's mode standing and queue NOTHING.
+    //
+    // The queue-DEPTH observation is what makes this leg falsifiable: sSoundMode
+    // alone cannot fail it, because the default branch does not write
+    // sSoundMode either way. Depth rather than opcode-match — an unassigned
+    // negative soundMode sign-extends over the opcode nibble (SeqCmdsQueuedSince).
+    memset(&gSaveContext, kPattern, sizeof(gSaveContext)); // audioSetting = 0x5A, no valid case
+    Combo_FreezeState("mm", kArrival, &gSaveContext, sizeof(gSaveContext));
+    memset(&gSaveContext, 0, sizeof(gSaveContext));
+    gSaveContext.options.audioSetting = SAVE_AUDIO_MONO;
+    Audio_SetFileSelectSettings(gSaveContext.options.audioSetting);
+    RESUME_ASSERT(sSoundMode == SOUNDMODE_MONO, "bootstrap sound mode not armed for the out-of-range leg");
+    Combo_SetStartupEntrance(kArrival);
+    const u8 seqCmdPosBeforeCorrupt = sSeqCmdWritePos;
+    MM_Play_ConsumeStartupEntrance();
+    RESUME_ASSERT(gSaveContext.options.audioSetting == kPattern,
+                  "out-of-range leg did not actually restore an out-of-range audioSetting");
+    RESUME_ASSERT(sSoundMode == SOUNDMODE_MONO, "out-of-range restored audioSetting was applied anyway (#483)");
+    RESUME_ASSERT(SeqCmdsQueuedSince(seqCmdPosBeforeCorrupt) == 0,
+                  "out-of-range restored audioSetting still queued a seq command (#483)");
 
     // Leave clean global state for later tests.
     Combo_ClearFrozenState("mm");
     Combo_ClearStartupEntrance();
     memset(&gSaveContext, 0, sizeof(gSaveContext));
+    Audio_SetFileSelectSettings(SAVE_AUDIO_STEREO);
 
     printf("[TEST] PASS: mm-startup-restore — restore-then-spawn contract holds\n");
     return 0;

--- a/games/mm/src/code/z_play.c
+++ b/games/mm/src/code/z_play.c
@@ -2352,6 +2352,46 @@ void MM_Play_ConsumeStartupEntrance(void) {
     // values every fresh-boot path uses, z_common_data.c).
     gSaveContext.seqId = NA_BGM_DISABLED;
     gSaveContext.ambienceId = AMBIENCE_ID_DISABLED;
+    // Sound mode is the one DERIVED audio state the restore above cannot carry:
+    // Audio_SetFileSelectSettings writes sSoundMode (code_8019AF00.c) and
+    // queues SEQCMD_SET_SOUND_MODE for the audio thread, and both of those live
+    // OUTSIDE gSaveContext. The boot chain already derived them, at
+    // ConsoleLogo_Destroy -> MM_Sram_InitSram (z_sram_NES.c) — but that runs
+    // BEFORE Combo_ConsumeFrozenState, so it derived them from the VANILLA
+    // BOOTSTRAP options (STEREO), not the player's restored ones. Re-apply from
+    // the save that actually reaches gameplay (#483, audit #482 row M5).
+    //
+    // Not self-healing, despite #483's original framing: Audio_SetFileSelectSettings
+    // is the ONLY writer of sSoundMode in the tree, and the only path to the
+    // audio thread's copy (SEQCMD_SET_SOUND_MODE -> AUDIOCMD_GLOBAL_SET_SOUND_MODE).
+    // Its other two call sites are MM's file-select options menu and the
+    // file-select save enumeration, neither of which a cross-game arrival
+    // passes through — so without this the bootstrap's mode is live for the
+    // whole MM session, not just the arrival frame.
+    //
+    // This deliberately does NOT ride the OnSaveLoad re-dispatch at the end of
+    // this function (#447). That re-dispatch re-arms save-SHAPE-dependent state
+    // (COND_HOOKs conditioned on IS_RANDO, read off
+    // gSaveContext.save.shipSaveInfo.saveType); SaveOptions is not save state —
+    // it sits at SaveContext+0x3F40, outside `Save`, outside the per-file blob
+    // the port serializes, and is a per-install preference rather than world
+    // identity (#564 classifies #483 exactly so). Hanging a global preference
+    // off a file-load event would also newly re-apply audio on every other
+    // OnSaveLoad dispatch (file select, map select, warp point) for no gain.
+    // It belongs here, with the other out-of-save audio globals this
+    // consumption point already re-authors for the arrival.
+    //
+    // Range-checked because a restored blob — unlike the freshly-initialised
+    // options block MM_Sram_InitSram sees — is not guaranteed in range, and
+    // Audio_SetFileSelectSettings' default branch leaves sSoundMode alone but
+    // still falls through to SEQCMD_SET_SOUND_MODE(soundMode) with soundMode
+    // never assigned; the audio thread then indexes sSoundModeList[5]
+    // (games/mm/src/audio/sequence.c) with that payload. Out of range we leave
+    // the boot chain's mode standing and queue nothing, which is exactly
+    // today's behavior on this path.
+    if (gSaveContext.options.audioSetting <= SAVE_AUDIO_SURROUND) {
+        Audio_SetFileSelectSettings(gSaveContext.options.audioSetting);
+    }
     // Neutralize live gameplay state carried in the frozen blob (#373). This is
     // the MM half of the OoT twin at games/oot/src/code/z_play.c
     // ("Per-session runtime state a fresh file-load always authors ... but the

--- a/src/common/test_runner.cpp
+++ b/src/common/test_runner.cpp
@@ -43,7 +43,9 @@ int CosmeticGfxStub_RunHeadless(void);
 //     malloc returned NULL -> memset(NULL) AV).
 // (b) mm-startup-restore — MM_Play_ConsumeStartupEntrance must re-apply the
 //     frozen MM save after the boot chain's SaveContext wipes, then spawn at
-//     the startup entrance with cutscene/game-mode state reset.
+//     the startup entrance with cutscene/game-mode state reset, and re-derive
+//     the sound mode from the restored options (sSoundMode lives outside
+//     gSaveContext, so the restore memcpy cannot carry it — #483).
 // Return 0 on pass, non-zero on fail.
 int MM_ResumeArena_RunHeadless(void);
 int MM_StartupRestore_RunHeadless(void);


### PR DESCRIPTION
Fixes #483. Lane D of the #564 one-game-semantics alignment wave — though #564 itself lists #483 under *Unaffected*: MM's `SaveOptions` is a per-install preference, not world identity. So this is the arrival-rehydration bug it always was (#482 row M5, the last open row), fixed on its own terms.

## The bug

`sSoundMode` (`games/mm/src/audio/code_8019AF00.c:224`) and the audio thread's copy live **outside `gSaveContext`**, so the frozen-save memcpy cannot carry them. On a cross-game arrival the boot chain derives them exactly once:

```
ConsoleLogo_Destroy            (z_title.c:253)
  -> MM_Sram_InitSram          (z_sram_NES.c:2180)
     -> Audio_SetFileSelectSettings(gSaveContext.options.audioSetting)
...
MM_Play_Init
  -> MM_Play_ConsumeStartupEntrance
     -> Combo_ConsumeFrozenState   <-- the player's options arrive HERE
```

The derivation runs **before** the restore, so it reads the vanilla bootstrap options (`SAVE_AUDIO_STEREO`), never the player's.

## #483's "self-healing" framing is wrong at source

The issue filed this as transient — "the arrival scene's audio bring-up re-derives the sound mode". It does not. `Audio_SetFileSelectSettings` is:

- the **only** writer of `sSoundMode` in the tree, and
- the only producer of `SEQCMD_SET_SOUND_MODE`, itself the only producer of `AUDIOCMD_GLOBAL_SET_SOUND_MODE` — so also the only path to the audio thread's copy.

Its other two call sites are the file-select Options submenu (`z_file_nameset_NES.c:779`) and the file-select save enumeration (`z_sram_NES.c:1944`). A cross-game arrival passes through neither. The bootstrap's mode was live for the **whole MM session**.

## Scope: contract now, audible later

Nothing in the combo currently moves `options.audioSetting` off the STEREO default — MM's Options submenu lives on the file select screen and an arrival fast-paths past it (`ConsoleLogo_Main` hands straight to `MM_TitleSetup_Init` when a startup entrance is pending). So today the re-apply re-asserts the value the boot chain already set. What lands is the contract: the arrival stops being the one place a live `options.audioSetting` is silently dropped, which is what the settings-convergence direction (#462, #451's one settings surface) needs, and #482's last open row closes either way.

## Why here and not on the #447 `OnSaveLoad` re-dispatch

The lane brief asked this explicitly. It is not the right home:

- That re-dispatch re-arms **save-shape-dependent** state — `COND_HOOK`s conditioned on `IS_RANDO`, read off `gSaveContext.save.shipSaveInfo.saveType`.
- No `OnSaveLoad` handler derives audio at all. There are exactly four registrations in MM: `Rando.cpp:41` (`OnSaveLoadHandler` → `MiscBehavior`/`ActorBehavior`/`CheckTracker`/`ClockShuffle::OnFileLoad` + `ShipInit::Init("IS_RANDO")`) and three in `SavingEnhancements.cpp` (`:255`, `:284`, `:333`). None touch the audio globals.
- `SaveOptions` is not save state: `SaveContext+0x3F40`, outside `Save`, outside the per-file blob the port serializes.
- Hanging a global preference off a file-load event would newly re-apply audio on every *other* `OnSaveLoad` dispatch (file select, map select, warp point) for no gain.

`MM_Play_ConsumeStartupEntrance` already owns exactly this responsibility for the arrival's other out-of-save audio globals (`seqId`, `ambienceId`, `forcedSeqId`). `sSoundMode` is the same shape and joins them, immediately after them.

## Range check

`Audio_SetFileSelectSettings`' switch has **no `default` case that assigns `soundMode`**, so an out-of-range `audioSetting` leaves `sSoundMode` standing but still runs `SEQCMD_SET_SOUND_MODE(soundMode)` on an uninitialised local — and `AudioSeq_ProcessSeqCmd` then indexes `sSoundModeList[5]` (`sequence.c:33`) with that payload. A restored blob, unlike the freshly-initialised options block `MM_Sram_InitSram` sees, is not guaranteed in range. Out of range we queue nothing and leave the boot chain's mode — exactly today's behavior on this path.

## Lock (ROM-free, `redship` tier)

Extends the existing `mm-startup-restore` row (`games/mm/2s2h/mm_resume_state_test.cpp`), which already drives the real `MM_Play_ConsumeStartupEntrance`:

| leg | arrange | assert |
|---|---|---|
| restored non-default | frozen save with `audioSetting = SAVE_AUDIO_HEADSET`; wipe; derive the bootstrap mode as `ConsoleLogo_Destroy` does (asserted to land on `SOUNDMODE_STEREO`, so nothing below passes vacuously) | `sSoundMode == SOUNDMODE_HEADSET` **and** the consume queued `SET_SOUND_MODE(SOUNDMODE_HEADSET)` for the audio thread |
| first entry | no frozen state, zeroed save | tracks the bootstrap mode (`SOUNDMODE_STEREO`) — re-derives, never invents. Non-vacuous: the previous leg left `HEADSET` live |
| out of range | frozen `audioSetting = 0x5A`, bootstrap `SAVE_AUDIO_MONO` | mode stays `SOUNDMODE_MONO` **and no `SET_SOUND_MODE` was queued** |

The third leg is asserted on the **command queue**, not on `sSoundMode`. That is deliberate: the `default` branch does not write `sSoundMode` either way, so an `sSoundMode`-only assertion there is vacuous — it would still pass with the range check deleted. The queue observation is the only one that fails.

## Verification (local, ROM-staged worktree)

Both tiers green on the final binary:

- `ctest -L "^redship$"` — **65/65 passed** (11.96 s)
- `ctest -L "^rando$"` — **15/15 passed** (27.41 s)
- MSVC/Ninja Release build clean; `clang-format` 14.0.6 `--dry-run -Werror` clean on both enforced files (`games/mm/src/code/z_play.c`, `games/mm/2s2h/mm_resume_state_test.cpp`).

**Both halves of the fix were falsified by rebuild-and-run, not asserted:**

| mutation | result |
|---|---|
| whole re-apply removed (`if (0)`) | `FAIL: restored options.audioSetting not re-applied to sSoundMode (#483)` at `mm_resume_state_test.cpp:239` |
| range guard removed (`if (1)`) | `FAIL: out-of-range restored audioSetting still queued a seq command (#483)` at `mm_resume_state_test.cpp:305` |

Note *which* assertion caught the second one: the queue-depth check, not `sSoundMode`. `sSoundMode` stayed `SOUNDMODE_MONO` in that run, exactly as predicted — which is why the `sSoundMode`-only version of that leg would have been a vacuous lock.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!--- section:artifacts:start -->
### Build Artifacts
  - [rsbs-windows.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/8784455459.zip)
  - [rsbs-linux.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/8784074850.zip)
<!--- section:artifacts:end -->