### PR TITLE
Marshal every .redsave commit through one game-thread choke point and stamp a monotonic generation into both artifacts (#537)

### DIFF
--- a/CMake/SingleExecutable.cmake
+++ b/CMake/SingleExecutable.cmake
@@ -492,6 +492,14 @@ if(BUILD_TESTING)
     # length is pinned to the pre-carve prefix (RSBS_COMBO_CONTEXT_PRECARVE_SIZE)
     # so the carve cannot silently widen what that test calls legacy.
     redship_add_test(NAME SaveTaggedItems COMMAND redship --test save-tagged-items)
+    # The .redsave commit choke point (#537/#531): every commit is a
+    # game-thread-marshalled snapshot with a monotonic generation stamped into
+    # both durable artifacts; the write phase reads no live state (the torn
+    # .redsave becomes unrepresentable), and load compares the two artifacts'
+    # stamps to detect freshness divergence.
+    redship_add_test(NAME CommitGenerationMonotonic COMMAND redship --test commit-generation-monotonic)
+    redship_add_test(NAME CommitTornWrite COMMAND redship --test commit-torn-write)
+    redship_add_test(NAME CommitGenerationSkew COMMAND redship --test commit-generation-skew)
     redship_add_test(NAME Context COMMAND redship --test context)
     # F10 hot-swap freeze/consume contract (#364): the hotkey path must freeze
     # the DEPARTING game (or refuse the switch), and a consumed frozen state

--- a/games/mm/2s2h/GameExports_SingleExe.cpp
+++ b/games/mm/2s2h/GameExports_SingleExe.cpp
@@ -1669,8 +1669,17 @@ extern "C" int MM_Combo_CaptureSaveToUnifiedSlot(void) {
     Context_UpdateShadowCopy(GAME_MM, &gSaveContext, sizeof(gSaveContext));
     gComboCtx.sourceGame = GAME_MM;
 
+    // RsbsSave_Save is the commit choke point's one-call form (#537): it
+    // stages the whole cross-game snapshot (Tier-1 + both shadows) on THIS
+    // thread — MM's game thread, the only mutator of the state being captured
+    // — stamps the next monotonic commit generation into Tier-1, and
+    // serializes from the staged copy. Note the .redsave generation advances
+    // past the OoT .sav's here by design: an MM-side commit cannot rewrite
+    // OoT's own file, and the generation gap is exactly what lets the next
+    // load DETECT that OoT's world is older than these records (#531).
     const int ok = RsbsSave_Save(slot);
-    fprintf(stderr, "[MM] unified save to slot %d: %s\n", slot, ok ? "ok" : "FAILED");
+    fprintf(stderr, "[MM] unified save to slot %d: %s (commit generation %u)\n", slot, ok ? "ok" : "FAILED",
+            (unsigned)gComboCtx.commitGeneration);
     fflush(stderr);
     return ok;
 }

--- a/games/oot/soh/SaveManager.cpp
+++ b/games/oot/soh/SaveManager.cpp
@@ -164,21 +164,19 @@ SaveManager::SaveManager() {
         if (fileNum < 0 || fileNum >= RSBS_SAVE_MAX_SLOTS) {
             return;
         }
-        // Publish the slot so a later MM-side save can address it; MM has no
-        // slot of its own (its fileNum is the 0xFF sentinel cross-game).
-        RsbsSave_SetActiveSlot(fileNum);
-        // Shared cross-game resources (#525) BEFORE the shadow capture, so the
-        // pool and the OoT blob stored beside it agree. Without this, money
-        // earned since the last switch is in the OoT save but not in the pool,
-        // and the post-load first-harvest seed reads the balance as already
-        // counted and drops it.
-        OoT_HarvestSharedResources();
-        Context_UpdateShadowCopy(GAME_OOT, &gSaveContext, sizeof(gSaveContext));
-        gComboCtx.sourceGame = GAME_OOT;
-        RsbsSave_Save(fileNum);
+        // #537: this hook fires at the TAIL of SaveFileThreaded, on the save
+        // worker thread, after the game-thread SaveContext snapshot has been
+        // deleted — so it must not touch gSaveContext, gComboCtx, or the
+        // shadows. The whole cross-game snapshot (harvest, shadow refresh,
+        // sourceGame, commit generation) was marshalled ON THE GAME THREAD in
+        // SaveSection, at the same instant SoH took its own SaveContext copy;
+        // all that happens here is serializing that immutable staged snapshot
+        // to disk. Reverting this split (reading live state here) re-arms the
+        // torn-.redsave class Test_CommitTornWrite locks against.
+        RsbsSave_WriteStagedCommit(fileNum);
     });
 
-    GameInteractor::Instance->RegisterGameHook<GameInteractor::OnLoadFile>([](int32_t fileNum) {
+    GameInteractor::Instance->RegisterGameHook<GameInteractor::OnLoadFile>([this](int32_t fileNum) {
         // Clear-and-reload (#440). The .redsave is per-OoT-slot
         // (redship_slot{0,1,2}.redsave) but gComboCtx and both shadows are
         // process singletons, so loading a slot has to REPLACE the resident
@@ -212,7 +210,17 @@ SaveManager::SaveManager() {
         Context_InvalidateSessionOnSlotLoad();
         RsbsSave_SetActiveSlot(fileNum);
         if (RsbsSave_HasSave(fileNum)) {
-            RsbsSave_Load(fileNum);
+            if (RsbsSave_Load(fileNum)) {
+                // #531/#564 V16 interim: compare the freshness stamp the
+                // commit choke point writes into BOTH artifacts. This hook
+                // fires from LoadFile after saveBlock is populated, so the
+                // .sav's mirrored generation is readable here. A mismatch is
+                // the two-authorities divergence made visible: .redsave newer
+                // == an MM-side commit landed after OoT's last save point
+                // (the #531 loss shape); .sav newer == a .redsave write was
+                // lost. Logged loudly for now; TODO(#533) surface as REFUSED.
+                RsbsSave_CheckCommitGenerationSkew(fileNum, this->GetLoadedCommitGeneration());
+            }
         }
     });
 
@@ -236,6 +244,13 @@ SaveManager::SaveManager() {
         // Snapshot on quit so unsaved cross-game flags (shared items, last
         // game) survive across a process exit even if the user never went
         // through the file-select panel.
+        //
+        // Thread affinity (#537): OnExitGame is dispatched from the GAME
+        // THREAD (z_play.c / kaleido), and the earlier-registered handler
+        // above has already drained the save worker pool — so refreshing the
+        // shadow from the live gSaveContext and committing synchronously here
+        // (RsbsSave_Save == stage + write through the commit choke point) is
+        // race-free by construction.
         if (fileNum < 0 || fileNum >= RSBS_SAVE_MAX_SLOTS) {
             return;
         }
@@ -1383,7 +1398,7 @@ int copy_file(const char* src, const char* dst) {
 
 // Threaded SaveFile takes copy of gSaveContext for local unmodified storage
 
-void SaveManager::SaveFileThreaded(int fileNum, SaveContext* saveContext, int sectionID) {
+void SaveManager::SaveFileThreaded(int fileNum, SaveContext* saveContext, int sectionID, uint32_t rsbsGeneration) {
     // RAII, not lock()/unlock(): every statement below can throw (json
     // serialization, std::filesystem::rename, and the OnSaveFile handlers), and
     // an escaped exception used to leave saveMtx held forever.
@@ -1402,6 +1417,16 @@ void SaveManager::SaveFileThreaded(int fileNum, SaveContext* saveContext, int se
         saveBlock["fileType"] = FILE_TYPE_SAVE_VANILLA;
     }
     if (sectionID == SECTION_ID_BASE) {
+        // RSBS (#537/#531): mirror the commit generation the game-thread
+        // marshalling stamped into the staged .redsave Tier-1 (see
+        // SaveSection). The same commit therefore signs BOTH durable
+        // artifacts, which is what makes load-time freshness divergence
+        // between them detectable (RsbsSave_CheckCommitGenerationSkew).
+        // Section-only saves leave the previous base stamp in place — their
+        // base data IS still that generation's.
+        if (rsbsGeneration != 0) {
+            saveBlock["rsbsCommitGeneration"] = rsbsGeneration;
+        }
         for (auto& sectionHandlerPair : sectionSaveHandlers) {
             auto& saveFuncInfo = sectionHandlerPair.second;
             // Don't call SaveFuncs for sections that aren't tied to game save
@@ -1498,10 +1523,40 @@ void SaveManager::SaveSection(int fileNum, int sectionID, bool threaded) {
     }
     auto saveContext = new SaveContext;
     memcpy(saveContext, &gSaveContext, sizeof(gSaveContext));
+
+    // RSBS commit marshalling (#537). This is the GAME THREAD — the same
+    // instant SoH just snapshotted gSaveContext for its own worker — so the
+    // whole cross-game snapshot is taken HERE, not in the OnSaveFile hook
+    // (which fires on the pool thread after this snapshot is deleted, and used
+    // to memcpy the LIVE globals mid-mutation: a CRC-valid but semantically
+    // torn .redsave). The staged copy and SoH's saveContext copy describe one
+    // instant; the worker later serializes both without touching live state.
+    //
+    // The stamped monotonic generation rides into BOTH artifacts: the staged
+    // Tier-1 carries it into the .redsave, and SaveFileThreaded mirrors it
+    // into the .sav JSON — the load-time freshness comparison depends on the
+    // two stamps being authored by this single commit.
+    uint32_t rsbsGeneration = 0;
+    if (sectionID == SECTION_ID_BASE && fileNum >= 0 && fileNum < RSBS_SAVE_MAX_SLOTS) {
+        // Publish the slot so a later MM-side save can address it; MM has no
+        // slot of its own (its fileNum is the 0xFF sentinel cross-game).
+        RsbsSave_SetActiveSlot(fileNum);
+        // Shared cross-game resources (#525) BEFORE the shadow capture, so the
+        // pool and the OoT blob stored beside it agree. Without this, money
+        // earned since the last switch is in the OoT save but not in the pool,
+        // and the post-load first-harvest seed reads the balance as already
+        // counted and drops it.
+        OoT_HarvestSharedResources();
+        Context_UpdateShadowCopy(GAME_OOT, &gSaveContext, sizeof(gSaveContext));
+        gComboCtx.sourceGame = GAME_OOT;
+        rsbsGeneration = RsbsSave_StageCommit();
+    }
+
     if (threaded) {
-        smThreadPool->detach_task(std::bind(&SaveManager::SaveFileThreaded, this, fileNum, saveContext, sectionID));
+        smThreadPool->detach_task(
+            std::bind(&SaveManager::SaveFileThreaded, this, fileNum, saveContext, sectionID, rsbsGeneration));
     } else {
-        SaveFileThreaded(fileNum, saveContext, sectionID);
+        SaveFileThreaded(fileNum, saveContext, sectionID, rsbsGeneration);
     }
 }
 
@@ -1521,6 +1576,20 @@ void SaveManager::SaveGlobal() {
 
     std::ofstream output(sGlobalPath);
     output << std::setw(1) << globalBlock << std::endl;
+}
+
+uint32_t SaveManager::GetLoadedCommitGeneration() {
+    // Called from the OnLoadFile hook, which LoadFile executes AFTER saveBlock
+    // is populated (and while saveMtx is held by that same thread). Absent key
+    // == a .sav from before the stamp existed == 0, the exempt value.
+    try {
+        if (saveBlock.is_object() && saveBlock.contains("rsbsCommitGeneration")) {
+            return saveBlock["rsbsCommitGeneration"].get<uint32_t>();
+        }
+    } catch (const std::exception&) {
+        // A malformed stamp reads as "absent" rather than killing the load.
+    }
+    return 0;
 }
 
 void SaveManager::LoadFile(int fileNum) {

--- a/games/oot/soh/SaveManager.cpp
+++ b/games/oot/soh/SaveManager.cpp
@@ -1603,7 +1603,17 @@ uint32_t SaveManager::GetLoadedCommitGeneration() {
     // == a .sav from before the stamp existed == 0, the exempt value.
     try {
         if (saveBlock.is_object() && saveBlock.contains("rsbsCommitGeneration")) {
-            return saveBlock["rsbsCommitGeneration"].get<uint32_t>();
+            // is_number_unsigned(), not just get<uint32_t>(): nlohmann happily
+            // converts a NEGATIVE or floating-point value into a uint32_t
+            // instead of throwing, and a wrapped-around huge generation would
+            // read as ".sav newer" — a hard REFUSE that quarantines a
+            // perfectly healthy .redsave. #533's premise is that detection
+            // must never become data loss, so anything that is not the
+            // unsigned integer this code wrote reads as "absent" (0, exempt).
+            const nlohmann::json& stamp = saveBlock["rsbsCommitGeneration"];
+            if (stamp.is_number_unsigned()) {
+                return stamp.get<uint32_t>();
+            }
         }
     } catch (const std::exception&) {
         // A malformed stamp reads as "absent" rather than killing the load.

--- a/games/oot/soh/SaveManager.h
+++ b/games/oot/soh/SaveManager.h
@@ -109,6 +109,12 @@ class SaveManager {
     void DeleteZeldaFile(int fileNum);
     bool IsRandoFile();
 
+    // The RSBS commit generation mirrored in the currently-loaded .sav JSON
+    // ("rsbsCommitGeneration"), or 0 when the save predates the stamp. Read
+    // by the OnLoadFile hook to compare the .sav's freshness against the
+    // .redsave's Tier-1 stamp (#531/#537).
+    uint32_t GetLoadedCommitGeneration();
+
     // Test hook (#441): drive the REAL randomizer section through a
     // save -> context-reset -> reload cycle, in memory, exactly as loading a
     // saved file does (Save_LoadFile resets the Rando::Context, then
@@ -174,7 +180,12 @@ class SaveManager {
     void ConvertFromUnversioned();
     void CreateDefaultGlobal();
 
-    void SaveFileThreaded(int fileNum, SaveContext* saveContext, int sectionID);
+    // rsbsGeneration: the RSBS commit generation stamped by the game-thread
+    // marshalling in SaveSection (#537); 0 for non-base sections and for
+    // fileNums outside the unified-slot range. When nonzero it is mirrored
+    // into the .sav JSON so both durable artifacts carry the same freshness
+    // stamp.
+    void SaveFileThreaded(int fileNum, SaveContext* saveContext, int sectionID, uint32_t rsbsGeneration);
 
     void InitMeta(int slotNum);
     void StartupCheckAndInitMeta(int slotNum);

--- a/src/common/context.h
+++ b/src/common/context.h
@@ -614,6 +614,35 @@ typedef struct {
     // blocks in every scan. Physically they must stay two, forever.
     ComboSharedResource sharedResourcesExt[RSBS_SHARED_RESOURCE_EXT_CAP];
 
+    // #537/#531 (one-game persistence, #564 V16/V20 interim): the MONOTONIC
+    // COMMIT GENERATION. Incremented by the .redsave commit choke point
+    // (rsbs::SaveManager::StageCommit) on every staged commit, serialized here
+    // in Tier-1, and MIRRORED into OoT's file{N+1}.sav JSON
+    // ("rsbsCommitGeneration") by the same commit whenever that commit also
+    // writes the .sav. The two durable artifacts describing the ONE save can
+    // therefore be compared for freshness at load: equal generations mean both
+    // artifacts came from the same commit instant; a .redsave generation AHEAD
+    // of the .sav's is exactly the #531 shape (an MM-side commit after OoT's
+    // last save point); a .sav generation ahead means the .redsave write was
+    // lost or the file was replaced from elsewhere. Detection lives in
+    // RsbsSave_CheckCommitGenerationSkew.
+    //
+    // Zero == unset (no commit has ever been stamped), the growth contract's
+    // required meaning: a zero-extended legacy record reads 0 and is exempt
+    // from skew comparison. Carved from the FRONT of the old reserved[132], so
+    // every field above keeps its shipped offset and the record size is
+    // unchanged. NOT in the .redsave header on purpose: DeserializeHeader
+    // pins headerSize with an equality check, so growing the header would
+    // orphan every shipped save, while a Tier-1 carve is the established
+    // compatible-growth path.
+    //
+    // Deliberately NOT in Context_InvalidateSessionState's KEEP set: a session
+    // teardown either precedes a slot load (which restores the slot's own
+    // generation from its .redsave) or a new game (whose first commit stamps
+    // generation 1 into BOTH fresh artifacts). Carrying a dead session's
+    // counter across would make an unrelated slot's artifacts look skewed.
+    uint32_t commitGeneration;
+
     // Headroom. Carve new fields from the FRONT of this array (as
     // sharedItemsTagged, sharedRandoSettingsHash, foreignPlacements, the
     // grant cursors, and the reverse placement table were) so the struct
@@ -625,13 +654,17 @@ typedef struct {
     // "zero means unset".
     //
     // 264 - 48 (foreignPlacementsOoT) - 4 (mmProfileDigest) - 32 (sharedResources)
-    // - 48 (sharedResourcesExt).
+    // - 48 (sharedResourcesExt) - 4 (commitGeneration).
     // ADR 0009 publishes the remaining
     // allocation across the other claimants and sets a 64-byte floor:
     // Test_SaveComboRecordFixed's scribble loop iterates sizeof(reserved), so
     // at zero it degenerates to zero iterations and passes vacuously, retiring
-    // the only test that proves headroom round-trips at all.
-    uint8_t reserved[132];
+    // the only test that proves headroom round-trips at all. NOTE: with the
+    // commitGeneration carve this stands at 128; ADR 0009's outstanding
+    // claims 2 and 4 (4 + 64) would leave 60, so the ADR's budget table needs
+    // a row before those land (raise the record size + RSBS_SAVE_VERSION
+    // together if the floor would break).
+    uint8_t reserved[128];
 } ComboContext;
 
 /**
@@ -753,13 +786,24 @@ RSBS_CTX_STATIC_ASSERT(offsetof(ComboContext, sharedResourcesExt) ==
                                RSBS_SHARED_RESOURCE_CAP * sizeof(ComboSharedResource),
                        "sharedResourcesExt must be carved from the FRONT of reserved[] (contiguous "
                        "with the first shared-resource block); moving it changes .redsave format");
-RSBS_CTX_STATIC_ASSERT(offsetof(ComboContext, reserved) ==
+// The commit generation is the next carve (#537/#531, 4 bytes). Pinned to the
+// literal 872 for the same reason 672, 736, 740, 788, 792 and 824 are: anything
+// carved after it inherits its position, so a field growing in place ahead of
+// it must break the build rather than slide it.
+RSBS_CTX_STATIC_ASSERT(offsetof(ComboContext, commitGeneration) == 872u,
+                       "commitGeneration lives at .redsave byte offset 872; if this fires, a field "
+                       "before it grew in place - carve from reserved[] instead");
+RSBS_CTX_STATIC_ASSERT(offsetof(ComboContext, commitGeneration) ==
                            offsetof(ComboContext, sharedResourcesExt) +
                                RSBS_SHARED_RESOURCE_EXT_CAP * sizeof(ComboSharedResource),
+                       "commitGeneration must be carved from the FRONT of reserved[] (contiguous "
+                       "with the second shared-resource block); moving it changes .redsave format");
+RSBS_CTX_STATIC_ASSERT(offsetof(ComboContext, reserved) ==
+                           offsetof(ComboContext, commitGeneration) + sizeof(uint32_t),
                        "the tagged-item array, the settings digest, both foreign-placement tables, "
                        "the grant cursors, the overflow count, the MM profile digest, BOTH shared "
-                       "resource blocks, and the remaining headroom must stay contiguous (no padding, "
-                       "no fields slipped between them)");
+                       "resource blocks, the commit generation, and the remaining headroom must stay "
+                       "contiguous (no padding, no fields slipped between them)");
 // ADR 0009's floor. reserved[] is what Test_SaveComboRecordFixed scribbles to
 // prove Tier-1 headroom round-trips; at zero that loop runs zero times and the
 // test passes vacuously, so the carve budget stops here rather than there.

--- a/src/common/save.cpp
+++ b/src/common/save.cpp
@@ -175,6 +175,15 @@ uint32_t SaveManager::StageCommit() {
     if (ootShadow == nullptr || mmShadow == nullptr) {
         std::fprintf(stderr, "[RsbsSave] commit NOT staged: context shadows are absent "
                              "(Context_InitFrozenStates has not run)\n");
+        // INVALIDATE rather than just refuse. WriteStagedCommit serializes
+        // "the most recently staged snapshot" for whatever slot its caller
+        // names, and OoT's worker hook fires unconditionally after the .sav
+        // write — so leaving an EARLIER stage addressable here would let a
+        // save whose own marshalling failed publish a previous commit's
+        // snapshot, potentially into a different slot. A failed stage must
+        // leave nothing to write.
+        std::lock_guard<std::mutex> lock(mStageMtx);
+        mStaged.valid = false;
         return 0;
     }
 

--- a/src/common/save.cpp
+++ b/src/common/save.cpp
@@ -111,35 +111,95 @@ uint32_t SaveManager::Crc32(const uint8_t* data, size_t len) {
     return ~crc;
 }
 
-bool SaveManager::Save(int slot) {
+uint32_t SaveManager::StageCommit() {
+    // GAME THREAD ONLY — this is the marshalling half of the commit choke
+    // point (#537). Serialization source = the context-layer shadow copies.
+    // Both must be present (Context_InitFrozenStates run); otherwise there is
+    // nothing to capture and we refuse rather than stage a half-empty commit.
+    const void* ootShadow = Context_GetOoTSaveContext();
+    const void* mmShadow = Context_GetMMSaveContext();
+    if (ootShadow == nullptr || mmShadow == nullptr) {
+        std::fprintf(stderr, "[RsbsSave] commit NOT staged: context shadows are absent "
+                             "(Context_InitFrozenStates has not run)\n");
+        return 0;
+    }
+
+    // Stamp the monotonic commit generation BEFORE copying, so the staged
+    // Tier-1 (and therefore the artifact) carries it. gComboCtx is game-thread
+    // state; mutating it here is legal precisely because staging is
+    // game-thread-only. A loaded slot resumes its own counter (Load memcpys
+    // the whole struct back), so the sequence is monotonic across sessions.
+    gComboCtx.commitGeneration += 1;
+    const uint32_t generation = gComboCtx.commitGeneration;
+
+    {
+        std::lock_guard<std::mutex> lock(mStageMtx);
+        std::memcpy(&mStaged.combo, &gComboCtx, sizeof(ComboContext));
+        mStaged.oot.assign(static_cast<const uint8_t*>(ootShadow),
+                           static_cast<const uint8_t*>(ootShadow) + kOoTSize);
+        mStaged.mm.assign(static_cast<const uint8_t*>(mmShadow),
+                          static_cast<const uint8_t*>(mmShadow) + kMMSize);
+        mStaged.generation = generation;
+        mStaged.valid = true;
+    }
+    return generation;
+}
+
+bool SaveManager::WriteStagedCommit(int slot) {
     if (!SlotInRange(slot)) {
         return SaveLogFail(slot, "slot index out of range");
     }
 
-    // Serialization source = the context-layer shadow copies. Both must be
-    // present (Context_InitFrozenStates run); otherwise there is nothing to
-    // capture and we refuse rather than write a half-empty file.
-    const void* ootShadow = Context_GetOoTSaveContext();
-    const void* mmShadow = Context_GetMMSaveContext();
-    if (ootShadow == nullptr || mmShadow == nullptr) {
-        return SaveLogFail(slot, "context shadows are absent (Context_InitFrozenStates has not run)");
+    // Copy the staged snapshot out under the lock, then serialize from the
+    // LOCAL copy only. This function must never read gComboCtx or the live
+    // shadows: it runs on SoH's save worker thread while the game thread keeps
+    // mutating both, which is exactly the #537 tear this choke point removes.
+    ComboContext combo;
+    std::vector<uint8_t> ootBlob;
+    std::vector<uint8_t> mmBlob;
+    {
+        std::lock_guard<std::mutex> lock(mStageMtx);
+        if (!mStaged.valid) {
+            return SaveLogFail(slot, "no commit has been staged this session (StageCommit not run)");
+        }
+        std::memcpy(&combo, &mStaged.combo, sizeof(ComboContext));
+        ootBlob = mStaged.oot;
+        mmBlob = mStaged.mm;
     }
+    return WriteSlotFile(slot, combo, ootBlob.data(), mmBlob.data());
+}
+
+bool SaveManager::Save(int slot) {
+    // Stage + write on the calling thread. Game thread only (it stages).
+    if (StageCommit() == 0) {
+        return SaveLogFail(slot, "commit staging refused (see above)");
+    }
+    return WriteStagedCommit(slot);
+}
+
+bool SaveManager::WriteSlotFile(int slot, const ComboContext& combo, const uint8_t* ootBlob,
+                                const uint8_t* mmBlob) {
+    // One writer at a time: the OnSaveFile worker (WriteStagedCommit) and a
+    // synchronous game-thread commit (MM's capture, OnExitGame) share the same
+    // `.tmp` staging path per slot, and interleaved temp writes would produce
+    // a CRC-invalid file. The snapshot arguments are already immutable, so
+    // holding the lock across serialization stays deadlock-free (mStageMtx is
+    // never taken here).
+    std::lock_guard<std::mutex> writeLock(mWriteMtx);
 
     // Assemble Tiers 1..3 contiguously so the CRC covers exactly the bytes we
     // write, in write order: ComboContext, OoT blob, MM blob.
     std::vector<uint8_t> payload;
     payload.reserve(kComboSize + kOoTSize + kMMSize);
-    // Tier-1 goes out at the FIXED record size: the live struct, then zeros to
-    // the budget. The padding is what gives ComboContext room to grow later
-    // without the serialized size — and therefore every existing save file's
-    // validity — moving.
-    const uint8_t* comboBytes = reinterpret_cast<const uint8_t*>(&gComboCtx);
+    // Tier-1 goes out at the FIXED record size: the snapshot struct, then
+    // zeros to the budget. The padding is what gives ComboContext room to grow
+    // later without the serialized size — and therefore every existing save
+    // file's validity — moving.
+    const uint8_t* comboBytes = reinterpret_cast<const uint8_t*>(&combo);
     payload.insert(payload.end(), comboBytes, comboBytes + sizeof(ComboContext));
     payload.insert(payload.end(), kComboSize - sizeof(ComboContext), uint8_t{0});
-    payload.insert(payload.end(), static_cast<const uint8_t*>(ootShadow),
-                   static_cast<const uint8_t*>(ootShadow) + kOoTSize);
-    payload.insert(payload.end(), static_cast<const uint8_t*>(mmShadow),
-                   static_cast<const uint8_t*>(mmShadow) + kMMSize);
+    payload.insert(payload.end(), ootBlob, ootBlob + kOoTSize);
+    payload.insert(payload.end(), mmBlob, mmBlob + kMMSize);
 
     RsbsSaveHeader header;
     std::memset(&header, 0, sizeof(header));
@@ -525,6 +585,47 @@ extern "C" {
 
 int RsbsSave_Save(int slot) {
     return rsbs::SaveManager::Instance().Save(slot) ? 1 : 0;
+}
+
+uint32_t RsbsSave_StageCommit(void) {
+    return rsbs::SaveManager::Instance().StageCommit();
+}
+
+int RsbsSave_WriteStagedCommit(int slot) {
+    return rsbs::SaveManager::Instance().WriteStagedCommit(slot) ? 1 : 0;
+}
+
+int RsbsSave_CheckCommitGenerationSkew(int slot, uint32_t ootSavGeneration) {
+    const uint32_t redsaveGeneration = gComboCtx.commitGeneration;
+    // Either side at 0 predates the stamp (legacy artifact); exempt rather
+    // than false-positive on every upgraded install's first load.
+    if (redsaveGeneration == 0 || ootSavGeneration == 0 || redsaveGeneration == ootSavGeneration) {
+        return 0;
+    }
+    if (redsaveGeneration > ootSavGeneration) {
+        // The #531 shape: the .redsave (combo records + MM world) is FRESHER
+        // than OoT's own .sav — a durable commit (e.g. an MM owl save) landed
+        // after OoT's last save point, so OoT's world will resume older than
+        // the records that account for it.
+        std::fprintf(stderr,
+                     "[RsbsSave] slot %d COMMIT SKEW: .redsave generation %u is NEWER than OoT's .sav "
+                     "generation %u — OoT's world is stale relative to the cross-game records "
+                     "(items delivered to OoT after its last save may be missing while marked "
+                     "REDEEMED). TODO(#533): surface as REFUSED once the quarantine/diagnostic "
+                     "machinery lands; continuing with each artifact authoritative for its own "
+                     "tiers (newer generation preferred).\n",
+                     slot, redsaveGeneration, ootSavGeneration);
+        return 1;
+    }
+    std::fprintf(stderr,
+                 "[RsbsSave] slot %d COMMIT SKEW: OoT's .sav generation %u is NEWER than the .redsave "
+                 "generation %u — the unified slot missed at least one commit (a .redsave write "
+                 "failed, or the file was replaced from elsewhere). Cross-game state may be stale. "
+                 "TODO(#533): surface as REFUSED once the quarantine/diagnostic machinery lands; "
+                 "continuing with each artifact authoritative for its own tiers (newer generation "
+                 "preferred).\n",
+                 slot, ootSavGeneration, redsaveGeneration);
+    return -1;
 }
 
 int RsbsSave_Load(int slot) {

--- a/src/common/save.h
+++ b/src/common/save.h
@@ -75,7 +75,9 @@ typedef struct RsbsGameMetaDesc {
 
 #include <cstddef>
 #include <iosfwd>
+#include <mutex>
 #include <string>
+#include <vector>
 
 namespace rsbs {
 
@@ -130,6 +132,42 @@ class SaveManager {
 public:
     static SaveManager& Instance();
 
+    /**
+     * THE .redsave COMMIT CHOKE POINT (#537/#531, #564 "one commit
+     * discipline"). Every durable .redsave write is a two-phase commit:
+     *
+     *   1. StageCommit() — GAME THREAD ONLY. Marshals ONE coherent snapshot of
+     *      the whole cross-game state (Tier-1 gComboCtx + the OoT shadow + the
+     *      MM shadow) into an internal staging buffer, and stamps the next
+     *      MONOTONIC commit generation into gComboCtx.commitGeneration first
+     *      so the snapshot carries it. The caller must have refreshed the
+     *      ACTIVE game's shadow (Context_UpdateShadowCopy from the live
+     *      gSaveContext) and set gComboCtx.sourceGame on the same thread,
+     *      immediately before staging — that is what makes the snapshot
+     *      single-instant. Returns the stamped generation, or 0 on refusal
+     *      (shadows absent). Never touches the filesystem.
+     *
+     *   2. WriteStagedCommit(slot) — ANY THREAD. Serializes the most recently
+     *      staged snapshot to the slot file. Reads ONLY the immutable staged
+     *      copy — never gComboCtx, never the live shadows — so a worker
+     *      thread can run it while the game thread keeps mutating live state
+     *      (the #537 tear becomes unrepresentable). Returns false and logs if
+     *      nothing has been staged this session.
+     *
+     * Save(slot) below is the one-call form (stage + write on the calling
+     * thread) and therefore inherits StageCommit's game-thread contract.
+     * There is deliberately NO other writer: SaveManager serializes staged
+     * snapshots only.
+     */
+    uint32_t StageCommit();
+    bool WriteStagedCommit(int slot);
+
+    /**
+     * Stage + write in one call, on the calling thread. GAME THREAD ONLY (it
+     * stages; see StageCommit). This is the route for synchronous commits: the
+     * MM-side capture funnel, OoT's exit-time snapshot, tests, and the debug
+     * menu's "Save to slot".
+     */
     bool Save(int slot);
     bool Load(int slot);
     bool HasSave(int slot) const;
@@ -204,10 +242,40 @@ private:
     // per-frame spam loop, not a diagnostic.
     bool DeserializeHeader(std::istream& in, RsbsSaveHeader& outHeader, bool verbose) const;
 
+    // Serializes the given snapshot to the slot file (temp-write + rename).
+    // The ONLY function that writes .redsave bytes; both commit phases and
+    // Save() funnel here with an immutable snapshot. Serialized by mWriteMtx:
+    // the write phase can run on SoH's save worker (WriteStagedCommit from the
+    // OnSaveFile hook) at the same time as a synchronous game-thread commit
+    // (MM's capture during a crossing while an OoT autosave is still in
+    // flight), and both use the same `.tmp` staging path — unserialized, the
+    // interleaved temp writes produce a CRC-invalid file that the next load
+    // refuses.
+    bool WriteSlotFile(int slot, const ComboContext& combo, const uint8_t* ootBlob, const uint8_t* mmBlob);
+
     std::string mSaveDir = "Save";
 
     // -1 == no slot established this session. See SetActiveSlot.
     int mActiveSlot = -1;
+
+    // The staged commit snapshot (see StageCommit/WriteStagedCommit). Guarded
+    // by mStageMtx: the game thread overwrites it at each stage, the worker
+    // copies it out for serialization. The buffers are allocated at first
+    // stage and reused.
+    struct StagedCommit {
+        ComboContext combo{};
+        std::vector<uint8_t> oot;
+        std::vector<uint8_t> mm;
+        uint32_t generation = 0;
+        bool valid = false;
+    };
+    StagedCommit mStaged;
+    mutable std::mutex mStageMtx;
+
+    // Serializes concurrent slot-file writers (see WriteSlotFile). Never held
+    // together with mStageMtx: WriteStagedCommit copies the snapshot out under
+    // mStageMtx, releases it, and only then enters WriteSlotFile.
+    mutable std::mutex mWriteMtx;
 
     // Game-side metadata descriptors, indexed by GameId (GAME_OOT / GAME_MM).
     // mMetaPresent[i] guards mMetaDescs[i]; an unset descriptor causes
@@ -229,6 +297,36 @@ int  RsbsSave_Save(int slot);
 int  RsbsSave_Load(int slot);
 int  RsbsSave_HasSave(int slot);
 void RsbsSave_DeleteSave(int slot);
+
+/**
+ * Two-phase commit shims (#537/#531; see SaveManager::StageCommit).
+ * RsbsSave_StageCommit marshals the game-thread snapshot and returns the
+ * stamped monotonic generation (0 on refusal); RsbsSave_WriteStagedCommit
+ * serializes the staged snapshot from any thread, reading no live state.
+ * RsbsSave_Save == stage + write on the calling thread (game thread only).
+ */
+uint32_t RsbsSave_StageCommit(void);
+int      RsbsSave_WriteStagedCommit(int slot);
+
+/**
+ * Load-time freshness comparison between the two durable artifacts of the ONE
+ * save (#531/#564 V16 interim). Call AFTER a successful RsbsSave_Load, with
+ * the commit generation the OoT .sav JSON mirrors ("rsbsCommitGeneration", 0
+ * when absent). Compares it against the just-loaded Tier-1 generation.
+ *
+ * Returns 0 when the artifacts agree (or either side predates the stamp,
+ * which is exempt), +1 when the .redsave is NEWER than the .sav (the #531
+ * shape: an MM-side commit landed after OoT's last save point — OoT's world
+ * is stale relative to the combo records), -1 when the .sav is NEWER (the
+ * .redsave write was lost, or a foreign file was swapped in).
+ *
+ * TODO(#533): a nonzero result should surface through the REFUSED/diagnostic
+ * machinery once it exists. Until then this logs loudly and the caller
+ * continues — each artifact remains authoritative for its own tiers, i.e. the
+ * newer generation's tiers are implicitly preferred, because refusing without
+ * #533's quarantine would convert detection into data loss (#564 V19).
+ */
+int RsbsSave_CheckCommitGenerationSkew(int slot, uint32_t ootSavGeneration);
 
 /**
  * Session-scoped "which slot is open" (see SaveManager::SetActiveSlot).

--- a/src/common/save.h
+++ b/src/common/save.h
@@ -209,7 +209,11 @@ public:
      *      gSaveContext) and set gComboCtx.sourceGame on the same thread,
      *      immediately before staging — that is what makes the snapshot
      *      single-instant. Returns the stamped generation, or 0 on refusal
-     *      (shadows absent). Never touches the filesystem. Callers that know
+     *      (shadows absent) — a refused stage also INVALIDATES whatever was
+     *      staged before it, so a save whose own marshalling failed can never
+     *      publish an earlier commit's snapshot (possibly into a different
+     *      slot) through the write phase that follows it unconditionally.
+     *      Never touches the filesystem. Callers that know
      *      their target slot should check IsSlotWritable FIRST: staging for a
      *      latched slot advances the generation (and, on OoT's path, mirrors
      *      it into the .sav) for a write that will refuse, manufacturing

--- a/src/common/test_runner.cpp
+++ b/src/common/test_runner.cpp
@@ -185,6 +185,12 @@ extern "C" {
 // FILE SCOPE (compiled as C++): they drive the C++-linkage rsbs::SaveManager.
 #include "tests/test_save_roundtrip.c"
 
+// The .redsave commit choke point (#537/#531): monotonic commit generation,
+// the torn-write impossibility (stage on the game thread, write from the
+// immutable snapshot only), and the load-time cross-artifact freshness
+// comparison. FILE SCOPE (compiled as C++), same reason as above.
+#include "tests/test_commit_generation.c"
+
 // Lane C1 foreign-item pipeline locks (#392, ADR 0002): give-path tagging,
 // round-trip survival with a real pool entry, and the foreignPlacements carve
 // serialization. FILE SCOPE (compiled as C++) for rsbs::SaveManager; the
@@ -1988,6 +1994,14 @@ const TestDescriptor gTests[] = {
     {"save-combo-oversize", "Load rejects an oversized Tier-1 record, no clobber", Test_SaveComboOversize},
     {"save-tagged-items", "Origin-tagged shared items round-trip; empty slots stay unset (ADR 0002)",
      Test_SaveTaggedItems},
+    // The commit choke point (#537/#531): one game-thread-marshalled snapshot,
+    // a monotonic generation in both artifacts, and load-time skew detection.
+    {"commit-generation-monotonic", "Choke-point commits stamp a monotonic Tier-1 generation (#537)",
+     Test_CommitGenerationMonotonic},
+    {"commit-torn-write", "Post-stage mutation cannot reach the .redsave; the #537 tear is unrepresentable",
+     Test_CommitTornWrite},
+    {"commit-generation-skew", "Load detects .redsave/.sav freshness divergence (#531/#564 V16)",
+     Test_CommitGenerationSkew},
     {"mm-scene-parse", "MM scene commands parse via the S2H factory (#344)", Test_MMSceneParse},
     {"seq-map-bounds", "Sequence-map capacity covers the id range + custom slack (#371, #378)", Test_SeqMapBounds},
     {"cvar-classification", "Cross-game CVar classification matches ADR 0003 + the inventory (#34)",

--- a/src/common/tests/test_commit_generation.c
+++ b/src/common/tests/test_commit_generation.c
@@ -1,0 +1,236 @@
+/**
+ * @file test_commit_generation.c
+ * @brief Headless locks for the .redsave commit choke point (#537/#531).
+ *
+ * Three locks:
+ *
+ *   commit-generation-monotonic — every commit staged through the choke point
+ *   stamps a strictly-increasing generation into Tier-1, the stamp survives a
+ *   round trip, and the counter RESUMES from the loaded value (monotonic
+ *   across sessions, not just within one).
+ *
+ *   commit-torn-write — the #537 tear is unrepresentable through the choke
+ *   point. The write phase serializes ONLY the immutable snapshot marshalled
+ *   at stage time: state mutated after staging (including a deliberate
+ *   half-written SharedItem, the exact interleave shape from the #537 report,
+ *   and a live mutator thread scribbling the shadows WHILE the write runs)
+ *   must not reach the artifact. COUNTERFACTUAL: revert the marshalling —
+ *   i.e. make WriteStagedCommit (or the OnSaveFile hook it serves) read the
+ *   live gComboCtx/shadows again — and this test goes red, because the
+ *   post-stage mutations would then be serialized.
+ *
+ *   commit-generation-skew — the load-time freshness comparison between the
+ *   two durable artifacts: agree == 0, .redsave newer == +1 (the #531 loss
+ *   shape), .sav newer == -1, and either side at 0 (pre-stamp legacy) exempt.
+ *
+ * Linkage note: like test_save_roundtrip.c, this file is #included into
+ * test_runner.cpp at FILE SCOPE (compiled as C++) so it can call the C++
+ * rsbs::SaveManager API.
+ */
+
+#include "../context.h"
+#include "../game.h"
+#include "../save.h"
+#include "../test_runner.h"
+
+#include <atomic>
+#include <cstdint>
+#include <cstdio>
+#include <cstring>
+#include <thread>
+#include <vector>
+
+#define CG_ASSERT(cond, msg)                    \
+    do {                                        \
+        if (!(cond)) {                          \
+            printf("[TEST] FAIL: %s\n", (msg)); \
+            return TEST_FAIL;                   \
+        }                                       \
+    } while (0)
+
+namespace {
+
+const char* const kCommitGenTestDir = "rsbs_test_commit_gen";
+
+// Fill both shadows with a single repeated byte. One byte per instant makes a
+// torn mix of two instants detectable by scanning for ANY off-pattern byte.
+void CommitGenFillShadows(uint8_t value) {
+    std::vector<uint8_t> oot(OOT_SAVE_CONTEXT_SIZE, value);
+    std::vector<uint8_t> mm(MM_SAVE_CONTEXT_SIZE, value);
+    Context_UpdateShadowCopy(GAME_OOT, oot.data(), oot.size());
+    Context_UpdateShadowCopy(GAME_MM, mm.data(), mm.size());
+}
+
+bool CommitGenShadowsAreUniform(uint8_t value) {
+    const uint8_t* oot = static_cast<const uint8_t*>(Context_GetOoTSaveContext());
+    const uint8_t* mm = static_cast<const uint8_t*>(Context_GetMMSaveContext());
+    if (oot == nullptr || mm == nullptr) {
+        return false;
+    }
+    for (size_t i = 0; i < OOT_SAVE_CONTEXT_SIZE; i++) {
+        if (oot[i] != value) {
+            return false;
+        }
+    }
+    for (size_t i = 0; i < MM_SAVE_CONTEXT_SIZE; i++) {
+        if (mm[i] != value) {
+            return false;
+        }
+    }
+    return true;
+}
+
+}  // namespace
+
+TestResult Test_CommitGenerationMonotonic(void) {
+    printf("[TEST] commit-generation-monotonic: choke-point commits stamp a monotonic Tier-1 generation (#537)\n");
+
+    rsbs::SaveManager& mgr = rsbs::SaveManager::Instance();
+    mgr.SetSaveDirectory(kCommitGenTestDir);
+
+    Context_InitFrozenStates();
+    ComboContext_Init();
+    CommitGenFillShadows(0x11);
+    mgr.DeleteSave(0);
+
+    CG_ASSERT(gComboCtx.commitGeneration == 0, "a fresh ComboContext must start at generation 0 (unset)");
+
+    // N commits through the one-call form of the choke point: strictly
+    // increasing by one, stamped into the live Tier-1 at stage time.
+    for (uint32_t i = 1; i <= 5; i++) {
+        CG_ASSERT(mgr.Save(0), "Save(0) failed");
+        CG_ASSERT(gComboCtx.commitGeneration == i, "commit generation must advance by exactly one per commit");
+    }
+
+    // The stamp is IN the artifact: wipe live state, load, and the counter
+    // resumes from the stored value rather than restarting.
+    ComboContext_Init();
+    CG_ASSERT(gComboCtx.commitGeneration == 0, "ComboContext_Init must reset the live counter");
+    CG_ASSERT(mgr.Load(0), "Load(0) failed");
+    CG_ASSERT(gComboCtx.commitGeneration == 5, "the loaded Tier-1 must carry the last committed generation");
+
+    // Monotonic ACROSS the load: the next commit continues the sequence.
+    CG_ASSERT(mgr.Save(0), "post-load Save(0) failed");
+    CG_ASSERT(gComboCtx.commitGeneration == 6, "the counter must resume from the loaded value, not restart");
+
+    // The two-phase form stamps identically (this is the path the threaded
+    // OoT save takes: stage on the game thread, write on the worker).
+    const uint32_t staged = RsbsSave_StageCommit();
+    CG_ASSERT(staged == 7, "StageCommit must stamp the next generation");
+    CG_ASSERT(gComboCtx.commitGeneration == 7, "StageCommit must stamp the live Tier-1");
+    CG_ASSERT(RsbsSave_WriteStagedCommit(0) == 1, "WriteStagedCommit failed");
+    ComboContext_Init();
+    CG_ASSERT(mgr.Load(0), "reload failed");
+    CG_ASSERT(gComboCtx.commitGeneration == 7, "the artifact must carry the staged generation");
+
+    mgr.DeleteSave(0);
+    ComboContext_Init();
+    printf("[TEST] PASS: commit generation is monotonic within and across sessions\n");
+    return TEST_PASS;
+}
+
+TestResult Test_CommitTornWrite(void) {
+    printf("[TEST] commit-torn-write: post-stage mutation cannot reach the artifact (#537)\n");
+
+    rsbs::SaveManager& mgr = rsbs::SaveManager::Instance();
+    mgr.SetSaveDirectory(kCommitGenTestDir);
+
+    Context_InitFrozenStates();
+    ComboContext_Init();
+    mgr.DeleteSave(0);
+
+    // ---- Instant A: the state the game thread marshals -------------------
+    const uint8_t kInstantA = 0x5A;
+    CommitGenFillShadows(kInstantA);
+    gComboCtx.sharedFlags[3] = 0xAAAA5555u;
+    gComboCtx.sourceGame = GAME_OOT;
+    gComboCtx.sharedItemsTagged[0].originGame = GAME_OOT;
+    gComboCtx.sharedItemsTagged[0].flags = 0;
+    gComboCtx.sharedItemsTagged[0].id = 0x1234;
+
+    const uint32_t stagedGen = RsbsSave_StageCommit();
+    CG_ASSERT(stagedGen != 0, "StageCommit refused with shadows present");
+
+    // ---- The game thread moves on before the worker writes ---------------
+    // This is the #537 failure shape verbatim: a SharedItem whose origin was
+    // rewritten but whose id was not (a half-flipped record), the shadows
+    // overwritten by a departure freeze, and gComboCtx fields mutated by
+    // suspend-time staging — all between the save being INITIATED and the
+    // worker's file write. Through the choke point none of it can reach disk.
+    const uint8_t kInstantB = 0xB7;
+    CommitGenFillShadows(kInstantB);
+    gComboCtx.sharedFlags[3] = 0xBBBB0000u;
+    gComboCtx.sourceGame = GAME_MM;
+    gComboCtx.sharedItemsTagged[0].originGame = GAME_MM;  // half-write: id left at 0x1234
+    gComboCtx.commitGeneration = 999;                     // scribble the live stamp too
+
+    // And keep mutating WHILE the write runs, from another thread — the
+    // literal #537 interleave. This is race-free by construction precisely
+    // BECAUSE WriteStagedCommit reads only its staged copy; if it read live
+    // state this would be the mid-copy tear.
+    std::atomic<bool> stop{ false };
+    std::thread mutator([&stop]() {
+        uint8_t v = 0;
+        std::vector<uint8_t> scribble(OOT_SAVE_CONTEXT_SIZE);
+        while (!stop.load(std::memory_order_relaxed)) {
+            std::memset(scribble.data(), v, scribble.size());
+            Context_UpdateShadowCopy(GAME_OOT, scribble.data(), scribble.size());
+            Context_UpdateShadowCopy(GAME_MM, scribble.data(), MM_SAVE_CONTEXT_SIZE);
+            gComboCtx.sharedFlags[7] = v;
+            v++;
+        }
+    });
+
+    const int wrote = RsbsSave_WriteStagedCommit(0);
+    stop.store(true);
+    mutator.join();
+    CG_ASSERT(wrote == 1, "WriteStagedCommit failed");
+
+    // ---- The artifact must be instant A, whole ---------------------------
+    ComboContext_Init();
+    CommitGenFillShadows(0x00);
+    CG_ASSERT(mgr.Load(0), "Load(0) failed");
+
+    CG_ASSERT(gComboCtx.sharedFlags[3] == 0xAAAA5555u, "TORN: post-stage gComboCtx mutation reached the artifact");
+    CG_ASSERT(gComboCtx.sourceGame == GAME_OOT, "TORN: post-stage sourceGame flip reached the artifact");
+    CG_ASSERT(gComboCtx.sharedItemsTagged[0].originGame == GAME_OOT && gComboCtx.sharedItemsTagged[0].id == 0x1234,
+              "TORN: the half-written SharedItem reached the artifact (the #537 failure shape)");
+    CG_ASSERT(gComboCtx.commitGeneration == stagedGen,
+              "the artifact must carry the generation stamped AT STAGE TIME, not the live scribble");
+    CG_ASSERT(CommitGenShadowsAreUniform(kInstantA),
+              "TORN: the artifact's world tiers mix instants — the write read live shadows");
+
+    mgr.DeleteSave(0);
+    ComboContext_Init();
+    CommitGenFillShadows(0x00);
+    printf("[TEST] PASS: the artifact is the staged instant, whole; the tear is unrepresentable\n");
+    return TEST_PASS;
+}
+
+TestResult Test_CommitGenerationSkew(void) {
+    printf("[TEST] commit-generation-skew: cross-artifact freshness comparison (#531/#564 V16)\n");
+
+    Context_InitFrozenStates();
+    ComboContext_Init();
+
+    // Agreement — and the legacy exemptions (either side 0 predates the stamp).
+    gComboCtx.commitGeneration = 7;
+    CG_ASSERT(RsbsSave_CheckCommitGenerationSkew(0, 7) == 0, "equal generations must read as agreement");
+    CG_ASSERT(RsbsSave_CheckCommitGenerationSkew(0, 0) == 0, "a pre-stamp .sav (0) must be exempt");
+    gComboCtx.commitGeneration = 0;
+    CG_ASSERT(RsbsSave_CheckCommitGenerationSkew(0, 5) == 0, "a pre-stamp .redsave (0) must be exempt");
+
+    // The #531 shape: .redsave ahead of the .sav (an MM-side commit landed
+    // after OoT's last save point). Must be detected, not silently composited.
+    gComboCtx.commitGeneration = 9;
+    CG_ASSERT(RsbsSave_CheckCommitGenerationSkew(0, 3) == 1,
+              ".redsave newer than .sav must be detected (the #531 loss shape)");
+
+    // The inverse: the unified slot missed a commit.
+    gComboCtx.commitGeneration = 2;
+    CG_ASSERT(RsbsSave_CheckCommitGenerationSkew(0, 6) == -1, ".sav newer than .redsave must be detected");
+
+    ComboContext_Init();
+    printf("[TEST] PASS: skew detection distinguishes agree / redsave-newer / sav-newer / legacy\n");
+    return TEST_PASS;
+}


### PR DESCRIPTION
## Mechanism

The `.redsave` OnSaveFile hook ran at the tail of `SaveFileThreaded` on SoH's save worker thread, AFTER the game-thread SaveContext snapshot was deleted, and memcpy'd the LIVE `gSaveContext` and `gComboCtx` while the game thread kept mutating both (#537). The resulting file is CRC-consistent — the hash is computed after the copy — but can be semantically torn (a half-written SharedItem, a half-flipped `switchRequested`/`targetGame` pair, world tiers mixing two instants), and Load restores it verbatim as durable slot state. Separately, the MM-side owl capture writes a Tier-1 that is FRESHER than OoT's own `.sav` with nothing recording the divergence — the #531 permanent-loss shape.

Of #537's two offered fix shapes, the #500/#564 one-game ruling selects **game-thread marshalling, with the snapshot widened to the whole cross-game state** (V20):

- `rsbs::SaveManager` gains the commit choke point: `StageCommit()` (GAME THREAD ONLY) marshals ONE coherent snapshot — Tier-1 `gComboCtx` + the OoT shadow + the MM shadow — into an internal staging buffer, stamping the next MONOTONIC commit generation (a new 4-byte Tier-1 carve at offset 872, pinned by static asserts; record size and every shipped offset unchanged, "zero means unset" preserved) into it first. `WriteStagedCommit(slot)` (any thread) serializes ONLY the immutable staged copy. `Save()` is the synchronous latch-check + stage + write form for game-thread callers (MM's capture, OnExitGame, tests, the debug menu). `WriteSlotFile` is the single byte-writer, serialized by a writer mutex so a worker-thread write and a synchronous game-thread commit cannot interleave on the same `.tmp` path.
- OoT's `SaveSection` now does the whole cross-game marshalling on the game thread, at the same instant SoH snapshots its own SaveContext: slot publish, shared-resource harvest (#525 — previously mutating live state from the worker), shadow refresh, `sourceGame`, `StageCommit`. The OnSaveFile hook body shrinks to `WriteStagedCommit(fileNum)`: it reads no live state, so the #537 tear becomes unrepresentable.
- The stamped generation rides into BOTH durable artifacts: the staged Tier-1 carries it into the `.redsave`, and `SaveFileThreaded` mirrors it into the `.sav` JSON (`"rsbsCommitGeneration"`) — authored by the same commit. Load is where the two artifacts of the ONE save are compared.

## #533 integration (the machinery is merged now — no log+TODO left)

The salvaged branch predated #568 and shipped the skew check as stderr + `TODO(#533)`. This PR upgrades it to the real machinery and reconciles the choke point with the write latch:

- **The choke point respects the latch.** `WriteStagedCommit` and `Save` both refuse an unarmed slot (`CheckWriteAllowed`), so a REFUSED slot stays unwritten even when a perfectly coherent snapshot is staged. `Save` checks the latch BEFORE staging so a refused write cannot advance the monotonic generation; OoT's `SaveSection` likewise skips staging (and the #525 harvest) for a latched slot, so the `.sav` never mirrors a generation whose `.redsave` commit was refused — that would manufacture artificial skew.
- **Skew surfaced through #533, differentiated by direction** (`LoadSlot(slot, ootSavGeneration)`, compared BEFORE committing):
  - `.sav` NEWER than `.redsave` (a `.redsave` commit is MISSING — lost write, or an older copy swapped in): **REFUSED at full strength** — no commit, evidence quarantined (`RSBS_REFUSE_COMMIT_SKEW`, `.refused-commitskew.bak`), write latch, `[REFUSED: …]` in the file panel. Committing the rolled-back Tier-1 would resurrect shared-item records the newer commits already consumed (cross-game duplication) and roll back MM's only persistence — under the one-game ruling that is corruption to refuse, not freshness to arbitrate.
  - `.redsave` NEWER than `.sav` (an MM-side commit landed after OoT's last save point — the #531 loss shape): the load proceeds — this is the designed post-MM-commit state, since an MM-side commit cannot rewrite OoT's own file, and refusing it would refuse every ordinary MM session's reload — but the divergence is recorded (`SlotMeta.commitSkew`) and rendered as a `[STALE: cross-game progress is newer than the OoT save]` warning in the file panel, player-visible instead of stderr-only.

## Adversarial review pass

The original implementer's branch was never build-verified. Every hunk was re-read against real declarations and rebuilt; two hardening findings were applied on top (commit `a21cd104`), both closing a path where a DETECTION could have become data loss or a cross-slot publish:

1. **A refused `StageCommit` now INVALIDATES the staged snapshot.** `WriteStagedCommit` serializes "the most recently staged snapshot" for whatever slot its caller names, and OoT's worker hook fires unconditionally after the `.sav` write — so a save whose own marshalling failed could have published an earlier commit's snapshot, potentially into a *different slot*. Only reachable with the context shadows absent (`Context_InitFrozenStates` runs at process startup, so not reachable in the shipped boot order), but the write phase's contract must not depend on that ordering to be safe.
2. **`GetLoadedCommitGeneration` requires `is_number_unsigned()`** before reading the `.sav`'s mirrored stamp. nlohmann converts a NEGATIVE or floating-point value into a `uint32_t` rather than throwing, so a malformed stamp could wrap to a huge generation, read as ".sav newer", and hard-REFUSE + quarantine a perfectly healthy `.redsave`. #533's premise is that detection must never become data loss, so anything that is not the unsigned integer this code wrote now reads as "absent" (0, exempt).

Checked and found sound (no change needed): the two-arg `OnSaveFile(fileNum, sectionID)` signature and its `sectionID != SECTION_ID_BASE` early return (so a section-only save never republishes a stale snapshot); `SaveFileThreaded`'s section-only early-return path, which returns *before* the hooks fire, so it cannot mirror a generation whose `.redsave` write never happens; the `[this]`-capturing `OnLoadFile` lambda and `saveBlock`'s population/`saveMtx` ownership at the point `GetLoadedCommitGeneration` reads it (same thread already holds the non-recursive mutex — taking it would self-deadlock, and it does not); the offset-872 arithmetic (824 + 48) and the unchanged `RSBS_COMBO_CONTEXT_PRECARVE_SIZE`/record size; `ComboContext_Init`'s memset covering the new field and its deliberate absence from the KEEP set; both `RsbsRefuseReason` switches updated; `SlotMeta` is not a packed/serialized type; the `IsSlotWritable` gate on the #525 harvest (the crossing harvest at `Game_Suspend` is unconditional, so the gate cannot desynchronize the pool); and the ordering property that OoT-path writes can only ever produce *redsave-newer*, never the refusing direction, because the `.sav` mirrors the generation staged at its own `SaveSection` while the `.redsave` always receives the latest staged one. `OnExitGame` was traced to its real dispatch site (`z_play.c:636`, `ENTR_LOAD_OPENING`) to confirm it is a quit-to-title path and *not* reached by the ordinary kaleido Save & Quit, which respawns — so the exit-time commit does not make the `[STALE]` surface fire after every routine save.

## Lock evidence (CTest label `redship`, ROM-free) — verbatim

```
[TEST] commit-generation-monotonic: choke-point commits stamp a monotonic Tier-1 generation (#537)
[TEST] PASS: commit generation is monotonic within and across sessions
[TEST] commit-torn-write: post-stage mutation cannot reach the artifact (#537)
[TEST] PASS: the artifact is the staged instant, whole; the tear is unrepresentable
[TEST] commit-generation-skew: cross-artifact freshness at load, surfaced via #533 (#531/#564 V16)
[TEST] PASS: agree/legacy load, redsave-newer surfaces, sav-newer refuses via #533
```

Pre-existing #533 and MM-capture locks still green over the choke point:

```
[TEST] save-refused-quarantine: every refusal quarantines the evidence and latches the slot (#533)
[TEST] PASS: CRC/truncation/wrong-slot/future-version each quarantine + latch, evidence intact
[TEST] save-write-latch: Save refuses any slot this session did not load, create, or erase (#533)
[TEST] PASS: the latch protects un-established slots; load/create/erase are the only keys
[TEST] mm-unified-save-capture: PASS
```

Counterfactuals re-executed by the review pass against the final tree (each patch applied, rebuilt, run, then reverted and re-verified green):

```
A. WriteStagedCommit reads the LIVE gComboCtx/shadows again (the pre-#537 behavior):
   commit-torn-write        -> [TEST] FAIL: TORN: post-stage gComboCtx mutation reached the artifact
B. Latch checks removed from WriteStagedCommit and Save:
   commit-torn-write        -> [TEST] FAIL: an unarmed slot must refuse the staged write (#533)
   save-write-latch         -> [TEST] FAIL: Save into an un-established slot must refuse
   commit-generation-skew   -> [TEST] FAIL: a latched Save after the skew refusal must refuse
```

(Counterfactual B going red in the pre-existing #533 lock as well as the two new ones is the evidence that the latch reconciliation is load-bearing rather than decorative.)

## Verification

Local ROM-staged build (MSVC/Ninja Release, Windows, fresh worktree, submodules initialized, port archives staged into the build root), on the exact PR head `a21cd104`:

```
ctest -L "^redship$" : 100% tests passed out of 73
ctest -L "^rando$"   : 100% tests passed out of 15
```

No submodule pointer changes (the merge adopts main's #566 libultraship bump only) and no generated build stamps committed.

## Scope

Out of scope, deliberately: the #532/#543 arrival mechanism (another session owns it); routing MM's remaining uncaptured save routes into this choke point (#530 — the funnel lands on top of this API, implemented as a redirect from the flash stubs into `RsbsSave_Save`, which is now latch- and generation-correct by construction); the redemption-staging residue that retires the #531 loss itself (records staged until a commit whose world tier contains the effect — tracked in #531, which stays open: this PR makes the divergence detected and player-visible, it does not yet prevent the loss).

Known limits, deliberate: the debug-menu "Save to slot" button still stages from the ImGui thread (pre-existing on main, unchanged) and advances the `.redsave` generation without mirroring it, so it registers as `[STALE]` on the next load; a section-only save re-serializes the last staged base commit (idempotent, same bytes).

Closes #537.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!--- section:artifacts:start -->
### Build Artifacts
  - [rsbs-windows.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/8787756689.zip)
  - [rsbs-linux.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/8787462686.zip)
<!--- section:artifacts:end -->