### PR TITLE
Check the write latch before MM's capture harvests the shared pool (#591)

### DIFF
--- a/.github/clang-format-paths.txt
+++ b/.github/clang-format-paths.txt
@@ -37,6 +37,7 @@ games/mm/2s2h/Rando/TrackerAdapterSingleExe.cpp
 games/mm/2s2h/ShipInit.hpp
 games/mm/2s2h/TrackersGuiSingleExe.cpp
 games/mm/2s2h/TrackersGuiSingleExe.h
+games/mm/2s2h/mm_capture_harvest_gate_test.cpp
 games/mm/2s2h/mm_culling_test.cpp
 games/mm/2s2h/mm_fb_effects_test.cpp
 games/mm/2s2h/mm_flash_filenum_test.cpp

--- a/CMake/SingleExecutable.cmake
+++ b/CMake/SingleExecutable.cmake
@@ -602,6 +602,16 @@ if(BUILD_TESTING)
     # capture is FULL-WIDTH rather than the sizeof(Save) prefix the excluded
     # file used. Display-free and ROM-free, so it runs in this redship tier.
     redship_add_test(NAME MMUnifiedSaveCapture COMMAND redship --test mm-unified-save-capture)
+    # MM's capture must not advance the SHARED-RESOURCE POOL for a commit the
+    # write latch refuses (#591, games/mm/2s2h/mm_capture_harvest_gate_test.cpp).
+    # MM_Combo_CaptureSaveToUnifiedSlot harvested rupees/hearts/magic/ammo into
+    # gComboCtx.sharedResources BEFORE RsbsSave_Save checked the #533/#568
+    # armed-session latch, so an un-established or REFUSED slot still moved the
+    # pool and the RAM watermark table for a record that never reached disk.
+    # Apply ASSIGNS the consumable kinds, so the far game materialized that
+    # phantom balance verbatim at the next arrival; the monotonic tiers it also
+    # raised could never decay back out. Display-free and ROM-free.
+    redship_add_test(NAME MMCaptureHarvestGate COMMAND redship --test mm-capture-harvest-gate)
     # MM single-exe hook dispatch (#511, #438): the COND_HOOK/COND_ID_HOOK
     # macros park registrations in the MM-owned S2H::GameHooks registry, but
     # ShouldActorInit / OnActorInit / OnActorDraw / OnOpenText dispatched

--- a/games/mm/2s2h/GameExports_SingleExe.cpp
+++ b/games/mm/2s2h/GameExports_SingleExe.cpp
@@ -1654,9 +1654,23 @@ extern "C" void MM_ResumeColdBootPrep(void) {
  * past Save (eventInf, cycleSceneFlags, the timer arrays, the runtime respawn
  * table, ShipSaveContext) at whatever a DIFFERENT point in time left there.
  *
- * @return 1 on a committed write, 0 when there was nothing to write to or the
- *         slot is latched against writes. A 0 return is a NO-OP on every store
- *         this function can reach — including the shared-resource pool (#591).
+ * @return 1 on a committed write, 0 otherwise.
+ *
+ * The two REFUSAL returns below — no active slot, and the #533/#568 write
+ * latch — are no-ops on every store this function can reach, the
+ * shared-resource pool and the RAM watermark table included (#591). That is
+ * the guarantee the gate exists to provide and the one MMCaptureHarvestGate
+ * locks.
+ *
+ * It is deliberately NOT extended to the late failures RsbsSave_Save can still
+ * report after the latch admits the write (StageCommit refusing because the
+ * context shadows are absent, or the file write itself failing): by then the
+ * harvest has run, and the pool carries it. Those are benign in a way a refused
+ * session is not — the session is coherent, the harvested balance is MM's real
+ * live balance rather than a divergent world's, and the very next crossing's
+ * MM_Game_Suspend would have folded the identical numbers into the pool anyway.
+ * Claiming a blanket "0 means nothing moved" here would be false on those paths
+ * and would invite a future caller to trust it.
  */
 extern "C" int MM_Combo_CaptureSaveToUnifiedSlot(void) {
     const int slot = RsbsSave_GetActiveSlot();

--- a/games/mm/2s2h/GameExports_SingleExe.cpp
+++ b/games/mm/2s2h/GameExports_SingleExe.cpp
@@ -1654,7 +1654,9 @@ extern "C" void MM_ResumeColdBootPrep(void) {
  * past Save (eventInf, cycleSceneFlags, the timer arrays, the runtime respawn
  * table, ShipSaveContext) at whatever a DIFFERENT point in time left there.
  *
- * @return 1 on a committed write, 0 when there was nothing to write to.
+ * @return 1 on a committed write, 0 when there was nothing to write to or the
+ *         slot is latched against writes. A 0 return is a NO-OP on every store
+ *         this function can reach — including the shared-resource pool (#591).
  */
 extern "C" int MM_Combo_CaptureSaveToUnifiedSlot(void) {
     const int slot = RsbsSave_GetActiveSlot();
@@ -1663,6 +1665,44 @@ extern "C" int MM_Combo_CaptureSaveToUnifiedSlot(void) {
         // defaulting to slot 0 here would let an MM session started from an
         // unsaved new file overwrite an unrelated slot.
         fprintf(stderr, "[MM] unified save skipped: no active slot for this session\n");
+        fflush(stderr);
+        return 0;
+    }
+
+    // #591 — THE LATCH IS CHECKED BEFORE THE HARVEST, not just inside
+    // RsbsSave_Save. The harvest below MUTATES process-global cross-game state
+    // (gComboCtx.sharedResources and the RAM watermark table), and a slot that
+    // is not writable this session — never established, or REFUSED for identity
+    // (#570) / generation (#500) divergence — means the commit that harvest is
+    // preparing for WILL NOT LAND. Advancing the pool for a record that is never
+    // written is the harvest/apply gate-asymmetry the #525 work already paid for
+    // once: apply ASSIGNS the consumable kinds (`*liveValue = applied`), so the
+    // phantom pool movement is materialized verbatim on the far side of the next
+    // crossing — rupees, the health bar, magic and every ammo count set from a
+    // commit nobody has. The monotonic kinds are worse in kind: max-merge cannot
+    // decay, so a tier harvested here is in the pool permanently.
+    //
+    // Returning here rather than rolling the harvest back afterwards is what
+    // keeps the ordering intact for the PERMITTED path: the harvest has to
+    // precede Context_UpdateShadowCopy so the pool and the MM blob stored beside
+    // it are one instant (see below), and there is no rollback that could
+    // restore the watermark table's pre-harvest owner/value pairs without
+    // duplicating the merge rules a second time.
+    //
+    // Symmetric with what OoT's side already does at its staging seam
+    // (games/oot/soh/SaveManager.cpp SaveSection: `if (RsbsSave_IsSlotWritable)`
+    // guards the harvest + shadow refresh + StageCommit together), and with
+    // SaveManager::Save itself, which checks the latch BEFORE staging so a
+    // refused write cannot advance the monotonic commit generation. Same rule,
+    // one store further out.
+    //
+    // Return 0, the same "nothing was committed" answer the refused
+    // RsbsSave_Save below would have produced, so no caller sees a new outcome.
+    if (!RsbsSave_IsSlotWritable(slot)) {
+        fprintf(stderr,
+                "[MM] unified save skipped: slot %d is not writable this session (#533/#568 latch);"
+                " shared-resource pool left untouched (#591)\n",
+                slot);
         fflush(stderr);
         return 0;
     }

--- a/games/mm/2s2h/mm_capture_harvest_gate_test.cpp
+++ b/games/mm/2s2h/mm_capture_harvest_gate_test.cpp
@@ -1,0 +1,240 @@
+/**
+ * @file mm_capture_harvest_gate_test.cpp
+ * ROM-free, display-free lock for #591: MM's unified-save capture must not
+ * advance the SHARED-RESOURCE POOL for a commit the write latch refuses.
+ * CTest label "redship", row MMCaptureHarvestGate in
+ * CMake/SingleExecutable.cmake, dispatch "mm-capture-harvest-gate" in
+ * src/common/test_runner.cpp.
+ *
+ * WHAT WAS BROKEN. MM_Combo_CaptureSaveToUnifiedSlot (games/mm/2s2h/
+ * GameExports_SingleExe.cpp) ran MM_HarvestSharedResources() and only THEN
+ * called RsbsSave_Save. RsbsSave_Save checks the #533/#568 armed-session latch
+ * and refuses outright when the slot was never established this session, or was
+ * REFUSED for identity (#570) / generation (#500) divergence — but by then the
+ * harvest had already folded MM's live rupees, wallet tier, hearts, magic and
+ * every ammo count into gComboCtx.sharedResources and moved the RAM watermark
+ * table. The pool had advanced for a record that never reached disk.
+ *
+ * WHY THAT CORRUPTS, and why it is not merely untidy. Harvest and apply are not
+ * symmetric: for the CONSUMABLE kinds apply ASSIGNS (`*liveValue = applied`,
+ * shared_resources.c), so whatever the phantom harvest left in the pool is
+ * materialized verbatim in the other game at the next arrival — the far side
+ * gets rupees, a health bar, a magic meter and ammo counts derived from a
+ * commit nobody holds, in EITHER direction (a lower live balance debits the
+ * pool just as a higher one credits it). The MONOTONIC kinds are worse in kind:
+ * max-merge cannot decay, so a wallet/quiver/heart tier that enters the pool
+ * here is in it permanently. This is the same one-sided-gate class the #525
+ * shared-resource work already paid for once with Combo_SaveIsLiveFile.
+ *
+ * THE INVARIANTS THIS LOCKS:
+ *
+ *   1. The harvest is REAL. A permitted capture into an established slot must
+ *      move the pool — otherwise every check below could pass against a
+ *      feature that does nothing. (This is the anti-vacuity check the whole
+ *      file turns on: "pool unchanged" is trivially true if nothing ever
+ *      changes the pool.)
+ *
+ *   2. A capture into a slot this session never established leaves the pool
+ *      BIT-FOR-BIT unchanged — the consumable count that would have been
+ *      credited, and the monotonic tier that would have been raised for good.
+ *
+ *   3. A capture into a slot refused for identity divergence (#570) does the
+ *      same, in the DEBIT direction: a live balance BELOW the watermark would
+ *      have walked the pool down.
+ *
+ *   4. The RAM watermark table is untouched by a refused capture. This is the
+ *      half a "pool value unchanged" assertion alone cannot see: a harvest that
+ *      dragged the watermark to the refused session's balance would leave the
+ *      pool looking correct right up until the next PERMITTED capture computed
+ *      its delta against the wrong baseline. Checked by re-arming the slot and
+ *      requiring the next permitted capture's delta to be measured from the
+ *      last COMMITTED balance.
+ *
+ *   5. The permitted path still works after all of it — the gate is a refusal,
+ *      not a removal. (Deleting MM_HarvestSharedResources() outright would
+ *      satisfy 2-4 and fails here.)
+ *
+ * COUNTERFACTUAL, run before landing: move the MM_HarvestSharedResources() call
+ * back above the RsbsSave_IsSlotWritable check in
+ * MM_Combo_CaptureSaveToUnifiedSlot and checks 2, 3 and 4 go red.
+ */
+
+#include "global.h"
+
+#include "save.h"
+#include "context.h"
+#include "shared_resources.h"
+
+#include <cstdio>
+#include <cstring>
+#include <filesystem>
+#include <string>
+
+extern "C" SaveContext gSaveContext;
+extern "C" int MM_Combo_CaptureSaveToUnifiedSlot(void);
+
+namespace {
+
+#define HGATE_ASSERT(cond, msg)                                           \
+    do {                                                                  \
+        if (!(cond)) {                                                    \
+            printf("[TEST] FAIL: %s (%s:%d)\n", msg, __FILE__, __LINE__); \
+            return 1;                                                     \
+        }                                                                 \
+    } while (0)
+
+// Read a pool value, reporting "never shared" as a distinguishable sentinel so
+// an absent slot and a zero-valued slot cannot be confused.
+int PoolValue(uint8_t kind) {
+    uint16_t value = 0;
+    if (!Combo_GetSharedResource(kind, &value)) {
+        return -1;
+    }
+    return (int)value;
+}
+
+// Put gSaveContext into the shape a live cross-game MM session runs in: the
+// 0xFF "no real flash slot" sentinel and GAMEMODE_NORMAL, which is what
+// Combo_SaveIsLiveFile requires before a harvest will do anything at all. A
+// zeroed context already reads as NORMAL; the assignment is written out so a
+// renumber upstream fails here rather than silently disarming the whole test.
+void ArmLiveMMSession(int32_t rupees, uint32_t walletTier) {
+    memset(&gSaveContext, 0, sizeof(SaveContext));
+    gSaveContext.fileNum = 0xFF;
+    gSaveContext.flashSaveAvailable = true;
+    gSaveContext.gameMode = GAMEMODE_NORMAL;
+    MM_Inventory_ChangeUpgrade(UPG_WALLET, walletTier);
+    gSaveContext.save.saveInfo.playerData.rupees = (s16)rupees;
+}
+
+} // namespace
+
+extern "C" int MM_CaptureHarvestGate_RunHeadless(void) {
+    // Isolated save directory so this never touches a real player's slots.
+    const std::filesystem::path dir = std::filesystem::temp_directory_path() / "rsbs_mm_capture_harvest_gate_test";
+    std::error_code ec;
+    std::filesystem::remove_all(dir, ec);
+    std::filesystem::create_directories(dir, ec);
+    rsbs::SaveManager::Instance().SetSaveDirectory(dir.string());
+    RsbsSave_ResetSlotSessionState();
+
+    Context_InitFrozenStates();
+    ComboContext_Init();
+    // Both stores start empty, so every "unchanged" assertion below is measured
+    // against a world this test authored rather than whatever ran before it in
+    // the same process.
+    Combo_ResetSharedResourceWatermarks();
+
+    const int kSlot = 0;
+    const int kUnestablished = 1;
+
+    // MM's wallet capacities are {99, 200, 500, 500} (z_inventory.c), so tier 1
+    // holds exactly kCommittedRupees and tier 2 holds well past kRefusedHigh —
+    // the harvest's own wallet clamp can never be what keeps a value out of the
+    // pool in this test.
+    const int32_t kCommittedRupees = 200;
+    const int32_t kRefusedHigh = 350;
+    const int32_t kRefusedLow = 20;
+
+    // ---- 1. The harvest is REAL ------------------------------------------
+    // Establish the slot the way production does (opening an empty slot IS the
+    // create path and arms it), then commit a balance so the pool has a
+    // non-trivial baseline for everything that follows.
+    RsbsSave_SetActiveSlot(kSlot);
+    HGATE_ASSERT(RsbsSave_LoadSlot(kSlot) == RSBS_LOAD_ABSENT, "an empty slot must open as ABSENT and arm");
+    ArmLiveMMSession(kCommittedRupees, 1u);
+    HGATE_ASSERT(MM_Combo_CaptureSaveToUnifiedSlot() == 1, "a capture into an armed slot must commit");
+    HGATE_ASSERT(PoolValue(RSBS_SHARED_RES_RUPEES) == kCommittedRupees,
+                 "a permitted capture must harvest MM's live rupees into the shared pool -- without this the "
+                 "'pool unchanged' checks below would all pass vacuously");
+    HGATE_ASSERT(PoolValue(RSBS_SHARED_RES_WALLET_TIER) == 1,
+                 "a permitted capture must harvest MM's wallet tier into the shared pool");
+
+    const uint32_t genAfterCommit = gComboCtx.commitGeneration;
+
+    // ---- 2. Never-established slot: no pool movement, either kind ---------
+    // The live session is RICHER than the pool and holds a HIGHER wallet tier.
+    // With the harvest ahead of the latch check, the pool would gain 150 rupees
+    // and a wallet tier it can never give back (monotonic max-merge cannot
+    // decay), for a .redsave write that is about to be refused.
+    {
+        RsbsSave_SetActiveSlot(kUnestablished);
+        HGATE_ASSERT(RsbsSave_IsSlotWritable(kUnestablished) == 0,
+                     "a slot this session never loaded/created/erased must not be writable (#533/#568)");
+        ArmLiveMMSession(kRefusedHigh, 2u);
+
+        HGATE_ASSERT(MM_Combo_CaptureSaveToUnifiedSlot() == 0,
+                     "a capture into an un-established slot must report that nothing was committed");
+        HGATE_ASSERT(RsbsSave_HasSave(kUnestablished) == 0,
+                     "a latch-refused capture must not have written a slot file");
+        HGATE_ASSERT(gComboCtx.commitGeneration == genAfterCommit,
+                     "a latch-refused capture must not advance the monotonic commit generation");
+        HGATE_ASSERT(PoolValue(RSBS_SHARED_RES_RUPEES) == kCommittedRupees,
+                     "a latch-refused capture must not credit the shared rupee pool -- the crossing that would "
+                     "spend it has no record on disk (#591)");
+        HGATE_ASSERT(PoolValue(RSBS_SHARED_RES_WALLET_TIER) == 1,
+                     "a latch-refused capture must not raise a MONOTONIC tier in the pool -- max-merge cannot "
+                     "decay, so this one would be permanent (#591)");
+    }
+
+    // ---- 3. Identity-refused slot: no pool movement in the DEBIT direction -
+    // #570 latches a slot whose FILE is healthy because the running session
+    // diverged from the pair's creation identity. Here the live balance is
+    // BELOW the watermark the committed capture left, so a harvest would walk
+    // the pool DOWN — the direction that silently deletes the player's money
+    // rather than inventing it.
+    {
+        RsbsSave_SetActiveSlot(kSlot);
+        HGATE_ASSERT(RsbsSave_IsSlotWritable(kSlot) == 1, "the slot must still be writable before the refusal");
+        RsbsSave_RefuseSlotIdentity(kSlot);
+        HGATE_ASSERT(RsbsSave_IsSlotWritable(kSlot) == 0, "an identity refusal must latch the slot (#570)");
+
+        ArmLiveMMSession(kRefusedLow, 2u);
+        HGATE_ASSERT(MM_Combo_CaptureSaveToUnifiedSlot() == 0,
+                     "a capture into an identity-refused slot must report that nothing was committed");
+        HGATE_ASSERT(gComboCtx.commitGeneration == genAfterCommit,
+                     "an identity-refused capture must not advance the monotonic commit generation");
+        HGATE_ASSERT(PoolValue(RSBS_SHARED_RES_RUPEES) == kCommittedRupees,
+                     "an identity-refused capture must not DEBIT the shared rupee pool either -- harvest is a "
+                     "delta against the watermark and runs in both directions (#591)");
+        HGATE_ASSERT(PoolValue(RSBS_SHARED_RES_WALLET_TIER) == 1,
+                     "an identity-refused capture must not raise the shared wallet tier");
+    }
+
+    // ---- 4/5. The watermark survived, and the permitted path still works --
+    // Re-arm through the file-create seam rather than a load: RsbsSave_LoadSlot
+    // deliberately DROPS the RAM watermarks (save.cpp, the first-harvest seed),
+    // which would erase the very state this check exists to inspect.
+    // ArmSlotOnCreate touches neither gComboCtx nor the watermark table.
+    {
+        RsbsSave_ArmSlotOnCreate(kSlot);
+        HGATE_ASSERT(RsbsSave_IsSlotWritable(kSlot) == 1, "the create seam must re-arm the slot");
+
+        ArmLiveMMSession(kRefusedHigh, 2u);
+        HGATE_ASSERT(MM_Combo_CaptureSaveToUnifiedSlot() == 1, "a capture into the re-armed slot must commit again");
+        HGATE_ASSERT(gComboCtx.commitGeneration == genAfterCommit + 1,
+                     "the permitted capture must advance the commit generation by exactly one");
+        // 200 committed + (350 - 200) earned since = 350. If a refused capture
+        // had moved the watermark to kRefusedLow (20), the delta measured here
+        // would be 330 and the pool would land at 350 + 180 = 530 instead.
+        HGATE_ASSERT(PoolValue(RSBS_SHARED_RES_RUPEES) == kRefusedHigh,
+                     "the permitted capture's delta must be measured from the last COMMITTED balance -- a "
+                     "refused capture must leave the RAM watermark alone as well as the pool (#591)");
+        HGATE_ASSERT(PoolValue(RSBS_SHARED_RES_WALLET_TIER) == 2,
+                     "the permitted capture must still raise the monotonic wallet tier -- the gate is a refusal, "
+                     "not a removal of the harvest");
+        HGATE_ASSERT(RsbsSave_HasSave(kSlot) == 1, "the permitted capture must have produced a readable slot file");
+    }
+
+    // Leave global state clean for whatever runs next in this process.
+    memset(&gSaveContext, 0, sizeof(SaveContext));
+    Context_ClearAllFrozenStates();
+    ComboContext_Init();
+    Combo_ResetSharedResourceWatermarks();
+    RsbsSave_SetActiveSlot(-1);
+    RsbsSave_ResetSlotSessionState();
+    std::filesystem::remove_all(dir, ec);
+
+    printf("[TEST] mm-capture-harvest-gate: PASS\n");
+    return 0;
+}

--- a/src/common/test_runner.cpp
+++ b/src/common/test_runner.cpp
@@ -95,6 +95,14 @@ int MM_FbEffectsBinding_RunHeadless(void);
 // all-Ocarina corruption). Returns 0 on pass, non-zero on fail.
 int MM_FlashFileNumOob_RunHeadless(void);
 int MM_UnifiedSaveCapture_RunHeadless(void);
+// MM capture harvest gate (games/mm/2s2h/mm_capture_harvest_gate_test.cpp,
+// #591): MM_Combo_CaptureSaveToUnifiedSlot harvested the shared-resource pool
+// BEFORE RsbsSave_Save checked the #533/#568 write latch, so a refused capture
+// still advanced gComboCtx.sharedResources and the RAM watermark table for a
+// commit that never landed -- and apply ASSIGNS the consumable kinds, so the
+// phantom pool was materialized verbatim on the far side of the next crossing.
+// Returns 0 on pass, non-zero on fail.
+int MM_CaptureHarvestGate_RunHeadless(void);
 // MM single-exe hook dispatch (games/mm/2s2h/mm_hook_dispatch_test.cpp, #511 /
 // #438): the COND_* macros park registrations in the MM-owned S2H::GameHooks
 // registry, but ShouldActorInit / OnActorInit / OnActorDraw / OnOpenText
@@ -366,6 +374,12 @@ static TestResult Test_MMFlashFileNumOob(void) {
 
 static TestResult Test_MMUnifiedSaveCapture(void) {
     return MM_UnifiedSaveCapture_RunHeadless() == 0 ? TEST_PASS : TEST_FAIL;
+}
+
+// MM capture harvest gate (#591; see the extern decl above). Thin wrapper over
+// the C entry point in games/mm/2s2h/mm_capture_harvest_gate_test.cpp.
+static TestResult Test_MMCaptureHarvestGate(void) {
+    return MM_CaptureHarvestGate_RunHeadless() == 0 ? TEST_PASS : TEST_FAIL;
 }
 
 // MM hook-dispatch lock (see the extern decl above). Thin wrapper over the C
@@ -2123,6 +2137,13 @@ const TestDescriptor gTests[] = {
     // Pure (no display, no ROM).
     {"mm-unified-save-capture", "MM captures its live SaveContext into the unified slot, full-width and round-tripping",
      Test_MMUnifiedSaveCapture},
+    // A capture the #533/#568 write latch refuses must be a no-op on the
+    // SHARED-RESOURCE POOL too, not just on the file: the harvest used to run
+    // ahead of the latch check, so a refused commit still credited (or debited)
+    // rupees/hearts/magic/ammo and raised permanent monotonic tiers for a record
+    // that never reached disk. Pure (no display, no ROM).
+    {"mm-capture-harvest-gate", "a latch-refused MM capture leaves the shared-resource pool untouched (#591)",
+     Test_MMCaptureHarvestGate},
     // Hook dispatch reaches the MM-owned registry the COND_* macros register
     // into. Registers through the production macros and drives each dispatcher
     // through the name MM's call sites spell, so both a deleted bridge and a


### PR DESCRIPTION
Closes #591.

## The defect

`MM_Combo_CaptureSaveToUnifiedSlot` (`games/mm/2s2h/GameExports_SingleExe.cpp`) ran
`MM_HarvestSharedResources()` and only *then* called `RsbsSave_Save`.

`RsbsSave_Save` checks the #533/#568 armed-session latch and refuses outright when the
slot was never established this session, or was REFUSED for identity divergence (#570) or
paired-generation failure (#500). By the time it refused, the harvest had already folded
MM's live rupees, wallet tier, hearts, current health, magic and every ammo count into
`gComboCtx.sharedResources` and advanced the RAM watermark table. **The shared pool moved
for a commit that never reached disk.**

Since #530 funneled every durable MM save route (owl, pause save-and-quit, Song of Time,
game-over, both special saves, autosave) into this function, every one of them could move
the pool on a refused session.

## Why that corrupts

This is the harvest/apply gate asymmetry the #525 shared-resource work already paid for
once with `Combo_SaveIsLiveFile`. Harvest and apply are **not** symmetric:

- **CONSUMABLE kinds** (rupees, current health, current magic, the five ammo counts) —
  apply *assigns*: `*liveValue = applied` (`src/common/shared_resources.c`). Whatever the
  phantom harvest left in the pool is materialized verbatim in the other game at the next
  arrival. It runs in **both directions**: harvest is a delta against the watermark, so a
  live balance *below* the watermark **debits** the pool just as a higher one credits it.
- **MONOTONIC kinds** (wallet/quiver/bomb-bag/stick/nut/hookshot tiers, health quarters,
  double defense, magic level) — worse in kind, because max-merge cannot decay. A tier that
  enters the pool here is in it permanently, and *a capacity tier carries its item with it*.

## The fix

Check `RsbsSave_IsSlotWritable(slot)` **before** the harvest and return the same `0` the
refused `RsbsSave_Save` would have returned, so no caller observes a new outcome.

Gating rather than rolling back, deliberately:

- the harvest must precede `Context_UpdateShadowCopy` so the pool and the MM blob stored
  beside it describe **one instant** (the existing comment's reason — otherwise the
  post-load first-harvest seed reads the balance as already counted and drops it);
- there is no rollback that could restore the watermark table's pre-harvest owner/value
  pairs without a second copy of the merge rules, which is exactly how the two halves drift.

This is the shape **OoT's side already uses** at its staging seam
(`games/oot/soh/SaveManager.cpp`, `SaveSection`: `if (RsbsSave_IsSlotWritable(fileNum))`
guards the harvest + shadow refresh + `StageCommit` together), and the same rule
`SaveManager::Save` applies one store further in, where the latch is checked *before*
staging so a refused write cannot advance the monotonic commit generation. Same rule, one
store further out.

**Deliberately not changed:** the unconditional harvest in `MM_Game_Suspend`. That one
serves a real in-memory crossing, which happens whether or not the session can write
durably; suppressing it there would desync the two live saves rather than protect them.

## The lock

New ROM-free, display-free row `MMCaptureHarvestGate` (dispatch `mm-capture-harvest-gate`,
CTest label `redship`), in `games/mm/2s2h/mm_capture_harvest_gate_test.cpp`.

1. **The harvest is real** — a permitted capture into an armed slot must move the pool.
   This is the anti-vacuity check the whole file turns on: "pool unchanged" is trivially
   true if nothing ever changes the pool.
2. **Never-established slot** — a capture leaves both a CONSUMABLE count and a MONOTONIC
   tier bit-for-bit unchanged (live session richer, holding a higher wallet tier).
3. **Identity-refused slot (#570)** — same, in the **debit** direction (live balance below
   the watermark).
4. **The RAM watermark survived** — the half a pool-value assertion alone cannot see. The
   slot is re-armed through the create seam (`RsbsSave_ArmSlotOnCreate`, chosen because
   `LoadSlot` deliberately *drops* the watermarks) and the next permitted capture's delta
   must be measured from the last **committed** balance, not the refused session's.
5. **The permitted path still works** — the gate is a refusal, not a removal. Deleting
   `MM_HarvestSharedResources()` outright satisfies 2-4 and fails here.

**Counterfactual (run):** move `MM_HarvestSharedResources()` back above the
`RsbsSave_IsSlotWritable` check and checks 2, 3 and 4 go red — 2 and 3 because the pool
moves, 4 because the watermark was dragged to the refused session's balance.

## Adversarial review (second pass)

Reviewed against the real declarations, not the report. Everything below was re-derived
from source in this worktree.

**The gate is exactly as strict as the write it stands in for, no stricter.**
`SaveManager::IsSlotWritable` is `SlotInRange(slot) && mSlotArmed[slot]`
(`src/common/save.cpp:793`); `SaveManager::Save` is `SlotInRange` then `CheckWriteAllowed`,
and `CheckWriteAllowed` tests `mSlotArmed[slot]` and nothing else (`save.cpp:225`). The new
early return therefore refuses precisely the set `RsbsSave_Save` was already refusing — it
introduces no new refusal and no new caller-visible outcome.

**The early return also skips `Context_UpdateShadowCopy` and `gComboCtx.sourceGame`, and
that is safe.** Neither is load-bearing on a refused path: the crossing path takes its own
snapshot through `Context_FreezeState` (`src/common/switch.cpp:96`), and the in-memory
`sourceGame` is re-set at `context.cpp:315`. The only consumer of the skipped shadow write
was the staged commit that is not happening.

**The defect had real reach.** `RsbsSave_RefuseSlotGeneration` is called from a live
gameplay seam (`games/mm/2s2h/GameExports_SingleExe.cpp:2960`, ADR 0010 increment 1.2): a
paired generation that exhausts the attempt ladder latches the slot and the player keeps
playing an unpaired vanilla Termina. Pre-fix, every owl save / autosave in that session
folded its rupees and its permanent tiers into the pool the paired world later consumes.

**Complete enumeration of the class.** Four harvest call sites exist. Two are crossing-time
(`MM_Game_Suspend`, `OoT_Game_Suspend`) and unconditional by design — a live crossing
happens whether or not the session can write durably, and gating there would desync the two
live saves. One is `SaveSection`, already guarded (`games/oot/soh/SaveManager.cpp:1553`).
This PR fixes the fourth. **One instance remains and is deliberately out of scope for this
diff:** the `OnExitGame` hook at `games/oot/soh/SaveManager.cpp:252-275` still calls
`OoT_HarvestSharedResources()` unconditionally before `RsbsSave_Save(fileNum)`. Smaller
blast radius (the process is exiting), same shape, worth a one-line follow-up matching
`:1553`.

**One correction applied** (second commit, comment only). The gate landed with an `@return`
promising a `0` is "a NO-OP on every store this function can reach". That holds for the two
refusal returns the gate governs and is **false** for the two late failures `RsbsSave_Save`
can still report *after* the latch admits the write — `StageCommit` refusing on absent
context shadows (`save.cpp:182`), and `WriteSlotFile` failing on I/O. Both run after the
harvest, so the pool carries it while the function reports `0`. Those paths are benign in a
way a refused session is not (the session is coherent; the numbers are MM's real live
balance; the next crossing's `MM_Game_Suspend` would fold the identical values in anyway) —
but a blanket guarantee is what a later caller trusts, so the doc now scopes the claim to
the refusal returns and names the exception.

## Verification — local, on this exact tree

ROM-staged local build in an isolated worktree, `-j4` at Idle priority per the standing
resource cap; staged `shipofharkinian.json` muted (`gGameMasterVolume` and every
`gSettings.Audio.*` set to 0).

| what | result |
| --- | --- |
| `ctest -L "^redship$"` | **74/74 pass** (`MMCaptureHarvestGate` #67, `AllTests` #73, `TestRegistrationComplete` #74) |
| `ctest -L "^rando$"` | **18/18 pass**, including `RandoDeterminism`, `SeedDeterminism` and `MMPairedAttemptDeterminism` — no RNG-stream movement |
| counterfactual | **RE-RUN, red** |
| clang-format 14 | clean on both enforced files |
| contamination | no submodule pointer change; generated stamps (`build.c`, `properties.h`) reverted; PR #543's files untouched |

The counterfactual was executed, not merely specified. Restoring the pre-fix ordering — a
single `MM_HarvestSharedResources();` line above the `RsbsSave_IsSlotWritable` check —
rebuilt and re-ran the row:

```
1/1 Test #67: MMCaptureHarvestGate .............***Failed    3.21 sec
[RsbsSave] slot 0 has no .redsave; armed for first write
[MM] unified save to slot 0: ok (commit generation 1)
[TEST] FAIL: a latch-refused capture must not credit the shared rupee pool -- the
crossing that would spend it has no record on disk (#591)
(games/mm/2s2h/mm_capture_harvest_gate_test.cpp:174)
```

Note what stayed green in that run: the anti-vacuity check (check 1) still committed and
still moved the pool, so the failure is the gate's absence and not a dead harvest. The line
was then reverted, rebuilt, and both tiers re-run green on the final state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
