### PR TITLE
Make a refused .redsave a first-class REFUSED state: quarantine the evidence, latch the slot, surface it (#533)

### DIFF
--- a/CMake/SingleExecutable.cmake
+++ b/CMake/SingleExecutable.cmake
@@ -461,6 +461,18 @@ if(BUILD_TESTING)
     redship_add_test(NAME SaveSizeMismatch COMMAND redship --test save-size-mismatch)
     redship_add_test(NAME SaveLegacySize COMMAND redship --test save-legacy-size)
     redship_add_test(NAME SaveCrcCorrupt COMMAND redship --test save-crc-corrupt)
+    # REFUSED-state locks (#533): a .redsave that fails validation (CRC,
+    # truncation, wrong header.slot, future version) is QUARANTINED (renamed
+    # aside byte-exact with a reason suffix, never overwritten), the refusing
+    # session takes a per-slot write latch so the next autosave cannot destroy
+    # the evidence, file-create quarantines before its first write, and the
+    # slot surface reports ABSENT / VALID / REFUSED as three different facts.
+    # Counterfactual: revert the latch and SaveWriteLatch's direct Save() call
+    # rename-overwrites the corrupt fixture — the exact #533 data loss.
+    redship_add_test(NAME SaveRefusedQuarantine COMMAND redship --test save-refused-quarantine)
+    redship_add_test(NAME SaveWriteLatch COMMAND redship --test save-write-latch)
+    redship_add_test(NAME SaveArmOnCreate COMMAND redship --test save-arm-on-create)
+    redship_add_test(NAME SaveRefusedMeta COMMAND redship --test save-refused-meta)
     # Tier-1 (ComboContext) format headroom — Phase 3 Wave 1. The loader used to
     # demand comboSize == sizeof(ComboContext) exactly, so the moment Lane A
     # widens sharedItems to carry an origin-game tag, every existing .redsave

--- a/games/mm/2s2h/mm_unified_save_test.cpp
+++ b/games/mm/2s2h/mm_unified_save_test.cpp
@@ -89,6 +89,9 @@ extern "C" int MM_UnifiedSaveCapture_RunHeadless(void) {
     std::filesystem::remove_all(dir, ec);
     std::filesystem::create_directories(dir, ec);
     rsbs::SaveManager::Instance().SetSaveDirectory(dir.string());
+    // #533: start from process-start latch state so earlier tests in the same
+    // process cannot have pre-armed the slots this test writes.
+    RsbsSave_ResetSlotSessionState();
 
     Context_InitFrozenStates();
     ComboContext_Init();
@@ -130,6 +133,15 @@ extern "C" int MM_UnifiedSaveCapture_RunHeadless(void) {
     reinterpret_cast<uint8_t*>(&gSaveContext)[TailProbeOffset()] = kTailStamp;
 
     RsbsSave_SetActiveSlot(2);
+    // #533 armed-session latch: an active slot alone is NOT enough — the slot
+    // must have been loaded, created, or erased THIS session, or MM's capture
+    // could destroy a refused slot's evidence.
+    USAVE_ASSERT(MM_Combo_CaptureSaveToUnifiedSlot() == 0,
+                 "capture into a slot this session never loaded/created/erased must be refused (#533 latch)");
+    USAVE_ASSERT(RsbsSave_HasSave(2) == 0, "a latched capture must not have written a slot file");
+    // Establish the slot the way production does (opening an empty slot arms
+    // it for its first write), then the capture must commit.
+    USAVE_ASSERT(RsbsSave_LoadSlot(2) == RSBS_LOAD_ABSENT, "an empty slot must open as ABSENT and arm");
     USAVE_ASSERT(MM_Combo_CaptureSaveToUnifiedSlot() == 1, "capture with an active slot must commit");
     USAVE_ASSERT(gComboCtx.sourceGame == GAME_MM, "an MM-authored save must record sourceGame == GAME_MM");
     USAVE_ASSERT(RsbsSave_HasSave(2) == 1, "capture must have produced a readable slot file");
@@ -163,6 +175,7 @@ extern "C" int MM_UnifiedSaveCapture_RunHeadless(void) {
     Context_ClearAllFrozenStates();
     ComboContext_Init();
     RsbsSave_SetActiveSlot(-1);
+    RsbsSave_ResetSlotSessionState();
     std::filesystem::remove_all(dir, ec);
 
     printf("[TEST] mm-unified-save-capture: PASS\n");

--- a/games/oot/soh/SaveManager.cpp
+++ b/games/oot/soh/SaveManager.cpp
@@ -211,9 +211,17 @@ SaveManager::SaveManager() {
         // somewhere to save.
         Context_InvalidateSessionOnSlotLoad();
         RsbsSave_SetActiveSlot(fileNum);
-        if (RsbsSave_HasSave(fileNum)) {
-            RsbsSave_Load(fileNum);
-        }
+        // ALWAYS attempt the load — no HasSave gate (#533). HasSave is
+        // header-only, so a header-refused file (future version, bad magic,
+        // wrong slot) made the gate report "no save": the load never ran, the
+        // refusal never registered, and the next autosave rename-overwrote
+        // the mostly-intact file — including the only copy of the MM half —
+        // with a blank Tier-1 and an all-zero Tier-3. LoadSlot distinguishes
+        // the three outcomes itself: OK commits and arms the slot for writes,
+        // ABSENT arms it for its first write, REFUSED quarantines the file
+        // aside and latches the slot so no later save can destroy the
+        // evidence.
+        RsbsSave_LoadSlot(fileNum);
     });
 
     GameInteractor::Instance->RegisterGameHook<GameInteractor::OnDeleteFile>([](int32_t fileNum) {

--- a/games/oot/src/code/z_sram.c
+++ b/games/oot/src/code/z_sram.c
@@ -20,6 +20,9 @@ void BossRush_InitSave(void);
 // does not have src/common on its include path (same convention z_play.c uses
 // for the Combo_* entry points). See src/common/context.h for the contract.
 extern void Context_InvalidateSessionOnNewGame(int isRandoFile);
+// #533 armed-session latch: creating a file is one of the three legitimate
+// ways a slot becomes writable this session. See src/common/save.h.
+extern void RsbsSave_ArmSlotOnCreate(int slot);
 
 /**
  *  Initialize new save.
@@ -301,6 +304,16 @@ void OoT_Sram_InitSave(FileChooseContext* fileChooseCtx) {
     // Combo_ForeignPairingActive() reporting a paired world that does not
     // exist).
     Context_InvalidateSessionOnNewGame(isRandoFile);
+
+    // ARM the unified slot for this create (#533). Save_SaveFile() below fires
+    // OnSaveFile -> RsbsSave_Save, and the armed-session latch refuses writes
+    // to any slot this session did not load, create, or erase — this call IS
+    // the "create" event. It also quarantines (renames aside, reason-tagged)
+    // any existing .redsave at this slot that fails validation, so creating a
+    // file over a corrupt unified save preserves the evidence instead of
+    // letting the first autosave rename-overwrite it. Uses gSaveContext.fileNum
+    // because that is exactly the slot Save_SaveFile() will write.
+    RsbsSave_ArmSlotOnCreate(gSaveContext.fileNum);
 
     if (isRandoFile) {
         gSaveContext.ship.quest.id = QUEST_RANDOMIZER;

--- a/src/common/ComboMenuBar.cpp
+++ b/src/common/ComboMenuBar.cpp
@@ -355,10 +355,29 @@ void ComboMenuBar::DrawFileSelect() {
         ImGui::Text("Slot %d", slot + 1);
         ImGui::SameLine();
 
-        if (!meta.exists) {
+        if (meta.state == RSBS_SLOT_REFUSED) {
+            // REFUSED is a first-class state, rendered distinctly from empty
+            // (#533): the file failed validation (or this session already
+            // refused and quarantined it) and writes to the slot are latched.
+            // stderr is not a surface — this is.
+            ImGui::TextColored(ImVec4(0.9f, 0.35f, 0.3f, 1.0f), "[REFUSED: %s]",
+                               rsbs::SaveManager::RefuseReasonLabel(meta.refuseReason));
+            if (meta.hasQuarantine) {
+                ImGui::TextDisabled("Original preserved beside the save (.bak). Writes to this slot are locked;");
+                ImGui::TextDisabled("Delete releases the slot (and discards the preserved file).");
+            } else {
+                ImGui::TextDisabled("File left in place. Writes to this slot are locked; Delete releases it.");
+            }
+        } else if (!meta.exists) {
             ImGui::TextDisabled("[empty]");
-        } else if (!meta.valid) {
-            ImGui::TextDisabled("[invalid header]");
+            if (meta.hasQuarantine) {
+                // A previous session refused + quarantined this slot's file.
+                // The slot itself is empty and usable, but the evidence is
+                // still on disk — say so instead of pretending nothing
+                // happened.
+                ImGui::SameLine();
+                ImGui::TextDisabled("(quarantined backup on disk)");
+            }
         } else {
             // Name: prefer OoT if started, else MM; show both if both are
             // started so a slot with progress in each game is unambiguous.
@@ -390,21 +409,31 @@ void ComboMenuBar::DrawFileSelect() {
             ImGui::TextUnformatted(meta.mmStarted ? "[MM v]" : "[MM _]");
         }
 
-        // Action buttons. Load / Delete are only meaningful when the slot
-        // exists; Save-to-slot is always available so the user can promote
-        // the in-memory state into any slot (it'll create one if missing).
-        if (meta.exists) {
+        // Action buttons. Load is only meaningful for a VALID slot file;
+        // Delete also appears for a REFUSED slot (the explicit erase that
+        // releases the write latch and discards the quarantined evidence) and
+        // whenever evidence alone remains. Save-to-slot is the explicit
+        // user-initiated promote/create action: it arms the slot through the
+        // create seam — which quarantines a failing existing file first — and
+        // is withheld entirely for a REFUSED slot, where the player must
+        // decide (Delete) before the slot can be written again.
+        if (meta.state == RSBS_SLOT_VALID) {
             if (ImGui::Button("Load")) {
-                RsbsSave_Load(slot);
+                RsbsSave_LoadSlot(slot);
             }
             ImGui::SameLine();
+        }
+        if (meta.state != RSBS_SLOT_ABSENT || meta.hasQuarantine) {
             if (ImGui::Button("Delete")) {
                 RsbsSave_DeleteSave(slot);
             }
             ImGui::SameLine();
         }
-        if (ImGui::Button("Save to slot")) {
-            RsbsSave_Save(slot);
+        if (meta.state != RSBS_SLOT_REFUSED) {
+            if (ImGui::Button("Save to slot")) {
+                RsbsSave_ArmSlotOnCreate(slot);
+                RsbsSave_Save(slot);
+            }
         }
 
         ImGui::Separator();

--- a/src/common/ComboMenuBar.cpp
+++ b/src/common/ComboMenuBar.cpp
@@ -417,19 +417,31 @@ void ComboMenuBar::DrawFileSelect() {
         // create seam — which quarantines a failing existing file first — and
         // is withheld entirely for a REFUSED slot, where the player must
         // decide (Delete) before the slot can be written again.
-        if (meta.state == RSBS_SLOT_VALID) {
+        //
+        // The SameLine calls are driven by what still FOLLOWS on the row, not
+        // by what was just drawn: a REFUSED slot's only button is Delete, and
+        // an unconditional trailing SameLine there would pull the Separator up
+        // onto the button row.
+        const bool showLoad = (meta.state == RSBS_SLOT_VALID);
+        const bool showDelete = (meta.state != RSBS_SLOT_ABSENT) || meta.hasQuarantine;
+        const bool showSave = (meta.state != RSBS_SLOT_REFUSED);
+        if (showLoad) {
             if (ImGui::Button("Load")) {
                 RsbsSave_LoadSlot(slot);
             }
-            ImGui::SameLine();
+            if (showDelete || showSave) {
+                ImGui::SameLine();
+            }
         }
-        if (meta.state != RSBS_SLOT_ABSENT || meta.hasQuarantine) {
+        if (showDelete) {
             if (ImGui::Button("Delete")) {
                 RsbsSave_DeleteSave(slot);
             }
-            ImGui::SameLine();
+            if (showSave) {
+                ImGui::SameLine();
+            }
         }
-        if (meta.state != RSBS_SLOT_REFUSED) {
+        if (showSave) {
             if (ImGui::Button("Save to slot")) {
                 RsbsSave_ArmSlotOnCreate(slot);
                 RsbsSave_Save(slot);

--- a/src/common/context.h
+++ b/src/common/context.h
@@ -995,10 +995,15 @@ void Context_InvalidateSessionOnNewGame(int isRandoFile);
  * state", which is the truth.
  *
  * Does NOT arm a frozen blob itself — this is the CLEAR half. The caller's
- * RsbsSave_Load repopulates gComboCtx and both shadows and performs its own
+ * RsbsSave_LoadSlot repopulates gComboCtx and both shadows and performs its own
  * explicit arming step (Context_ArmShadowAsFrozen) for a tier that actually
  * carries data. Ordering matters and is already correct at the call site: the
  * clear runs BEFORE the load, so it never wipes the bytes just read.
+ *
+ * The load is now attempted UNCONDITIONALLY (#533) — there is no HasSave gate
+ * in front of it — so this clear also covers the REFUSED outcome: a slot whose
+ * .redsave fails validation ends up with no resident cross-game state and a
+ * write latch, rather than silently inheriting the previous session's.
  */
 void Context_InvalidateSessionOnSlotLoad(void);
 

--- a/src/common/save.cpp
+++ b/src/common/save.cpp
@@ -68,7 +68,57 @@ bool SaveLogFail(int slot, const char* reason) {
     return false;
 }
 
+// Filename-safe tag for the quarantine rename, so the renamed-aside evidence
+// names its own diagnosis: redship_slot0.redsave.refused-crc.bak.
+const char* RefuseReasonSlug(RsbsRefuseReason reason) {
+    switch (reason) {
+        case RSBS_REFUSE_UNREADABLE:
+            return "unreadable";
+        case RSBS_REFUSE_HEADER:
+            return "header";
+        case RSBS_REFUSE_VERSION:
+            return "version";
+        case RSBS_REFUSE_TIER_SIZE:
+            return "tiersize";
+        case RSBS_REFUSE_WRONG_SLOT:
+            return "wrongslot";
+        case RSBS_REFUSE_TRUNCATED:
+            return "truncated";
+        case RSBS_REFUSE_CRC:
+            return "crc";
+        case RSBS_REFUSE_COMBO_MAGIC:
+            return "combomagic";
+        case RSBS_REFUSE_NONE:
+        default:
+            return "unknown";
+    }
+}
+
 }  // namespace
+
+const char* SaveManager::RefuseReasonLabel(RsbsRefuseReason reason) {
+    switch (reason) {
+        case RSBS_REFUSE_UNREADABLE:
+            return "file unreadable";
+        case RSBS_REFUSE_HEADER:
+            return "not a .redsave (bad header)";
+        case RSBS_REFUSE_VERSION:
+            return "unsupported format version";
+        case RSBS_REFUSE_TIER_SIZE:
+            return "tier larger than this build supports";
+        case RSBS_REFUSE_WRONG_SLOT:
+            return "file claims a different slot";
+        case RSBS_REFUSE_TRUNCATED:
+            return "file truncated";
+        case RSBS_REFUSE_CRC:
+            return "corrupt (CRC mismatch)";
+        case RSBS_REFUSE_COMBO_MAGIC:
+            return "cross-game record damaged";
+        case RSBS_REFUSE_NONE:
+        default:
+            return "";
+    }
+}
 
 SaveManager& SaveManager::Instance() {
     static SaveManager sInstance;
@@ -114,6 +164,20 @@ uint32_t SaveManager::Crc32(const uint8_t* data, size_t len) {
 bool SaveManager::Save(int slot) {
     if (!SlotInRange(slot)) {
         return SaveLogFail(slot, "slot index out of range");
+    }
+
+    // #533 armed-session latch. Writing is legal only after THIS SESSION
+    // successfully loaded, created, or erased the slot. Without this gate, a
+    // session that refused (or simply never looked at) a slot's .redsave could
+    // rename-overwrite the only copy of the player's MM half with a blank
+    // Tier-1 + all-zero Tier-3 — the #533 data-loss conversion this latch
+    // exists to prevent. The refusal-specific message names the evidence.
+    if (!mSlotArmed[slot]) {
+        if (mSlotRefused[slot] != RSBS_REFUSE_NONE) {
+            return SaveLogFail(slot, "write latched: this session REFUSED the slot's .redsave "
+                                     "(evidence quarantined beside it); erase the slot to write");
+        }
+        return SaveLogFail(slot, "write latched: slot was not loaded, created, or erased this session");
     }
 
     // Serialization source = the context-layer shadow copies. Both must be
@@ -188,18 +252,24 @@ bool SaveManager::Save(int slot) {
     return true;
 }
 
-bool SaveManager::DeserializeHeader(std::istream& in, RsbsSaveHeader& outHeader,
-                                    bool verbose) const {
+bool SaveManager::DeserializeHeader(std::istream& in, int expectedSlot, RsbsSaveHeader& outHeader,
+                                    bool verbose, RsbsRefuseReason* outReason) const {
+    RsbsRefuseReason scratch = RSBS_REFUSE_NONE;
+    RsbsRefuseReason& reason = outReason != nullptr ? *outReason : scratch;
+    reason = RSBS_REFUSE_NONE;
+
     RsbsSaveHeader h;
     in.read(reinterpret_cast<char*>(&h), sizeof(h));
     if (!in || in.gcount() != static_cast<std::streamsize>(sizeof(h))) {
         SaveLogReject(verbose, "short header read", static_cast<unsigned long long>(in.gcount()),
                       sizeof(h));
+        reason = RSBS_REFUSE_HEADER;
         return false;
     }
 
     if (std::memcmp(h.magic, RSBS_SAVE_MAGIC, sizeof(h.magic)) != 0) {
         SaveLogReject(verbose, "bad magic (not a .redsave)", 0, 0);
+        reason = RSBS_REFUSE_HEADER;
         return false;
     }
     // A version WINDOW, not an equality test. Bumping RSBS_SAVE_VERSION against
@@ -207,14 +277,27 @@ bool SaveManager::DeserializeHeader(std::istream& in, RsbsSaveHeader& outHeader,
     // save; older versions inside the window are prefix-compatible and load.
     if (h.version < RSBS_SAVE_VERSION_MIN || h.version > RSBS_SAVE_VERSION) {
         SaveLogReject(verbose, "unsupported format version", h.version, RSBS_SAVE_VERSION);
+        reason = RSBS_REFUSE_VERSION;
         return false;
     }
     if (h.endian != RSBS_SAVE_ENDIAN_LE) {
         SaveLogReject(verbose, "wrong byte order", h.endian, RSBS_SAVE_ENDIAN_LE);
+        reason = RSBS_REFUSE_HEADER;
         return false;
     }
     if (h.headerSize != sizeof(RsbsSaveHeader)) {
         SaveLogReject(verbose, "unexpected header size", h.headerSize, sizeof(RsbsSaveHeader));
+        reason = RSBS_REFUSE_HEADER;
+        return false;
+    }
+    // header.slot was stamped at write time but never compared until #533
+    // (V13): a cloud-sync conflict or hand copy of slot 2's file sitting at
+    // slot 0's path would load silently, attaching one pair's identity and MM
+    // world to a different OoT file. Same treatment as a CRC failure: refuse.
+    if (expectedSlot >= 0 && h.slot != static_cast<uint8_t>(expectedSlot)) {
+        SaveLogReject(verbose, "header.slot does not match this slot path", h.slot,
+                      static_cast<unsigned long long>(expectedSlot));
+        reason = RSBS_REFUSE_WRONG_SLOT;
         return false;
     }
     // ALL THREE tiers are size-field-driven. A STORED size smaller than this
@@ -228,14 +311,17 @@ bool SaveManager::DeserializeHeader(std::istream& in, RsbsSaveHeader& outHeader,
     // truncate, because truncating Tier-1 would silently drop cross-game state.
     if (h.comboSize == 0 || h.comboSize > kComboSize) {
         SaveLogReject(verbose, "Tier-1 (ComboContext) size out of range", h.comboSize, kComboSize);
+        reason = RSBS_REFUSE_TIER_SIZE;
         return false;
     }
     if (h.ootSize == 0 || h.ootSize > kOoTSize) {
         SaveLogReject(verbose, "Tier-2 (OoT) size out of range", h.ootSize, kOoTSize);
+        reason = RSBS_REFUSE_TIER_SIZE;
         return false;
     }
     if (h.mmSize == 0 || h.mmSize > kMMSize) {
         SaveLogReject(verbose, "Tier-3 (MM) size out of range", h.mmSize, kMMSize);
+        reason = RSBS_REFUSE_TIER_SIZE;
         return false;
     }
 
@@ -243,21 +329,37 @@ bool SaveManager::DeserializeHeader(std::istream& in, RsbsSaveHeader& outHeader,
     return true;
 }
 
-bool SaveManager::Load(int slot) {
-    if (!SlotInRange(slot)) {
-        return false;
-    }
+struct SaveManager::SlotFileData {
+    RsbsSaveHeader header{};
+    std::vector<uint8_t> comboRecord;
+    std::vector<uint8_t> ootBlob;
+    std::vector<uint8_t> mmBlob;
+};
 
-    std::ifstream in(SlotPath(slot), std::ios::binary);
+SaveManager::SlotReadResult SaveManager::ReadSlotFile(int slot, SlotFileData& out,
+                                                      RsbsRefuseReason& outReason, bool verbose) const {
+    outReason = RSBS_REFUSE_NONE;
+
+    const std::string path = SlotPath(slot);
+    std::ifstream in(path, std::ios::binary);
     if (!in) {
-        std::fprintf(stderr, "[RsbsSave] cannot open slot %d for load\n", slot);
-        return false;
+        std::error_code ec;
+        if (!std::filesystem::exists(path, ec)) {
+            return SlotReadResult::Absent;
+        }
+        // Present but unopenable is NOT absence — treating it as absence is
+        // exactly the #533 collapse this type exists to prevent.
+        if (verbose) {
+            std::fprintf(stderr, "[RsbsSave] slot %d exists but cannot be opened\n", slot);
+        }
+        outReason = RSBS_REFUSE_UNREADABLE;
+        return SlotReadResult::Refused;
     }
 
-    RsbsSaveHeader header;
-    if (!DeserializeHeader(in, header, /*verbose=*/true)) {
-        return false;
+    if (!DeserializeHeader(in, slot, out.header, verbose, &outReason)) {
+        return SlotReadResult::Refused;
     }
+    const RsbsSaveHeader& header = out.header;
 
     // Read the whole payload into locals FIRST and validate everything before
     // committing — a bad file (short read, CRC mismatch, bad inner magic) must
@@ -269,50 +371,138 @@ bool SaveManager::Load(int slot) {
     // struct is copied out of the FRONT of it, so fields appended since the file
     // was written read as zero — exactly the value ComboContext_Init gives them
     // — instead of whatever was on the stack.
-    std::vector<uint8_t> comboRecord(kComboSize, 0);
-    std::vector<uint8_t> ootBlob(kOoTSize, 0);
-    std::vector<uint8_t> mmBlob(kMMSize, 0);
+    out.comboRecord.assign(kComboSize, 0);
+    out.ootBlob.assign(kOoTSize, 0);
+    out.mmBlob.assign(kMMSize, 0);
 
-    in.read(reinterpret_cast<char*>(comboRecord.data()), header.comboSize);
+    in.read(reinterpret_cast<char*>(out.comboRecord.data()), header.comboSize);
     if (!in || in.gcount() != static_cast<std::streamsize>(header.comboSize)) {
-        std::fprintf(stderr, "[RsbsSave] slot %d truncated in Tier-1\n", slot);
-        return false;
+        if (verbose) {
+            std::fprintf(stderr, "[RsbsSave] slot %d truncated in Tier-1\n", slot);
+        }
+        outReason = RSBS_REFUSE_TRUNCATED;
+        return SlotReadResult::Refused;
     }
-    in.read(reinterpret_cast<char*>(ootBlob.data()), header.ootSize);
+    in.read(reinterpret_cast<char*>(out.ootBlob.data()), header.ootSize);
     if (!in || in.gcount() != static_cast<std::streamsize>(header.ootSize)) {
-        std::fprintf(stderr, "[RsbsSave] slot %d truncated in Tier-2 (OoT)\n", slot);
-        return false;
+        if (verbose) {
+            std::fprintf(stderr, "[RsbsSave] slot %d truncated in Tier-2 (OoT)\n", slot);
+        }
+        outReason = RSBS_REFUSE_TRUNCATED;
+        return SlotReadResult::Refused;
     }
-    in.read(reinterpret_cast<char*>(mmBlob.data()), header.mmSize);
+    in.read(reinterpret_cast<char*>(out.mmBlob.data()), header.mmSize);
     if (!in || in.gcount() != static_cast<std::streamsize>(header.mmSize)) {
-        std::fprintf(stderr, "[RsbsSave] slot %d truncated in Tier-3 (MM)\n", slot);
-        return false;
+        if (verbose) {
+            std::fprintf(stderr, "[RsbsSave] slot %d truncated in Tier-3 (MM)\n", slot);
+        }
+        outReason = RSBS_REFUSE_TRUNCATED;
+        return SlotReadResult::Refused;
     }
-
-    ComboContext combo;
-    std::memcpy(&combo, comboRecord.data(), sizeof(ComboContext));
 
     // CRC over Tiers 1..3 exactly as stored (not the zero-extended tails), in
     // the same contiguous order they were written.
     std::vector<uint8_t> payload;
     payload.reserve(header.comboSize + header.ootSize + header.mmSize);
-    payload.insert(payload.end(), comboRecord.begin(), comboRecord.begin() + header.comboSize);
-    payload.insert(payload.end(), ootBlob.begin(), ootBlob.begin() + header.ootSize);
-    payload.insert(payload.end(), mmBlob.begin(), mmBlob.begin() + header.mmSize);
+    payload.insert(payload.end(), out.comboRecord.begin(), out.comboRecord.begin() + header.comboSize);
+    payload.insert(payload.end(), out.ootBlob.begin(), out.ootBlob.begin() + header.ootSize);
+    payload.insert(payload.end(), out.mmBlob.begin(), out.mmBlob.begin() + header.mmSize);
     if (Crc32(payload.data(), payload.size()) != header.crc32) {
-        std::fprintf(stderr, "[RsbsSave] slot %d failed CRC — file is corrupt, load refused\n", slot);
-        return false;
+        if (verbose) {
+            std::fprintf(stderr, "[RsbsSave] slot %d failed CRC — file is corrupt, load refused\n", slot);
+        }
+        outReason = RSBS_REFUSE_CRC;
+        return SlotReadResult::Refused;
     }
 
     // Inner ComboContext magic guards against a structurally-valid file whose
     // Tier-1 contents are not actually a ComboContext.
+    ComboContext combo;
+    std::memcpy(&combo, out.comboRecord.data(), sizeof(ComboContext));
     if (std::memcmp(combo.magic, COMBO_CONTEXT_MAGIC, sizeof(combo.magic)) != 0) {
-        std::fprintf(stderr, "[RsbsSave] slot %d Tier-1 is not a ComboContext, load refused\n", slot);
-        return false;
+        if (verbose) {
+            std::fprintf(stderr, "[RsbsSave] slot %d Tier-1 is not a ComboContext, load refused\n", slot);
+        }
+        outReason = RSBS_REFUSE_COMBO_MAGIC;
+        return SlotReadResult::Refused;
+    }
+
+    return SlotReadResult::Ok;
+}
+
+void SaveManager::QuarantineSlotFile(int slot, RsbsRefuseReason reason) {
+    const std::string path = SlotPath(slot);
+    std::error_code ec;
+    if (!std::filesystem::exists(path, ec)) {
+        return;
+    }
+    // Reason-suffixed, and NEVER overwriting existing evidence: a second
+    // refusal of the same kind dedupes with a numeric suffix instead of
+    // replacing the first quarantined file.
+    const std::string base = path + ".refused-" + RefuseReasonSlug(reason);
+    std::string target = base + ".bak";
+    for (int n = 2; std::filesystem::exists(target, ec); n++) {
+        target = base + "-" + std::to_string(n) + ".bak";
+    }
+    std::filesystem::rename(path, target, ec);
+    if (ec) {
+        // Rename failed (locked file, permissions). The evidence stays IN
+        // PLACE, which is still safe: the caller latches the slot and Save()
+        // refuses to touch an unarmed slot, so nothing overwrites it.
+        std::fprintf(stderr, "[RsbsSave] slot %d quarantine FAILED (%s); refused file left in place\n",
+                     slot, ec.message().c_str());
+        return;
+    }
+    std::fprintf(stderr, "[RsbsSave] slot %d refused file quarantined to '%s'\n", slot, target.c_str());
+}
+
+RsbsLoadOutcome SaveManager::LoadSlot(int slot) {
+    if (!SlotInRange(slot)) {
+        return RSBS_LOAD_REFUSED;
+    }
+
+    SlotFileData data;
+    RsbsRefuseReason reason = RSBS_REFUSE_NONE;
+    const SlotReadResult result = ReadSlotFile(slot, data, reason, /*verbose=*/true);
+
+    if (result == SlotReadResult::Absent) {
+        if (mSlotRefused[slot] != RSBS_REFUSE_NONE) {
+            // Sticky refusal: this session already refused (and quarantined)
+            // this slot's file. The now-empty slot path must NOT quietly
+            // become writable — the refusal stands until the player
+            // explicitly erases the slot or a load actually succeeds.
+            std::fprintf(stderr, "[RsbsSave] slot %d still REFUSED this session (%s); writes stay latched\n",
+                         slot, RefuseReasonLabel(mSlotRefused[slot]));
+            return RSBS_LOAD_REFUSED;
+        }
+        // Opening an empty slot IS the create path: the session legitimately
+        // established the slot and there is nothing on disk to destroy, so
+        // the first write is armed.
+        mSlotArmed[slot] = true;
+        std::fprintf(stderr, "[RsbsSave] slot %d has no .redsave; armed for first write\n", slot);
+        return RSBS_LOAD_ABSENT;
+    }
+
+    if (result == SlotReadResult::Refused) {
+        // REFUSED, first-class (#533): quarantine the evidence aside, record
+        // why, and latch the slot so no later autosave/capture can destroy
+        // what is left. Every refusal path used to fall through to a state
+        // indistinguishable from "no save at all".
+        QuarantineSlotFile(slot, reason);
+        mSlotRefused[slot] = reason;
+        mSlotArmed[slot] = false;
+        std::fprintf(stderr, "[RsbsSave] slot %d REFUSED (%s); slot latched against writes this session\n",
+                     slot, RefuseReasonLabel(reason));
+        return RSBS_LOAD_REFUSED;
     }
 
     // All checks passed — commit. gComboCtx and both shadows are updated.
+    ComboContext combo;
+    std::memcpy(&combo, data.comboRecord.data(), sizeof(ComboContext));
     std::memcpy(&gComboCtx, &combo, sizeof(ComboContext));
+
+    const std::vector<uint8_t>& ootBlob = data.ootBlob;
+    const std::vector<uint8_t>& mmBlob = data.mmBlob;
 
     // The shared-resource watermarks (#525) are RAM-only and describe the
     // PREVIOUS session's live save; the pool we just loaded belongs to a
@@ -359,7 +549,18 @@ bool SaveManager::Load(int slot) {
     const int armed = Context_ArmShadowAsFrozen(GAME_MM, MM_ENTR_SOUTH_CLOCK_TOWN_0);
     std::fprintf(stderr, "[RsbsSave] slot %d loaded; MM half %s\n", slot,
                  armed ? "armed for restore" : "empty (MM will cold-boot)");
-    return true;
+
+    // A successful load is one of the three legitimate arming events, and it
+    // retires any earlier refusal record — if a loadable file is back at the
+    // slot path (say, the player restored the quarantined .bak by hand), the
+    // slot is theirs again.
+    mSlotArmed[slot] = true;
+    mSlotRefused[slot] = RSBS_REFUSE_NONE;
+    return RSBS_LOAD_OK;
+}
+
+bool SaveManager::Load(int slot) {
+    return LoadSlot(slot) == RSBS_LOAD_OK;
 }
 
 bool SaveManager::HasSave(int slot) const {
@@ -371,7 +572,7 @@ bool SaveManager::HasSave(int slot) const {
         return false;
     }
     RsbsSaveHeader header;
-    return DeserializeHeader(in, header, /*verbose=*/false);
+    return DeserializeHeader(in, slot, header, /*verbose=*/false, nullptr);
 }
 
 void SaveManager::DeleteSave(int slot) {
@@ -379,10 +580,119 @@ void SaveManager::DeleteSave(int slot) {
         return;
     }
     std::error_code ec;
-    const std::string path = SlotPath(slot);
+    const std::filesystem::path path = SlotPath(slot);
     std::filesystem::remove(path, ec);
-    std::filesystem::remove(path + ".tmp", ec);
-    std::filesystem::remove(path + ".bak", ec);
+    std::filesystem::remove(path.string() + ".tmp", ec);
+    // Quarantined evidence goes with the slot on an EXPLICIT erase — this is
+    // the sanctioned disposal path (the .bak removal DeleteSave always
+    // promised). Quarantine names carry a reason suffix and a dedupe counter,
+    // so match by prefix instead of hard-coding one name.
+    const std::string prefix = path.filename().string();
+    std::filesystem::directory_iterator it(path.parent_path(), ec);
+    if (!ec) {
+        for (const auto& entry : it) {
+            const std::string name = entry.path().filename().string();
+            if (name.size() > prefix.size() && name.compare(0, prefix.size(), prefix) == 0 &&
+                name.size() >= 4 && name.compare(name.size() - 4, 4, ".bak") == 0) {
+                std::error_code rmEc;
+                std::filesystem::remove(entry.path(), rmEc);
+            }
+        }
+    }
+    // Erasing the slot this session is an explicit player decision: the slot
+    // is legitimately empty and writable, and any refusal record is retired
+    // with the evidence.
+    mSlotArmed[slot] = true;
+    mSlotRefused[slot] = RSBS_REFUSE_NONE;
+}
+
+void SaveManager::ArmSlotOnCreate(int slot) {
+    if (!SlotInRange(slot)) {
+        return;
+    }
+    // Creating a file over a slot whose .redsave fails validation must
+    // preserve the evidence BEFORE the new file's first Save_SaveFile
+    // rename-overwrites it. Full validation (CRC included) — this runs once
+    // per file creation, not per frame.
+    SlotFileData data;
+    RsbsRefuseReason reason = RSBS_REFUSE_NONE;
+    if (ReadSlotFile(slot, data, reason, /*verbose=*/false) == SlotReadResult::Refused) {
+        std::fprintf(stderr, "[RsbsSave] slot %d create: existing .redsave fails validation (%s); quarantining\n",
+                     slot, RefuseReasonLabel(reason));
+        QuarantineSlotFile(slot, reason);
+    }
+    mSlotArmed[slot] = true;
+    mSlotRefused[slot] = RSBS_REFUSE_NONE;
+}
+
+bool SaveManager::IsSlotWritable(int slot) const {
+    return SlotInRange(slot) && mSlotArmed[slot];
+}
+
+RsbsSlotState SaveManager::GetSlotState(int slot) const {
+    if (!SlotInRange(slot)) {
+        return RSBS_SLOT_ABSENT;
+    }
+    // The session's refusal record wins: after a quarantine the slot path is
+    // empty, but the slot is REFUSED, not absent — that distinction is the
+    // whole point (#533).
+    if (mSlotRefused[slot] != RSBS_REFUSE_NONE) {
+        return RSBS_SLOT_REFUSED;
+    }
+    std::ifstream in(SlotPath(slot), std::ios::binary);
+    if (!in) {
+        return RSBS_SLOT_ABSENT;
+    }
+    RsbsSaveHeader header;
+    return DeserializeHeader(in, slot, header, /*verbose=*/false, nullptr) ? RSBS_SLOT_VALID
+                                                                          : RSBS_SLOT_REFUSED;
+}
+
+RsbsRefuseReason SaveManager::GetSlotRefuseReason(int slot) const {
+    if (!SlotInRange(slot)) {
+        return RSBS_REFUSE_NONE;
+    }
+    if (mSlotRefused[slot] != RSBS_REFUSE_NONE) {
+        return mSlotRefused[slot];
+    }
+    // No session record: probe the on-disk header so an in-place failing file
+    // (not yet load-attempted) still names its reason in the panel.
+    std::ifstream in(SlotPath(slot), std::ios::binary);
+    if (!in) {
+        return RSBS_REFUSE_NONE;
+    }
+    RsbsSaveHeader header;
+    RsbsRefuseReason reason = RSBS_REFUSE_NONE;
+    DeserializeHeader(in, slot, header, /*verbose=*/false, &reason);
+    return reason;
+}
+
+bool SaveManager::HasQuarantine(int slot) const {
+    if (!SlotInRange(slot)) {
+        return false;
+    }
+    std::error_code ec;
+    const std::filesystem::path path = SlotPath(slot);
+    const std::string prefix = path.filename().string();
+    std::filesystem::directory_iterator it(path.parent_path(), ec);
+    if (ec) {
+        return false;
+    }
+    for (const auto& entry : it) {
+        const std::string name = entry.path().filename().string();
+        if (name.size() > prefix.size() && name.compare(0, prefix.size(), prefix) == 0 &&
+            name.size() >= 4 && name.compare(name.size() - 4, 4, ".bak") == 0) {
+            return true;
+        }
+    }
+    return false;
+}
+
+void SaveManager::ResetSlotSessionState() {
+    for (int i = 0; i < RSBS_SAVE_MAX_SLOTS; i++) {
+        mSlotArmed[i] = false;
+        mSlotRefused[i] = RSBS_REFUSE_NONE;
+    }
 }
 
 void SaveManager::RegisterGameMeta(GameId game, const RsbsGameMetaDesc* desc) {
@@ -451,9 +761,20 @@ SlotMeta SaveManager::ReadMeta(int slot) const {
     SlotMeta meta{};
     meta.slot = static_cast<uint8_t>(slot < 0 ? 0 : slot);
     meta.lastGame = GAME_NONE;
+    meta.state = RSBS_SLOT_ABSENT;
+    meta.refuseReason = RSBS_REFUSE_NONE;
 
     if (!SlotInRange(slot)) {
         return meta;
+    }
+
+    // Session refusal record + on-disk quarantine evidence. The record wins
+    // over whatever is (or is not) at the slot path: a quarantined slot's
+    // path is empty, but the slot is REFUSED, not "[empty]" (#533).
+    meta.hasQuarantine = HasQuarantine(slot);
+    if (mSlotRefused[slot] != RSBS_REFUSE_NONE) {
+        meta.state = RSBS_SLOT_REFUSED;
+        meta.refuseReason = mSlotRefused[slot];
     }
 
     std::ifstream in(SlotPath(slot), std::ios::binary);
@@ -463,10 +784,20 @@ SlotMeta SaveManager::ReadMeta(int slot) const {
     meta.exists = true;
 
     RsbsSaveHeader header;
-    if (!DeserializeHeader(in, header, /*verbose=*/false)) {
-        return meta;  // exists=true, valid=false
+    RsbsRefuseReason headerReason = RSBS_REFUSE_NONE;
+    if (!DeserializeHeader(in, slot, header, /*verbose=*/false, &headerReason)) {
+        // exists=true, valid=false: a file is present but this build refuses
+        // it. Surface it as REFUSED even before any load attempt.
+        meta.state = RSBS_SLOT_REFUSED;
+        if (meta.refuseReason == RSBS_REFUSE_NONE) {
+            meta.refuseReason = headerReason;
+        }
+        return meta;
     }
     meta.valid = true;
+    if (meta.state != RSBS_SLOT_REFUSED) {
+        meta.state = RSBS_SLOT_VALID;
+    }
     meta.slot = header.slot;
 
     // Read Tier-1 (ComboContext) and the game tiers at their STORED sizes to
@@ -482,6 +813,8 @@ SlotMeta SaveManager::ReadMeta(int slot) const {
     in.read(reinterpret_cast<char*>(comboRecord.data()), header.comboSize);
     if (!in || in.gcount() != static_cast<std::streamsize>(header.comboSize)) {
         meta.valid = false;
+        meta.state = RSBS_SLOT_REFUSED;
+        meta.refuseReason = RSBS_REFUSE_TRUNCATED;
         return meta;
     }
     ComboContext combo;
@@ -494,12 +827,16 @@ SlotMeta SaveManager::ReadMeta(int slot) const {
     in.read(reinterpret_cast<char*>(ootBlob.data()), header.ootSize);
     if (!in || in.gcount() != static_cast<std::streamsize>(header.ootSize)) {
         meta.valid = false;
+        meta.state = RSBS_SLOT_REFUSED;
+        meta.refuseReason = RSBS_REFUSE_TRUNCATED;
         return meta;
     }
     std::vector<uint8_t> mmBlob(header.mmSize);
     in.read(reinterpret_cast<char*>(mmBlob.data()), header.mmSize);
     if (!in || in.gcount() != static_cast<std::streamsize>(header.mmSize)) {
         meta.valid = false;
+        meta.state = RSBS_SLOT_REFUSED;
+        meta.refuseReason = RSBS_REFUSE_TRUNCATED;
         return meta;
     }
 
@@ -529,6 +866,34 @@ int RsbsSave_Save(int slot) {
 
 int RsbsSave_Load(int slot) {
     return rsbs::SaveManager::Instance().Load(slot) ? 1 : 0;
+}
+
+int RsbsSave_LoadSlot(int slot) {
+    return static_cast<int>(rsbs::SaveManager::Instance().LoadSlot(slot));
+}
+
+void RsbsSave_ArmSlotOnCreate(int slot) {
+    rsbs::SaveManager::Instance().ArmSlotOnCreate(slot);
+}
+
+int RsbsSave_IsSlotWritable(int slot) {
+    return rsbs::SaveManager::Instance().IsSlotWritable(slot) ? 1 : 0;
+}
+
+int RsbsSave_GetSlotState(int slot) {
+    return static_cast<int>(rsbs::SaveManager::Instance().GetSlotState(slot));
+}
+
+int RsbsSave_GetSlotRefuseReason(int slot) {
+    return static_cast<int>(rsbs::SaveManager::Instance().GetSlotRefuseReason(slot));
+}
+
+int RsbsSave_HasQuarantine(int slot) {
+    return rsbs::SaveManager::Instance().HasQuarantine(slot) ? 1 : 0;
+}
+
+void RsbsSave_ResetSlotSessionState(void) {
+    rsbs::SaveManager::Instance().ResetSlotSessionState();
 }
 
 int RsbsSave_HasSave(int slot) {

--- a/src/common/save.h
+++ b/src/common/save.h
@@ -55,6 +55,42 @@
 #define RSBS_SAVE_ENDIAN_LE  1
 #define RSBS_SAVE_MAX_SLOTS  3           // matches each game's MaxFiles
 
+// ---- Slot state: ABSENT / VALID / REFUSED are three DIFFERENT facts ---------
+// (#533). A .redsave that fails validation used to leave the session in a state
+// byte-for-byte identical to "this slot has no cross-game state at all"; the
+// next OoT autosave then rename-overwrote the mostly-intact original with a
+// blank Tier-1 and an all-zero Tier-3 — MM's ONLY persistence — unrecoverably.
+// REFUSED is now first-class: the refused file is quarantined (renamed aside,
+// never overwritten in place), the refusing session latches the slot against
+// writes, and the file panel renders REFUSED distinctly from empty.
+typedef enum RsbsSlotState {
+    RSBS_SLOT_ABSENT = 0,   // no slot file (and this session refused nothing)
+    RSBS_SLOT_VALID = 1,    // slot file present, header passes every compat check
+    RSBS_SLOT_REFUSED = 2,  // file failed validation, in place or already quarantined
+} RsbsSlotState;
+
+// Why a load/validation was refused. Doubles as the quarantine filename tag so
+// the renamed-aside evidence names its own diagnosis.
+typedef enum RsbsRefuseReason {
+    RSBS_REFUSE_NONE = 0,
+    RSBS_REFUSE_UNREADABLE,   // file exists but cannot be opened/read
+    RSBS_REFUSE_HEADER,       // short header / bad magic / endianness / headerSize
+    RSBS_REFUSE_VERSION,      // outside [RSBS_SAVE_VERSION_MIN, RSBS_SAVE_VERSION]
+    RSBS_REFUSE_TIER_SIZE,    // a stored tier size exceeds this build's capacity
+    RSBS_REFUSE_WRONG_SLOT,   // header.slot != the slot this path belongs to
+    RSBS_REFUSE_TRUNCATED,    // a tier read came up short
+    RSBS_REFUSE_CRC,          // payload CRC mismatch
+    RSBS_REFUSE_COMBO_MAGIC,  // Tier-1 bytes are not a ComboContext
+} RsbsRefuseReason;
+
+// What a load attempt actually did — richer than the old bool, because ABSENT
+// and REFUSED must never collapse into one "false" again.
+typedef enum RsbsLoadOutcome {
+    RSBS_LOAD_OK = 0,       // loaded and committed; slot armed for writes
+    RSBS_LOAD_ABSENT = 1,   // no slot file; nothing loaded; slot armed (safe to create)
+    RSBS_LOAD_REFUSED = 2,  // validation failed; evidence quarantined; writes latched
+} RsbsLoadOutcome;
+
 // ---- C-visible per-game metadata-offset descriptor ------------------------
 // Registered by each game's TU (which alone knows its SaveContext layout) so
 // that save.cpp can read player-name / play-time / "valid" marker bytes from a
@@ -97,6 +133,16 @@ struct SlotMeta {
     uint32_t mmPlayTime;   // raw u32 at the registered MM play-time offset
     bool     ootStarted;   // OoT validMarker bytes match (file has been started)
     bool     mmStarted;    // MM  validMarker bytes match
+
+    // #533: REFUSED distinct from ABSENT. `state` folds together what is on
+    // disk right now AND what this session refused (a quarantined slot's file
+    // is gone from the slot path, but the slot is REFUSED, not empty).
+    // `refuseReason` names the failing check; `hasQuarantine` reports whether
+    // renamed-aside evidence (*.bak) sits next to the slot path, which
+    // survives process restarts even after `state` degrades to ABSENT.
+    RsbsSlotState    state;
+    RsbsRefuseReason refuseReason;
+    bool             hasQuarantine;
 };
 
 #pragma pack(push, 1)
@@ -130,10 +176,76 @@ class SaveManager {
 public:
     static SaveManager& Instance();
 
+    /**
+     * Write the resident cross-game state into `slot` — IF the armed-session
+     * latch allows it (#533). A slot is writable only after this session
+     * successfully loaded, created, or erased it; anything else refuses, so a
+     * session that REFUSED a slot's .redsave can never rename-overwrite the
+     * evidence with a blank Tier-1 + all-zero Tier-3.
+     */
     bool Save(int slot);
+
+    /**
+     * Full-validation load. RSBS_LOAD_OK commits and arms the slot;
+     * RSBS_LOAD_ABSENT arms the slot for its first write (opening an empty
+     * slot IS the create path); RSBS_LOAD_REFUSED quarantines the failing file
+     * (renamed aside with a reason suffix, never overwritten in place) and
+     * latches the slot against writes for the rest of the session. A refusal
+     * is sticky: re-opening the now-empty slot path stays REFUSED until the
+     * player explicitly erases the slot or a load actually succeeds.
+     */
+    RsbsLoadOutcome LoadSlot(int slot);
+
+    /** Compatibility wrapper: LoadSlot(slot) == RSBS_LOAD_OK. */
     bool Load(int slot);
+
     bool HasSave(int slot) const;
+
+    /**
+     * Explicit player-initiated erase: removes the slot file, its temp file,
+     * and any quarantined evidence, then ARMS the slot (erasing it this
+     * session is one of the three legitimate ways to make it writable) and
+     * clears any refusal record.
+     */
     void DeleteSave(int slot);
+
+    /**
+     * The file-create seam's arming call (#533): OoT's Sram_InitSave runs this
+     * for the slot the new file occupies, BEFORE its first Save_SaveFile fires
+     * the OnSaveFile -> RsbsSave_Save chain. If a slot file exists but fails
+     * validation, it is quarantined FIRST — creating a file over a corrupt
+     * .redsave must preserve the evidence, not rename-overwrite it — then the
+     * slot is armed and any refusal record cleared.
+     */
+    void ArmSlotOnCreate(int slot);
+
+    /** Armed-session latch state: true iff Save(slot) would be allowed to write. */
+    bool IsSlotWritable(int slot) const;
+
+    /**
+     * ABSENT / VALID / REFUSED for the slot, combining the on-disk file (header
+     * compat checks only — no CRC, this is called per-frame) with this
+     * session's refusal record, which wins: a quarantined slot reads REFUSED
+     * even though its slot path is now empty.
+     */
+    RsbsSlotState GetSlotState(int slot) const;
+
+    /** Why the slot is REFUSED (RSBS_REFUSE_NONE when it is not). */
+    RsbsRefuseReason GetSlotRefuseReason(int slot) const;
+
+    /** True iff renamed-aside quarantine evidence (*.bak) exists for the slot. */
+    bool HasQuarantine(int slot) const;
+
+    /**
+     * Restore process-start latch state: all slots unarmed, no refusal records.
+     * Headless tests use this to simulate a fresh session; production code has
+     * no business calling it (the latch deliberately survives session
+     * invalidation — it is a fact about the PROCESS, not about a session).
+     */
+    void ResetSlotSessionState();
+
+    /** Human-readable label for a refuse reason (for the file panel). */
+    static const char* RefuseReasonLabel(RsbsRefuseReason reason);
 
     /**
      * Read a cheap summary of `slot` (header + name/playtime bytes from each
@@ -191,23 +303,52 @@ public:
 private:
     SaveManager() = default;
 
-    // Validates magic / version / endian / headerSize and that all three
-    // stored tier sizes fit this build's capacities. Stored sizes may be
+    // Everything ReadSlotFile stages before any commit decision is made.
+    struct SlotFileData;
+
+    enum class SlotReadResult { Absent, Ok, Refused };
+
+    // Validates magic / version / endian / headerSize / slot and that all
+    // three stored tier sizes fit this build's capacities. Stored sizes may be
     // SMALLER (older builds wrote shorter tiers; Load zero-extends) but never
     // larger. Returns true and fills outHeader only on a fully valid header;
-    // never mutates live state.
+    // never mutates live state. `expectedSlot` >= 0 additionally requires
+    // header.slot to match — a cloud-synced or hand-copied file that claims a
+    // different slot must not silently attach one pair's identity + MM world
+    // to another OoT file (#533 / V13).
     //
     // `verbose` gates the rejection logging. Load() passes true — a user-
     // initiated load that silently does nothing is the failure mode this whole
     // path exists to prevent. HasSave/ReadMeta pass false: ReadMeta runs for
     // every slot on every file-select frame, so logging there would be a
     // per-frame spam loop, not a diagnostic.
-    bool DeserializeHeader(std::istream& in, RsbsSaveHeader& outHeader, bool verbose) const;
+    bool DeserializeHeader(std::istream& in, int expectedSlot, RsbsSaveHeader& outHeader, bool verbose,
+                           RsbsRefuseReason* outReason) const;
+
+    // Reads + FULLY validates (header, slot, tier reads, CRC, inner magic) the
+    // slot file into `out` without touching live state. The one validator both
+    // LoadSlot and the create-seam probe share, so "what counts as refused"
+    // cannot fork between them.
+    SlotReadResult ReadSlotFile(int slot, SlotFileData& out, RsbsRefuseReason& outReason, bool verbose) const;
+
+    // Renames the slot file aside as `<slot>.refused-<reason>[-N].bak`,
+    // never overwriting an existing quarantine file (dedupe suffix). On rename
+    // failure the file stays in place — still safe, because the caller latches
+    // the slot and Save() then refuses to touch it.
+    void QuarantineSlotFile(int slot, RsbsRefuseReason reason);
 
     std::string mSaveDir = "Save";
 
     // -1 == no slot established this session. See SetActiveSlot.
     int mActiveSlot = -1;
+
+    // #533 armed-session latch. A slot becomes writable ONLY via this
+    // session's own successful Load, an explicit erase, or the file-create
+    // seam — never by default. Deliberately NOT reset by session
+    // invalidation: "this process successfully established slot N" stays true
+    // across in-process session changes, while a refusal stays sticky.
+    bool             mSlotArmed[RSBS_SAVE_MAX_SLOTS]{};
+    RsbsRefuseReason mSlotRefused[RSBS_SAVE_MAX_SLOTS]{};
 
     // Game-side metadata descriptors, indexed by GameId (GAME_OOT / GAME_MM).
     // mMetaPresent[i] guards mMetaDescs[i]; an unset descriptor causes
@@ -229,6 +370,22 @@ int  RsbsSave_Save(int slot);
 int  RsbsSave_Load(int slot);
 int  RsbsSave_HasSave(int slot);
 void RsbsSave_DeleteSave(int slot);
+
+/**
+ * #533 REFUSED-state surface. LoadSlot is RsbsSave_Load with the three-way
+ * outcome preserved (returns RsbsLoadOutcome); ArmSlotOnCreate is the
+ * file-create seam's arming call (quarantines a failing existing file first);
+ * GetSlotState / GetSlotRefuseReason / HasQuarantine feed the file panel;
+ * IsSlotWritable reports the armed-session latch. ResetSlotSessionState
+ * restores process-start latch state and exists for the headless tests.
+ */
+int  RsbsSave_LoadSlot(int slot);
+void RsbsSave_ArmSlotOnCreate(int slot);
+int  RsbsSave_IsSlotWritable(int slot);
+int  RsbsSave_GetSlotState(int slot);
+int  RsbsSave_GetSlotRefuseReason(int slot);
+int  RsbsSave_HasQuarantine(int slot);
+void RsbsSave_ResetSlotSessionState(void);
 
 /**
  * Session-scoped "which slot is open" (see SaveManager::SetActiveSlot).

--- a/src/common/test_runner.cpp
+++ b/src/common/test_runner.cpp
@@ -177,6 +177,12 @@ extern "C" {
 // FILE SCOPE (compiled as C++): they drive the C++-linkage rsbs::SaveManager.
 #include "tests/test_save_roundtrip.c"
 
+// REFUSED-state locks (#533): refusal quarantines the evidence (renamed aside,
+// reason-tagged, never overwritten), the refusing session latches the slot
+// against writes, and ABSENT / VALID / REFUSED surface as three different
+// facts. FILE SCOPE (compiled as C++) for rsbs::SaveManager.
+#include "tests/test_save_refusal.c"
+
 // Lane C1 foreign-item pipeline locks (#392, ADR 0002): give-path tagging,
 // round-trip survival with a real pool entry, and the foreignPlacements carve
 // serialization. FILE SCOPE (compiled as C++) for rsbs::SaveManager; the
@@ -1888,6 +1894,14 @@ const TestDescriptor gTests[] = {
     {"save-size-mismatch", "Unified save Load rejects oversized tier, no clobber (#35)", Test_SaveSizeMismatch},
     {"save-legacy-size", "Unified save Load zero-extends shorter legacy tiers (#35)", Test_SaveLegacySize},
     {"save-crc-corrupt", "Unified save Load rejects corrupt payload, no clobber (#35)", Test_SaveCrcCorrupt},
+    // #533: REFUSED as a first-class slot state, distinct from ABSENT.
+    {"save-refused-quarantine", "A refused .redsave is quarantined byte-exact and the slot write-latched (#533)",
+     Test_SaveRefusedQuarantine},
+    {"save-write-latch", "Save refuses slots this session never loaded/created/erased (#533)", Test_SaveWriteLatch},
+    {"save-arm-on-create", "File-create quarantines a failing .redsave before its first write (#533)",
+     Test_SaveArmOnCreate},
+    {"save-refused-meta", "The slot surface reports ABSENT / VALID / REFUSED distinctly (#533)",
+     Test_SaveRefusedMeta},
     // Tier-1 format-headroom locks: the migration path Lane A's widened
     // sharedItems rides on. Without these, "ComboContext can grow" is a claim.
     {"save-combo-legacy-record", "Pre-headroom Tier-1 still loads and zero-extends", Test_SaveComboLegacyRecord},

--- a/src/common/tests/test_save_refusal.c
+++ b/src/common/tests/test_save_refusal.c
@@ -1,0 +1,467 @@
+/**
+ * @file test_save_refusal.c
+ * @brief REFUSED-state locks for the unified .redsave (#533).
+ *
+ * The bug class: a .redsave that failed validation (CRC, truncation, wrong
+ * slot, future version) left the session byte-for-byte identical to "this slot
+ * is empty", and the next OoT autosave rename-overwrote the mostly-intact
+ * original — including the ONLY copy of the MM half — with a blank Tier-1 and
+ * an all-zero Tier-3. These tests lock the three #533 mechanisms:
+ *
+ *   1. QUARANTINE: every refusal renames the failing file aside with a reason
+ *      suffix, byte-identical, never overwritten in place (dedupe on repeat).
+ *   2. LATCH: the refusing session takes a per-slot write latch; Save() into
+ *      an unarmed slot refuses. The counterfactual is authored directly: a
+ *      Save() aimed at an un-established slot holding a corrupt fixture must
+ *      leave the fixture untouched — revert the latch and that exact call
+ *      rename-overwrites it.
+ *   3. SURFACE: ReadMeta/GetSlotState report REFUSED as a first-class state,
+ *      distinct from ABSENT, both while the failing file is in place and
+ *      after it was quarantined away.
+ *
+ * Linkage note: like test_save_roundtrip.c, this file is #included into
+ * test_runner.cpp at FILE SCOPE (compiled as C++, NOT inside extern "C") so it
+ * can drive the C++ rsbs::SaveManager API.
+ */
+
+#include "../context.h"
+#include "../game.h"
+#include "../save.h"
+#include "../test_runner.h"
+
+#include <algorithm>
+#include <cstddef>
+#include <cstdint>
+#include <cstdio>
+#include <cstring>
+#include <filesystem>
+#include <fstream>
+#include <string>
+#include <vector>
+
+#define REFUSE_ASSERT(cond, msg)                \
+    do {                                        \
+        if (!(cond)) {                          \
+            printf("[TEST] FAIL: %s\n", (msg)); \
+            return TEST_FAIL;                   \
+        }                                       \
+    } while (0)
+
+namespace {
+
+const char* const kRefusalTestDir = "rsbs_test_refusal_saves";
+
+uint8_t RefusalOoTByte(size_t i) {
+    return static_cast<uint8_t>(0x9Du + i * 13u);
+}
+uint8_t RefusalMMByte(size_t i) {
+    return static_cast<uint8_t>(0x31u + i * 29u);
+}
+
+// Seed gComboCtx + both shadows so Save() has real content to serialize and a
+// refused Load has recognizable live state to (not) clobber.
+void RefusalSeed(uint32_t tag) {
+    Context_InitFrozenStates();
+    ComboContext_Init();
+    gComboCtx.saveSlot = static_cast<int32_t>(tag);
+    gComboCtx.sharedRandoSeed = tag ^ 0x5A5A5A5Au;
+    gComboCtx.sourceGame = GAME_OOT;
+
+    std::vector<uint8_t> oot(OOT_SAVE_CONTEXT_SIZE);
+    std::vector<uint8_t> mm(MM_SAVE_CONTEXT_SIZE);
+    for (size_t i = 0; i < oot.size(); i++) {
+        oot[i] = RefusalOoTByte(i);
+    }
+    for (size_t i = 0; i < mm.size(); i++) {
+        mm[i] = RefusalMMByte(i);
+    }
+    Context_UpdateShadowCopy(GAME_OOT, oot.data(), oot.size());
+    Context_UpdateShadowCopy(GAME_MM, mm.data(), mm.size());
+}
+
+bool RefusalReadFile(const std::string& path, std::vector<uint8_t>& out) {
+    std::ifstream in(path, std::ios::binary);
+    if (!in) {
+        return false;
+    }
+    out.assign(std::istreambuf_iterator<char>(in), std::istreambuf_iterator<char>());
+    return true;
+}
+
+bool RefusalPatchU32(const std::string& path, size_t offset, uint32_t value) {
+    std::fstream f(path, std::ios::in | std::ios::out | std::ios::binary);
+    if (!f) {
+        return false;
+    }
+    f.seekp(static_cast<std::streamoff>(offset), std::ios::beg);
+    uint8_t bytes[4] = { static_cast<uint8_t>(value & 0xFFu), static_cast<uint8_t>((value >> 8) & 0xFFu),
+                         static_cast<uint8_t>((value >> 16) & 0xFFu), static_cast<uint8_t>((value >> 24) & 0xFFu) };
+    f.write(reinterpret_cast<const char*>(bytes), sizeof(bytes));
+    return static_cast<bool>(f);
+}
+
+bool RefusalFlipPayloadByte(const std::string& path) {
+    std::fstream f(path, std::ios::in | std::ios::out | std::ios::binary);
+    if (!f) {
+        return false;
+    }
+    const std::streamoff at = static_cast<std::streamoff>(sizeof(rsbs::RsbsSaveHeader)) + 8;
+    f.seekg(at, std::ios::beg);
+    char b = 0;
+    f.read(&b, 1);
+    if (!f) {
+        return false;
+    }
+    b = static_cast<char>(b ^ 0xFF);
+    f.seekp(at, std::ios::beg);
+    f.write(&b, 1);
+    return static_cast<bool>(f);
+}
+
+// All quarantine files for a slot: "<slotfile>.<...>.bak", sorted for
+// deterministic assertions.
+std::vector<std::string> RefusalQuarantines(int slot) {
+    std::vector<std::string> found;
+    const std::filesystem::path slotPath = rsbs::SaveManager::Instance().SlotPath(slot);
+    const std::string prefix = slotPath.filename().string();
+    std::error_code ec;
+    std::filesystem::directory_iterator it(slotPath.parent_path(), ec);
+    if (ec) {
+        return found;
+    }
+    for (const auto& entry : it) {
+        const std::string name = entry.path().filename().string();
+        if (name.size() > prefix.size() && name.compare(0, prefix.size(), prefix) == 0 && name.size() >= 4 &&
+            name.compare(name.size() - 4, 4, ".bak") == 0) {
+            found.push_back(entry.path().string());
+        }
+    }
+    std::sort(found.begin(), found.end());
+    return found;
+}
+
+// Wipe the test directory and the per-slot session latches: the fixture setup
+// for "a fresh process meets this file".
+void RefusalFreshDir() {
+    std::error_code ec;
+    std::filesystem::remove_all(kRefusalTestDir, ec);
+    std::filesystem::create_directories(kRefusalTestDir, ec);
+    rsbs::SaveManager::Instance().ResetSlotSessionState();
+}
+
+// Author a VALID slot-0 .redsave, then reset the latches so the file looks
+// like it was written by a previous session.
+bool RefusalAuthorValidSlot(int slot, uint32_t tag) {
+    rsbs::SaveManager& mgr = rsbs::SaveManager::Instance();
+    RefusalSeed(tag);
+    mgr.ArmSlotOnCreate(slot);
+    if (!mgr.Save(slot)) {
+        return false;
+    }
+    mgr.ResetSlotSessionState();
+    return true;
+}
+
+// The shared per-fixture body: given a corrupt file already at `slot`'s path,
+// assert the full refusal contract — refused outcome, live state untouched,
+// evidence quarantined byte-identical, latch set, follow-up Save refused and
+// destroying nothing.
+TestResult RefusalExpectRefusal(int slot, RsbsRefuseReason expectedReason, const char* what) {
+    rsbs::SaveManager& mgr = rsbs::SaveManager::Instance();
+    const std::string slotPath = mgr.SlotPath(slot);
+
+    std::vector<uint8_t> fixture;
+    REFUSE_ASSERT(RefusalReadFile(slotPath, fixture), "could not snapshot the corrupt fixture");
+
+    // Distinct live state, so a refused load that commits anyway is caught.
+    RefusalSeed(0x0BADF00Du);
+    gComboCtx.saveSlot = 0x0BADF00D;
+
+    printf("[TEST]   fixture: %s\n", what);
+    REFUSE_ASSERT(mgr.LoadSlot(slot) == RSBS_LOAD_REFUSED, "corrupt fixture was not REFUSED");
+    REFUSE_ASSERT(gComboCtx.saveSlot == 0x0BADF00D, "refused load clobbered live ComboContext");
+
+    // QUARANTINED, not deleted, not left at the slot path.
+    REFUSE_ASSERT(!std::filesystem::exists(slotPath), "refused file was left at the slot path");
+    std::vector<std::string> baks = RefusalQuarantines(slot);
+    REFUSE_ASSERT(baks.size() == 1, "expected exactly one quarantine file");
+    REFUSE_ASSERT(baks[0].find(std::string("refused-")) != std::string::npos,
+                  "quarantine filename must carry a reason suffix");
+    std::vector<uint8_t> quarantined;
+    REFUSE_ASSERT(RefusalReadFile(baks[0], quarantined), "could not read the quarantine file");
+    REFUSE_ASSERT(quarantined == fixture, "quarantined evidence is not byte-identical to the refused file");
+
+    // REFUSED is a first-class state, distinct from ABSENT, with the reason.
+    REFUSE_ASSERT(mgr.GetSlotState(slot) == RSBS_SLOT_REFUSED, "slot must read REFUSED after a refusal");
+    REFUSE_ASSERT(mgr.GetSlotRefuseReason(slot) == expectedReason, "refusal reason mismatch");
+    REFUSE_ASSERT(!mgr.IsSlotWritable(slot), "refused slot must not be writable");
+
+    // The LATCH: the very next save (the autosave that used to destroy the
+    // evidence) must refuse and mint nothing.
+    REFUSE_ASSERT(!mgr.Save(slot), "Save into a REFUSED slot must be latched");
+    REFUSE_ASSERT(!std::filesystem::exists(slotPath), "a latched Save still wrote the slot path");
+    std::vector<uint8_t> after;
+    REFUSE_ASSERT(RefusalReadFile(baks[0], after), "quarantine file vanished after the latched Save");
+    REFUSE_ASSERT(after == fixture, "the latched Save altered the quarantined evidence");
+
+    return TEST_PASS;
+}
+
+}  // namespace
+
+TestResult Test_SaveRefusedQuarantine(void) {
+    printf("[TEST] save-refused-quarantine: every refusal quarantines the evidence and latches the slot (#533)\n");
+
+    rsbs::SaveManager& mgr = rsbs::SaveManager::Instance();
+    mgr.SetSaveDirectory(kRefusalTestDir);
+
+    // ---- CRC-corrupt (single flipped payload byte) -----------------------
+    RefusalFreshDir();
+    REFUSE_ASSERT(RefusalAuthorValidSlot(0, 0xC1C1C1C1u), "could not author the valid base save");
+    REFUSE_ASSERT(RefusalFlipPayloadByte(mgr.SlotPath(0)), "could not flip a payload byte");
+    if (RefusalExpectRefusal(0, RSBS_REFUSE_CRC, "flipped payload byte (CRC)") != TEST_PASS) {
+        return TEST_FAIL;
+    }
+
+    // ---- Truncated (short Tier-3, e.g. torn cloud sync) ------------------
+    RefusalFreshDir();
+    REFUSE_ASSERT(RefusalAuthorValidSlot(0, 0x72C472C4u), "could not author the valid base save");
+    {
+        std::error_code ec;
+        const uintmax_t full = std::filesystem::file_size(mgr.SlotPath(0), ec);
+        REFUSE_ASSERT(!ec && full > 4096, "could not stat the authored save");
+        std::filesystem::resize_file(mgr.SlotPath(0), full - 2048, ec);
+        REFUSE_ASSERT(!ec, "could not truncate the fixture");
+    }
+    if (RefusalExpectRefusal(0, RSBS_REFUSE_TRUNCATED, "truncated Tier-3") != TEST_PASS) {
+        return TEST_FAIL;
+    }
+
+    // ---- Wrong slot (slot 2's file copied over slot 1's path) ------------
+    // The V13 case: header.slot is stamped but was never compared, so a
+    // cloud-sync/manual copy silently attached one pair's identity + MM world
+    // to a different OoT file.
+    RefusalFreshDir();
+    REFUSE_ASSERT(RefusalAuthorValidSlot(2, 0x51075107u), "could not author the valid slot-2 save");
+    {
+        std::error_code ec;
+        std::filesystem::copy_file(mgr.SlotPath(2), mgr.SlotPath(1), ec);
+        REFUSE_ASSERT(!ec, "could not copy slot 2's file to slot 1's path");
+    }
+    if (RefusalExpectRefusal(1, RSBS_REFUSE_WRONG_SLOT, "slot 2's file at slot 1's path") != TEST_PASS) {
+        return TEST_FAIL;
+    }
+    // The donor file is untouched and still valid at its own slot.
+    REFUSE_ASSERT(mgr.GetSlotState(2) == RSBS_SLOT_VALID, "the donor slot must remain VALID");
+    REFUSE_ASSERT(mgr.HasSave(2), "the donor slot must still read as having a save");
+
+    // ---- Future version (newer build's file opened by this one) ----------
+    RefusalFreshDir();
+    REFUSE_ASSERT(RefusalAuthorValidSlot(0, 0xF07F07F0u), "could not author the valid base save");
+    REFUSE_ASSERT(RefusalPatchU32(mgr.SlotPath(0), offsetof(rsbs::RsbsSaveHeader, version),
+                                  RSBS_SAVE_VERSION + 1u),
+                  "could not patch the version field");
+    if (RefusalExpectRefusal(0, RSBS_REFUSE_VERSION, "future format version") != TEST_PASS) {
+        return TEST_FAIL;
+    }
+
+    std::error_code ec;
+    std::filesystem::remove_all(kRefusalTestDir, ec);
+    rsbs::SaveManager::Instance().ResetSlotSessionState();
+    printf("[TEST] PASS: CRC/truncation/wrong-slot/future-version each quarantine + latch, evidence intact\n");
+    return TEST_PASS;
+}
+
+TestResult Test_SaveWriteLatch(void) {
+    printf("[TEST] save-write-latch: Save refuses any slot this session did not load, create, or erase (#533)\n");
+
+    rsbs::SaveManager& mgr = rsbs::SaveManager::Instance();
+    mgr.SetSaveDirectory(kRefusalTestDir);
+
+    // ---- The counterfactual, authored directly ---------------------------
+    // A corrupt fixture sits at slot 0; the session never opened the slot;
+    // an autosave-shaped Save(0) arrives. WITH the latch it refuses and the
+    // fixture survives byte-identical IN PLACE. Revert the latch and this
+    // exact call rename-overwrites the fixture with a blank Tier-1 +
+    // all-zero Tier-3 — the #533 data loss.
+    RefusalFreshDir();
+    REFUSE_ASSERT(RefusalAuthorValidSlot(0, 0x1A7C41A7u), "could not author the valid base save");
+    REFUSE_ASSERT(RefusalFlipPayloadByte(mgr.SlotPath(0)), "could not corrupt the fixture");
+    std::vector<uint8_t> fixture;
+    REFUSE_ASSERT(RefusalReadFile(mgr.SlotPath(0), fixture), "could not snapshot the fixture");
+
+    RefusalSeed(0xA07A57A0u);  // live state to (not) serialize
+    REFUSE_ASSERT(!mgr.IsSlotWritable(0), "an un-established slot must not be writable");
+    REFUSE_ASSERT(!mgr.Save(0), "Save into an un-established slot must refuse");
+
+    std::vector<uint8_t> after;
+    REFUSE_ASSERT(RefusalReadFile(mgr.SlotPath(0), after), "the fixture vanished — the latched Save destroyed it");
+    REFUSE_ASSERT(after == fixture, "the latched Save altered the fixture in place");
+    REFUSE_ASSERT(RefusalQuarantines(0).empty(), "a refused Save must not quarantine by itself");
+
+    // ---- Absent slot: still unwritable until established -----------------
+    REFUSE_ASSERT(!mgr.Save(2), "Save into a never-opened empty slot must refuse");
+    REFUSE_ASSERT(!std::filesystem::exists(mgr.SlotPath(2)), "the refused Save minted a file anyway");
+
+    // ---- The three legitimate arming events ------------------------------
+    // (a) Opening an empty slot (the load path's ABSENT outcome).
+    REFUSE_ASSERT(mgr.LoadSlot(2) == RSBS_LOAD_ABSENT, "an empty slot must open as ABSENT");
+    REFUSE_ASSERT(mgr.IsSlotWritable(2), "opening an empty slot must arm it");
+    REFUSE_ASSERT(mgr.Save(2), "Save after establishing the empty slot must succeed");
+    REFUSE_ASSERT(mgr.GetSlotState(2) == RSBS_SLOT_VALID, "the established slot's save must be valid");
+
+    // (b) A successful load.
+    mgr.ResetSlotSessionState();
+    REFUSE_ASSERT(!mgr.IsSlotWritable(2), "a fresh session must start with the slot latched");
+    REFUSE_ASSERT(mgr.LoadSlot(2) == RSBS_LOAD_OK, "the valid save must load");
+    REFUSE_ASSERT(mgr.IsSlotWritable(2), "a successful load must arm the slot");
+
+    // (c) An explicit erase.
+    mgr.ResetSlotSessionState();
+    mgr.DeleteSave(2);
+    REFUSE_ASSERT(mgr.IsSlotWritable(2), "an explicit erase must arm the slot");
+    REFUSE_ASSERT(!std::filesystem::exists(mgr.SlotPath(2)), "erase must remove the slot file");
+
+    std::error_code ec;
+    std::filesystem::remove_all(kRefusalTestDir, ec);
+    mgr.ResetSlotSessionState();
+    printf("[TEST] PASS: the latch protects un-established slots; load/create/erase are the only keys\n");
+    return TEST_PASS;
+}
+
+TestResult Test_SaveArmOnCreate(void) {
+    printf("[TEST] save-arm-on-create: file-create quarantines a failing .redsave before its first write (#533)\n");
+
+    rsbs::SaveManager& mgr = rsbs::SaveManager::Instance();
+    mgr.SetSaveDirectory(kRefusalTestDir);
+
+    // ---- Create over a corrupt .redsave preserves the evidence -----------
+    // The z_sram.c seam: a new OoT file is created in a slot whose stale
+    // .redsave is corrupt and was never load-attempted. The first
+    // Save_SaveFile must not rename-overwrite it: ArmSlotOnCreate quarantines
+    // first, then arms.
+    RefusalFreshDir();
+    REFUSE_ASSERT(RefusalAuthorValidSlot(0, 0xCEA7E000u), "could not author the valid base save");
+    REFUSE_ASSERT(RefusalFlipPayloadByte(mgr.SlotPath(0)), "could not corrupt the fixture");
+    std::vector<uint8_t> fixture;
+    REFUSE_ASSERT(RefusalReadFile(mgr.SlotPath(0), fixture), "could not snapshot the fixture");
+
+    RefusalSeed(0x0EA7E001u);
+    mgr.ArmSlotOnCreate(0);
+    REFUSE_ASSERT(!std::filesystem::exists(mgr.SlotPath(0)), "create must have moved the corrupt file aside");
+    {
+        std::vector<std::string> baks = RefusalQuarantines(0);
+        REFUSE_ASSERT(baks.size() == 1, "create over a corrupt file must quarantine it");
+        std::vector<uint8_t> quarantined;
+        REFUSE_ASSERT(RefusalReadFile(baks[0], quarantined), "could not read the quarantine file");
+        REFUSE_ASSERT(quarantined == fixture, "create's quarantine is not byte-identical to the evidence");
+    }
+    REFUSE_ASSERT(mgr.IsSlotWritable(0), "create must arm the slot");
+    REFUSE_ASSERT(mgr.Save(0), "the new file's first save must commit");
+    REFUSE_ASSERT(mgr.GetSlotState(0) == RSBS_SLOT_VALID, "the new save must be valid");
+    {
+        // The new save did not disturb the evidence.
+        std::vector<std::string> baks = RefusalQuarantines(0);
+        REFUSE_ASSERT(baks.size() == 1, "the first save must not touch the quarantine");
+        std::vector<uint8_t> quarantined;
+        REFUSE_ASSERT(RefusalReadFile(baks[0], quarantined) && quarantined == fixture,
+                      "the first save altered the quarantined evidence");
+    }
+
+    // ---- Sticky refusal + dedupe: evidence is NEVER overwritten ----------
+    RefusalFreshDir();
+    REFUSE_ASSERT(RefusalAuthorValidSlot(0, 0x57ECC000u), "could not author the valid base save");
+    REFUSE_ASSERT(RefusalFlipPayloadByte(mgr.SlotPath(0)), "could not corrupt the fixture");
+    REFUSE_ASSERT(mgr.LoadSlot(0) == RSBS_LOAD_REFUSED, "first refusal");
+    // The slot path is now empty, but re-opening it must NOT flip to
+    // ABSENT-and-armed: the refusal is sticky for the session.
+    REFUSE_ASSERT(mgr.LoadSlot(0) == RSBS_LOAD_REFUSED, "a refused slot must stay REFUSED on re-open");
+    REFUSE_ASSERT(!mgr.IsSlotWritable(0), "a refused slot must stay latched on re-open");
+    // Cloud sync re-materializes another corrupt file: refusing it must
+    // quarantine to a SECOND name, not overwrite the first evidence.
+    REFUSE_ASSERT(RefusalAuthorValidSlot(0, 0x57ECC001u), "could not re-author the slot file");
+    // (Re-authoring reset the latches; corrupt it and refuse again.)
+    REFUSE_ASSERT(RefusalFlipPayloadByte(mgr.SlotPath(0)), "could not corrupt the re-authored file");
+    REFUSE_ASSERT(mgr.LoadSlot(0) == RSBS_LOAD_REFUSED, "second refusal");
+    REFUSE_ASSERT(RefusalQuarantines(0).size() == 2, "the second refusal must dedupe, never overwrite evidence");
+
+    // ---- The explicit erase releases everything --------------------------
+    mgr.DeleteSave(0);
+    REFUSE_ASSERT(mgr.GetSlotState(0) == RSBS_SLOT_ABSENT, "erase must clear the REFUSED state");
+    REFUSE_ASSERT(RefusalQuarantines(0).empty(), "erase is the sanctioned disposal of quarantined evidence");
+    REFUSE_ASSERT(mgr.IsSlotWritable(0), "erase must arm the slot");
+
+    std::error_code ec;
+    std::filesystem::remove_all(kRefusalTestDir, ec);
+    mgr.ResetSlotSessionState();
+    printf("[TEST] PASS: create quarantines before first write; refusals are sticky; evidence dedupes\n");
+    return TEST_PASS;
+}
+
+TestResult Test_SaveRefusedMeta(void) {
+    printf("[TEST] save-refused-meta: the slot surface reports REFUSED distinctly from empty (#533)\n");
+
+    rsbs::SaveManager& mgr = rsbs::SaveManager::Instance();
+    mgr.SetSaveDirectory(kRefusalTestDir);
+
+    // ---- Empty slot: ABSENT, no quarantine -------------------------------
+    RefusalFreshDir();
+    {
+        rsbs::SlotMeta meta = mgr.ReadMeta(0);
+        REFUSE_ASSERT(meta.state == RSBS_SLOT_ABSENT && !meta.hasQuarantine && !meta.exists,
+                      "an empty slot must read ABSENT with no quarantine");
+    }
+
+    // ---- In-place header-refused file (never load-attempted) -------------
+    {
+        std::ofstream out(mgr.SlotPath(0), std::ios::binary | std::ios::trunc);
+        const char junk[64] = "NOTASAVE-this is not a redsave header at all............";
+        out.write(junk, sizeof(junk));
+    }
+    {
+        rsbs::SlotMeta meta = mgr.ReadMeta(0);
+        REFUSE_ASSERT(meta.state == RSBS_SLOT_REFUSED, "a failing file in place must read REFUSED, not empty");
+        REFUSE_ASSERT(meta.refuseReason == RSBS_REFUSE_HEADER, "the header reason must surface");
+        REFUSE_ASSERT(meta.exists, "the failing file does exist");
+        REFUSE_ASSERT(mgr.GetSlotState(0) == RSBS_SLOT_REFUSED, "GetSlotState must agree");
+    }
+
+    // ---- After the load attempt: quarantined, still REFUSED --------------
+    REFUSE_ASSERT(mgr.LoadSlot(0) == RSBS_LOAD_REFUSED, "the junk file must refuse");
+    {
+        rsbs::SlotMeta meta = mgr.ReadMeta(0);
+        REFUSE_ASSERT(meta.state == RSBS_SLOT_REFUSED, "a quarantined slot must STILL read REFUSED");
+        REFUSE_ASSERT(!meta.exists, "the slot path is empty after quarantine");
+        REFUSE_ASSERT(meta.hasQuarantine, "the quarantine evidence must be reported");
+    }
+
+    // ---- A fresh process: evidence outlives the session record -----------
+    mgr.ResetSlotSessionState();
+    {
+        rsbs::SlotMeta meta = mgr.ReadMeta(0);
+        REFUSE_ASSERT(meta.state == RSBS_SLOT_ABSENT, "a fresh session sees the empty slot as ABSENT");
+        REFUSE_ASSERT(meta.hasQuarantine, "…but the on-disk quarantine evidence still surfaces");
+    }
+
+    // ---- Wrong-slot file in place surfaces before any load --------------
+    RefusalFreshDir();
+    REFUSE_ASSERT(RefusalAuthorValidSlot(2, 0x33E7A000u), "could not author the valid slot-2 save");
+    {
+        std::error_code ec;
+        std::filesystem::copy_file(mgr.SlotPath(2), mgr.SlotPath(1), ec);
+        REFUSE_ASSERT(!ec, "could not copy slot 2's file to slot 1's path");
+    }
+    {
+        rsbs::SlotMeta meta = mgr.ReadMeta(1);
+        REFUSE_ASSERT(meta.state == RSBS_SLOT_REFUSED, "a wrong-slot file must read REFUSED in place");
+        REFUSE_ASSERT(meta.refuseReason == RSBS_REFUSE_WRONG_SLOT, "the wrong-slot reason must surface");
+        rsbs::SlotMeta donor = mgr.ReadMeta(2);
+        REFUSE_ASSERT(donor.state == RSBS_SLOT_VALID, "the donor slot must stay VALID");
+    }
+
+    std::error_code ec;
+    std::filesystem::remove_all(kRefusalTestDir, ec);
+    mgr.ResetSlotSessionState();
+    printf("[TEST] PASS: ABSENT / VALID / REFUSED are three different surfaced facts\n");
+    return TEST_PASS;
+}

--- a/src/common/tests/test_session_invalidation.c
+++ b/src/common/tests/test_session_invalidation.c
@@ -417,6 +417,11 @@ TestResult Test_SessionInvalidation(void) {
         std::filesystem::create_directories(kSessionTestDir, ec);
         rsbs::SaveManager& mgr = rsbs::SaveManager::Instance();
         mgr.SetSaveDirectory(kSessionTestDir);
+        // #533: writes are latched per-slot until this session loads, creates,
+        // or erases the slot. Simulate a fresh session, then arm slot 1 the
+        // way production's create seam does before its first Save.
+        mgr.ResetSlotSessionState();
+        mgr.ArmSlotOnCreate(1);
 
         SeedSessionA(0x2468u, 0x1357u);
         std::vector<uint8_t> mmLive(MM_SAVE_CONTEXT_SIZE, kSessionAByte);
@@ -488,6 +493,7 @@ TestResult Test_SessionInvalidation(void) {
             SeedSessionA(0x1111u, 0x2222u);
             std::vector<uint8_t> mmEmpty(MM_SAVE_CONTEXT_SIZE, 0);
             Context_UpdateShadowCopy(GAME_MM, mmEmpty.data(), mmEmpty.size());
+            mgr.ArmSlotOnCreate(0); // #533: this block creates slot 0's save
             SESSION_ASSERT(mgr.Save(0));
 
             Context_InvalidateSessionOnSlotLoad();
@@ -521,6 +527,9 @@ TestResult Test_SessionInvalidation(void) {
         SeedSessionA(0x3333u, 0x4444u);
         StampGeneratedSeed(0x99999999u, 0x5555u);
         Context_InvalidateSessionOnNewGame(/*isRandoFile=*/1);
+        // #533: mirror z_sram.c's create seam, which arms the slot right after
+        // the invalidation and before the file's first save.
+        mgr.ArmSlotOnCreate(2);
         SESSION_ASSERT(Combo_CountForeignPlacementsOoT() == 1);
         SESSION_ASSERT(mgr.Save(2));
         // Clear first, so what the assertions below read came out of the file


### PR DESCRIPTION
Closes #533. Part of the #564 one-game alignment plan — this is **step 1, the gate**: `#564` sequences it before every identity-mismatch guard (`#498`'s profile freeze, `#537`/`#531`'s commit generation, the cross-carrier compare), because while refusal destroys data, every new detection converts into data loss (V19).

## Mechanism (the bug)

A `.redsave` that `RsbsSave_Load` refused — CRC mismatch, truncation, bad inner magic, an unreadable or forward-version header — left the running session **byte-for-byte identical to "this slot has no cross-game state at all"**. Three separate things made that unrecoverable:

1. `SaveManager.cpp`'s `OnLoadFile` gated the reload on `RsbsSave_HasSave(fileNum)` and then **discarded `RsbsSave_Load`'s `bool`**. `HasSave` is header-only by design, so a header-level refusal (including the forward version bump `context.h` itself prescribes for future growth) made the gate report "no save" and the load never even ran.
2. `OnSaveFile` had **no "did this slot load?" precondition**. It unconditionally called `RsbsSave_Save(fileNum)`, which writes a temp file and renames it over the slot path — blank Tier-1, 65536 zero Tier-3 bytes.
3. Nothing quarantined anything. `DeleteSave` removed `path + ".bak"`, but **no code path anywhere ever wrote a `.bak`**.

Net effect: one flipped byte, one torn cloud sync, or one older build opening a newer build's file, and three minutes later the ordinary autosave renamed the mostly-intact original away and replaced it. Since `#527` gave MM its redship-native save path, Tier-3 is MM's **only** persistence, so the player discovered it at the next Happy Mask Shop crossing, when MM cold-booted a brand-new file. The only signal was an `fprintf` to a stderr no GUI-launched player sees.

## Changes

**ABSENT / VALID / REFUSED become three different facts** (`src/common/save.h`, `save.cpp`). New `RsbsSlotState`, `RsbsRefuseReason` (8 named failure modes) and `RsbsLoadOutcome`. `LoadSlot()` replaces the old `bool Load()` as the real entry point and returns the three-way outcome; `Load()` stays as `LoadSlot(slot) == RSBS_LOAD_OK` for existing callers.

**One validator, shared.** `ReadSlotFile` reads and *fully* validates (header, slot, three tier reads, CRC, inner `ComboContext` magic) into locals before any commit decision, and is the single function both `LoadSlot` and the create-seam probe call — so "what counts as refused" cannot fork between them. `SlotReadResult::Absent` is distinguished from `Refused`: a file that exists but cannot be opened is **not** absence, which is exactly the collapse this type exists to prevent.

**The missing `header.slot` comparison (#564 V13).** `header.slot` has been stamped at write time since day one and compared nowhere; `ReadMeta` even echoed the foreign slot back to the panel. A cloud-sync conflict or hand copy of slot 2's file sitting at slot 0's path loaded silently, attaching one pair's identity and MM world to a different OoT file. `DeserializeHeader` now takes an `expectedSlot` and refuses a mismatch with the same treatment as a CRC failure.

**Quarantine.** Every refusal renames the failing file aside as `<slot>.refused-<reason>[-N].bak` — byte-exact, reason-tagged so the evidence names its own diagnosis, and **never overwriting existing evidence** (a second refusal of the same kind dedupes with a numeric suffix). If the rename itself fails (locked file, permissions) the file stays in place, which is still safe because the caller latches the slot. `DeleteSave` — the explicit player-initiated erase, and the one sanctioned disposal path — matches quarantines by prefix rather than the one hard-coded name it used to expect.

**The armed-session write latch.** `Save(slot)` now writes only after **this session** successfully loaded, created, or erased that slot. Three arming events, no defaults:
- `LoadSlot` → `RSBS_LOAD_OK` (a real load) or `RSBS_LOAD_ABSENT` (opening an empty slot *is* the create path — nothing on disk to destroy);
- `DeleteSave` (explicit erase, which also retires the refusal record and the evidence);
- `ArmSlotOnCreate`, the new file-create seam, called from `OoT_Sram_InitSave` right after `Context_InvalidateSessionOnNewGame` and before `Save_SaveFile()` fires the `OnSaveFile` → `RsbsSave_Save` chain. It **quarantines a failing existing file first**, so creating a file over a corrupt `.redsave` preserves the evidence instead of letting the first autosave rename-overwrite it.

A refusal is sticky for the session and clears `mSlotArmed`: re-opening the now-empty slot path stays REFUSED rather than quietly flipping to ABSENT-and-armed. The latch is deliberately **not** reset by session invalidation — "this process successfully established slot N" is a fact about the process, not about a session.

**No more `HasSave` gate on load.** `OnLoadFile` always calls `RsbsSave_LoadSlot(fileNum)` and lets it distinguish the three outcomes itself.

**Surfaced — stderr is not a surface.** `SlotMeta` gains `state`, `refuseReason` and `hasQuarantine`, and `ComboMenuBar::DrawFileSelect` renders `[REFUSED: <reason>]` in red, distinctly from `[empty]`, together with what the player can do about it. Save-to-slot is withheld entirely for a REFUSED slot (the player must decide via Delete first); Load is offered only for a VALID one; Delete also appears when only quarantined evidence remains. An empty slot whose evidence is still on disk from a previous session says so instead of pretending nothing happened.

## Locks and counterfactual

Four ROM-free `redship`-tier CTest rows, driven from `src/common/tests/test_save_refusal.c` through `test_runner.cpp`:

- **`SaveRefusedQuarantine`** — four authored-corrupt fixtures (a flipped payload byte → CRC; a Tier-3 truncated by 2048 bytes; slot 2's file copied to slot 1's path → the V13 case; `version` patched to `RSBS_SAVE_VERSION + 1`). Each must land `RSBS_LOAD_REFUSED` with the named reason, leave live `gComboCtx` untouched, produce exactly one quarantine file whose bytes are **identical to the pre-load fixture**, read `RSBS_SLOT_REFUSED` / `!IsSlotWritable`, and survive the follow-up `Save()` unaltered. The wrong-slot case additionally asserts the donor slot stays VALID.
- **`SaveWriteLatch`** — **the counterfactual, authored directly.** A corrupt fixture sits at slot 0, the session never opened the slot, and an autosave-shaped `Save(0)` arrives. With the latch it refuses and the fixture survives byte-identical *in place*; the row then walks the three legitimate arming events (`ABSENT` open, successful load, explicit erase) and proves each one unlocks a write.
- **`SaveArmOnCreate`** — the `z_sram.c` seam: create over a corrupt `.redsave` quarantines byte-exact *before* the first write, arms, and the first save commits without disturbing the evidence; refusals are sticky across re-open; a second refusal dedupes to a second name instead of overwriting the first; the explicit erase releases everything.
- **`SaveRefusedMeta`** — ABSENT / VALID / REFUSED surfaced distinctly, both for a failing file still in place (never load-attempted) and after quarantine, with the evidence outliving the session record.

### Local verification (MSVC Release, Ninja, `-j4` low priority per the workstation throttle)

Cold build from a clean worktree, **zero compile errors**, then both ROM-free tiers:

```
41/69 Test #41: SaveRefusedQuarantine ............   Passed    0.11 sec
42/69 Test #42: SaveWriteLatch ...................   Passed    0.11 sec
43/69 Test #43: SaveArmOnCreate ..................   Passed    0.11 sec
44/69 Test #44: SaveRefusedMeta ..................   Passed    0.09 sec
68/69 Test #68: AllTests .........................   Passed    1.47 sec

100% tests passed out of 69
Label Time Summary:
redship    =  14.95 sec*proc (69 tests)
```

```
100% tests passed out of 15
Label Time Summary:
rando    =  25.00 sec*proc (15 tests)
```

`AllTests` matters here specifically: it runs every row in ONE process, which is where the latch could have broken existing tests by leaving slots unarmed across rows. Every pre-existing `Save()` call site was audited and each is preceded by one of the three arming events (the legacy save tests all `DeleteSave(0)` first, which arms; `test_session_invalidation.c` and `mm_unified_save_test.cpp` were given explicit arm/reset calls).

### The counterfactual, run and confirmed non-vacuous

The latch was reverted (`if (false && !mSlotArmed[slot])`), rebuilt, and the rows re-run:

```
1/3 Test #41: SaveRefusedQuarantine ............***Failed    2.46 sec
[TEST]   fixture: flipped payload byte (CRC)
[TEST] FAIL: Save into a REFUSED slot must be latched

2/3 Test #42: SaveWriteLatch ...................***Failed    0.10 sec
[TEST] FAIL: Save into an un-established slot must refuse

3/3 Test #43: SaveArmOnCreate ..................   Passed    0.11 sec

33% tests passed, 2 tests failed out of 3
```

Both failures land on the *positive* assertion — `Save()` returned **true** and wrote — which is exactly the #533 conversion: an autosave-shaped write into a slot the session never established rename-overwrites the corrupt fixture. The rows are not passing for some unrelated precondition (`RefusalSeed` installs both shadows, so `Save`'s other guards are satisfied). `SaveArmOnCreate` correctly stays green, because it arms legitimately and is testing the quarantine-before-first-write seam rather than the latch.

The counterfactual was then reverted (`git diff HEAD -- src/common/save.cpp` empty), rebuilt, and both tiers re-run: **69/69 and 15/15 green**.

### Review commit on top

`1fb6355b` is an adversarial-review follow-up, comment/layout only: a REFUSED row's trailing `ImGui::SameLine()` had no following widget (the state deliberately withholds Save-to-slot), which pulled the `Separator` onto the button row; and `context.h`'s `Context_InvalidateSessionOnSlotLoad` contract still named `RsbsSave_Load` as "the caller's" load after `OnLoadFile` moved to `RsbsSave_LoadSlot`.

## Notes for reviewers

- Every existing `RsbsSave_Save` call site was audited against the latch. In the single-executable build the production writers are OoT's `OnSaveFile`/`OnExitGame` (armed by `OnLoadFile` or the create seam) and MM's `MM_Combo_CaptureSaveToUnifiedSlot` (armed by the OoT leg that the crossing necessarily came through). `games/mm/2s2h/SaveManager/SaveManager.cpp` also calls it, but that TU is filtered out of the single-exe link.
- Consequence worth stating plainly: after a refusal, **the slot stays unwritten for the rest of the session**, including MM owl saves. That is the intended trade — #564's ruling is that a refused `.redsave` beside a healthy `.sav` is a torn ONE save, and the file panel is now where the player is told.
- Deliberately *not* in scope, and sequenced after this in #564: the cross-carrier identity comparison at load (V12), the commit generation / load-time skew refusal (V16), and the MM profile freeze with arrival compare-and-refuse (#498, V1/V8/V9) — which is the PR that stacks on this one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!--- section:artifacts:start -->
### Build Artifacts
  - [rsbs-windows.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/8784578122.zip)
  - [rsbs-linux.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/8784417794.zip)
<!--- section:artifacts:end -->