### PR TITLE
Freeze the MM profile into the pairing identity at creation; refuse divergent arrivals through the #533 surface (#498, #564)

### DIFF
--- a/docs/adr/0004-menu-information-architecture.md
+++ b/docs/adr/0004-menu-information-architecture.md
@@ -256,6 +256,21 @@ stamps `gComboCtx.mmProfileDigest`, the two `src/common` option writers reject a
 renders the frozen banner with every row disabled. The predicate is `Combo_MMProfileFrozen()`,
 the `src/common` fact §6 prescribes.
 
+**Residue, named rather than implied: state 4 is implemented as the gate and the presentation, not
+yet as the frozen VALUES.** §6 also requires that where a frozen key's value is shown, it be the
+value *from the save* rather than the CVar. This pane still renders live CVar reads. That is
+correct-but-fragile today — the two `src/common` writers are the only in-app writers and they
+reject while frozen, so the two agree — and it is genuinely unimplementable under the interim
+hybrid: the hybrid persists only the digest, so there is no frozen profile in `src/common`-owned
+storage to publish (§6's own "publishing the frozen profile into a `src/common` view is part of the
+freeze work" is the ask, and #564's carve budget shows a 47-option Tier-1 record does not fit).
+An out-of-band write the writers never see — a hand-edited config, libultraship's console
+`cvar_set` — therefore makes the pane display a value the world was not built from while labelled
+"frozen at creation". It is caught (the next arrival refuses on the digest) but it is displayed
+wrongly until then. Closing this is part of #564 step 11's move to delivery option 1, where the
+frozen profile lives in MM's Tier-3 `RANDO_SAVE_OPTIONS` and reaches the pane through the same
+`src/common` accessor the digest already uses.
+
 > **Amended 2026-07-30 (#564): the host conclusion survives and gets stronger; the deadline is
 > restated.** "Reachable while OoT is the running game, before the switch" was the right host
 > argument off the wrong deadline. Under one-game semantics the MM option profile freezes at the

--- a/docs/adr/0004-menu-information-architecture.md
+++ b/docs/adr/0004-menu-information-architecture.md
@@ -249,11 +249,12 @@ arming condition is untouched (mechanized as the MM-side reader allowlist in
 
 **Consequence accepted: §4.2's shared-intent marker does not apply to this pane.** All 47 options
 are tier-3 (O) MM-only keys; none is in `kSharedIntentKeys`, so there is no "applies to both
-games" claim to mark. §6's presentation states DO apply: live, editable-but-not-active
-("Majora's Mask — suspended"), and disabled-by-capability with a reason are implemented; §6's
-fourth state (frozen-at-creation, read-only) applies to this pane too and is **not** implemented
-— it is owed with the freeze work (#564 V5), and until it exists the pane is a live CVar editor
-at all times, including after the world it describes has been created.
+games" claim to mark. §6's presentation states DO apply, all four: live, editable-but-not-active
+("Majora's Mask — suspended"), disabled-by-capability with a reason, and — implemented with the
+#564-V5 freeze work (#498 phase 2 step 9) — frozen-at-creation, read-only: once a creation event
+stamps `gComboCtx.mmProfileDigest`, the two `src/common` option writers reject and the pane
+renders the frozen banner with every row disabled. The predicate is `Combo_MMProfileFrozen()`,
+the `src/common` fact §6 prescribes.
 
 > **Amended 2026-07-30 (#564): the host conclusion survives and gets stronger; the deadline is
 > restated.** "Reachable while OoT is the running game, before the switch" was the right host

--- a/games/mm/2s2h/GameExports_SingleExe.cpp
+++ b/games/mm/2s2h/GameExports_SingleExe.cpp
@@ -40,6 +40,12 @@
 // Paired-world keying + placement-table accessors (#439 switch-entry
 // activation logs the placement count at the pairing decision point).
 #include "foreign_items.h"
+// MM_Rando_ComputeProfileStamp — the arrival's identity re-resolution
+// (#498/#564: compare against the creation-frozen mmProfileDigest).
+#include "combo_mm_options_view.h"
+// OoT_Notification_Emit — the shared toast overlay (#427 bridge): the arrival
+// refusal must be player-visible in-game, not only in the file panel.
+#include "notification_bridge.h"
 #include "entrance.h"
 #include <ship/resource/ResourceManager.h>
 #include <ship/resource/ResourceLoader.h>
@@ -2786,6 +2792,68 @@ void MM_Rando_PairOnCrossGameArrival(int hadFrozenState) {
         fprintf(stderr, "[MM] pairing: skipped-because-already-paired (mmFinalSeed=%08X foreignPlacements=%d)\n",
                 gSaveContext.save.shipSaveInfo.rando.finalSeed, Combo_CountForeignPlacements());
         return;
+    }
+
+    // ------------------------------------------------------------------------
+    // The arrival identity gate (#498 decision 1 per #564, phase 2 step 9).
+    //
+    // The one game's MM profile was frozen into the pairing identity at the
+    // CREATION event (Playthrough_Init stamped gComboCtx.mmProfileDigest from
+    // the same MM_Rando_ComputeProfileStamp computation run here). Generation
+    // below would resolve the profile from the LIVE CVars/config — so before
+    // dispatching it, prove that resolution still IS the frozen identity.
+    // Divergence is corruption to refuse, never a choice to honor: no world is
+    // generated, the identity stamp is left untouched (never self-healed), and
+    // the refusal surfaces through the #533 machinery — the active slot is
+    // latched against writes (the divergent session must not capture its
+    // unpaired world into the healthy pair's .redsave) and the file panel
+    // renders the slot REFUSED with the reason.
+    // ------------------------------------------------------------------------
+    if (gComboCtx.mmProfileDigest != 0) {
+        const uint32_t arrivalDigest = MM_Rando_ComputeProfileStamp();
+        if (arrivalDigest != gComboCtx.mmProfileDigest) {
+            const int slot = RsbsSave_GetActiveSlot();
+            fprintf(stderr,
+                    "[MM] pairing: REFUSED — the MM option profile resolved at this arrival (%08X) does not match "
+                    "the identity frozen at creation (%08X). MM options/excluded checks/starting items changed "
+                    "after the paired world was created. No MM world is generated; the creation stamp is left "
+                    "untouched; unified-save slot %d is latched against writes this session\n",
+                    (unsigned)arrivalDigest, (unsigned)gComboCtx.mmProfileDigest, slot);
+            fflush(stderr);
+            RsbsSave_RefuseSlotIdentity(slot);
+
+            // Player-visible, immediately, on the shared overlay — stderr is
+            // not a surface and the file panel is only seen later.
+            ComboNotification refusalToast;
+            memset(&refusalToast, 0, sizeof(refusalToast));
+            refusalToast.prefix = "Cross-game pairing REFUSED:";
+            refusalToast.prefixColor[0] = 0.9f;
+            refusalToast.prefixColor[1] = 0.35f;
+            refusalToast.prefixColor[2] = 0.3f;
+            refusalToast.prefixColor[3] = 1.0f;
+            refusalToast.message = "Majora's Mask options no longer match this file's creation. "
+                                   "Termina stays un-randomized and progress here will not be saved to the pair.";
+            refusalToast.messageColor[0] = 1.0f;
+            refusalToast.messageColor[1] = 1.0f;
+            refusalToast.messageColor[2] = 1.0f;
+            refusalToast.messageColor[3] = 1.0f;
+            refusalToast.remainingTime = 15.0f;
+            // Muted: the overlay's ding is OoT's Audio_PlaySoundGeneral, and
+            // this call site runs on MM's boot path (and in the display-free
+            // rando tier) where OoT's audio session is not a given. The toast
+            // is the surface; the sound is not load-bearing.
+            refusalToast.mute = 1;
+            OoT_Notification_Emit(&refusalToast);
+            return;
+        }
+        fprintf(stderr, "[MM] pairing: arrival profile matches the creation-frozen identity (%08X)\n",
+                (unsigned)arrivalDigest);
+    } else {
+        // A LEGACY pre-freeze pair: its creation predates the identity stamp,
+        // so its profile freezes at this first crossing instead
+        // (ResolvePairedProfile stamps it during the generation below).
+        fprintf(stderr, "[MM] pairing: no creation-time profile stamp (pre-freeze pair); the profile freezes at "
+                        "this arrival\n");
     }
 
     fprintf(stderr, "[MM] pairing: armed on switch-entry (masterSeed=%u settingsHash=%08X) — dispatching OnSaveInit\n",

--- a/games/mm/2s2h/Rando/Foreign.cpp
+++ b/games/mm/2s2h/Rando/Foreign.cpp
@@ -174,6 +174,31 @@ static std::string ProfileIdentityString(const uint32_t* values) {
         s += std::to_string((int)randoItemId);
         s += ',';
     }
+    // ------------------------------------------------------------------------
+    // WHAT IS DELIBERATELY *NOT* FOLDED, and why. #564 V4 asks for each
+    // remaining CVar family to be CLASSIFIED world-identity vs runtime flavour
+    // rather than "left as an accident" — an unclassified key defaults to
+    // identity (ADR 0004 §6 scope note), so silence here is not neutral.
+    //
+    //  - `gRando.Traps.*` (Traps.cpp's trapToCvarMap: Freeze/Blast/Shock/Jinx/
+    //    Wallet/Enemy/Time) are RUNTIME FLAVOUR, not world identity. Their sole
+    //    consumer is RollTrapType(), called from actor behaviour when a trap is
+    //    collected (ActorBehavior/EnGirlA.cpp:73, Traps.cpp:133) — it draws
+    //    from the LIVE Ship_Random stream at pickup time and never runs inside
+    //    a fill. The trap knobs that DO shape the world (RO_SHUFFLE_TRAPS,
+    //    RO_TRAP_AMOUNT, read by GeneratePools.cpp:281) are ordinary option
+    //    rows and are already folded by the loop above. Flipping which trap
+    //    flavour fires changes no placement, so folding these would refuse
+    //    arrivals over a cosmetic preference.
+    //  - `gRando.SpoilerFile` / `gRando.SpoilerFileIndex` / `gRando.InputSeed`
+    //    are NOT identity and folding them would be actively harmful: the
+    //    paired path ignores all three by construction (OnFileCreate.cpp:83
+    //    forces generation over any stale spoiler index when rsbsPaired, and
+    //    :101 replaces the input seed with PairedInputSeedString), and
+    //    OnFileCreate.cpp:289 WRITES gRando.SpoilerFile after every successful
+    //    generation — so a pair that folded it would diverge its own identity
+    //    the instant it generated.
+    // ------------------------------------------------------------------------
     return s;
 }
 

--- a/games/mm/2s2h/Rando/Foreign.cpp
+++ b/games/mm/2s2h/Rando/Foreign.cpp
@@ -47,6 +47,7 @@
 
 #include <cstddef>
 #include <cstdio>
+#include <stdexcept>
 #include <string>
 #include <vector>
 
@@ -76,6 +77,11 @@ static std::string MMOptionsString() {
     // The persisted options ARE the finalized MM settings profile — the loop
     // below must run after OnFileCreate copied them into the save. std::map
     // iteration gives a stable option order.
+    //
+    // SEED-DERIVATION INPUT ONLY, deliberately unchanged by the #498/#564
+    // identity widening: MixPairedFinalSeed() hashes this exact string, so
+    // touching it would re-derive every shipped pair's MM world. The widened
+    // IDENTITY string lives in ProfileIdentityString below.
     std::string s;
     for (auto& [randoOptionId, randoStaticOption] : Rando::StaticData::Options) {
         s += std::to_string(RANDO_SAVE_OPTIONS[randoOptionId]);
@@ -84,69 +90,154 @@ static std::string MMOptionsString() {
     return s;
 }
 
-uint32_t ResolvePairedProfile(bool paired) {
+// ---------------------------------------------------------------------------
+// The profile freeze (#498 decision 1 per #564, phase 2 step 9).
+//
+// ONE resolution, ONE identity string, TWO call sites. The creation event
+// (OoT's Playthrough_Init, via MM_Rando_ComputeProfileStamp at the bottom of
+// this file) resolves the profile from the CVars and stamps its digest into
+// gComboCtx.mmProfileDigest; every later arrival that would generate resolves
+// the SAME way and compares. Both sites go through ResolveProfileValues +
+// ProfileIdentityString, so "what creation froze" and "what arrival checks"
+// cannot drift apart — they are one computation.
+// ---------------------------------------------------------------------------
+
+/** Resolve the full option profile from the CVars into `values` (RO_MAX
+ *  entries), with no side effects: the generic copy, the skulltula
+ *  correction, and — paired only — the RO_LOGIC default pin. This is the
+ *  resolution OnFileCreate has always performed; extracting it is what lets
+ *  the creation event run it without an MM save to write into. */
+static void ResolveProfileValues(uint32_t* values, bool paired) {
     // (1) The generic copy: every registered option's CVar, with the
-    // StaticData row's default as the fallback. Unchanged from the loop this
-    // was extracted from — it is what makes the pane's CVars the profile.
+    // StaticData row's default as the fallback — what makes the pane's CVars
+    // the (pre-creation) authoring surface.
     for (auto& [randoOptionId, randoStaticOption] : Rando::StaticData::Options) {
-        RANDO_SAVE_OPTIONS[randoOptionId] =
-            (uint32_t)CVarGetInteger(randoStaticOption.cvar, randoStaticOption.defaultValue);
+        values[randoOptionId] = (uint32_t)CVarGetInteger(randoStaticOption.cvar, randoStaticOption.defaultValue);
     }
 
     // (2) Derived correction: with skulltulas unshuffled the token requirement
     // is the vanilla one, whatever the slider says. Runs for solo and paired
     // files alike, as it always has.
-    if (!RANDO_SAVE_OPTIONS[RO_SHUFFLE_GOLD_SKULLTULAS]) {
-        RANDO_SAVE_OPTIONS[RO_MINIMUM_SKULLTULA_TOKENS] = SPIDER_HOUSE_TOKENS_REQUIRED;
+    if (!values[RO_SHUFFLE_GOLD_SKULLTULAS]) {
+        values[RO_MINIMUM_SKULLTULA_TOKENS] = SPIDER_HOUSE_TOKENS_REQUIRED;
+    }
+
+    if (!paired) {
+        return;
+    }
+
+    // (3) The logic pin (#426 rationale), a DEFAULT rather than a law (#499
+    // step 3): the MVP pairs under Nearly No Logic unless the player made an
+    // explicit choice. EXISTENCE, not "is the value already extreme" — only
+    // existence distinguishes "the player chose Glitchless" from "nobody ever
+    // touched the key and the default is Glitchless". Because the pin runs
+    // inside the shared resolution, the RESOLVED value is what both the
+    // creation stamp and the arrival compare see (#564 V3): nothing after
+    // creation depends on CVar existence except through this one resolution,
+    // and a mid-gap flip of the key is a detected divergence, not a silently
+    // honored choice.
+    if (!Combo_CVarIsExplicitInt(Rando::StaticData::Options[RO_LOGIC].cvar)) {
+        SPDLOG_INFO("Paired profile resolution: no explicit MM logic choice; defaulting to Nearly No Logic (#426)");
+        values[RO_LOGIC] = RO_LOGIC_NEARLY_NO_LOGIC;
+    } else {
+        SPDLOG_INFO("Paired profile resolution: honouring explicit MM logic choice ({})", (unsigned)values[RO_LOGIC]);
+    }
+}
+
+/** The canonical identity string the profile digest hashes (#564 V4's widened
+ *  term). Wider than MMOptionsString on purpose: gRando.ExcludedChecks and the
+ *  StartingItems config block shape the generated world exactly as the 47
+ *  options do (Logic/GeneratePools.cpp:32, StartingItems.cpp:135), so a digest
+ *  that omits them is a vacuous guard — same seed + same digest could still
+ *  yield different MM worlds. OoT's own settings hash is the precedent: it
+ *  folds excludes and tricks. */
+static std::string ProfileIdentityString(const uint32_t* values) {
+    std::string s;
+    for (auto& [randoOptionId, randoStaticOption] : Rando::StaticData::Options) {
+        s += std::to_string(values[randoOptionId]);
+        s += ';';
+    }
+    // The excluded-check list, folded as the raw CVar string GeneratePools
+    // consumes. Raw rather than parse-normalized on purpose: the only writer
+    // is UI code emitting a canonical "id,id,..." form, and a string that
+    // changed in ANY way between creation and arrival means something wrote
+    // the identity input mid-pair — which is precisely what the digest exists
+    // to catch.
+    s += "|excluded:";
+    s += CVarGetString("gRando.ExcludedChecks", "");
+    // The StartingItems config block, folded as the resolved item-id list —
+    // the SAME accessor generation consumes (unknown names dropped both
+    // places, defaults on an absent config/context both places), so the
+    // identity term and the generation input are one computation.
+    s += "|starting:";
+    for (RandoItemId randoItemId : Rando::GetStartingItemsFromConfig()) {
+        s += std::to_string((int)randoItemId);
+        s += ',';
+    }
+    return s;
+}
+
+/** Hash the identity string, displacing 0: zero is the growth contract's
+ *  "unset" for every field carved from reserved[] (context.h) — and now also
+ *  the frozen-state predicate's "not frozen" — so a real profile hashing to 0
+ *  would read as "no identity recorded", a mismatch that silently cannot be
+ *  detected. The collision this introduces is with one other profile out of
+ *  2^32, against a certainty of a false negative. */
+static uint32_t DigestFromIdentity(const std::string& identity) {
+    uint32_t digest = Ship_Hash(identity);
+    if (digest == 0) {
+        digest = 0x4D4D5044u; // 'MMPD'
+    }
+    return digest;
+}
+
+uint32_t ResolvePairedProfile(bool paired) {
+    std::vector<uint32_t> values(RO_MAX, 0);
+    ResolveProfileValues(values.data(), paired);
+    for (auto& [randoOptionId, randoStaticOption] : Rando::StaticData::Options) {
+        RANDO_SAVE_OPTIONS[randoOptionId] = values[randoOptionId];
     }
 
     if (!paired) {
         // A solo MM rando file has no cross-game identity to publish, and must
         // not stamp one: gComboCtx.mmProfileDigest is read as "the paired
-        // world was generated under this profile", and writing it here would
-        // make an unpaired file claim a pairing it does not have.
+        // world's frozen profile", and writing it here would make an unpaired
+        // file claim a pairing it does not have.
         return 0;
     }
 
-    // (3) The logic pin (#426 rationale), now a DEFAULT rather than a law
-    // (#499 step 3). The pin exists because the MVP pairs under Nearly No
-    // Logic — free-form placement, with the spoiler carrying what logic would
-    // otherwise carry. That is the right default and the wrong law: once the
-    // options pane can express a choice, overriding an explicit one would make
-    // the control a lie in exactly ADR 0004 section 5's sense (it flips a CVar
-    // and changes nothing).
-    //
-    // EXISTENCE, not "is the value already extreme". The old condition could
-    // not tell "the player chose Glitchless" from "nobody has ever touched
-    // this key and the StaticData default is Glitchless", so it pinned both.
-    // Existence is the only signal that distinguishes them. (Combo_ prefixed
-    // rather than libultraship's CVarExists, which is declared but undefined in
-    // the pinned submodule — see combo_mm_options_view.h.)
-    if (!Combo_CVarIsExplicitInt(Rando::StaticData::Options[RO_LOGIC].cvar)) {
-        SPDLOG_INFO("Paired-world generation: no explicit MM logic choice; defaulting to Nearly No Logic (#426)");
-        RANDO_SAVE_OPTIONS[RO_LOGIC] = RO_LOGIC_NEARLY_NO_LOGIC;
-    } else {
-        SPDLOG_INFO("Paired-world generation: honouring explicit MM logic choice ({})",
-                    (unsigned)RANDO_SAVE_OPTIONS[RO_LOGIC]);
+    // Compare-or-stamp against the creation identity (#498/#564 phase 2).
+    // Seed-INDEPENDENT on purpose: this answers "was this world generated
+    // under the frozen MM rules", a question about the rules alone;
+    // MixPairedFinalSeed() folds the master seed separately for the different
+    // question of "which world does this seed derive".
+    const uint32_t digest = DigestFromIdentity(ProfileIdentityString(values.data()));
+    if (gComboCtx.mmProfileDigest != 0 && gComboCtx.mmProfileDigest != digest) {
+        // NEVER self-heal (overwrite the stamp with the divergent profile) and
+        // NEVER generate under it. Throwing lands in OnFileCreate's catch,
+        // which reverts the save to vanilla — no divergent world is authored.
+        // The player-visible surface for the natural path lives EARLIER, in
+        // MM_Rando_PairOnCrossGameArrival, which runs this same computation
+        // and refuses before dispatching generation at all; this throw is the
+        // class-level backstop for every other route into OnFileCreate (MM
+        // file-select escapes, dev tools).
+        char msg[160];
+        snprintf(msg, sizeof(msg),
+                 "paired profile identity mismatch: creation stamped %08X, this resolution yields %08X "
+                 "(options/excludes/starting items changed after creation)",
+                 (unsigned)gComboCtx.mmProfileDigest, (unsigned)digest);
+        SPDLOG_ERROR("{}", msg);
+        throw std::runtime_error(msg);
     }
-
-    // (4) Publish the profile's identity. Seed-INDEPENDENT on purpose: this
-    // answers "were both halves generated under the same MM rules", which is a
-    // question about the rules alone. MixPairedFinalSeed() folds the master
-    // seed into the same option string for the different question of "which
-    // world does this seed derive"; sharing MMOptionsString() between them is
-    // what stops the two from drifting apart.
-    uint32_t digest = Ship_Hash(MMOptionsString());
-    if (digest == 0) {
-        // Zero is the growth contract's "unset" for every field carved from
-        // reserved[] (context.h), so a real profile that happened to hash to 0
-        // would read as "no profile recorded" — a mismatch that silently
-        // cannot be detected. Displace it to a fixed non-zero constant; the
-        // collision this introduces is with one other profile out of 2^32,
-        // against a certainty of a false negative.
-        digest = 0x4D4D5044u; // 'MMPD'
+    if (gComboCtx.mmProfileDigest == 0) {
+        // LEGACY pre-freeze pair (created before the creation event stamped
+        // identities): the first crossing is where its profile freezes. The
+        // one transitional writer besides the creation event.
+        fprintf(stderr, "[MM] profile: no creation-time stamp (pre-freeze pair); freezing profile at this "
+                        "generation (digest %08X)\n",
+                (unsigned)digest);
+        gComboCtx.mmProfileDigest = digest;
     }
-    gComboCtx.mmProfileDigest = digest;
     return digest;
 }
 
@@ -385,6 +476,25 @@ bool RecordForeignPickup(RandoCheckId randoCheckId) {
 
 } // namespace Foreign
 } // namespace Rando
+
+// ============================================================================
+// Creation-stamp bridge (#498/#564 phase 2 step 9; declared in
+// src/common/combo_mm_options_view.h).
+//
+// The ONE freeze/compare computation, callable from outside MM: resolves the
+// full profile identity from the CVars — through the SAME ResolveProfileValues
+// + ProfileIdentityString the arrival's ResolvePairedProfile uses — and
+// returns its digest, with no side effects on any save, CVar, or gComboCtx.
+// OoT's Playthrough_Init assigns the result to gComboCtx.mmProfileDigest as
+// part of publishing the pairing identity (the creation event); MM's arrival
+// gate (MM_Rando_PairOnCrossGameArrival) recomputes it to compare against
+// that stamp before any generation dispatch.
+// ============================================================================
+extern "C" uint32_t MM_Rando_ComputeProfileStamp(void) {
+    std::vector<uint32_t> values(RO_MAX, 0);
+    ResolveProfileValues(values.data(), /*paired=*/true);
+    return DigestFromIdentity(ProfileIdentityString(values.data()));
+}
 
 // ============================================================================
 // ROM-free test bridge (redship tier; src/common/tests/test_foreign_items.c).

--- a/games/mm/2s2h/Rando/Foreign.cpp
+++ b/games/mm/2s2h/Rando/Foreign.cpp
@@ -233,8 +233,9 @@ uint32_t ResolvePairedProfile(bool paired) {
         // LEGACY pre-freeze pair (created before the creation event stamped
         // identities): the first crossing is where its profile freezes. The
         // one transitional writer besides the creation event.
-        fprintf(stderr, "[MM] profile: no creation-time stamp (pre-freeze pair); freezing profile at this "
-                        "generation (digest %08X)\n",
+        fprintf(stderr,
+                "[MM] profile: no creation-time stamp (pre-freeze pair); freezing profile at this "
+                "generation (digest %08X)\n",
                 (unsigned)digest);
         gComboCtx.mmProfileDigest = digest;
     }

--- a/games/mm/2s2h/Rando/Foreign.cpp
+++ b/games/mm/2s2h/Rando/Foreign.cpp
@@ -493,8 +493,8 @@ bool RecordForeignPickup(RandoCheckId randoCheckId) {
 // ============================================================================
 extern "C" uint32_t MM_Rando_ComputeProfileStamp(void) {
     std::vector<uint32_t> values(RO_MAX, 0);
-    ResolveProfileValues(values.data(), /*paired=*/true);
-    return DigestFromIdentity(ProfileIdentityString(values.data()));
+    Rando::Foreign::ResolveProfileValues(values.data(), /*paired=*/true);
+    return Rando::Foreign::DigestFromIdentity(Rando::Foreign::ProfileIdentityString(values.data()));
 }
 
 // ============================================================================

--- a/games/mm/2s2h/Rando/Foreign.h
+++ b/games/mm/2s2h/Rando/Foreign.h
@@ -28,8 +28,8 @@ bool PairingActive();
 std::string PairedInputSeedString();
 
 /** Resolve MM's randomizer option profile into RANDO_SAVE_OPTIONS and, for a
- *  paired world, publish its digest into gComboCtx.mmProfileDigest
- *  (#499 steps 2-4; ADR 0009 claim 3).
+ *  paired world, CHECK it against the creation-frozen identity
+ *  (#499 steps 2-4; ADR 0009 claim 3; #498/#564 phase 2).
  *
  *  This is the ONE place the profile is decided. It was three inline blocks in
  *  MiscBehavior/OnFileCreate.cpp, reachable only by running a whole fill, which
@@ -37,10 +37,20 @@ std::string PairedInputSeedString();
  *  what lets the display-free MMPairedProfile CTest drive the REAL resolution
  *  rather than a copy of it.
  *
+ *  FREEZE SEMANTICS (#564): the paired identity digest is stamped by the
+ *  CREATION event (OoT's Playthrough_Init via MM_Rando_ComputeProfileStamp,
+ *  the same computation). When gComboCtx.mmProfileDigest is nonzero, this
+ *  function COMPARES the resolution against it and THROWS std::runtime_error
+ *  on a mismatch — landing in OnFileCreate's catch, which reverts the file to
+ *  vanilla, so a divergent world is never authored and the stamp is never
+ *  self-healed. When the stamp is zero (a LEGACY pre-freeze pair), the digest
+ *  is stamped here, at the pair's first crossing — the one transitional
+ *  writer besides creation.
+ *
  *  @param paired  true on the cross-game path (Foreign::PairingActive()). Only
- *                 a paired world gets the logic pin and the digest; a solo MM
- *                 rando file resolves its options and nothing else, exactly as
- *                 before.
+ *                 a paired world gets the logic pin and the identity check; a
+ *                 solo MM rando file resolves its options and nothing else,
+ *                 exactly as before.
  *  @return the profile digest (0 when `paired` is false).
  *
  *  ORDERING CONTRACT, unchanged and load-bearing: call this BEFORE

--- a/games/mm/2s2h/Rando/StartingItems.cpp
+++ b/games/mm/2s2h/Rando/StartingItems.cpp
@@ -133,8 +133,18 @@ void SetStartingItemsInSave(RandoSaveInfo& randoSaveInfo, std::vector<RandoItemI
 }
 
 std::vector<RandoItemId> GetStartingItemsFromConfig() {
-    auto allConfig = Ship::Context::GetInstance()->GetConfig()->GetNestedJson();
     std::vector<RandoItemId> startingItems = { RI_PROGRESSIVE_SWORD, RI_SHIELD_HERO, RI_OCARINA, RI_SONG_TIME };
+
+    // Null-guarded for the display-free harness (#498/#564): the profile
+    // identity folds this list (Foreign.cpp's ProfileIdentityString), and the
+    // ROM-free tier runs without a Ship::Context. An absent context yields the
+    // same defaults an absent config block does, so the identity term is one
+    // computation with one default in one place.
+    auto shipContext = Ship::Context::GetInstance();
+    if (shipContext == nullptr || shipContext->GetConfig() == nullptr) {
+        return startingItems;
+    }
+    auto allConfig = shipContext->GetConfig()->GetNestedJson();
 
     // Verify that the config has CVars.gRando.StartingItems and its an array
     if (allConfig.find("CVars") != allConfig.end() && allConfig["CVars"].is_object() &&

--- a/games/mm/2s2h/mm_rando_gen_test.cpp
+++ b/games/mm/2s2h/mm_rando_gen_test.cpp
@@ -23,6 +23,7 @@
 #include <cstdio>
 #include <cstring>
 #include <cstdint>
+#include <filesystem>
 #include <fstream>
 #include <string>
 
@@ -43,6 +44,12 @@
 // src/common — placement table + pool surface (Lane C1). Outside extern "C":
 // it pulls context.h, whose <type_traits> include must not sit in C linkage.
 #include "foreign_items.h"
+// src/common — the #533 REFUSED surface (the arrival identity gate latches the
+// active slot; Phase 4 of the switch-entry lock asserts it) and the
+// creation-side profile stamp (combo_mm_options_view.h declares
+// MM_Rando_ComputeProfileStamp, defined in Foreign.cpp).
+#include "combo_mm_options_view.h"
+#include "save.h"
 
 extern "C" {
 #include "z64save.h"
@@ -888,6 +895,11 @@ extern "C" int MM_Rando_HeadlessPairSwitchEntry(void) {
         gComboCtx.sourceIsRando = 1;
         gComboCtx.sharedRandoSeed = masterSeed;
         gComboCtx.sharedRandoSettingsHash = 0x5DAD32CEu;
+        // Each iteration models a fresh LEGACY (pre-freeze) pair: no creation
+        // stamp, so the arrival identity gate (#498/#564) takes the
+        // freeze-at-first-crossing path rather than comparing against a stale
+        // digest a previous iteration froze.
+        gComboCtx.mmProfileDigest = 0;
 
         // The cold gamestate-chain boot a switch performs: ConsoleLogo skips
         // to TitleSetup, TitleSetup authors a VANILLA bootstrap file with
@@ -1108,13 +1120,134 @@ extern "C" int MM_Rando_HeadlessPairSwitchEntry(void) {
     }
     fprintf(stderr, "[MM-PAIR-SWITCH] existing vanilla save left untouched (skip path)\n");
 
+    // ----------------------------------------------------------------------
+    // Phase 4 — the arrival identity gate (#498 decision 1 per #564, phase 2
+    // step 9): a creation-stamped pair whose inputs diverged by arrival is
+    // REFUSED — no world generated, stamp never self-healed, the active slot
+    // latched and surfaced REFUSED through the #533 machinery — while a
+    // matching arrival still generates.
+    //
+    // THE COUNTERFACTUAL THIS LOCKS: revert the digest compare in
+    // MM_Rando_PairOnCrossGameArrival and the divergent leg below GENERATES a
+    // world under the mid-session-edited CVars — a post-creation edit silently
+    // changing the paired world, exactly what the one-game ruling forbids —
+    // and FAIL(22) goes red.
+    // ----------------------------------------------------------------------
+    const char* const kPhase4SaveDir = "rsbs_test_pairswitch_saves";
+    rsbs::SaveManager::Instance().SetSaveDirectory(kPhase4SaveDir);
+    RsbsSave_ResetSlotSessionState();
+    RsbsSave_ArmSlotOnCreate(0); // the create seam: slot 0 is this session's
+    RsbsSave_SetActiveSlot(0);
+    if (!RsbsSave_IsSlotWritable(0)) {
+        fprintf(stderr, "[MM-PAIR-SWITCH] FAIL(30): phase 4 could not arm its slot fixture\n");
+        return 30;
+    }
+
+    // 4a. The refuse leg. A fresh pair "created" under the CVars in force
+    // since Phase 1: the stamp is computed exactly as Playthrough_Init
+    // computes it (same MM_Rando_ComputeProfileStamp call).
+    Combo_ClearFrozenState("mm");
+    Combo_ClearStartupEntrance();
+    Combo_ClearForeignPlacements();
+    gComboCtx.sourceIsRando = 1;
+    gComboCtx.sharedRandoSeed = usedMasterSeed;
+    gComboCtx.sharedRandoSettingsHash = 0x5DAD32CEu;
+    gComboCtx.mmProfileDigest = MM_Rando_ComputeProfileStamp();
+    const uint32_t phase4Stamp = gComboCtx.mmProfileDigest;
+    if (phase4Stamp == 0) {
+        fprintf(stderr, "[MM-PAIR-SWITCH] FAIL(31): creation stamp computed as zero\n");
+        return 31;
+    }
+
+    // The mid-session divergence: an option edit AFTER creation.
+    CVarSetInteger(Rando::StaticData::Options[RO_SHUFFLE_COWS].cvar, RO_GENERIC_ON);
+
+    memset(&gSaveContext, 0, sizeof(gSaveContext));
+    MM_Sram_InitNewSave();
+    GameInteractor_ExecuteOnSaveLoad(gSaveContext.fileNum);
+    Combo_SetStartupEntrance(kArrival);
+    MM_Play_ConsumeStartupEntrance();
+
+    if (gSaveContext.save.shipSaveInfo.saveType == SAVETYPE_RANDO) {
+        fprintf(stderr, "[MM-PAIR-SWITCH] FAIL(22): a DIVERGENT arrival generated a world — a mid-session option "
+                        "edit changed the paired world instead of being refused (#498/#564)\n");
+        return 22;
+    }
+    if (gComboCtx.mmProfileDigest != phase4Stamp) {
+        fprintf(stderr, "[MM-PAIR-SWITCH] FAIL(23): the refusal self-healed the creation stamp (%08X -> %08X)\n",
+                phase4Stamp, gComboCtx.mmProfileDigest);
+        return 23;
+    }
+    if (RsbsSave_GetSlotState(0) != (int)RSBS_SLOT_REFUSED) {
+        fprintf(stderr, "[MM-PAIR-SWITCH] FAIL(24): the refused arrival did not surface REFUSED on the active slot "
+                        "(state=%d)\n",
+                RsbsSave_GetSlotState(0));
+        return 24;
+    }
+    if (RsbsSave_GetSlotRefuseReason(0) != (int)RSBS_REFUSE_IDENTITY) {
+        fprintf(stderr, "[MM-PAIR-SWITCH] FAIL(25): refusal reason is %d, expected RSBS_REFUSE_IDENTITY\n",
+                RsbsSave_GetSlotRefuseReason(0));
+        return 25;
+    }
+    if (RsbsSave_IsSlotWritable(0)) {
+        fprintf(stderr, "[MM-PAIR-SWITCH] FAIL(26): the refused arrival left the slot writable — the divergent "
+                        "session could capture its unpaired world into the pair's .redsave\n");
+        return 26;
+    }
+    fprintf(stderr, "[MM-PAIR-SWITCH] divergent arrival refused: no world, stamp intact, slot latched + surfaced\n");
+
+    // 4b. The match leg: same pair, divergence undone — the gate must not
+    // refuse a faithful arrival. (Same master seed and CVars as Phase 1, so
+    // the fill is known to succeed.)
+    CVarClear(Rando::StaticData::Options[RO_SHUFFLE_COWS].cvar);
+    RsbsSave_ResetSlotSessionState();
+    RsbsSave_ArmSlotOnCreate(0);
+    RsbsSave_SetActiveSlot(0);
+    Combo_ClearFrozenState("mm");
+    Combo_ClearStartupEntrance();
+    Combo_ClearForeignPlacements();
+    gComboCtx.mmProfileDigest = MM_Rando_ComputeProfileStamp();
+    if (gComboCtx.mmProfileDigest != phase4Stamp) {
+        fprintf(stderr, "[MM-PAIR-SWITCH] FAIL(27): undoing the divergence did not restore the creation profile "
+                        "(%08X vs %08X) — the identity computation is unstable\n",
+                gComboCtx.mmProfileDigest, phase4Stamp);
+        return 27;
+    }
+
+    memset(&gSaveContext, 0, sizeof(gSaveContext));
+    MM_Sram_InitNewSave();
+    GameInteractor_ExecuteOnSaveLoad(gSaveContext.fileNum);
+    Combo_SetStartupEntrance(kArrival);
+    MM_Play_ConsumeStartupEntrance();
+
+    if (gSaveContext.save.shipSaveInfo.saveType != SAVETYPE_RANDO) {
+        fprintf(stderr, "[MM-PAIR-SWITCH] FAIL(28): a MATCHING arrival was refused or dead-ended — the identity "
+                        "gate must pass a faithful arrival through to generation\n");
+        return 28;
+    }
+    if (!RsbsSave_IsSlotWritable(0)) {
+        fprintf(stderr, "[MM-PAIR-SWITCH] FAIL(29): a matching arrival latched the slot anyway\n");
+        return 29;
+    }
+    fprintf(stderr, "[MM-PAIR-SWITCH] matching arrival generated normally under the frozen profile\n");
+
     // Leave clean global state for later dispatches in the same process.
+    RsbsSave_DeleteSave(0);
+    RsbsSave_ResetSlotSessionState();
+    RsbsSave_SetActiveSlot(-1);
+    rsbs::SaveManager::Instance().SetSaveDirectory("Save"); // the documented harness default
+    {
+        std::error_code phase4Ec;
+        std::filesystem::remove_all(kPhase4SaveDir, phase4Ec);
+    }
     Combo_ClearFrozenState("mm");
     Combo_ClearStartupEntrance();
     Combo_ClearForeignPlacements();
     memset(&gSaveContext, 0, sizeof(gSaveContext));
+    ComboContext_Init();
 
-    fprintf(stderr, "[MM-PAIR-SWITCH] PASS: pairing activates on the switch-entry path, existing saves untouched\n");
+    fprintf(stderr, "[MM-PAIR-SWITCH] PASS: pairing activates on the switch-entry path, existing saves untouched, "
+                    "and a divergent arrival refuses through the #533 surface\n");
     return 0;
 }
 

--- a/games/mm/2s2h/mm_rando_gen_test.cpp
+++ b/games/mm/2s2h/mm_rando_gen_test.cpp
@@ -1127,11 +1127,21 @@ extern "C" int MM_Rando_HeadlessPairSwitchEntry(void) {
     // latched and surfaced REFUSED through the #533 machinery — while a
     // matching arrival still generates.
     //
-    // THE COUNTERFACTUAL THIS LOCKS: revert the digest compare in
-    // MM_Rando_PairOnCrossGameArrival and the divergent leg below GENERATES a
-    // world under the mid-session-edited CVars — a post-creation edit silently
-    // changing the paired world, exactly what the one-game ruling forbids —
-    // and FAIL(22) goes red.
+    // THE COUNTERFACTUALS THIS LOCKS — TWO LAYERS, each independently red
+    // (both measured, 2026-07-31, not asserted):
+    //
+    //  - Revert the digest compare in MM_Rando_PairOnCrossGameArrival ALONE
+    //    and FAIL(24)/FAIL(26) go red, NOT FAIL(22): the arrival dispatches
+    //    generation, ResolvePairedProfile's backstop throws, and OnFileCreate's
+    //    catch reverts to vanilla — so no divergent world is authored, but the
+    //    refusal degrades into #564 V7's silent vanilla revert. No REFUSED
+    //    state, no reason, no write latch: the healthy pair's .redsave is left
+    //    open to this session's captures. That is what the arrival gate buys
+    //    over the backstop, and it is what these assertions measure.
+    //  - Revert BOTH compares (arrival gate + ResolvePairedProfile) and
+    //    FAIL(22) goes red: the divergent leg GENERATES a world under the
+    //    mid-session-edited CVars — a post-creation edit silently changing the
+    //    paired world, exactly what the one-game ruling forbids.
     // ----------------------------------------------------------------------
     const char* const kPhase4SaveDir = "rsbs_test_pairswitch_saves";
     rsbs::SaveManager::Instance().SetSaveDirectory(kPhase4SaveDir);

--- a/games/mm/2s2h/mm_rando_options_test.cpp
+++ b/games/mm/2s2h/mm_rando_options_test.cpp
@@ -40,21 +40,31 @@
  *      indexed by generation code.
  *
  * ============================================================================
- * mm-paired-profile — the profile lock (#499 Tier 1)
+ * mm-paired-profile — the profile lock (#499 Tier 1; #498/#564 phase 2)
  * ============================================================================
  *
  * Drives the REAL `Rando::Foreign::ResolvePairedProfile()` — the same function
  * OnFileCreate calls, not a re-derivation — over a zeroed MM SaveContext, with
- * no fill and no display. It asserts the profile, the logic default's new
- * honour-an-explicit-choice rule, and the `gComboCtx.mmProfileDigest` carve.
+ * no fill and no display. It asserts the profile, the logic default's
+ * honour-an-explicit-choice rule, and the FREEZE semantics the #564 ruling
+ * made mandatory:
+ *
+ *  - an unstamped (legacy) pair freezes its profile at resolution;
+ *  - a stamped pair REFUSES a divergent resolution (throws, never overwrites
+ *    the stamp — reverting the compare turns the refusal assertions red);
+ *  - the creation-side computation (MM_Rando_ComputeProfileStamp, what OoT's
+ *    Playthrough_Init stamps) and the arrival-side resolution agree bit-exact
+ *    under identical inputs — the two sites cannot drift;
+ *  - the identity term is WIDER than the option table (#564 V4): a
+ *    gRando.ExcludedChecks edit moves the digest even though no option value
+ *    changed. Under the pre-widening digest that assertion is red.
  *
  * THE TRAP THIS DESIGN AVOIDS, stated because the obvious test is vacuous: an
  * assertion of the form "set a CVar, generate, observe it in the save" passes
  * TODAY — that path has always worked — and proves nothing about the profile
- * being chosen rather than defaulted. What is asserted instead is the thing
- * that was not true before: that an explicitly-set option survives the paired
- * pin, that an unset one gets the pinned default, and that the two produce
- * DIFFERENT digests.
+ * being chosen rather than defaulted. What is asserted instead is behavior
+ * that was not true before: explicit choices survive the pin, divergence
+ * refuses, and every generation input moves the digest.
  */
 
 #ifdef RSBS_SINGLE_EXECUTABLE
@@ -62,6 +72,7 @@
 #include <cstdarg>
 #include <cstdio>
 #include <cstring>
+#include <stdexcept>
 #include <string>
 
 #include <libultraship/bridge/consolevariablebridge.h>
@@ -304,13 +315,20 @@ extern "C" int MM_PairedProfile_RunHeadless(void) {
         return Fail(55, "unpaired resolution stamped a profile digest (%08X)", gComboCtx.mmProfileDigest);
     }
 
-    // ---- paired, nothing chosen: the #426 default applies ------------------
-    // Stamp the Lane B carrier the way OoT's producer would, so
-    // Combo_ForeignPairingActive() is true for the summary read below.
-    gComboCtx.sourceIsRando = true;
-    gComboCtx.sharedRandoSeed = 0xC0FFEE11u;
-    gComboCtx.sharedRandoSettingsHash = 0x5EED0411u;
+    // Every paired probe below starts from a FRESH, unstamped pairing carrier:
+    // under freeze semantics a stamped pair refuses a different profile rather
+    // than re-stamping, so digest-motion probes must model what they are — a
+    // NEW creation under new inputs, not an edit to a live pair.
+    auto restampUnfrozenCarrier = []() {
+        ComboContext_Init();
+        gComboCtx.sourceIsRando = true;
+        gComboCtx.sharedRandoSeed = 0xC0FFEE11u;
+        gComboCtx.sharedRandoSettingsHash = 0x5EED0411u;
+    };
+    CVarClear("gRando.ExcludedChecks");
 
+    // ---- paired, nothing chosen: the #426 default applies ------------------
+    restampUnfrozenCarrier();
     const uint32_t defaultDigest = Rando::Foreign::ResolvePairedProfile(true);
     if (RANDO_SAVE_OPTIONS[RO_LOGIC] != RO_LOGIC_NEARLY_NO_LOGIC) {
         return Fail(56, "with no explicit choice, the paired profile did not default RO_LOGIC to Nearly No Logic "
@@ -318,13 +336,26 @@ extern "C" int MM_PairedProfile_RunHeadless(void) {
                     (unsigned)RANDO_SAVE_OPTIONS[RO_LOGIC]);
     }
     if (defaultDigest == 0 || gComboCtx.mmProfileDigest != defaultDigest) {
-        return Fail(57, "paired resolution did not publish a non-zero digest (returned %08X, ctx holds %08X)",
+        return Fail(57, "unstamped paired resolution did not freeze a non-zero digest (returned %08X, ctx holds "
+                        "%08X)",
                     defaultDigest, gComboCtx.mmProfileDigest);
     }
 
-    // Stability: same inputs, same digest. Without this, "the digest detects a
-    // mismatch" is unprovable — an unstable digest reports a mismatch between
-    // a world and itself.
+    // ---- the creation site and the arrival site are ONE computation --------
+    // MM_Rando_ComputeProfileStamp is what OoT's Playthrough_Init stamps at
+    // the creation event; ResolvePairedProfile is what the arrival resolves.
+    // If they can disagree under identical inputs, every post-freeze pair
+    // refuses its own arrival — the falsifiable no-drift lock (#498/#564).
+    const uint32_t creationStamp = MM_Rando_ComputeProfileStamp();
+    if (creationStamp != defaultDigest) {
+        return Fail(65, "creation-side stamp %08X disagrees with the arrival-side resolution %08X under identical "
+                        "inputs — every pair would refuse its own arrival",
+                    creationStamp, defaultDigest);
+    }
+
+    // Stability: same inputs, same digest, no refusal. Without this, "the
+    // digest detects a mismatch" is unprovable — an unstable digest reports a
+    // mismatch between a world and itself.
     const uint32_t repeatDigest = Rando::Foreign::ResolvePairedProfile(true);
     if (repeatDigest != defaultDigest) {
         return Fail(58, "the profile digest is not stable across runs (%08X then %08X)", defaultDigest,
@@ -339,12 +370,39 @@ extern "C" int MM_PairedProfile_RunHeadless(void) {
                     summary.mmProfileDigest);
     }
 
+    // ---- STAMPED pair + divergent inputs: REFUSED, never re-stamped --------
+    // The freeze lock itself (#564 V8: the digest acquires comparators).
+    // gComboCtx still carries defaultDigest; choosing a different logic mode
+    // now models a post-creation edit reaching generation. The resolution must
+    // THROW (OnFileCreate's catch turns that into the vanilla revert — no
+    // divergent world is authored) and must NOT self-heal the stamp. Revert
+    // the compare in ResolvePairedProfile and both halves go red.
+    CVarSetInteger(Rando::StaticData::Options[RO_LOGIC].cvar, RO_LOGIC_GLITCHLESS);
+    {
+        bool refused = false;
+        try {
+            Rando::Foreign::ResolvePairedProfile(true);
+        } catch (const std::exception&) {
+            refused = true;
+        }
+        if (!refused) {
+            return Fail(66, "a stamped pair accepted a DIVERGENT profile resolution — post-creation edits would be "
+                            "honored instead of refused (#564)");
+        }
+        if (gComboCtx.mmProfileDigest != defaultDigest) {
+            return Fail(67, "the refusal self-healed the creation stamp (%08X -> %08X) — divergence must never "
+                            "rewrite identity",
+                        defaultDigest, gComboCtx.mmProfileDigest);
+        }
+    }
+
     // ---- paired, logic explicitly chosen: the choice survives --------------
     // This is the behaviour #499 step 3 asked for and the reason the pin moved
     // from "unless already extreme" to "unless the player chose". The old
     // condition could not tell a chosen Glitchless from an untouched key whose
-    // StaticData default happens to be Glitchless, and pinned both.
-    CVarSetInteger(Rando::StaticData::Options[RO_LOGIC].cvar, RO_LOGIC_GLITCHLESS);
+    // StaticData default happens to be Glitchless, and pinned both. A fresh
+    // carrier: this is a NEW creation under the chosen logic.
+    restampUnfrozenCarrier();
     const uint32_t chosenDigest = Rando::Foreign::ResolvePairedProfile(true);
     if (RANDO_SAVE_OPTIONS[RO_LOGIC] != RO_LOGIC_GLITCHLESS) {
         return Fail(60, "an explicitly chosen RO_LOGIC was overridden by the paired pin (got %u)",
@@ -358,6 +416,7 @@ extern "C" int MM_PairedProfile_RunHeadless(void) {
     // ---- a flipped shuffle row also moves the digest -----------------------
     CVarClear(Rando::StaticData::Options[RO_LOGIC].cvar);
     CVarSetInteger(Rando::StaticData::Options[RO_SHUFFLE_COWS].cvar, RO_GENERIC_ON);
+    restampUnfrozenCarrier();
     const uint32_t cowsDigest = Rando::Foreign::ResolvePairedProfile(true);
     if (RANDO_SAVE_OPTIONS[RO_SHUFFLE_COWS] != RO_GENERIC_ON) {
         return Fail(62, "an explicitly enabled shuffle did not reach RANDO_SAVE_OPTIONS");
@@ -366,11 +425,29 @@ extern "C" int MM_PairedProfile_RunHeadless(void) {
         return Fail(63, "flipping RO_SHUFFLE_COWS did not change the profile digest");
     }
 
+    // ---- the WIDENED identity term (#564 V4) -------------------------------
+    // gRando.ExcludedChecks shapes the generated world (GeneratePools reads it
+    // at fill time) but is not an option row, so the pre-widening digest could
+    // not see it: same seed + same digest, different world — a vacuous guard.
+    // With every option back at its default, an excluded-check edit ALONE must
+    // move the digest. Narrow the identity back to the option table and this
+    // goes red.
+    ClearAllOptionCVars();
+    CVarSetString("gRando.ExcludedChecks", "12,34");
+    restampUnfrozenCarrier();
+    const uint32_t excludedDigest = Rando::Foreign::ResolvePairedProfile(true);
+    if (excludedDigest == defaultDigest) {
+        return Fail(68, "editing gRando.ExcludedChecks did not change the profile digest — the identity term is "
+                        "narrower than the generator's input set (#564 V4)");
+    }
+    CVarClear("gRando.ExcludedChecks");
+
     // ---- the derived correction still applies -----------------------------
     // With skulltulas unshuffled the token requirement is the vanilla one
     // whatever the slider says. Regressing this makes an unreachable check.
     CVarSetInteger(Rando::StaticData::Options[RO_SHUFFLE_GOLD_SKULLTULAS].cvar, RO_GENERIC_OFF);
     CVarSetInteger(Rando::StaticData::Options[RO_MINIMUM_SKULLTULA_TOKENS].cvar, 5);
+    restampUnfrozenCarrier();
     Rando::Foreign::ResolvePairedProfile(true);
     if (RANDO_SAVE_OPTIONS[RO_MINIMUM_SKULLTULA_TOKENS] != SPIDER_HOUSE_TOKENS_REQUIRED) {
         return Fail(64, "with skulltulas unshuffled the token requirement was not forced to vanilla (got %u)",
@@ -379,12 +456,13 @@ extern "C" int MM_PairedProfile_RunHeadless(void) {
 
     // Leave global state clean for whatever runs next.
     ClearAllOptionCVars();
+    CVarClear("gRando.ExcludedChecks");
     memset(&gSaveContext, 0, sizeof(gSaveContext));
     ComboContext_Init();
     Context_SetCurrentGame(prevGame);
 
-    printf("[TEST] PASS: the paired profile honours an explicit choice, defaults the rest, and publishes a stable "
-           "digest that moves when the profile does\n");
+    printf("[TEST] PASS: the paired profile honours an explicit choice, freezes at creation, refuses divergence "
+           "without self-healing, and its widened digest moves with every generation input\n");
     return 0;
 }
 

--- a/games/oot/soh/Enhancements/randomizer/3drando/playthrough.cpp
+++ b/games/oot/soh/Enhancements/randomizer/3drando/playthrough.cpp
@@ -17,6 +17,9 @@
 #include "context.h" // src/common — gComboCtx, Lane B unified-seed carrier (ADR 0002)
 #ifdef RSBS_SINGLE_EXECUTABLE
 #include "foreign_items.h" // src/common — OoT_PlaceForeignItems (#510)
+// src/common — MM_Rando_ComputeProfileStamp (defined MM-side, Foreign.cpp):
+// the creation event freezes the MM half's option profile too (#498/#564).
+#include "combo_mm_options_view.h"
 #endif
 
 namespace Playthrough {
@@ -121,6 +124,19 @@ int Playthrough_Init(uint32_t seed, std::set<RandomizerCheck> excludedLocations,
     gComboCtx.sharedRandoSettingsHash = rsbsSettingsHash;
 
 #ifdef RSBS_SINGLE_EXECUTABLE
+    // #498/#564 phase 2 step 9: the creation event freezes the MM half's
+    // option profile INTO the pairing identity, here, alongside the seed and
+    // settings stamps it already publishes — everything about the one game
+    // decides at one creation event. MM_Rando_ComputeProfileStamp resolves the
+    // full profile (47 options with the resolved RO_LOGIC pin, excluded
+    // checks, starting items) from the CVars through the SAME computation MM's
+    // arrival re-runs to compare; a mismatch at arrival is refused through the
+    // #533 machinery, never honored. This stamp — like the two above — is
+    // carried through file-create invalidation by the KEEP policy
+    // (context.cpp), and this is its ONLY writer for post-freeze pairs.
+    gComboCtx.mmProfileDigest = MM_Rando_ComputeProfileStamp();
+    SPDLOG_INFO("Paired identity: MM profile frozen at creation (digest {:08X})", gComboCtx.mmProfileDigest);
+
     // #510, the reverse foreign pool: hand a few MM items to OoT checks now that
     // this world's paired identity is stamped just above (the placement stream is
     // derived from it, so the order is load-bearing — not stylistic).

--- a/src/common/ComboMmOptionsWindow.cpp
+++ b/src/common/ComboMmOptionsWindow.cpp
@@ -97,12 +97,24 @@ void DrawPairingSummary() {
  * frozen-at-creation, read-only, with the reason stated where the rows are.
  * Distinct from "live", from "editable but suspended", and from "disabled by
  * capability" — collapsing it into any of those would misdescribe it.
+ *
+ * The copy names the ACTUAL escape, which is not obvious and is not "create a
+ * new paired world": the stamp lands at GENERATION (Playthrough_Init), so a
+ * player who generates a seed and only then wants different MM options is
+ * frozen with no file in existence yet, and re-generating re-stamps the same
+ * frozen profile. The only unfreezing events are the DROP paths in
+ * Context_InvalidateSessionState — returning to the title screen (the reset
+ * route through TitleSetup), starting a vanilla file, or loading a slot whose
+ * .redsave is unfrozen. Telling the player to "create a new paired world"
+ * without naming the title screen is advice they cannot act on, which is ADR
+ * 0004 §5's vacuous gate wearing a help string.
  */
 void DrawFrozenBanner() {
     ImGui::TextColored(ImVec4(0.55f, 0.78f, 0.98f, 1.0f), "Frozen at creation");
     ImGui::TextWrapped("This paired world's Majora's Mask profile was stamped into its identity when the world was "
                        "generated. The options below show the authoring surface read-only; changing them is no "
-                       "longer possible for this pair. To play different MM options, create a new paired world.");
+                       "longer possible for this pair. To play different MM options, return to the title screen — "
+                       "these unlock there — then set them and generate a new seed.");
     ImGui::Separator();
 }
 

--- a/src/common/ComboMmOptionsWindow.cpp
+++ b/src/common/ComboMmOptionsWindow.cpp
@@ -36,18 +36,21 @@ namespace {
  * It is not replaced by a "now fixed" notice: the pane states current hazards,
  * and a resolved one is simply absent.
  */
-void DrawStandingWarnings() {
+void DrawStandingWarnings(bool frozen) {
     const ImVec4 warn(0.98f, 0.76f, 0.24f, 1.0f);
 
-    // (1) The timing constraint (#499). The profile is snapshotted when MM's
-    // cross-game arrival dispatches OnSaveInit, and an existing MM save is
-    // never regenerated. Changing an option after crossing does nothing at
-    // all, which is exactly the kind of silent no-op this pane exists to stop
-    // being possible.
-    ImGui::TextColored(warn, "These apply to the NEXT Majora's Mask file.");
-    ImGui::TextWrapped("The paired MM world snapshots these options the first time you cross into Majora's Mask. An "
-                       "MM save that already exists is never regenerated, so set them before you cross.");
-    ImGui::Spacing();
+    if (!frozen) {
+        // (1) The timing contract (#498/#564): the profile freezes into the
+        // paired world's identity at the CREATION event, and after that a
+        // divergent arrival is refused, never honored. The old copy here —
+        // "set them before you cross" — taught the retired renegotiation
+        // window and went with it (#564 V5).
+        ImGui::TextColored(warn, "These freeze into the paired world's identity.");
+        ImGui::TextWrapped("Generating a randomized Ocarina of Time world stamps these options into the pair's "
+                           "identity. From that point they are locked: the Majora's Mask half is generated under "
+                           "exactly this profile, and a crossing whose options no longer match is refused.");
+        ImGui::Spacing();
+    }
 
     // (2) The silent-vanilla-revert hazard. A paired generation that throws
     // reverts the save to vanilla with no retry and no error surface; the
@@ -78,12 +81,28 @@ void DrawPairingSummary() {
     ImGui::Text("Paired seed: %u", (unsigned)summary.sharedRandoSeed);
     ImGui::Text("OoT settings digest: %08X", (unsigned)summary.sharedRandoSettingsHash);
     if (summary.mmProfileDigest == 0) {
-        // Zero is "unset", not "broken": the MM half has not been generated
-        // yet, which is the normal state for a player still in OoT.
-        ImGui::TextUnformatted("MM profile digest: not resolved yet (no MM file generated)");
+        // Zero means "identity not frozen" (#564 V8) — for a post-freeze pair
+        // this state is unreachable (creation stamps it), so a paired world
+        // showing it is a LEGACY pre-freeze pair whose profile freezes at its
+        // first crossing.
+        ImGui::TextUnformatted("MM profile: not frozen (pre-freeze pair; freezes at the first crossing)");
     } else {
-        ImGui::Text("MM profile digest: %08X", (unsigned)summary.mmProfileDigest);
+        ImGui::Text("MM profile digest: %08X (frozen at creation)", (unsigned)summary.mmProfileDigest);
     }
+    ImGui::Separator();
+}
+
+/**
+ * The FOURTH presentation state (ADR 0004 §6 as amended by #564 V25):
+ * frozen-at-creation, read-only, with the reason stated where the rows are.
+ * Distinct from "live", from "editable but suspended", and from "disabled by
+ * capability" — collapsing it into any of those would misdescribe it.
+ */
+void DrawFrozenBanner() {
+    ImGui::TextColored(ImVec4(0.55f, 0.78f, 0.98f, 1.0f), "Frozen at creation");
+    ImGui::TextWrapped("This paired world's Majora's Mask profile was stamped into its identity when the world was "
+                       "generated. The options below show the authoring surface read-only; changing them is no "
+                       "longer possible for this pair. To play different MM options, create a new paired world.");
     ImGui::Separator();
 }
 
@@ -218,9 +237,16 @@ void ComboMmOptionsWindow::DrawElement() {
         return;
     }
 
+    // Read once per frame so every widget below agrees with the banner: the
+    // writers reject on their own (the pane is not the gate, just its face).
+    const bool frozen = Combo_MMProfileFrozen();
+
     DrawPairingSummary();
     DrawActiveGameState();
-    DrawStandingWarnings();
+    if (frozen) {
+        DrawFrozenBanner();
+    }
+    DrawStandingWarnings(frozen);
 
     // Grouped in MM's own taxonomy rather than in id order: id order is the
     // enum's, which interleaves access conditions with hints with shuffles.
@@ -242,6 +268,13 @@ void ComboMmOptionsWindow::DrawElement() {
             continue;
         }
         ImGui::PushID((int)group);
+        // Frozen wraps the whole group body: the rows stay visible (the frozen
+        // profile is worth READING) but every widget is inert. The reason is
+        // stated once, legibly, by DrawFrozenBanner above — ADR 0004 §5's
+        // "disabled with a visible cause", pane-wide because the cause is.
+        if (frozen) {
+            ImGui::BeginDisabled();
+        }
         for (int i = 0; i < count; i++) {
             const ComboMMOptionDesc* desc = Combo_MMOptionAt(i);
             if (desc == NULL || desc->group != group) {
@@ -251,11 +284,23 @@ void ComboMmOptionsWindow::DrawElement() {
             DrawOptionRow(desc);
             ImGui::PopID();
         }
+        if (frozen) {
+            ImGui::EndDisabled();
+        }
         ImGui::PopID();
     }
 
     ImGui::Separator();
-    if (ImGui::Button("Reset all to defaults")) {
+    if (frozen) {
+        // The Reset button is a 47-write batch; drawing it live under a frozen
+        // profile would be a control that (correctly) does nothing — ADR 0004
+        // §5's vacuous gate. Disabled, with its cause inline.
+        ImGui::BeginDisabled();
+        ImGui::Button("Reset all to defaults");
+        ImGui::EndDisabled();
+        ImGui::SameLine();
+        ImGui::TextDisabled("- profile frozen at creation");
+    } else if (ImGui::Button("Reset all to defaults")) {
         // Clears the CVars rather than writing the defaults back. The two are
         // NOT the same: ResolvePairedProfile distinguishes "the player chose
         // this" from "nobody ever touched it" via CVarExists, and writing a

--- a/src/common/ComboMmOptionsWindow.h
+++ b/src/common/ComboMmOptionsWindow.h
@@ -21,23 +21,27 @@
  *     by src/common and registered on the shared Ship::Context Gui. This pane
  *     reads `gComboCtx` and CVars — never either game's `gSaveContext` — so it
  *     satisfies ADR 0008 rule 5 and needs no active-game gating to be SAFE.
- *  2. The paired profile is snapshotted when MM's cross-game arrival dispatches
- *     `OnSaveInit`, and an existing MM save is never regenerated. The chooser
- *     therefore has to be reachable **while OoT is active, before the switch**
- *     (#499's timing constraint). A common-owned window is reachable in every
- *     session state; that is the property being bought.
+ *  2. The paired profile freezes into the world's identity at the CREATION
+ *     event (#498/#564: Playthrough_Init stamps gComboCtx.mmProfileDigest),
+ *     and an arrival that no longer matches the stamp is refused. The chooser
+ *     therefore has to be reachable **while OoT is active, before creation**.
+ *     A common-owned window is reachable in every session state; that is the
+ *     property being bought.
  *
- * THREE PRESENTATION STATES, per ADR 0004 section 6 — and they are three, not
- * two:
+ * FOUR PRESENTATION STATES, per ADR 0004 section 6 as amended by #564 V25:
  *
  *  - LIVE: the option's behaviour is dispatched. Editable, unmarked.
- *  - EDITABLE BUT NOT ACTIVE: MM is not the running game. Still fully editable
- *    (that is the whole point — you set these before you cross), but the pane
- *    says so, because "editable" and "in effect right now" are different facts.
+ *  - EDITABLE BUT NOT ACTIVE: MM is not the running game. Still editable while
+ *    the profile is unfrozen, but the pane says so, because "editable" and "in
+ *    effect right now" are different facts.
  *  - DISABLED BY CAPABILITY: the behaviour has no MM dispatch point (#438), so
  *    the row is drawn disabled WITH ITS REASON. A control that flips a CVar and
  *    changes nothing is the vacuous gate in UI form; collapsing this into
  *    "editable" would produce exactly that.
+ *  - FROZEN AT CREATION (#498/#564): a creation event stamped the profile into
+ *    the paired world's identity (Combo_MMProfileFrozen). Every row read-only,
+ *    with the reason stated pane-wide; the underlying writers reject on their
+ *    own, so the greying is honest rather than the gate.
  *
  * Openability: `Ship::GuiWindow` latches its visibility CVar in the ctor and
  * nothing re-syncs CVar -> visibility per frame, so `Draw()` reads the CVar live

--- a/src/common/combo_mm_options_view.c
+++ b/src/common/combo_mm_options_view.c
@@ -114,6 +114,16 @@ void Combo_MMOptionSetValue(const ComboMMOptionDesc* desc, int32_t value) {
     if (desc == NULL) {
         return;
     }
+    // #498/#564: post-creation the profile is world identity, not a setting.
+    // Rejecting here (rather than only greying the pane) is the actual gate —
+    // the pane is one caller, but any future caller of the writer inherits it.
+    if (Combo_MMProfileFrozen()) {
+        fprintf(stderr,
+                "[MMOptions] write to '%s' REJECTED: the MM profile is frozen into the paired world's "
+                "creation identity (digest %08X)\n",
+                desc->cvar, (unsigned)gComboCtx.mmProfileDigest);
+        return;
+    }
     int32_t lo = 0;
     int32_t hi = 0;
     OptionRange(desc, &lo, &hi);
@@ -149,7 +159,23 @@ void Combo_MMOptionClear(const ComboMMOptionDesc* desc) {
     if (desc == NULL) {
         return;
     }
+    // Clearing is a write too (see the header): it changes the resolved value
+    // and the logic pin's explicitness, both folded into the frozen identity.
+    if (Combo_MMProfileFrozen()) {
+        fprintf(stderr,
+                "[MMOptions] clear of '%s' REJECTED: the MM profile is frozen into the paired world's "
+                "creation identity (digest %08X)\n",
+                desc->cvar, (unsigned)gComboCtx.mmProfileDigest);
+        return;
+    }
     CVarClear(desc->cvar);
+}
+
+bool Combo_MMProfileFrozen(void) {
+    // The creation-stamped digest IS the predicate (#564 V5): a src/common
+    // fact, never a gSaveContext read — ADR 0008 rule 5 and this pane's own
+    // game-agnosticism tripwire both forbid the latter.
+    return gComboCtx.mmProfileDigest != 0;
 }
 
 void Combo_MMProfileSummary(ComboMMProfileSummary* out) {

--- a/src/common/combo_mm_options_view.h
+++ b/src/common/combo_mm_options_view.h
@@ -22,10 +22,10 @@
  * WHY NOT A SohMenu PANE. ADR 0008 settled the seam for panels that belong to
  * neither game: they are owned by src/common and registered on the shared
  * Ship::Context Gui. This pane must be reachable **while OoT is active, before
- * the switch**, because the paired profile is snapshotted when MM's arrival
- * dispatches OnSaveInit and an existing MM save is never regenerated (#499's
- * timing constraint). A pane hung off MM's boot would only exist after the point
- * at which it can still change anything.
+ * the paired world is created**, because the profile freezes into the world's
+ * identity at the creation event (#498/#564) and a divergent arrival is
+ * refused. A pane hung off MM's boot would only exist after the point at which
+ * it can still change anything.
  *
  * CAPABILITY GATING IS PART OF THE MODEL, NOT THE WIDGET (ADR 0004 section 5).
  * Every descriptor carries a liveness class and, when it is not live, a reason
@@ -35,10 +35,17 @@
  * and changes nothing is the vacuous gate in UI form; the table refuses to
  * describe one as enabled.
  *
- * VALUES LIVE IN CVars, NOT HERE. Per ADR 0009 decision 1, CVars author the
- * settings and the save carries only a digest. This model reads and writes
- * `gRando.Options.*` directly and caches nothing, so a value changed anywhere
- * else is visible on the next call.
+ * VALUES LIVE IN CVars — UNTIL THE CREATION EVENT (#498/#564; ADR 0009 D1 as
+ * amended). CVars are the AUTHORING surface for the one window in which
+ * authoring is legal: before the paired world is generated. Generation stamps
+ * the resolved profile's identity into gComboCtx.mmProfileDigest, and from that
+ * moment the profile is world identity: the two writers below
+ * (Combo_MMOptionSetValue / Combo_MMOptionClear) REJECT writes while
+ * Combo_MMProfileFrozen() is true, and the pane renders read-only. A
+ * post-creation edit would not "apply later" — it would make the next MM
+ * arrival's resolved profile diverge from the creation stamp, which the
+ * arrival refuses as corruption (never honors). This model still reads the
+ * CVars directly and caches nothing.
  *
  * Locked ROM-free by the MMRandoOptions CTest (table coverage and honesty,
  * driven MM-side where both tables are in scope) and the ComboMMOptionsWindow
@@ -180,6 +187,9 @@ int32_t Combo_MMOptionGetValue(const ComboMMOptionDesc* desc);
  * `RANDO_SAVE_OPTIONS` and then indexed by generation code, so an out-of-range
  * write reaches MM's tables as an out-of-range index. Refusing silently would
  * leave the pane showing a value the save does not hold.
+ *
+ * REJECTED (no CVar write, stderr log) while Combo_MMProfileFrozen() is true:
+ * post-creation the profile is world identity, not a setting (#498/#564).
  */
 void Combo_MMOptionSetValue(const ComboMMOptionDesc* desc, int32_t value);
 
@@ -206,8 +216,39 @@ bool Combo_CVarIsExplicitInt(const char* cvar);
  *  paired logic default turns on — see Rando::Foreign::ResolvePairedProfile. */
 bool Combo_MMOptionIsExplicit(const ComboMMOptionDesc* desc);
 
-/** Clear the option's CVar, returning it to "never chosen". */
+/** Clear the option's CVar, returning it to "never chosen". REJECTED while
+ *  Combo_MMProfileFrozen() is true, same as Combo_MMOptionSetValue: clearing is
+ *  a write (it flips the resolved value back to the default and the logic pin
+ *  back to "no explicit choice"), so it diverges the arrival profile exactly
+ *  as a set does. */
 void Combo_MMOptionClear(const ComboMMOptionDesc* desc);
+
+/**
+ * The frozen-state predicate (#498/#564; ADR 0004 §6's fourth presentation
+ * state, ADR 0009 D1 as amended): true once a creation event has stamped the
+ * MM profile identity — literally `gComboCtx.mmProfileDigest != 0`, a
+ * src/common fact, never a gSaveContext read (ADR 0008 rule 5). While true,
+ * the two option writers above reject and the pane renders read-only. Cleared
+ * only when the identity itself goes: session invalidation on a DROP path, or
+ * a .redsave load of an unfrozen pair.
+ */
+bool Combo_MMProfileFrozen(void);
+
+/**
+ * Resolve the FULL MM profile identity from the option CVars and compute its
+ * digest, with NO side effects — nothing is written to any save, CVar, or
+ * gComboCtx. DEFINED MM-SIDE (games/mm/2s2h/Rando/Foreign.cpp, the TU that
+ * owns the one canonical identity-string builder), declared here because the
+ * two callers live outside MM: OoT's Playthrough_Init stamps the result into
+ * gComboCtx.mmProfileDigest at the creation event, and MM's arrival gate
+ * recomputes it to compare against that stamp (#498/#564 phase 2 step 9).
+ *
+ * The identity covers every generation input the digest guards: the 47
+ * resolved option values (including the paired RO_LOGIC default pin),
+ * gRando.ExcludedChecks, and the StartingItems config block (#564 V4 — a
+ * digest narrower than the generator's input set is vacuous).
+ */
+uint32_t MM_Rando_ComputeProfileStamp(void);
 
 /**
  * Pairing header for the pane: whether a paired world exists, its identity, and
@@ -215,9 +256,11 @@ void Combo_MMOptionClear(const ComboMMOptionDesc* desc);
  *
  * `paired == false` means the worlds were never paired; the other fields are
  * then whatever `gComboCtx` holds (typically 0) and must not be shown as a real
- * pairing. `mmProfileDigest == 0` means no paired profile has been resolved
- * yet — which is the normal state while the player is still in OoT choosing
- * options, and is NOT an error.
+ * pairing. `mmProfileDigest == 0` means the profile IDENTITY IS NOT FROZEN
+ * (#564 V8's reinterpretation): for a pair created since the freeze that state
+ * is unreachable (creation stamps it), so it marks a LEGACY pre-freeze pair
+ * that has not crossed yet — whose options remain editable until its first
+ * crossing stamps them.
  */
 typedef struct {
     bool paired;

--- a/src/common/combo_tracker_view.h
+++ b/src/common/combo_tracker_view.h
@@ -77,7 +77,7 @@ typedef struct {
     bool paired;                      // Combo_ForeignPairingActive()
     uint32_t sharedRandoSeed;         // gComboCtx.sharedRandoSeed
     uint32_t sharedRandoSettingsHash; // gComboCtx.sharedRandoSettingsHash
-    uint32_t mmProfileDigest;         // gComboCtx.mmProfileDigest (0 = unresolved)
+    uint32_t mmProfileDigest;         // gComboCtx.mmProfileDigest (0 = identity not frozen, #498/#564)
     int mmHostedForeign;              // OoT items placed into MM checks
     int ootHostedForeign;             // MM items placed into OoT checks
 } ComboTrackerIdentity;

--- a/src/common/context.cpp
+++ b/src/common/context.cpp
@@ -332,6 +332,15 @@ void Context_InvalidateSessionState(ComboSeedStampPolicy seedPolicy) {
     const bool savedSourceIsRando = gComboCtx.sourceIsRando;
     const uint32_t savedSeed = gComboCtx.sharedRandoSeed;
     const uint32_t savedSettingsHash = gComboCtx.sharedRandoSettingsHash;
+    // #498/#564 V9: the MM profile identity is stamped by the creation event
+    // (Playthrough_Init, via MM_Rando_ComputeProfileStamp) alongside the seed
+    // stamp above — same author, same moment — so it joins the KEEP set by the
+    // ComboSeedStampPolicy rule (context.h): any identity term stamped at or
+    // before file-create that KEEP does not carry is wiped by the creation
+    // itself, the stamping act destroying its own output. Before this entry,
+    // that is exactly what happened: file-create ran the re-init below and the
+    // creation-stamped digest never reached the file it named.
+    const uint32_t savedMmProfileDigest = gComboCtx.mmProfileDigest;
     // #534: the reverse placement table (OoT checks hosting MM items, #524)
     // travels WITH the stamp because it has the same author and the same
     // moment of authorship: Playthrough_Init stamps the pairing identity and
@@ -383,6 +392,11 @@ void Context_InvalidateSessionState(ComboSeedStampPolicy seedPolicy) {
         gComboCtx.sourceIsRando = savedSourceIsRando;
         gComboCtx.sharedRandoSeed = savedSeed;
         gComboCtx.sharedRandoSettingsHash = savedSettingsHash;
+        // The frozen MM profile identity travels with the stamp (#498/#564 V9)
+        // — and, like the stamp, is DROPPED on every other path: a surviving
+        // digest with no generation behind it would freeze the options pane
+        // (Combo_MMProfileFrozen) for a pair that no longer exists.
+        gComboCtx.mmProfileDigest = savedMmProfileDigest;
         // The other generation-authored artifact (#534) — see the snapshot
         // note above. KEEP-only on purpose: on a DROP path a populated table
         // belongs to a dead session and must go with it.
@@ -406,10 +420,10 @@ void Context_InvalidateSessionState(ComboSeedStampPolicy seedPolicy) {
 
     fprintf(stderr,
             "[Context] Session state invalidated (seed stamp %s: rando=%d seed=%u settings=%08X "
-            "reversePlacements=%d)\n",
+            "mmProfile=%08X reversePlacements=%d)\n",
             (seedPolicy == RSBS_SEED_STAMP_KEEP) ? "kept" : "dropped", (int)gComboCtx.sourceIsRando,
             (unsigned)gComboCtx.sharedRandoSeed, (unsigned)gComboCtx.sharedRandoSettingsHash,
-            Combo_CountForeignPlacementsOoT());
+            (unsigned)gComboCtx.mmProfileDigest, Combo_CountForeignPlacementsOoT());
 }
 
 int Context_InvalidateSessionOnReturnToTitle(void) {

--- a/src/common/context.h
+++ b/src/common/context.h
@@ -572,16 +572,32 @@ typedef struct {
     // different MM halves — with nothing able to detect it. This field is the
     // missing term: the paired world's identity now covers both halves.
     //
-    // Computed by Rando::Foreign::ResolvePairedProfile() from the SAME string
-    // MixPairedFinalSeed() hashes, so "changing an MM option changes the derived
-    // MM world" and "changing an MM option changes the recorded identity" cannot
-    // drift apart — they are one input.
+    // WRITER AND MEANING (#498/#564 phase 2): stamped by the CREATION event —
+    // Playthrough_Init resolves the MM profile from the option CVars through
+    // MM_Rando_ComputeProfileStamp at the same moment it stamps
+    // sharedRandoSeed/sharedRandoSettingsHash — and carried through file-create
+    // invalidation by the KEEP policy. The digest is WIDER than the option
+    // table alone: it also folds gRando.ExcludedChecks, the StartingItems
+    // config block, and the RESOLVED RO_LOGIC value (#564 V4), because those
+    // shape the generated world just as the 47 options do. Every MM arrival
+    // that would generate re-resolves the same identity and COMPARES: mismatch
+    // refuses the pairing through the #533 REFUSED machinery — divergence is
+    // corruption to refuse, never a choice to honor. Rando::Foreign owns both
+    // computations (one shared string builder), so "changing an input changes
+    // the derived MM world" and "changing an input changes the recorded
+    // identity" cannot drift apart.
     //
-    // Zero == unset (no paired profile has been resolved), the growth contract's
-    // required meaning: a non-rando or zero-extended legacy record reads 0.
-    // Carved from the FRONT of the old reserved[216] under that contract, so
-    // every field above keeps its shipped offset and the record size is
-    // unchanged.
+    // Zero == "identity not frozen" (#564 V8's loud reinterpretation: it no
+    // longer reads as the benign "MM hasn't generated yet"). Nonzero is the
+    // frozen-state predicate the options pane and the two src/common option
+    // writers gate on (Combo_MMProfileFrozen). A LEGACY pre-freeze pair reads
+    // 0 until its first crossing, where ResolvePairedProfile stamps it — the
+    // one transitional writer besides creation.
+    //
+    // Zero is also the growth contract's required meaning: a non-rando or
+    // zero-extended legacy record reads 0. Carved from the FRONT of the old
+    // reserved[216] under that contract, so every field above keeps its
+    // shipped offset and the record size is unchanged.
     uint32_t mmProfileDigest;
 
     // #525: the shared cross-game RESOURCES — one quantity spanning both games,

--- a/src/common/save.cpp
+++ b/src/common/save.cpp
@@ -88,6 +88,12 @@ const char* RefuseReasonSlug(RsbsRefuseReason reason) {
             return "crc";
         case RSBS_REFUSE_COMBO_MAGIC:
             return "combomagic";
+        case RSBS_REFUSE_IDENTITY:
+            // Never actually used in a quarantine name today — an identity
+            // refusal leaves the healthy slot file in place (RefuseSlotIdentity
+            // quarantines nothing) — but kept total so a future producer that
+            // does rename gets a truthful tag instead of "unknown".
+            return "identity";
         case RSBS_REFUSE_NONE:
         default:
             return "unknown";
@@ -114,6 +120,8 @@ const char* SaveManager::RefuseReasonLabel(RsbsRefuseReason reason) {
             return "corrupt (CRC mismatch)";
         case RSBS_REFUSE_COMBO_MAGIC:
             return "cross-game record damaged";
+        case RSBS_REFUSE_IDENTITY:
+            return "options differ from this pair's creation";
         case RSBS_REFUSE_NONE:
         default:
             return "";
@@ -629,6 +637,26 @@ bool SaveManager::IsSlotWritable(int slot) const {
     return SlotInRange(slot) && mSlotArmed[slot];
 }
 
+void SaveManager::RefuseSlotIdentity(int slot) {
+    if (!SlotInRange(slot)) {
+        // -1 is the legitimate "no active slot" value; a divergent session with
+        // no slot has nothing durable to protect, and the caller's own log line
+        // is the surface.
+        return;
+    }
+    // Deliberately NO quarantine: the .redsave is healthy — it is the running
+    // session (its live CVar/config state) that diverged from the creation
+    // identity. The latch is what matters: without it, the divergent session's
+    // next capture would freeze its un-paired world into the healthy pair's
+    // Tier-3 under the pair's identity.
+    mSlotArmed[slot] = false;
+    mSlotRefused[slot] = RSBS_REFUSE_IDENTITY;
+    std::fprintf(stderr,
+                 "[RsbsSave] slot %d REFUSED (%s); slot latched against writes this session — the on-disk "
+                 ".redsave is intact and untouched\n",
+                 slot, RefuseReasonLabel(RSBS_REFUSE_IDENTITY));
+}
+
 RsbsSlotState SaveManager::GetSlotState(int slot) const {
     if (!SlotInRange(slot)) {
         return RSBS_SLOT_ABSENT;
@@ -878,6 +906,10 @@ void RsbsSave_ArmSlotOnCreate(int slot) {
 
 int RsbsSave_IsSlotWritable(int slot) {
     return rsbs::SaveManager::Instance().IsSlotWritable(slot) ? 1 : 0;
+}
+
+void RsbsSave_RefuseSlotIdentity(int slot) {
+    rsbs::SaveManager::Instance().RefuseSlotIdentity(slot);
 }
 
 int RsbsSave_GetSlotState(int slot) {

--- a/src/common/save.h
+++ b/src/common/save.h
@@ -81,6 +81,12 @@ typedef enum RsbsRefuseReason {
     RSBS_REFUSE_TRUNCATED,    // a tier read came up short
     RSBS_REFUSE_CRC,          // payload CRC mismatch
     RSBS_REFUSE_COMBO_MAGIC,  // Tier-1 bytes are not a ComboContext
+    // #498/#564: the MM option profile resolved at a cross-game arrival does
+    // not match the identity frozen at the pair's creation
+    // (gComboCtx.mmProfileDigest). Unlike every reason above, the slot FILE is
+    // healthy — the running SESSION diverged — so this refusal latches and
+    // surfaces without quarantining anything (see RefuseSlotIdentity).
+    RSBS_REFUSE_IDENTITY,
 } RsbsRefuseReason;
 
 // What a load attempt actually did — richer than the old bool, because ABSENT
@@ -221,6 +227,18 @@ public:
 
     /** Armed-session latch state: true iff Save(slot) would be allowed to write. */
     bool IsSlotWritable(int slot) const;
+
+    /**
+     * #498/#564: record that THIS SESSION's resolved state diverged from the
+     * identity the slot's pair was created under (the arrival digest-mismatch
+     * producer). Latches the slot against writes and surfaces REFUSED with
+     * RSBS_REFUSE_IDENTITY, exactly like a refused load — but quarantines
+     * NOTHING: the on-disk .redsave is healthy and is precisely what must be
+     * protected from the divergent session's captures. Released by the same
+     * three events as any refusal (successful load, explicit erase, create).
+     * Out-of-range slots (including -1, "no active slot") are a no-op.
+     */
+    void RefuseSlotIdentity(int slot);
 
     /**
      * ABSENT / VALID / REFUSED for the slot, combining the on-disk file (header
@@ -382,6 +400,7 @@ void RsbsSave_DeleteSave(int slot);
 int  RsbsSave_LoadSlot(int slot);
 void RsbsSave_ArmSlotOnCreate(int slot);
 int  RsbsSave_IsSlotWritable(int slot);
+void RsbsSave_RefuseSlotIdentity(int slot);
 int  RsbsSave_GetSlotState(int slot);
 int  RsbsSave_GetSlotRefuseReason(int slot);
 int  RsbsSave_HasQuarantine(int slot);

--- a/src/common/tests/test_combo_mm_options_window.c
+++ b/src/common/tests/test_combo_mm_options_window.c
@@ -33,6 +33,15 @@
  *    a test or a headless run has every reason to read the options and none to
  *    draw them.
  *
+ * 4. THE FROZEN-PROFILE WRITE GATE (#498/#564 V5). Once a creation event has
+ *    stamped gComboCtx.mmProfileDigest, the two src/common option writers
+ *    (Combo_MMOptionSetValue / Combo_MMOptionClear) must REJECT — the profile
+ *    is world identity, and a post-creation edit would diverge the next MM
+ *    arrival from the creation stamp. Locked at the writers rather than the
+ *    widgets because the writers are the gate; the pane is just its face.
+ *    Falsifiable: remove the Combo_MMProfileFrozen() check from either writer
+ *    and its half goes red.
+ *
  * Deliberately absent: any assertion about appearance. Whether the grouping
  * reads well, whether the disabled rows' reasons are legible beside their
  * widgets, and whether the three standing warnings land are operator
@@ -169,6 +178,45 @@ extern "C" int Combo_MMOptionsWindow_RunHeadless(void) {
     }
 
     Context_SetCurrentGame(prevGame);
+
+    // ---- Frozen-profile write gate (#498/#564 V5) -------------------------
+    {
+        // Any checkbox row will do: 0/1 are always legal values for it, so a
+        // rejected write is distinguishable from a clamped one.
+        const ComboMMOptionDesc* checkbox = NULL;
+        for (int i = 0; i < Combo_MMOptionCount(); i++) {
+            const ComboMMOptionDesc* d = Combo_MMOptionAt(i);
+            if (d != NULL && d->widget == COMBO_MM_WIDGET_CHECKBOX) {
+                checkbox = d;
+                break;
+            }
+        }
+        CMOW_ASSERT(checkbox != NULL);
+
+        // Unfrozen (digest 0): the authoring window. Writes land.
+        ComboContext_Init();
+        CMOW_ASSERT(!Combo_MMProfileFrozen());
+        Combo_MMOptionClear(checkbox);
+        Combo_MMOptionSetValue(checkbox, 1);
+        CMOW_ASSERT(Combo_MMOptionGetValue(checkbox) == 1);
+        CMOW_ASSERT(Combo_MMOptionIsExplicit(checkbox));
+
+        // Frozen (a creation stamped the identity): both writers reject, and
+        // the CVar state is byte-for-byte what it was before the attempts.
+        gComboCtx.mmProfileDigest = 0x4D4D0001u;
+        CMOW_ASSERT(Combo_MMProfileFrozen());
+        Combo_MMOptionSetValue(checkbox, 0);
+        CMOW_ASSERT(Combo_MMOptionGetValue(checkbox) == 1);
+        Combo_MMOptionClear(checkbox);
+        CMOW_ASSERT(Combo_MMOptionIsExplicit(checkbox));
+        CMOW_ASSERT(Combo_MMOptionGetValue(checkbox) == 1);
+
+        // Unfrozen again (the pair's identity was dropped): authoring resumes.
+        gComboCtx.mmProfileDigest = 0;
+        CMOW_ASSERT(!Combo_MMProfileFrozen());
+        Combo_MMOptionClear(checkbox);
+        CMOW_ASSERT(!Combo_MMOptionIsExplicit(checkbox));
+    }
 
     // Leave global state clean for any subsequent test.
     CVarClear(ComboGui::kComboMMOptionsVisibilityCVar);

--- a/src/common/tests/test_save_refusal.c
+++ b/src/common/tests/test_save_refusal.c
@@ -322,10 +322,44 @@ TestResult Test_SaveWriteLatch(void) {
     REFUSE_ASSERT(mgr.IsSlotWritable(2), "an explicit erase must arm the slot");
     REFUSE_ASSERT(!std::filesystem::exists(mgr.SlotPath(2)), "erase must remove the slot file");
 
+    // ---- #498/#564: the arrival IDENTITY refusal — latch, no quarantine ----
+    // The fourth refusal producer. Unlike every load refusal above, the slot
+    // FILE is healthy — the running session's resolved profile diverged from
+    // the pair's creation identity — so RefuseSlotIdentity must latch and
+    // surface REFUSED while leaving the file byte-identical IN PLACE and
+    // minting no quarantine evidence: the healthy .redsave is exactly what
+    // the latch is protecting from the divergent session's captures.
+    RefusalFreshDir();
+    REFUSE_ASSERT(RefusalAuthorValidSlot(0, 0x1DE47177u), "could not author the healthy pair fixture");
+    std::vector<uint8_t> healthy;
+    REFUSE_ASSERT(RefusalReadFile(mgr.SlotPath(0), healthy), "could not snapshot the healthy fixture");
+    REFUSE_ASSERT(mgr.LoadSlot(0) == RSBS_LOAD_OK, "the healthy fixture must load");
+    REFUSE_ASSERT(mgr.IsSlotWritable(0), "the loaded slot must be writable before the refusal");
+
+    mgr.RefuseSlotIdentity(0);
+    REFUSE_ASSERT(!mgr.IsSlotWritable(0), "identity refusal must latch the slot");
+    REFUSE_ASSERT(mgr.GetSlotState(0) == RSBS_SLOT_REFUSED, "identity refusal must surface REFUSED");
+    REFUSE_ASSERT(mgr.GetSlotRefuseReason(0) == RSBS_REFUSE_IDENTITY, "the reason must name the identity mismatch");
+    REFUSE_ASSERT(!mgr.Save(0), "Save must refuse after an identity refusal");
+    {
+        std::vector<uint8_t> afterIdentity;
+        REFUSE_ASSERT(RefusalReadFile(mgr.SlotPath(0), afterIdentity) && afterIdentity == healthy,
+                      "the identity refusal (or its latched Save) altered the HEALTHY slot file");
+    }
+    REFUSE_ASSERT(RefusalQuarantines(0).empty(), "an identity refusal must not quarantine the healthy file");
+    // -1 is the legitimate "no active slot" value the arrival can hand over;
+    // it must be a no-op, not an out-of-bounds write.
+    mgr.RefuseSlotIdentity(-1);
+    // The explicit erase releases it, like every other refusal.
+    mgr.DeleteSave(0);
+    REFUSE_ASSERT(mgr.IsSlotWritable(0), "erase must release the identity latch");
+    REFUSE_ASSERT(mgr.GetSlotRefuseReason(0) == RSBS_REFUSE_NONE, "erase must clear the identity refusal record");
+
     std::error_code ec;
     std::filesystem::remove_all(kRefusalTestDir, ec);
     mgr.ResetSlotSessionState();
-    printf("[TEST] PASS: the latch protects un-established slots; load/create/erase are the only keys\n");
+    printf("[TEST] PASS: the latch protects un-established slots; load/create/erase are the only keys; the "
+           "identity refusal latches without touching the healthy file\n");
     return TEST_PASS;
 }
 

--- a/src/common/tests/test_session_invalidation.c
+++ b/src/common/tests/test_session_invalidation.c
@@ -113,6 +113,13 @@ const uint16_t kSessionAReverseCheck = 501;
 const uint16_t kGenReverseCheck = 777;
 const uint16_t kGenReverseItemId = 91;
 
+// MM profile identity stamps (#498/#564 V9): one belonging to the dead session
+// A, one authored by the mirrored generation pass. Distinct for the same
+// reason the reverse-table rows are — the KEEP case must prove it kept
+// GENERATION's stamp, and every DROP case must prove the dead session's went.
+const uint32_t kSessionAMmProfileDigest = 0x4D4DDEADu;
+const uint32_t kGenMmProfileDigest = 0x4D4D0777u;
+
 // Put a recognizable, fully-populated session into every global the bug leaks
 // through: both frozen blobs, both shadows, the seed stamp, the crossing
 // tables, and a staged-but-uncommitted pickup in the RAM outbox.
@@ -131,6 +138,7 @@ void SeedSessionA(uint32_t seed, uint32_t settingsHash) {
     gComboCtx.sourceIsRando = true;
     gComboCtx.sharedRandoSeed = seed;
     gComboCtx.sharedRandoSettingsHash = settingsHash;
+    gComboCtx.mmProfileDigest = kSessionAMmProfileDigest;
 
     // The two fields the netplay grant model composes with (#460).
     Combo_RecordSharedItem(GAME_OOT, 42);
@@ -195,6 +203,9 @@ void StampGeneratedSeed(uint32_t seed, uint32_t settingsHash) {
     gComboCtx.sourceIsRando = true;
     gComboCtx.sharedRandoSeed = seed;
     gComboCtx.sharedRandoSettingsHash = settingsHash;
+    // #498/#564: Playthrough_Init freezes the MM profile identity in the same
+    // publish block as the two stamps above (MM_Rando_ComputeProfileStamp).
+    gComboCtx.mmProfileDigest = kGenMmProfileDigest;
 
     Combo_ClearForeignPlacementsOoT();
     SharedItem mmItem;
@@ -285,6 +296,10 @@ TestResult Test_SessionInvalidation(void) {
     // `sourceIsRando && sharedRandoSettingsHash != 0`.
     SESSION_ASSERT(gComboCtx.sharedRandoSeed == 0);
     SESSION_ASSERT(gComboCtx.sharedRandoSettingsHash == 0);
+    // The frozen MM profile identity goes with the stamp (#498/#564): a
+    // surviving digest would keep the options pane frozen
+    // (Combo_MMProfileFrozen) for a pair that no longer exists.
+    SESSION_ASSERT(gComboCtx.mmProfileDigest == 0);
     SESSION_ASSERT(!Combo_ForeignPairingActive());
     // Both placement tables go with the session on a DROP — the reverse one
     // included, because at the title nothing stands behind it any more than
@@ -366,6 +381,15 @@ TestResult Test_SessionInvalidation(void) {
     SESSION_ASSERT(SessionIsClear(/*expectSeedStamp=*/true));
     SESSION_ASSERT(gComboCtx.sharedRandoSeed == 0x99999999u);
     SESSION_ASSERT(gComboCtx.sharedRandoSettingsHash == 0x5555u);
+    // ---- 5a. #498/#564 V9: the creation-frozen MM profile survives too ------
+    // Playthrough_Init stamps it in the same publish block as the seed stamp,
+    // BEFORE the file exists; if KEEP does not carry it, the creation event
+    // wipes its own identity output and every post-freeze pair arrives at MM
+    // with digest 0 — silently degrading the arrival compare into the legacy
+    // stamp-at-arrival path. This is the falsifiable KEEP lock: remove the
+    // mmProfileDigest snapshot/restore from Context_InvalidateSessionState and
+    // this goes red.
+    SESSION_ASSERT(gComboCtx.mmProfileDigest == kGenMmProfileDigest);
     // ---- 5b. #534: generation's REVERSE placement table survives too -------
     // Playthrough_Init authored it seconds after the stamp, for THIS file, and
     // nothing re-places it after file creation (the forward direction is
@@ -398,6 +422,9 @@ TestResult Test_SessionInvalidation(void) {
     SESSION_ASSERT(SessionIsClear(/*expectSeedStamp=*/false));
     SESSION_ASSERT(gComboCtx.sharedRandoSeed == 0);
     SESSION_ASSERT(gComboCtx.sharedRandoSettingsHash == 0);
+    // The frozen MM profile identity is DROP-only here too (#498/#564): no
+    // generation stands behind a vanilla file.
+    SESSION_ASSERT(gComboCtx.mmProfileDigest == 0);
     // No generation stands behind a vanilla file, so the reverse table is the
     // dead session's and goes with it — the #534 keep-set is KEEP-only.
     SESSION_ASSERT(Combo_CountForeignPlacementsOoT() == 0);


### PR DESCRIPTION
Implements #564 phase 2 step 9 — the profile freeze + arrival compare-and-refuse that the one-game ruling made #498 decision 1's settled answer. Unstacked by the merged #533 REFUSED machinery (#568), which this change plugs its fourth refusal producer into.

## What changes

**1. The creation event stamps the MM profile identity (V1 minimal form, V3, V8).**
`Playthrough_Init` now freezes the MM half's option profile into the pairing identity at the same publish point that stamps `sourceIsRando` / `sharedRandoSeed` / `sharedRandoSettingsHash`: `gComboCtx.mmProfileDigest = MM_Rando_ComputeProfileStamp()`. The stamp is computed by the SAME `ResolveProfileValues` + `ProfileIdentityString` pair MM's arrival re-runs (one shared builder in `Foreign.cpp`), so creation and arrival cannot drift. The resolved `RO_LOGIC` pin value is what gets stamped — nothing after creation depends on CVar existence except through this one resolution (V3).

**2. The digest widens to the generator's full input set (V4).**
`ProfileIdentityString` folds the 47 resolved option values **plus** `gRando.ExcludedChecks` (the CVar `GeneratePools` consumes) **plus** the StartingItems config block (via the same `GetStartingItemsFromConfig` accessor generation calls, now null-guarded for the display-free harness so the identity term and the generation input stay one computation). `MMOptionsString` — the **seed-derivation** input `MixPairedFinalSeed` hashes — is deliberately untouched: widening it would re-derive every shipped pair's MM world.

**3. KEEP carries the stamp through file-create invalidation (V9).**
`Context_InvalidateSessionState` snapshots/restores `mmProfileDigest` with the seed stamp, per the "the rule, not the list" contract #565 wrote into `ComboSeedStampPolicy`. DROP paths clear it, so a dead pair's digest can't freeze the pane for a world that no longer exists.

**4. Post-creation writes are rejected; the pane renders frozen (V5).**
New src/common predicate `Combo_MMProfileFrozen()` (`gComboCtx.mmProfileDigest != 0` — a src/common fact, never a gSaveContext read, per ADR 0008 rule 5). Both option writers (`Combo_MMOptionSetValue`, `Combo_MMOptionClear`) reject while frozen; the pane draws ADR 0004 §6's fourth presentation state (frozen banner, all rows disabled, Reset disabled with inline reason) and the "set them before you cross" copy that taught the retired renegotiation window is gone.

**5. MM arrival compares and refuses (V8: the digest acquires comparators).**
`MM_Rando_PairOnCrossGameArrival` re-resolves the identity before dispatching generation. Mismatch => REFUSE through the #533 machinery: no `OnSaveInit` dispatch (never author a divergent world), stamp left untouched (never self-heal), the active slot latched + surfaced via new `RSBS_REFUSE_IDENTITY` (`RefuseSlotIdentity` latches **without quarantining** — the on-disk .redsave is healthy and is exactly what the latch protects from the divergent session's captures), plus an immediate toast on the shared overlay. `ResolvePairedProfile` throws on the same mismatch as the class-level backstop for the non-arrival generation routes (MM file-select escapes, dev warps). A `mmProfileDigest == 0` pair is a LEGACY pre-freeze pair and keeps the old freeze-at-first-crossing behavior — the one transitional writer besides creation.

**6. The remaining CVar families are CLASSIFIED, not deferred (V4's tail).**
`gRando.Traps.*` is **runtime flavour, not world identity**: its only consumer `RollTrapType()` is called from actor behaviour when a trap is collected (`ActorBehavior/EnGirlA.cpp:73`, `Traps.cpp:133`), drawing from the live `Ship_Random` stream at pickup — never inside a fill. The trap knobs that *do* shape the world (`RO_SHUFFLE_TRAPS`, `RO_TRAP_AMOUNT`, read at `GeneratePools.cpp:281`) are ordinary option rows and are already folded. `gRando.SpoilerFile` / `SpoilerFileIndex` / `InputSeed` are excluded and folding them would be actively harmful: the paired path ignores all three by construction (`OnFileCreate.cpp:83` forces generation over a stale spoiler index when paired; `:101` replaces the input seed with `PairedInputSeedString`), and `OnFileCreate.cpp:289` *writes* `gRando.SpoilerFile` after every successful generation — a pair that folded it would diverge its own identity the instant it generated. Recorded in `ProfileIdentityString`, because ADR 0004 §6's scope note defaults an unclassified key to identity: silence is not neutral.

## Locks (all falsifiable, all counterfactuals MEASURED not asserted)

| Lock | Where | Counterfactual that goes red |
|---|---|---|
| Divergent switch-entry arrival **surfaces** the refusal: slot REFUSED w/ `RSBS_REFUSE_IDENTITY`, write-latched, stamp intact | `mm-pair-switch-entry` phase 4 (rando tier) | Revert the compare in `MM_Rando_PairOnCrossGameArrival` **alone** -> FAIL(24)/FAIL(26) (measured 2026-07-31). Note: **not** FAIL(22) — the backstop below still stops the world from being authored, so this layer buys the *surface*, and reverting it degrades the refusal into #564 V7's silent vanilla revert |
| Divergent arrival authors **no world** | `mm-pair-switch-entry` phase 4 | Revert **both** compares (arrival gate + `ResolvePairedProfile`) -> FAIL(22) + `mm-paired-profile` FAIL(66) (measured 2026-07-31): the divergent leg generates a world under the mid-session-edited CVars |
| Stamped-mismatch resolution throws and never self-heals; creation-side stamp == arrival-side digest under identical inputs | `mm-paired-profile` (redship tier) | Revert the compare/stamp split in `ResolvePairedProfile` -> FAIL(66)/FAIL(67) |
| Excluded-checks edit alone moves the digest | `mm-paired-profile` | Narrow the identity string back to the option table (the pre-widening digest) -> FAIL(68) |
| Frozen writers reject; unfrozen writers work | `combo-mm-options-window` | Remove the `Combo_MMProfileFrozen()` gate from either writer |
| KEEP preserves the stamp across file-create invalidation; every DROP clears it | `session-invalidation` | Remove the `mmProfileDigest` snapshot/restore from the KEEP set |
| Identity refusal latches + surfaces without touching or quarantining the healthy slot file; erase releases it | `save-write-latch` | Remove the latch (or add a quarantine) in `RefuseSlotIdentity` |

## Verification

Independently re-verified at head `dbcaf843` on a fresh local build (Ninja/MSVC Release, submodules initialized, ROM-staged archives, worktree isolated from every other checkout):

- `ctest -L "^redship$"` — **100% tests passed out of 70**
- `ctest -L "^rando$"` — **100% tests passed out of 15** (including `RandoDeterminism`, `SeedDeterminism`, `MMRandoGen`, `ForeignPlacementOoT`, `MMPairSwitchEntry`)
- clang-format 14.0.6 clean on every enforced path this PR touches (`GameExports_SingleExe.cpp`, `Foreign.cpp`, `Foreign.h`).
- Both counterfactuals executed, not asserted (results in the table above). No submodule pointer and no generated stamp (`build.c`, `properties.h`) is in any commit.

Determinism check performed as part of review: `Ship_Hash` is pure FNV-1a and consumes no RNG, and nothing on the OoT reverse-placement path reads `mmProfileDigest`, so inserting the stamp before `OoT_PlaceForeignItems` cannot shift any existing pair's placement stream — confirmed by `SeedDeterminism`/`RandoDeterminism` staying green.

## Known consequences, stated rather than discovered later

- **The stamp lands at GENERATION, not at file-create.** That is what #564 step 1 requires (the freeze must precede OoT's `Fill()`, V24), and it mirrors OoT's own snapshot-at-generation precedent — but it means a player who generates a seed and only *then* wants different MM options is frozen with no file in existence yet, and re-generating re-stamps the same frozen profile. The only unfreezing events are `Context_InvalidateSessionState`'s DROP paths: returning to the title screen, starting a vanilla file, or loading a slot whose `.redsave` is unfrozen. The frozen banner now names that escape explicitly instead of saying "create a new paired world", which from the frozen state is advice the player cannot act on.
- **State 4 ships as the gate and the presentation, not yet as the frozen VALUES.** ADR 0004 §6 also requires a frozen key's value be shown *from the save*; the pane still renders live CVar reads. That is unimplementable under the interim hybrid, which persists only the digest (#564's carve budget shows a 47-option Tier-1 record does not fit). In-app the two agree — the writers are the only in-app writers and they reject — but an out-of-band write (hand-edited config, libultraship console `cvar_set`) makes the pane display a value the world was not built from, caught only at the next arrival. Named as residue in ADR 0004 §4.1a and owed to #564 step 11's move to delivery option 1.
- **#564's acknowledged hybrid cost stands:** a pair created-but-never-crossed whose inputs later change refuses its MM half until erased. Surfaced loudly, latched, recoverable via erase.
- **`gRando.ExcludedChecks` is folded as the raw CVar string**, so any mid-pair write to it is divergence by definition. In single-exe this is safe by construction: its only writer, MM's `Rando/Menu.cpp`, is link-elided (`games/mm/CMakeLists.txt:141,:146`).

## Scope notes

Part of #498 / #564 phase 1 (in #564's numbering: phase 2 step 9, the freeze's minimal form). **Closes nothing yet** — #498 retains real scope beyond this: the combo-level settings tier itself (`comboSettingsHash`, tier-4 keys, decision 3's display-name collision), and #564's step 11 (merged generation at creation, at which point arrival loses its generation dispatch entirely and this compare becomes hydrate-or-refuse). The one-spoiler identity (V23) remains out of scope.

Avoided per lane constraints: the #532/#543 `TitleSetup` mechanism (untouched — the gate lives in the #439 `MM_Rando_PairOnCrossGameArrival` dispatch) and the libultraship submodule pointer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!--- section:artifacts:start -->
### Build Artifacts
  - [rsbs-windows.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/8800498102.zip)
  - [rsbs-linux.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/8800164318.zip)
<!--- section:artifacts:end -->