### PR TITLE
Funnel every durable MM save route into the #569 commit choke point (#530)

### DIFF
--- a/games/mm/2s2h/Enhancements/Saving/SavingEnhancements.cpp
+++ b/games/mm/2s2h/Enhancements/Saving/SavingEnhancements.cpp
@@ -8,6 +8,14 @@ extern "C" {
 #include <functions.h>
 }
 
+#ifdef RSBS_SINGLE_EXECUTABLE
+// src/common/save.h is a mixed C/C++ header that drags in the whole rsbs::
+// SaveManager surface; this TU needs exactly one C entry point out of it, so
+// declare it rather than include it — the convention the decomp TUs already use
+// for the Combo_* entry points.
+extern "C" int RsbsSave_GetActiveSlot(void);
+#endif
+
 #define CVAR_REMEMBER_SAVE_LOCATION_NAME "gEnhancements.RememberSaveLocation"
 #define CVAR_REMEMBER_SAVE_LOCATION CVarGetInteger(CVAR_REMEMBER_SAVE_LOCATION_NAME, 0)
 
@@ -60,14 +68,49 @@ extern "C" int SavingEnhancements_GetSaveEntrance() {
     }
 }
 
+/**
+ * RSBS (#530): is there ANY durable destination for a save right now?
+ *
+ * The vanilla predicate is "MM owns a real flash slot" — flashSaveAvailable
+ * plus a fileNum that is not the 0xFF no-real-slot sentinel. In a cross-game
+ * session that is permanently false: fileNum is pinned to 0xFF for the whole
+ * life of the MM half, so autosave and the hold-B pause save never even
+ * ARMED, and MM's periodic save silently did not exist. (That is the milder
+ * half of #530 — the other four uncaptured routes ran their whole ceremony
+ * and wrote nothing; these two did not run at all. The hold-B pause save is
+ * not a seventh route: VB_SAVE_ON_B_BUTTON_IN_PAUSE_MENU is a shortcut into
+ * the kaleido save-and-quit route, and it shares this gate.)
+ *
+ * Under the one-game ruling the combo's MM half has a durable destination
+ * whenever the session has an active `.redsave` slot, so the predicate widens
+ * to "a real flash slot OR an active unified slot". It stays a pure
+ * availability question: whether the write is actually PERMITTED is the commit
+ * choke point's business (the #533/#568 armed-session latch and the #570
+ * identity refusal both live in RsbsSave_Save), and a latched slot simply
+ * produces a refused commit rather than a silent one.
+ *
+ * Split out from SavingEnhancements_CanSave so the mm-unified-save-capture lock
+ * can drive it without fabricating a PlayState and a Player actor.
+ */
+extern "C" bool SavingEnhancements_HasDurableDestination() {
+    if (gSaveContext.flashSaveAvailable && gSaveContext.fileNum != 255) {
+        return true;
+    }
+#ifdef RSBS_SINGLE_EXECUTABLE
+    return RsbsSave_GetActiveSlot() >= 0;
+#else
+    return false;
+#endif
+}
+
 extern "C" bool SavingEnhancements_CanSave() {
     // Game State
     if (MM_gPlayState == NULL || GET_PLAYER(MM_gPlayState) == NULL) {
         return false;
     }
 
-    // Owl saving available
-    if (!gSaveContext.flashSaveAvailable || gSaveContext.fileNum == 255) {
+    // Owl saving available (vanilla flash slot, or this session's unified slot)
+    if (!SavingEnhancements_HasDurableDestination()) {
         return false;
     }
 
@@ -177,11 +220,20 @@ void HandleAutoSave() {
         SavingEnhancements_AdvancePlaytime();
         Play_SaveCycleSceneFlags(MM_gPlayState);
         gSaveContext.save.saveInfo.playerData.savedSceneId = MM_gPlayState->sceneId;
+        // RSBS (#530): the autosave's unified-slot commit rides inside this
+        // marshal (Sram_ComboCommitUnifiedSave, z_sram_NES.c), after the owl
+        // flags / entrance / scene above — the state an autosave means to record.
         func_8014546C(&MM_gPlayState->sramCtx);
-        Sram_SetFlashPagesOwlSave(&MM_gPlayState->sramCtx,
-                                  gFlashOwlSaveStartPages[gSaveContext.fileNum * FLASH_SAVE_MAIN_MULTIPLIER],
-                                  gFlashOwlSaveNumPages[gSaveContext.fileNum * FLASH_SAVE_MAIN_MULTIPLIER]);
-        Sram_StartWriteToFlashOwlSave(&MM_gPlayState->sramCtx);
+        // 2S2H [Port] The 0xFF sentinel guard the other flash routes carry: with
+        // SavingEnhancements_CanSave now also arming for a cross-game session
+        // (which has no flash slot at all), these two subscripts would otherwise
+        // index gFlashOwlSave*Pages at 510, hundreds of entries past the end.
+        if (Sram_FileNumHasFlashSlot(gSaveContext.fileNum)) {
+            Sram_SetFlashPagesOwlSave(&MM_gPlayState->sramCtx,
+                                      gFlashOwlSaveStartPages[gSaveContext.fileNum * FLASH_SAVE_MAIN_MULTIPLIER],
+                                      gFlashOwlSaveNumPages[gSaveContext.fileNum * FLASH_SAVE_MAIN_MULTIPLIER]);
+            Sram_StartWriteToFlashOwlSave(&MM_gPlayState->sramCtx);
+        }
         gSaveContext.save.isOwlSave = false;
         gSaveContext.save.shipSaveInfo.pauseSaveEntrance = -1;
     }

--- a/games/mm/2s2h/Enhancements/Saving/SavingEnhancements.h
+++ b/games/mm/2s2h/Enhancements/Saving/SavingEnhancements.h
@@ -10,6 +10,9 @@ extern "C" {
 
 int SavingEnhancements_GetSaveEntrance();
 bool SavingEnhancements_CanSave();
+// RSBS (#530): "is there any durable destination for a save right now" — a real
+// flash slot, or (cross-game) this session's active unified `.redsave` slot.
+bool SavingEnhancements_HasDurableDestination();
 void SavingEnhancements_AdvancePlaytime();
 
 #ifdef __cplusplus

--- a/games/mm/2s2h/mm_unified_save_test.cpp
+++ b/games/mm/2s2h/mm_unified_save_test.cpp
@@ -48,6 +48,62 @@
  *      first: without that, a prefix write would leave zeros there and a
  *      "did the byte survive" check could pass vacuously against a zeroed
  *      buffer rather than against genuinely stale data.
+ *
+ * ---------------------------------------------------------------------------
+ * #530 EXTENSION: the two-site allowlist becomes one funnel.
+ *
+ * Checks 1-5 above lock the CAPTURE. They say nothing about which of MM's save
+ * ROUTES reach it, and until #530 only two did: the owl statue and the pause
+ * save-and-quit, each rescued by a capture call pasted in beside its flash
+ * write. The other five -- Song of Time new-cycle, the game-over save, the two
+ * special saves (first entry to Clock Town, "Dawn of the New Day"), and the
+ * periodic autosave -- still bottomed out in the no-op flash stub and persisted
+ * ZERO bytes while presenting a completed save. (The autosave is the one
+ * exception in kind: it did not run a ceremony and write nothing, it never ran
+ * at all -- see check 10.)
+ *
+ * The fix routes them through the layer they all converge on:
+ * Sram_ComboCommitUnifiedSave, called from the tails of MM's two save-buffer
+ * marshallers func_8014546C and func_80145698 (games/mm/src/code/z_sram_NES.c).
+ * Checks 6-10 below lock that, and each has the same counterfactual: delete the
+ * Sram_ComboCommitUnifiedSave() call from the marshaller a route reaches
+ * through, and that route persists nothing again -- HasSave stays 0, the
+ * monotonic commit generation does not advance, Tier-3 reloads as zeros.
+ *
+ *   6. Every marshalling shape commits, once. func_8014546C's owl branch, its
+ *      non-owl branch, and func_80145698 each produce a durable commit whose
+ *      Tier-3 is non-zero and whose #537 commit generation advanced by exactly
+ *      one. Exactly one matters as much as non-zero: a funnel that fires twice
+ *      per save would inflate the generation the load-time skew check compares
+ *      against OoT's .sav.
+ *
+ *   7. A whole route, end to end. Sram_SaveSpecialEnterClockTown is driven for
+ *      real (it is the one funneled route with no PlayState dependency beyond
+ *      &play->sramCtx) at the 0xFF cross-game fileNum, and must commit. This is
+ *      also the route that proves the funnel had to sit in BOTH marshallers:
+ *      it is the only one that reaches disk through func_80145698.
+ *
+ *   8. The commit gates still hold at the NEW call sites. A funneled marshal
+ *      into a slot this session never established must not write and must not
+ *      advance the generation (#533/#568 write latch), and neither must one
+ *      into a slot refused for identity divergence (#570,
+ *      RSBS_REFUSE_IDENTITY). Widening the set of routes that can commit is
+ *      only safe if it does not widen what may be committed INTO.
+ *
+ *   9. MM_gPlayState stays NULL for all of the above (#516). Two of the
+ *      funneled routes fire from cutscene/message state machines that can run
+ *      before the play state is published, so the funnel must not have
+ *      introduced a play-state dependency. The test asserts the null rather
+ *      than merely relying on it.
+ *
+ *  10. Autosave's gate actually opens. Autosave and the hold-B pause save were
+ *      not writing zero bytes -- they never ran at all, because
+ *      SavingEnhancements_CanSave rejected the 0xFF fileNum outright. The
+ *      widened predicate (SavingEnhancements_HasDurableDestination) must accept
+ *      a cross-game session with an active unified slot, still reject one with
+ *      no destination at all, and leave the vanilla flash-slot answer alone --
+ *      while Sram_FileNumHasFlashSlot keeps the now-reachable autosave from
+ *      indexing the flash page tables at 0xFF.
  */
 
 #include "global.h"
@@ -55,6 +111,8 @@
 #include "save.h"
 #include "context.h"
 #include "game.h"
+
+#include "2s2h/Enhancements/Saving/SavingEnhancements.h"
 
 #include <cstdio>
 #include <cstring>
@@ -78,6 +136,92 @@ namespace {
 // Offset well past sizeof(Save), used to prove the capture is full-width.
 size_t TailProbeOffset() {
     return sizeof(SaveContext) - 1;
+}
+
+// ---- #530 funnel-check scaffolding ---------------------------------------
+
+// The probe byte the ROUTE checks stamp and then look for in the reloaded
+// Tier-3. Deliberately NOT TailProbeOffset(): that byte lands inside
+// ShipSaveContext, and route 6 (Sram_SaveSpecialEnterClockTown) calls
+// SavingEnhancements_AdvancePlaytime, which writes
+// shipSaveContext.lastTimeLog -- so the route would erase its own stamp and
+// the check would fail for a reason that has nothing to do with the funnel.
+// masksGivenOnMoon sits at 0x48CA, four and a half KiB past sizeof(Save)
+// (0x100C), so the stamp still proves the capture is full-width rather than a
+// sizeof(Save) prefix write; no save route writes it. (Check 5 above keeps the
+// literal last byte covered.)
+size_t RouteProbeOffset() {
+    return offsetof(SaveContext, masksGivenOnMoon);
+}
+
+// Backing store for the marshallers' saveBuf. Static so the 128 KiB does not
+// land on the test's stack (same reason mm_flash_filenum_test.cpp does it).
+u8 sSaveBuf[SAVE_BUFFER_SIZE];
+
+// Put gSaveContext into the shape a cross-game MM session actually runs in --
+// the 0xFF "no real flash slot" sentinel, flash reported available (Title_Init
+// sets it true and nothing clears it) -- and stamp a byte past sizeof(Save) so
+// the commit that follows is identifiable in the reloaded Tier-3.
+void ArmCrossGameSaveContext(u8 stamp) {
+    memset(&gSaveContext, 0, sizeof(SaveContext));
+    gSaveContext.fileNum = 0xFF;
+    gSaveContext.flashSaveAvailable = true;
+    reinterpret_cast<uint8_t*>(&gSaveContext)[RouteProbeOffset()] = stamp;
+}
+
+// Poison the MM shadow so "Tier-3 is non-zero" can never pass against leftovers
+// and so a reload that restored nothing is visible as zeros.
+void PoisonMMShadow(uint8_t value) {
+    std::vector<uint8_t> poison(MM_SAVE_CONTEXT_SIZE, value);
+    Context_UpdateShadowCopy(GAME_MM, poison.data(), poison.size());
+}
+
+// Did `what` produce a real durable commit? Requires: the monotonic #537
+// generation advanced by EXACTLY one (a funnel that double-fires would inflate
+// the generation the load-time skew check compares against OoT's .sav), a slot
+// file exists, and a fresh Load brings back a non-zero Tier-3 carrying `stamp`.
+// Prints its own diagnosis and returns false on failure.
+bool CommitReached(int slot, uint32_t genBefore, u8 stamp, const char* what) {
+    const uint32_t genAfter = gComboCtx.commitGeneration;
+    if (genAfter != genBefore + 1) {
+        printf("[TEST] FAIL: %s must advance the commit generation by exactly 1 (%u -> %u)\n", what,
+               (unsigned)genBefore, (unsigned)genAfter);
+        return false;
+    }
+    if (RsbsSave_HasSave(slot) != 1) {
+        printf("[TEST] FAIL: %s must have produced a readable slot file\n", what);
+        return false;
+    }
+
+    // Make the check about the FILE: wipe every trace from memory first.
+    Context_ClearAllFrozenStates();
+    if (RsbsSave_Load(slot) != 1) {
+        printf("[TEST] FAIL: %s produced a slot file that will not load back\n", what);
+        return false;
+    }
+
+    const uint8_t* mm = static_cast<const uint8_t*>(Context_GetMMSaveContext());
+    if (mm == nullptr) {
+        printf("[TEST] FAIL: %s left no MM shadow after the reload\n", what);
+        return false;
+    }
+    if (mm[RouteProbeOffset()] != stamp) {
+        printf("[TEST] FAIL: %s did not round-trip its Tier-3 stamp (got 0x%02X, want 0x%02X)\n", what,
+               (unsigned)mm[RouteProbeOffset()], (unsigned)stamp);
+        return false;
+    }
+
+    size_t nonZero = 0;
+    for (size_t i = 0; i < MM_SAVE_CONTEXT_SIZE; i++) {
+        if (mm[i] != 0) {
+            nonZero++;
+        }
+    }
+    if (nonZero == 0) {
+        printf("[TEST] FAIL: %s wrote an all-zero Tier-3 -- the #530 shape exactly\n", what);
+        return false;
+    }
+    return true;
 }
 
 } // namespace
@@ -168,6 +312,158 @@ extern "C" int MM_UnifiedSaveCapture_RunHeadless(void) {
         USAVE_ASSERT(mm[TailProbeOffset()] == kTailStamp,
                      "a byte past sizeof(Save) must survive: the capture must be full-width, not a "
                      "sizeof(Save) prefix write over a non-zero tail");
+    }
+
+    // ======================================================================
+    // #530: the routes. Everything below runs on slot 0, established the way
+    // production establishes one, and with the cross-game 0xFF fileNum.
+    // ======================================================================
+
+    // ---- 9. #516: no play state, for every check that follows -------------
+    // The Song of Time and "Dawn of the New Day" routes fire from message and
+    // cutscene state machines that can run before MM_gPlayState is published.
+    // Assert the null instead of merely happening to have one.
+    USAVE_ASSERT(MM_gPlayState == NULL, "the #530 funnel checks must run with no play state (#516)");
+
+    const int kSlot = 0;
+    RsbsSave_SetActiveSlot(kSlot);
+    USAVE_ASSERT(RsbsSave_LoadSlot(kSlot) == RSBS_LOAD_ABSENT, "an empty slot must open as ABSENT and arm");
+
+    SramContext sramCtx;
+    memset(&sramCtx, 0, sizeof(sramCtx));
+    sramCtx.saveBuf = sSaveBuf;
+
+    // ---- 6. Every marshalling shape commits, once -------------------------
+    // func_8014546C, owl branch. Reached by the owl statue, the pause
+    // save-and-quit, and (newly) the autosave.
+    {
+        ArmCrossGameSaveContext(0xB1);
+        gSaveContext.save.isOwlSave = true;
+        PoisonMMShadow(0x00);
+        const uint32_t gen = gComboCtx.commitGeneration;
+        func_8014546C(&sramCtx);
+        USAVE_ASSERT(CommitReached(kSlot, gen, 0xB1, "func_8014546C (owl branch)"),
+                     "the owl-shaped marshal must reach the commit funnel (#530)");
+    }
+
+    // func_8014546C, non-owl branch. Reached by Song of Time's new cycle, the
+    // game-over save, and Sram_SaveSpecialNewDay.
+    {
+        ArmCrossGameSaveContext(0xB2);
+        gSaveContext.save.isOwlSave = false;
+        PoisonMMShadow(0x00);
+        const uint32_t gen = gComboCtx.commitGeneration;
+        func_8014546C(&sramCtx);
+        USAVE_ASSERT(CommitReached(kSlot, gen, 0xB2, "func_8014546C (non-owl branch)"),
+                     "the non-owl marshal must reach the commit funnel -- this is the Song of Time / "
+                     "game-over / new-day shape (#530)");
+    }
+
+    // func_80145698, the other marshaller. Reached only by
+    // Sram_SaveSpecialEnterClockTown, which is why the funnel is in both.
+    {
+        ArmCrossGameSaveContext(0xB3);
+        PoisonMMShadow(0x00);
+        const uint32_t gen = gComboCtx.commitGeneration;
+        func_80145698(&sramCtx);
+        USAVE_ASSERT(CommitReached(kSlot, gen, 0xB3, "func_80145698"),
+                     "the second marshaller must reach the commit funnel too (#530)");
+    }
+
+    // ---- 7. A whole route, end to end -------------------------------------
+    // Sram_SaveSpecialEnterClockTown touches nothing on PlayState but
+    // &play->sramCtx, so the real route runs headless. At the 0xFF sentinel its
+    // flash write is skipped (Sram_FileNumHasFlashSlot) -- the commit inside
+    // func_80145698 is the ONLY thing that persists anything at all here.
+    {
+        std::vector<uint8_t> playMem(sizeof(PlayState), uint8_t(0));
+        PlayState* play = reinterpret_cast<PlayState*>(playMem.data());
+        play->sramCtx.saveBuf = sSaveBuf;
+
+        ArmCrossGameSaveContext(0xB4);
+        PoisonMMShadow(0x00);
+        const uint32_t gen = gComboCtx.commitGeneration;
+        Sram_SaveSpecialEnterClockTown(play);
+        USAVE_ASSERT(CommitReached(kSlot, gen, 0xB4, "Sram_SaveSpecialEnterClockTown"),
+                     "the first-entry-to-Clock-Town special save must persist (#530)");
+        USAVE_ASSERT(gSaveContext.save.isFirstCycle, "the route's own save-state writes must still happen");
+    }
+
+    // ---- 8. The commit gates hold at the NEW call sites --------------------
+    // (a) #533/#568 write latch: a slot this session never loaded, created, or
+    //     erased stays unwritten, and the monotonic generation must not move --
+    //     RsbsSave_Save checks the latch BEFORE staging for exactly that reason.
+    {
+        const int kUnestablished = 1;
+        RsbsSave_SetActiveSlot(kUnestablished);
+        ArmCrossGameSaveContext(0xB5);
+        PoisonMMShadow(0x00);
+        const uint32_t gen = gComboCtx.commitGeneration;
+        func_8014546C(&sramCtx);
+        USAVE_ASSERT(gComboCtx.commitGeneration == gen,
+                     "a funneled marshal into an un-established slot must not advance the commit generation");
+        USAVE_ASSERT(RsbsSave_HasSave(kUnestablished) == 0,
+                     "a funneled marshal into an un-established slot must not write a slot file (#533/#568)");
+    }
+
+    // (b) #570 identity refusal: the slot FILE is healthy, the running session
+    //     diverged from the identity frozen at the pair's creation. It latches
+    //     through the same gate, so the funnel must stay silent there too.
+    {
+        RsbsSave_SetActiveSlot(kSlot);
+        USAVE_ASSERT(RsbsSave_IsSlotWritable(kSlot) == 1, "the slot must still be writable before the refusal");
+        RsbsSave_RefuseSlotIdentity(kSlot);
+        USAVE_ASSERT(RsbsSave_IsSlotWritable(kSlot) == 0, "an identity refusal must latch the slot (#570)");
+
+        ArmCrossGameSaveContext(0xB6);
+        PoisonMMShadow(0x00);
+        const uint32_t gen = gComboCtx.commitGeneration;
+        func_8014546C(&sramCtx);
+        USAVE_ASSERT(gComboCtx.commitGeneration == gen,
+                     "a funneled marshal into an identity-refused slot must not advance the commit generation");
+
+        // The healthy file is still there (identity refusal quarantines
+        // nothing), so prove it was not REWRITTEN: its Tier-3 must still carry
+        // the previous phase's stamp, not this one's.
+        RsbsSave_ResetSlotSessionState();
+        Context_ClearAllFrozenStates();
+        USAVE_ASSERT(RsbsSave_Load(kSlot) == 1, "the identity-refused slot's healthy file must still load");
+        const uint8_t* mm = static_cast<const uint8_t*>(Context_GetMMSaveContext());
+        USAVE_ASSERT(mm != nullptr, "MM shadow must exist after the reload");
+        USAVE_ASSERT(mm[RouteProbeOffset()] == 0xB4,
+                     "an identity-refused slot must still hold the LAST permitted commit, not the refused one");
+    }
+
+    // ---- 10. Autosave's gate actually opens -------------------------------
+    // Autosave and the hold-B pause save never ran at all cross-game: the
+    // fileNum == 255 clause rejected them before any marshal. The widened
+    // predicate must accept a cross-game session that has somewhere to write.
+    {
+        memset(&gSaveContext, 0, sizeof(SaveContext));
+        gSaveContext.flashSaveAvailable = true;
+        gSaveContext.fileNum = 0xFF;
+
+        RsbsSave_SetActiveSlot(-1);
+        USAVE_ASSERT(!SavingEnhancements_HasDurableDestination(),
+                     "no flash slot and no unified slot means no durable destination");
+
+        RsbsSave_SetActiveSlot(kSlot);
+        USAVE_ASSERT(SavingEnhancements_HasDurableDestination(),
+                     "a cross-game session with an active unified slot HAS a durable destination -- without "
+                     "this, autosave and the hold-B pause save are gated off entirely (#530)");
+
+        // The vanilla answer is unchanged in both directions.
+        RsbsSave_SetActiveSlot(-1);
+        gSaveContext.fileNum = 0;
+        USAVE_ASSERT(SavingEnhancements_HasDurableDestination(), "a real flash slot is still a durable destination");
+        gSaveContext.flashSaveAvailable = false;
+        USAVE_ASSERT(!SavingEnhancements_HasDurableDestination(),
+                     "no flash available and no unified slot is still no destination");
+
+        // ...and the guard that keeps the now-reachable autosave from indexing
+        // the flash page tables at the sentinel it just started accepting.
+        USAVE_ASSERT(!Sram_FileNumHasFlashSlot(0xFF),
+                     "0xFF must still be rejected as a flash slot -- the autosave's page-table index depends on it");
     }
 
     // Leave global state clean for whatever runs next.

--- a/games/mm/2s2h/mm_unified_save_test.cpp
+++ b/games/mm/2s2h/mm_unified_save_test.cpp
@@ -83,6 +83,15 @@
  *      also the route that proves the funnel had to sit in BOTH marshallers:
  *      it is the only one that reaches disk through func_80145698.
  *
+ *  7b. The funnel's PLACEMENT, not just its presence. Sram_SaveSpecialNewDay
+ *      rolls gSaveContext over to the new cycle, marshals, and then restores
+ *      day/time/cutsceneIndex so the cutscene can keep playing -- so the live
+ *      context after the route holds the OLD cycle while the marshalled bytes
+ *      hold the NEW one. The committed Tier-3 must carry the new cycle
+ *      (day 0). Committing at the CALL SITE instead of the marshal tail -- the
+ *      shape the retired #527/#529 patches used -- would durably record the old
+ *      cycle, and only this check goes red for it.
+ *
  *   8. The commit gates still hold at the NEW call sites. A funneled marshal
  *      into a slot this session never established must not write and must not
  *      advance the generation (#533/#568 write latch), and neither must one
@@ -181,7 +190,14 @@ void PoisonMMShadow(uint8_t value) {
 // the generation the load-time skew check compares against OoT's .sav), a slot
 // file exists, and a fresh Load brings back a non-zero Tier-3 carrying `stamp`.
 // Prints its own diagnosis and returns false on failure.
-bool CommitReached(int slot, uint32_t genBefore, u8 stamp, const char* what) {
+//
+// `stamp` < 0 skips the stamp comparison, for a route that legitimately writes
+// the probe field itself: Sram_SaveSpecialNewDay (check 7b) runs
+// Sram_SaveEndOfCycle, which zeroes masksGivenOnMoon (z_sram_NES.c), so the
+// route erases its own stamp exactly the way route 6 erased a lastTimeLog-based
+// one. That check carries its own, stronger content evidence instead -- the
+// committed cycle -- and full-width capture is already locked by checks 5-7.
+bool CommitReached(int slot, uint32_t genBefore, int stamp, const char* what) {
     const uint32_t genAfter = gComboCtx.commitGeneration;
     if (genAfter != genBefore + 1) {
         printf("[TEST] FAIL: %s must advance the commit generation by exactly 1 (%u -> %u)\n", what,
@@ -205,7 +221,7 @@ bool CommitReached(int slot, uint32_t genBefore, u8 stamp, const char* what) {
         printf("[TEST] FAIL: %s left no MM shadow after the reload\n", what);
         return false;
     }
-    if (mm[RouteProbeOffset()] != stamp) {
+    if (stamp >= 0 && mm[RouteProbeOffset()] != (uint8_t)stamp) {
         printf("[TEST] FAIL: %s did not round-trip its Tier-3 stamp (got 0x%02X, want 0x%02X)\n", what,
                (unsigned)mm[RouteProbeOffset()], (unsigned)stamp);
         return false;
@@ -389,6 +405,66 @@ extern "C" int MM_UnifiedSaveCapture_RunHeadless(void) {
         USAVE_ASSERT(gSaveContext.save.isFirstCycle, "the route's own save-state writes must still happen");
     }
 
+    // ---- 7b. The INSTANT, not merely the route -----------------------------
+    // Sram_SaveSpecialNewDay is the other headless-drivable route (it touches
+    // nothing on PlayState but sramCtx, sceneId and actorCtx.sceneFlags), and it
+    // is the one that makes the funnel's PLACEMENT falsifiable rather than just
+    // asserted in a comment.
+    //
+    // The route rolls gSaveContext over to the new cycle (Sram_SaveEndOfCycle
+    // sets day = 0), marshals, and then RESTORES day/time/cutsceneIndex right
+    // after the marshal so the "Dawn of the New Day" cutscene can keep playing.
+    // So once the route returns, the live gSaveContext holds the OLD cycle while
+    // the bytes the route meant to make durable hold the NEW one. Committing
+    // from the marshal tail captures the new cycle; committing at the call site
+    // -- the "simpler" hookup, and the one the retired #527/#529 patches used --
+    // would durably record the old cycle instead. Song of Time
+    // (MSGMODE_NEW_CYCLE_0) has the identical shape but is buried in a message
+    // state machine that cannot run headless, so this route stands in for both.
+    {
+        std::vector<uint8_t> playMem(sizeof(PlayState), uint8_t(0));
+        PlayState* play = reinterpret_cast<PlayState*>(playMem.data());
+        play->sramCtx.saveBuf = sSaveBuf;
+
+        const s32 kOldCycleDay = 3;
+        ArmCrossGameSaveContext(0xB7);
+        gSaveContext.save.day = kOldCycleDay;
+        const s32 resetsBefore = gSaveContext.save.saveInfo.playerData.threeDayResetCount;
+        PoisonMMShadow(0x00);
+        const uint32_t gen = gComboCtx.commitGeneration;
+        Sram_SaveSpecialNewDay(play);
+        // NOTE: no tail stamp for this route -- Sram_SaveEndOfCycle zeroes
+        // masksGivenOnMoon, the probe field, so the route would erase its own
+        // stamp. The committed cycle below is the stronger evidence anyway.
+
+        // The route really did do both halves: roll the cycle over, then rewind
+        // the LIVE context back to the old day. Without this the check below
+        // could pass vacuously on a route that simply never restored.
+        USAVE_ASSERT(gSaveContext.save.saveInfo.playerData.threeDayResetCount == resetsBefore + 1,
+                     "Sram_SaveSpecialNewDay must actually roll the cycle over (end-of-cycle writes)");
+        USAVE_ASSERT(gSaveContext.save.day == kOldCycleDay,
+                     "Sram_SaveSpecialNewDay must restore the live day after the marshal -- if it does not, "
+                     "this check cannot tell marshal-time from call-site-time");
+
+        // CommitReached reloads the committed Tier-3 from disk into the shadow.
+        USAVE_ASSERT(CommitReached(kSlot, gen, -1, "Sram_SaveSpecialNewDay"),
+                     "the Dawn-of-the-New-Day special save must persist (#530)");
+
+        const uint8_t* mm = static_cast<const uint8_t*>(Context_GetMMSaveContext());
+        USAVE_ASSERT(mm != nullptr, "MM shadow must exist after the reload");
+        s32 committedDay = -1;
+        memcpy(&committedDay, mm + offsetof(SaveContext, save.day), sizeof(committedDay));
+        USAVE_ASSERT(committedDay == 0,
+                     "the commit must capture the NEW cycle the marshal holds (day 0), not the old cycle the "
+                     "route restores immediately after it -- this is exactly why the funnel sits at the "
+                     "marshal tail and not at the call site (#530)");
+        // Corroborate from a second, independent field, so a zeroed/garbage
+        // blob cannot pass the day check by accident.
+        USAVE_ASSERT(mm[offsetof(SaveContext, save.saveInfo.playerData.threeDayResetCount)] ==
+                         (uint8_t)(resetsBefore + 1),
+                     "the committed blob must carry the rolled-over cycle's reset count too");
+    }
+
     // ---- 8. The commit gates hold at the NEW call sites --------------------
     // (a) #533/#568 write latch: a slot this session never loaded, created, or
     //     erased stays unwritten, and the monotonic generation must not move --
@@ -416,6 +492,12 @@ extern "C" int MM_UnifiedSaveCapture_RunHeadless(void) {
         USAVE_ASSERT(RsbsSave_IsSlotWritable(kSlot) == 0, "an identity refusal must latch the slot (#570)");
 
         ArmCrossGameSaveContext(0xB6);
+        // A day the last PERMITTED commit (7b's new cycle) cannot have, so the
+        // reload below can tell the refused world from the kept one. 7b's
+        // end-of-cycle zeroed masksGivenOnMoon, so the tail stamp alone can no
+        // longer distinguish them.
+        const s32 kRefusedDay = 9;
+        gSaveContext.save.day = kRefusedDay;
         PoisonMMShadow(0x00);
         const uint32_t gen = gComboCtx.commitGeneration;
         func_8014546C(&sramCtx);
@@ -430,8 +512,13 @@ extern "C" int MM_UnifiedSaveCapture_RunHeadless(void) {
         USAVE_ASSERT(RsbsSave_Load(kSlot) == 1, "the identity-refused slot's healthy file must still load");
         const uint8_t* mm = static_cast<const uint8_t*>(Context_GetMMSaveContext());
         USAVE_ASSERT(mm != nullptr, "MM shadow must exist after the reload");
-        USAVE_ASSERT(mm[RouteProbeOffset()] == 0xB4,
-                     "an identity-refused slot must still hold the LAST permitted commit, not the refused one");
+        s32 keptDay = -1;
+        memcpy(&keptDay, mm + offsetof(SaveContext, save.day), sizeof(keptDay));
+        USAVE_ASSERT(keptDay != kRefusedDay, "an identity-refused slot must not have absorbed the refused world");
+        USAVE_ASSERT(keptDay == 0,
+                     "an identity-refused slot must still hold the LAST permitted commit (7b's new cycle), "
+                     "not the refused one");
+        USAVE_ASSERT(mm[RouteProbeOffset()] != 0xB6, "the refused commit's tail must not have reached the file either");
     }
 
     // ---- 10. Autosave's gate actually opens -------------------------------

--- a/games/mm/include/z64save.h
+++ b/games/mm/include/z64save.h
@@ -1856,6 +1856,16 @@ void MM_Sram_InitDebugSave(void);
 s32 Sram_FileNumHasFlashSlot(s32 fileNum);
 void Sram_ResetSaveFromMoonCrash(SramContext* sramCtx);
 void MM_Sram_OpenSave(struct FileSelectState* fileSelect, SramContext* sramCtx);
+// #region 2S2H/RSBS [Port] #530: the one cross-game commit funnel every durable
+// MM save route reaches through func_8014546C / func_80145698. Non-static so
+// the mm-unified-save-capture lock can drive it directly.
+void Sram_ComboCommitUnifiedSave(void);
+// The second save-buffer marshaller, previously undeclared here because its one
+// vanilla caller (Sram_SaveSpecialEnterClockTown) sits in the same TU. #530
+// makes it one of the two homes of the commit funnel, so the lock has to be able
+// to drive it.
+void func_80145698(SramContext* sramCtx);
+// #endregion
 void func_8014546C(SramContext* sramCtx);
 void func_801457CC(struct GameState* gameState, SramContext* sramCtx);
 void Sram_EraseSave(struct FileSelectState* fileSelect2, SramContext* sramCtx, s32 fileNum);

--- a/games/mm/src/code/z_message.c
+++ b/games/mm/src/code/z_message.c
@@ -19,12 +19,6 @@
 #include "2s2h_assets.h"
 #include <libultraship/bridge/consolevariablebridge.h>
 
-// RSBS single-exe: MM's redship-native unified-save capture, defined in
-// games/mm/2s2h/GameExports_SingleExe.cpp. Declared locally rather than via a
-// header because src/common is not on this decomp TU's include path — the same
-// convention z_play.c uses for the Combo_* entry points.
-extern int MM_Combo_CaptureSaveToUnifiedSlot(void);
-
 const char* gBombersNotebookPhotos[] = {
     gBombersNotebookPhotoAnjuTex,
     gBombersNotebookPhotoKafeiTex,
@@ -6200,6 +6194,13 @@ void MM_Message_Update(PlayState* play) {
 
             Sram_SaveEndOfCycle(play);
             gSaveContext.timerStates[TIMER_ID_MOON_CRASH] = TIMER_STATE_OFF;
+            // RSBS (#530): the Song of Time new-cycle save commits to the
+            // unified .redsave from inside this marshal
+            // (Sram_ComboCommitUnifiedSave, z_sram_NES.c). Note the commit MUST
+            // happen here and not after the three restores below: those rewind
+            // gSaveContext to the CURRENT instant so the cutscene can keep
+            // playing, while the save this route means to make durable is the
+            // NEW cycle Sram_SaveEndOfCycle just built.
             func_8014546C(&play->sramCtx);
 
             gSaveContext.save.day = sp40;
@@ -6232,26 +6233,22 @@ void MM_Message_Update(PlayState* play) {
             play->state.unk_A3 = 1;
             gSaveContext.save.isOwlSave = true;
             Play_SaveCycleSceneFlags(play);
-            func_8014546C(&play->sramCtx);
-
-            // RSBS (#35 follow-up): commit the owl save to the unified
-            // .redsave, OUTSIDE the fileNum gate below on purpose.
+            // RSBS (#35 follow-up, generalized by #530): the cross-game
+            // .redsave commit for this route now rides INSIDE func_8014546C
+            // above (Sram_ComboCommitUnifiedSave, z_sram_NES.c) rather than
+            // being pasted in beside the flash write here. Same instant, same
+            // ordering requirement — after Play_SaveCycleSceneFlags and the
+            // marshal, so the checksummed cycle flags are already in
+            // gSaveContext — but now it is the funnel every durable MM route
+            // shares instead of a two-site allowlist that left Song of Time,
+            // the game-over save, the special saves and autosave persisting
+            // zero bytes while presenting a completed save.
             //
-            // A cross-game MM session (entered via the Happy Mask Shop) runs
-            // with fileNum pinned to the 0xFF sentinel for its entire life, so
-            // the vanilla branch below never runs — yet the state machine
-            // still advances to MSGMODE_OWL_SAVE_1/_2 and plays the whole
-            // save-and-quit sequence. The player therefore saw a complete,
-            // indistinguishable owl save that attempted zero bytes of
-            // persistence, with no diagnostic. This call is what makes the owl
-            // save real in that session. It must come AFTER
-            // Play_SaveCycleSceneFlags/func_8014546C so the checksummed cycle
-            // flags are already in gSaveContext.
-            //
-            // Deliberately NOT fixed by handing cross-game MM a fake real
+            // Still deliberately NOT fixed by handing cross-game MM a fake real
             // fileNum: that would re-arm every slot-addressed flash path the
-            // 0xFF guards were added to close (#487/#515).
-            MM_Combo_CaptureSaveToUnifiedSlot();
+            // 0xFF guards were added to close (#487/#515). Hence the commit
+            // living outside the gate below rather than inside it.
+            func_8014546C(&play->sramCtx);
 
             if (gSaveContext.fileNum != 0xFF) {
                 Sram_SetFlashPagesOwlSave(&play->sramCtx,

--- a/games/mm/src/code/z_sram_NES.c
+++ b/games/mm/src/code/z_sram_NES.c
@@ -12,6 +12,15 @@
 void Sram_SyncWriteToFlash(SramContext* sramCtx, s32 curPage, s32 numPages);
 void func_80147414(SramContext* sramCtx, s32 fileNum, s32 arg2);
 
+#ifdef RSBS_SINGLE_EXECUTABLE
+// RSBS single-exe: MM's redship-native unified-save capture, defined in
+// games/mm/2s2h/GameExports_SingleExe.cpp. Declared locally because src/common
+// is not on this decomp TU's include path — the convention z_play.c already
+// uses for the Combo_* entry points. Guarded because that TU is only added to
+// the link in the single-exe branch of games/mm/CMakeLists.txt.
+extern int MM_Combo_CaptureSaveToUnifiedSlot(void);
+#endif
+
 #define CHECK_NEWF(newf)                                                                                 \
     ((newf)[0] != 'Z' || (newf)[1] != 'E' || (newf)[2] != 'L' || (newf)[3] != 'D' || (newf)[4] != 'A' || \
      (newf)[5] != '3')
@@ -1578,6 +1587,62 @@ void MM_Sram_OpenSave(FileSelectState* fileSelect, SramContext* sramCtx) {
     }
 }
 
+/**
+ * 2S2H/RSBS [Port] #530: the ONE cross-game commit funnel for MM's durable save
+ * routes.
+ *
+ * MM has SEVEN durable-save routes and they all converge here, on the two
+ * save-buffer marshallers below (func_8014546C and func_80145698): Song of Time
+ * new-cycle (z_message.c MSGMODE_NEW_CYCLE_0), owl statue (z_message.c
+ * MSGMODE_OWL_SAVE_0), pause save-and-quit (z_kaleido_scope_NES.c
+ * PAUSE_SAVEPROMPT_STATE_1), game-over save (z_kaleido_scope_NES.c
+ * PAUSE_STATE_GAMEOVER_SAVE_PROMPT), autosave (2s2h SavingEnhancements.cpp
+ * HandleAutoSave), and the two special saves (Sram_SaveSpecialEnterClockTown /
+ * Sram_SaveSpecialNewDay, driven from z_demo.c). Downstream of here every one
+ * of them is dead in a cross-game session, twice over: the flash funnel's write
+ * half is a no-op stub (games/mm/2s2h/mm_save_manager_stubs.c, because
+ * games/mm/CMakeLists.txt filters out 2s2h/SaveManager/*.cpp), and the
+ * Sram_FileNumHasFlashSlot / fileNum != 0xFF gates every flash write sits
+ * behind can never be satisfied while fileNum is pinned to the cross-game
+ * sentinel. Two of the seven (owl statue #527, pause save-and-quit #529) had
+ * been rescued individually with a capture call pasted beside their flash
+ * write; the other five still presented the full save ceremony and persisted
+ * zero bytes — or, for the autosave, never ran at all (#530).
+ *
+ * Hooking the marshallers instead of the call sites is what makes that
+ * structural rather than an allowlist: a route reaches disk iff it marshals,
+ * and a future route inherits the commit by construction. It is also the right
+ * INSTANT — the marshallers are the last thing every route does to
+ * gSaveContext before handing bytes to the flash layer, so the state captured
+ * here is exactly the state the route intended to make durable (Song of Time,
+ * for one, rewinds day/time in gSaveContext *after* the marshal so the cutscene
+ * can keep playing; capturing at the call site after that rewind would durably
+ * record the old cycle).
+ *
+ * The commit itself is MM_Combo_CaptureSaveToUnifiedSlot -> RsbsSave_Save, the
+ * #537 choke point's one-call form. Everything that makes the commit legal is
+ * enforced in there, not here, and deliberately so:
+ *   - no active .redsave slot => honest no-op (a standalone MM session, or a
+ *     cross-game session that never established a slot, writes nothing);
+ *   - the #533/#568 write latch => a slot this session refused, or never
+ *     loaded/created/erased, stays unwritten and the monotonic generation does
+ *     not advance;
+ *   - the #570 identity refusal (RSBS_REFUSE_IDENTITY) latches through that
+ *     same gate, so a session whose MM profile diverged from the pairing
+ *     identity frozen at creation cannot commit a divergent world here either.
+ *
+ * Touches no PlayState: MM_Combo_CaptureSaveToUnifiedSlot reads gSaveContext
+ * and gComboCtx only, and MM_HarvestSharedResources is likewise MM_gPlayState-
+ * free and gated on a live file. That matters because two of the funneled
+ * routes run from cutscene and message state machines that can fire before
+ * MM_gPlayState is published (#516).
+ */
+void Sram_ComboCommitUnifiedSave(void) {
+#ifdef RSBS_SINGLE_EXECUTABLE
+    MM_Combo_CaptureSaveToUnifiedSlot();
+#endif
+}
+
 // Similar to func_80145698, but accounts for owl saves?
 void func_8014546C(SramContext* sramCtx) {
     s32 i;
@@ -1612,6 +1677,9 @@ void func_8014546C(SramContext* sramCtx) {
             memcpy(&sramCtx->saveBuf[SAVE_BUFFER_SIZE_HALF], &gSaveContext.save, sizeof(Save));
         }
     }
+
+    // RSBS (#530): cross-game commit funnel. See Sram_ComboCommitUnifiedSave.
+    Sram_ComboCommitUnifiedSave();
 }
 
 /**
@@ -1634,6 +1702,9 @@ void func_80145698(SramContext* sramCtx) {
         memcpy(sramCtx->saveBuf, &gSaveContext, sizeof(Save));
         memcpy(&sramCtx->saveBuf[SAVE_BUFFER_SIZE_HALF], &gSaveContext.save, sizeof(Save));
     }
+
+    // RSBS (#530): cross-game commit funnel. See Sram_ComboCommitUnifiedSave.
+    Sram_ComboCommitUnifiedSave();
 }
 
 // Verifies save and use backup if corrupted?
@@ -2210,6 +2281,10 @@ void Sram_SaveSpecialEnterClockTown(PlayState* play) {
     gSaveContext.save.isOwlSave = false;
     // 2S2H [Enhancement] Store playtime before saving
     SavingEnhancements_AdvancePlaytime();
+    // RSBS (#530): commits to the unified .redsave from inside the marshal
+    // (Sram_ComboCommitUnifiedSave). This is the only route that reaches the
+    // commit through func_80145698 rather than func_8014546C, which is why the
+    // funnel has to sit in BOTH marshallers and not just the owl-aware one.
     func_80145698(sramCtx);
     // 2S2H [Port] Skip the flash write for the 0xFF "no real slot" sentinel (cross-game /
     // title / debug session); indexing gFlashSaveStartPages[fileNum * ...] would be OOB.
@@ -2233,6 +2308,10 @@ void Sram_SaveSpecialNewDay(PlayState* play) {
     CLEAR_WEEKEVENTREG(WEEKEVENTREG_84_20);
 
     Sram_SaveEndOfCycle(play);
+    // RSBS (#530): commits to the unified .redsave from inside the marshal
+    // (Sram_ComboCommitUnifiedSave), i.e. BEFORE the three restores below rewind
+    // gSaveContext to the current instant — the new cycle is what this route
+    // makes durable, exactly as in z_message.c's MSGMODE_NEW_CYCLE_0.
     func_8014546C(&play->sramCtx);
 
     gSaveContext.save.day = day;

--- a/games/mm/src/overlays/kaleido_scope/ovl_kaleido_scope/z_kaleido_scope_NES.c
+++ b/games/mm/src/overlays/kaleido_scope/ovl_kaleido_scope/z_kaleido_scope_NES.c
@@ -17,11 +17,6 @@
 #include "BenPort.h"
 #include <libultraship/bridge/gfxdebuggerbridge.h>
 
-// RSBS single-exe: MM's redship-native unified-save capture, defined in
-// games/mm/2s2h/GameExports_SingleExe.cpp. Declared locally because src/common
-// is not on this decomp TU's include path — the convention z_play.c and
-// z_message.c already use for the Combo_* entry points.
-extern int MM_Combo_CaptureSaveToUnifiedSlot(void);
 #include "archives/item_name_static/item_name_static.h"
 #include "archives/map_name_static/map_name_static.h"
 #include "2s2h/Enhancements/FrameInterpolation/FrameInterpolation.h"
@@ -3590,28 +3585,23 @@ void MM_KaleidoScope_Update(PlayState* play) {
                             }
                             Play_SaveCycleSceneFlags(play);
                             gSaveContext.save.saveInfo.playerData.savedSceneId = play->sceneId;
-                            func_8014546C(sramCtx);
-
-                            // RSBS (#35 follow-up): persist the pause save-and-quit to the
-                            // unified .redsave, OUTSIDE the fileNum gate immediately below,
-                            // for the same reason as the owl-statue capture in z_message.c.
-                            //
-                            // A cross-game MM session runs at the 0xFF fileNum sentinel for
-                            // its whole life, so the else-branch below never runs and this
-                            // leg wrote ZERO bytes -- "save and exit in MM" persisted
-                            // nothing at all. Placed after Play_SaveCycleSceneFlags /
-                            // savedSceneId / func_8014546C so the checksummed cycle flags
-                            // and scene are already in gSaveContext.
+                            // RSBS (#35 follow-up, generalized by #530): the cross-game
+                            // .redsave commit for save-and-quit now rides inside this
+                            // marshal (Sram_ComboCommitUnifiedSave, z_sram_NES.c), at the
+                            // same instant the hand-placed capture used to occupy and for
+                            // the same reason: a cross-game MM session runs at the 0xFF
+                            // fileNum sentinel for its whole life, so the else-branch below
+                            // never runs and this leg wrote ZERO bytes.
                             //
                             // NOTE the asymmetry this leg has and the owl statue does not:
                             // when the PauseSave enhancement is on, isOwlSave and
                             // pauseSaveEntrance are set ABOVE (before the gate), while the
                             // pair that clears them again lives in the else-branch and so
-                            // never runs cross-game. Capturing here is what makes that
-                            // state meaningful -- MM's spawn policy prefers
+                            // never runs cross-game. Committing before that clear is what
+                            // makes the state meaningful -- MM's spawn policy prefers
                             // pauseSaveEntrance over owlWarpId, which is the correct
                             // reading of a pause save.
-                            MM_Combo_CaptureSaveToUnifiedSlot();
+                            func_8014546C(sramCtx);
 
                             if (!gSaveContext.flashSaveAvailable ||
                                 gSaveContext.fileNum ==
@@ -3901,13 +3891,36 @@ void MM_KaleidoScope_Update(PlayState* play) {
                     Play_SaveCycleSceneFlags(play);
                     gSaveContext.save.saveInfo.playerData.savedSceneId = play->sceneId;
                     gSaveContext.save.saveInfo.playerData.health = 0x30;
+                    // RSBS (#530): the game-over save is one of the five routes that
+                    // presented the full save ceremony and persisted zero bytes in a
+                    // cross-game session. It commits to the unified .redsave from
+                    // inside this marshal (Sram_ComboCommitUnifiedSave, z_sram_NES.c),
+                    // after the health/scene/cycle-flag writes above, which is exactly
+                    // the state a "save and continue from a game over" means to record.
                     func_8014546C(sramCtx);
                     if (!gSaveContext.flashSaveAvailable) {
                         pauseCtx->state = PAUSE_STATE_GAMEOVER_8;
                     } else {
-                        Sram_SetFlashPagesDefault(sramCtx, gFlashSaveStartPages[gSaveContext.fileNum],
-                                                  gFlashSaveNumPages[gSaveContext.fileNum]);
-                        Sram_StartWriteToFlashDefault(sramCtx);
+                        // 2S2H [Port] Same 0xFF sentinel guard the other flash routes
+                        // carry (Sram_FileNumHasFlashSlot). This was the one flash site
+                        // in MM with NO fileNum guard at all, and it subscripts the
+                        // FLASH_SAVE_MAX-entry (14) gFlashSave*Pages tables by fileNum
+                        // directly, so a cross-game session -- where flashSaveAvailable
+                        // is true (Title_Init sets it and nothing clears it) but fileNum
+                        // is the 0xFF sentinel -- read 241 entries past their end and
+                        // handed the garbage to the flash funnel as a page and count.
+                        //
+                        // The state still advances to PAUSE_STATE_GAMEOVER_7, NOT the
+                        // GAMEOVER_8 "could not save" branch: the .redsave commit inside
+                        // func_8014546C above DID persist this save, so the flow the
+                        // player gets must be the succeeded-save one. GAMEOVER_7 waits on
+                        // sramCtx->status == 0, which is already true when no async write
+                        // was started, so it advances on the next frame.
+                        if (Sram_FileNumHasFlashSlot(gSaveContext.fileNum)) {
+                            Sram_SetFlashPagesDefault(sramCtx, gFlashSaveStartPages[gSaveContext.fileNum],
+                                                      gFlashSaveNumPages[gSaveContext.fileNum]);
+                            Sram_StartWriteToFlashDefault(sramCtx);
+                        }
                         pauseCtx->state = PAUSE_STATE_GAMEOVER_7;
                     }
                     sDelayTimer = 90;


### PR DESCRIPTION
Chain B part 2, on top of #569's commit choke point.

## The routes, re-derived at source

MM has **seven** durable-save routes, and every one of them reaches disk through
exactly one of two save-buffer marshallers — `func_8014546C` (the owl-aware one)
and `func_80145698`. Nothing else in the tree calls either function; file-select
reads, copies and erases have their own paths.

| # | Route | Site | Marshaller | Committed to `.redsave` before this PR? |
|---|---|---|---|---|
| 1 | Song of Time, new cycle | `z_message.c` `MSGMODE_NEW_CYCLE_0` | `func_8014546C` | **no** |
| 2 | Owl statue | `z_message.c` `MSGMODE_OWL_SAVE_0` | `func_8014546C` | yes (#527) |
| 3 | Pause save-and-quit | `z_kaleido_scope_NES.c` `PAUSE_SAVEPROMPT_STATE_1` | `func_8014546C` | yes (#529) |
| 4 | Game-over save | `z_kaleido_scope_NES.c` `PAUSE_STATE_GAMEOVER_SAVE_PROMPT` | `func_8014546C` | **no** |
| 5 | Autosave | `SavingEnhancements.cpp` `HandleAutoSave` | `func_8014546C` | **no — never ran at all** |
| 6 | Special save: first entry to South Clock Town | `Sram_SaveSpecialEnterClockTown` | `func_80145698` | **no** |
| 7 | Special save: "Dawn of the New Day" | `Sram_SaveSpecialNewDay` | `func_8014546C` | **no** |

The hold-B pause save is *not* an eighth route: `VB_SAVE_ON_B_BUTTON_IN_PAUSE_MENU`
is a shortcut into route 3 and shares its gate.

Downstream of the marshallers every route is dead in a cross-game session, twice
over: `games/mm/CMakeLists.txt` filters `2s2h/SaveManager/*.cpp` out of the link
(the replacement in `mm_save_manager_stubs.c` is a `-1` read and an EMPTY write),
and every slot-addressed flash path additionally sits behind a `fileNum != 0xFF`
/ `Sram_FileNumHasFlashSlot` gate that a session pinned to the cross-game
sentinel for its whole life can never satisfy.

## Fix: one funnel, not five more call-site patches

`Sram_ComboCommitUnifiedSave()` (`games/mm/src/code/z_sram_NES.c`) sits at the
**tail** of both marshallers and calls `MM_Combo_CaptureSaveToUnifiedSlot()` →
`RsbsSave_Save(slot)`, #569's choke point. The two hand-placed captures from
#527/#529 are retired into it: same instant, byte-identical for those two routes
(nothing mutates `gSaveContext` between the marshal and where the capture call
used to sit).

Hooking the marshallers rather than the call sites is what makes this structural
instead of an allowlist: **a route commits iff it marshals**, and a future route
inherits the commit by construction.

The marshal is also the right *instant*, not merely a convenient one. Song of
Time (route 1) and `Sram_SaveSpecialNewDay` (route 7) both rewind
`day` / `time` / `cutsceneIndex` in `gSaveContext` **after** the marshal so the
cutscene can keep playing; a commit placed at the call site after that rewind
would durably record the *old* cycle instead of the new one the flash buffer
holds.

## Respecting #568 and #570 at every new call site

The funnel enforces nothing itself — deliberately. Everything that makes a
commit legal already lives in `RsbsSave_Save` and is inherited unchanged:

- **No active slot** → honest no-op (a session that never established one writes
  nothing; it does not guess at slot 0).
- **#533/#568 write latch** → a slot this session refused, or never
  loaded/created/erased, stays unwritten *and* the monotonic generation stays
  put, because `Save` checks the latch **before** staging.
- **#570 identity refusal** (`RSBS_REFUSE_IDENTITY`) latches through that same
  gate, so a session whose MM profile diverged from the pairing identity frozen
  at creation cannot commit a divergent world here either.

**#516:** the funnel touches no `PlayState`. `MM_Combo_CaptureSaveToUnifiedSlot`
reads `gSaveContext` and `gComboCtx` only, and `MM_HarvestSharedResources` is
likewise `MM_gPlayState`-free and gated on `gameMode` rather than `fileNum`.
That matters because routes 1 and 7 fire from message/cutscene state machines
that can run before `MM_gPlayState` is published. The lock asserts
`MM_gPlayState == NULL` across every funnel check rather than merely happening
to have no play state, and the `rando` tier drives the play-state paths as well.

## Two routes needed more than the funnel

- **Autosave was gated off entirely, not writing nothing.**
  `SavingEnhancements_CanSave` rejected the `0xFF` fileNum outright, so the
  interval elapsed, the icon never drew, and no marshal ever ran. The
  destination test is split out as `SavingEnhancements_HasDurableDestination`
  and widened to "a real flash slot **or** this session's active unified slot".
  It stays a pure *availability* question; whether the write is *permitted*
  remains the choke point's business. Autosave is opt-in
  (`gEnhancements.Autosave` defaults to 0), so this does not change the default
  session's commit cadence.
- **Two unguarded flash page-table subscripts.** With autosave now reachable,
  `HandleAutoSave`'s `gFlashOwlSave*Pages[fileNum * FLASH_SAVE_MAIN_MULTIPLIER]`
  would index at 510. The game-over route had the *same* latent OOB already live
  on `main` — it is the one flash site in MM with **no** fileNum guard at all,
  and `flashSaveAvailable` is set true by `Title_Init` and never cleared, so a
  cross-game game-over save reads `gFlashSave*Pages[255]` today and hands the
  garbage to the flash funnel as a page number and count. Both are guarded with
  `Sram_FileNumHasFlashSlot`, the same guard the other flash routes carry
  (#487/#515 class).

  The game-over route keeps `PAUSE_STATE_GAMEOVER_7` when the write is skipped
  rather than falling to the `GAMEOVER_8` "could not save" branch: the
  `.redsave` commit inside the marshal *did* persist the save, so the player
  must get the succeeded-save flow (`GAMEOVER_8` diverts to the continue prompt
  and a respawn). `GAMEOVER_7` waits on `sramCtx->status == 0`, which is already
  true when no async write was started.

## Discrepancies with #530's body, noted rather than papered over

The issue's **title** names the bug this PR fixes. Its **body** describes a
different mechanism — Tier-1 being fresher than OoT's own `.sav`, and the
`RSBS_SHARED_ITEM_REDEEMED` residue that survives it — i.e. **#531**, which #569
has since made *detected and player-visible* (`[STALE: …]`) but which remains
open for the redemption-staging residue. Nothing in this PR addresses that.

Two further drifts in the title's list:

1. **Pause save-and-quit was already captured** by #529, so five routes
   remained, not the six the title implies.
2. **Autosave's failure was of a different kind.** It did not "present a
   completed save while persisting zero bytes" — it never ran.

## Locks (`mm-unified-save-capture`, CTest label `redship`, checks 6–10 + 7b)

Extends the existing lock rather than adding a row: checks 1–5 already lock the
*capture*, and 6–10 lock which *routes* reach it — plus 7b, which locks *where
in the route* the commit happens.

6. **Every marshalling shape commits, exactly once.** `func_8014546C`'s owl
   branch, its non-owl branch, and `func_80145698` each produce a durable commit
   with a non-zero Tier-3 and a generation advanced by **exactly one**. Exactly
   one matters as much as non-zero: a funnel that double-fires would inflate the
   generation the load-time skew check compares against OoT's `.sav`.
7. **A whole route, end to end.** `Sram_SaveSpecialEnterClockTown` is driven for
   real at the `0xFF` cross-game fileNum and must commit — it is the only route
   reaching disk through `func_80145698`, which is why the funnel has to live in
   both marshallers and not just the owl-aware one.
7b. **The funnel's *placement*, not just its presence.** `Sram_SaveSpecialNewDay`
   rolls `gSaveContext` over to the new cycle (`Sram_SaveEndOfCycle` sets
   `day = 0`), marshals, then restores `day`/`time`/`cutsceneIndex` so the
   cutscene can keep playing — so once the route returns the *live* context
   holds the OLD cycle while the marshalled bytes hold the NEW one. The
   committed Tier-3 must carry day 0. This is the check that goes red if the
   commit is moved to the call site, which is the shape the retired #527/#529
   patches used; Song of Time has the identical shape but is buried in a message
   state machine that cannot run headless, so this route stands in for both. It
   also closes the last uncovered route — 7 and 7b are the two special saves.
8. **The gates hold at the NEW call sites.** A funneled marshal into an
   un-established slot (#533/#568) and into an identity-refused slot (#570) must
   write nothing and leave the generation still; the refused slot's healthy file
   must still hold the *last permitted* commit, not the refused one.
9. **`MM_gPlayState` is NULL throughout** (#516), asserted rather than assumed.
10. **Autosave's gate actually opens** for a cross-game session with an active
    unified slot, still rejects "no destination at all", leaves the vanilla
    flash-slot answer unchanged in both directions, and
    `Sram_FileNumHasFlashSlot(0xFF)` still rejects.

### Counterfactuals, executed

Each patch was applied to the final tree, rebuilt, run, then reverted and
re-verified green.

**A — funnel deleted from `func_8014546C`** (routes 1–5, 7):

```
[TEST] FAIL: func_8014546C (owl branch) must advance the commit generation by exactly 1 (1 -> 1)
[TEST] FAIL: the owl-shaped marshal must reach the commit funnel (#530)
```

**B — funnel deleted from `func_80145698`** (route 6, the only one that reaches
disk through it — this is what proves the funnel had to live in *both*):

```
[TEST] FAIL: func_80145698 must advance the commit generation by exactly 1 (3 -> 3)
[TEST] FAIL: the second marshaller must reach the commit funnel too (#530)
```

**C — `HasDurableDestination` narrowed back to flash-only** (autosave regated
off):

```
[TEST] FAIL: a cross-game session with an active unified slot HAS a durable destination --
without this, autosave and the hold-B pause save are gated off entirely (#530)
```

**D — the three restores in `Sram_SaveSpecialNewDay` moved to *before* the
marshal** (the perturbation check 7b exists to catch — it simulates a call-site
commit without touching the funnel, so the blast radius is exactly one check):

```
[TEST] FAIL: the commit must capture the NEW cycle the marshal holds (day 0),
not the old cycle the route restores immediately after it -- this is exactly
why the funnel sits at the marshal tail and not at the call site (#530)
```

No other check fired, which is the point: 7b isolates the *placement* claim from
the *presence* claim that A and B cover.

A note on the probe, because the lock caught a real thing while being written:
the route checks stamp `masksGivenOnMoon` (0x48CA) rather than the last byte of
`SaveContext`. That byte lands inside `ShipSaveContext`, and route 6 calls
`SavingEnhancements_AdvancePlaytime`, which writes
`shipSaveContext.lastTimeLog` — the route erased its own stamp and check 7
failed with `got 0x00, want 0xB4` until the probe moved. 0x48CA is still 4.5 KiB
past `sizeof(Save)` (0x100C), so the stamp still proves a full-width capture,
and check 5 keeps the literal tail byte covered.

Check 7b hit the *same class* a second time, on a different field:
`Sram_SaveEndOfCycle` zeroes `masksGivenOnMoon` itself, so that route erases its
own stamp too (`got 0x00, want 0xB7`). `CommitReached` therefore grows a
negative-stamp opt-out, and 7b carries stronger content evidence instead — the
committed cycle, corroborated by `threeDayResetCount`. Full-width capture stays
locked by checks 5–7. The knock-on: the tail stamp can no longer distinguish
7b's commit from a refused one, so check 8(b)'s refused arm now writes a
distinctive `day` and 8(b) asserts on the *kept cycle* rather than the stamp —
strictly more falsifiable than before, because it now names both the world that
must survive and the world that must not.

## Verification

Local ROM-staged build (MSVC/Ninja Release, Windows, fresh worktree, submodules
initialized, assets extracted and `soh.o2r`/`2ship.o2r` staged into the build
root), both ctest tiers — re-run independently on the final head `b15a0789`
after the review pass, not carried over from the first commit:

```
ctest --test-dir build-cmake -L "^redship$" : 100% tests passed out of 73
ctest --test-dir build-cmake -L "^rando$"   : 100% tests passed out of 15
```

The `rando` tier was run deliberately, not incidentally: it drives the
play-state paths, which is where the #516 class of regression shows up.

The funnel's own lock, verbatim:

```
[MM] unified save to slot 0: ok (commit generation 2)
[MM] unified save to slot 0: ok (commit generation 3)
[MM] unified save to slot 0: ok (commit generation 4)
[MM] unified save to slot 0: ok (commit generation 5)
[MM] unified save to slot 0: ok (commit generation 6)
[RsbsSave] slot 1 NOT saved: write latched: slot was not loaded, created, or erased this session
[MM] unified save to slot 1: FAILED (commit generation 6)
[RsbsSave] slot 0 REFUSED (options differ from this pair's creation); slot latched against writes
this session — the on-disk .redsave is intact and untouched
[MM] unified save to slot 0: FAILED (commit generation 6)
[TEST] mm-unified-save-capture: PASS
```

(The five `ok` lines are the five funnel-driven commits — three marshalling
shapes plus the two end-to-end special-save routes; the two `FAILED` lines are
the #568 latch and the #570 identity refusal holding at the new call sites, with
the generation frozen at 6 across both.)

`clang-format` 14.0.6 — the version the CI gate pins — reports no changes on
`games/mm/2s2h/mm_unified_save_test.cpp`, the only touched file on
`.github/clang-format-paths.txt`.

No submodule pointer changes and no generated build stamps committed
(`games/mm/src/boot/build.c`, `games/oot/src/boot/build.c`,
`games/mm/windows/properties.h`, `games/oot/properties.h` are regenerated by the
build and were restored before each commit).

### Adversarial review pass

The second commit on this branch is a review follow-up, not new mechanism. What
was re-derived independently at source rather than taken on trust:

- **Caller set.** `git grep` over `games/` confirms `func_8014546C` has exactly
  six callers and `func_80145698` exactly one, and all seven are durable-save
  routes — nothing else (file-select read/copy/erase, moon-crash reset) reaches
  either. That is what makes "commit iff it marshals" safe rather than
  over-broad.
- **Game-over flow.** `PAUSE_STATE_GAMEOVER_7` waits on `sramCtx->status == 0`
  and then goes to `PAUSE_STATE_OFF`; `GAMEOVER_8` decrements `sDelayTimer` into
  the continue prompt and a respawn. `status` is 0 unless a flash write is in
  flight, and none is started cross-game — so keeping `GAMEOVER_7` is correct
  and advances on the next frame.
- **Widened gate's blast radius.** `SavingEnhancements_CanSave` has exactly two
  consumers: `HandleAutoSave` and `PauseSave.cpp`'s hold-B shortcut into route
  3. Both are intended. `RegisterAutosave` really is dispatched in single-exe
  (`GameExports_SingleExe.cpp:1468`, hooks executed from `game.c:179`), so the
  autosave fix is not a dead registrar (#512/#517 class), and
  `gEnhancements.Autosave` defaults to 0.
- **Harvest composition (#525/#559).** Five new routes now reach
  `MM_HarvestSharedResources`. It is gated on `gameMode` via
  `Combo_SaveIsLiveFile`, every funneled route fires from a live NORMAL-mode
  world, and repeated harvests are watermark-idempotent — so the added call
  sites do not debit the shared pool. The marshal instant is also the *correct*
  one here: the harvest and the MM blob stored beside it describe the same
  instant.
- **Linkage.** `RsbsSave_GetActiveSlot` is inside `save.h`'s `extern "C"` block,
  so the local redeclaration matches (the OTRGlobals C-only-declaration trap did
  not apply). `RSBS_SINGLE_EXECUTABLE` is defined on both affected targets
  (`2ship_src`, `2ship_enh`), so neither guard is silently dead. Neither
  newly-header-declared symbol collides with anything in `games/oot`.

## Scope

Out of scope, deliberately: #531's redemption-staging residue (the issue body's
mechanism — still open); the #532/#543 owl-exit mechanism (another branch owns
it, and this PR does not touch `z_play.c`).

Refs #530.

🤖 Generated with [Claude Code](https://claude.com/claude-code)




<!--- section:artifacts:start -->
### Build Artifacts
  - [rsbs-windows.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/8827039647.zip)
  - [rsbs-linux.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/8826430921.zip)
<!--- section:artifacts:end -->