### PR TITLE
Keep a created file's combo identity only when it names that file's world (#597)

### DIFF
--- a/docs/adr/0002-origin-tagged-shared-items.md
+++ b/docs/adr/0002-origin-tagged-shared-items.md
@@ -109,6 +109,17 @@ time), read by MM's consumption path when Lane C makes it reachable. No new
 seed fields; no shape change. If B needs a settings digest beyond the seed, it
 carves that from `reserved[384]` under the same growth contract.
 
+> **Note added by #598 (record kept, fact corrected).** The parenthetical above
+> is wrong on one detail and stale on another. `OoT_FreezeState` was never
+> *compiled*: its guard was `#ifdef SINGLE_EXECUTABLE_BUILD`, a CMake option
+> name that is never turned into a compile definition (the single-exe define is
+> `RSBS_SINGLE_EXECUTABLE`). And it no longer exists — #598 deleted it, so that
+> a future reader grepping for a freeze-time writer of `sharedRandoSeed` finds
+> no precedent to imitate. The decision itself stands unchanged: the ONLY
+> sanctioned writer of the identity stamps is the creation event
+> (`3drando/playthrough.cpp`), which is what "written in the live path at OoT
+> generation time (not at freeze time)" already said.
+
 ### 4. Version knobs: neither moves
 
 - `RSBS_SAVE_VERSION` stays **2**. It bumps only with

--- a/games/oot/soh/Enhancements/randomizer/3drando/playthrough.cpp
+++ b/games/oot/soh/Enhancements/randomizer/3drando/playthrough.cpp
@@ -110,8 +110,11 @@ int Playthrough_Init(uint32_t seed, std::set<RandomizerCheck> excludedLocations,
 
     // Lane B unified-seed producer (ADR 0002 §3): publish this OoT world's
     // identity into the process-global ComboContext at GENERATION time — NOT at
-    // freeze time (the legacy OoT_FreezeState / BenPort freeze-time producers are
-    // dead code and must not be imitated). Both the live GUI path
+    // freeze time. This is the ONE sanctioned stamp site (#598): OoT's legacy
+    // freeze-time producer (OoT_FreezeState) has been deleted outright, and MM's
+    // mirror in games/mm/2s2h/BenPort.cpp sits behind the same never-defined
+    // `SINGLE_EXECUTABLE_BUILD` macro — neither is precedent for a second
+    // writer. Both the live GUI path
     // (RandoMain::GenerateRando -> GenerateRandomizer -> here) and the headless
     // harness (Rando_HeadlessSeedTest -> GenerateRandomizer -> here) funnel
     // through this one point, and we only reach it on a fully successful fill +

--- a/games/oot/soh/OTRGlobals.cpp
+++ b/games/oot/soh/OTRGlobals.cpp
@@ -2898,91 +2898,24 @@ extern "C" uint32_t Ship_GetInterpolationFrameCount() {
 // ============================================================================
 // Cross-game switching support (for single-executable architecture)
 // ============================================================================
-
-#ifdef SINGLE_EXECUTABLE_BUILD
-
-#include "common/context.h"
-#include "common/entrance.h"
-
-extern "C" {
-
-/**
- * Freeze OoT game state before switching to MM
- * Called by Context_ProcessSwitch() in switch.cpp
- *
- * Saves the current SaveContext to frozen state and records rando status
- * for cross-game state propagation.
- */
-void OoT_FreezeState(ComboContext* ctx) {
-    fprintf(stderr, "[OoT] FreezeState called\n");
-
-    // Get the return entrance (where we'll spawn when coming back)
-    uint16_t returnEntrance = ctx->sourceEntrance;
-
-    // Save the current SaveContext to frozen state
-    Context_FreezeState(GAME_OOT, returnEntrance, &gSaveContext, sizeof(gSaveContext));
-
-    // Record rando status for the target game (MM)
-    // OoT uses IS_RANDO macro which checks gSaveContext.ship.quest.id == QUEST_RANDOMIZER
-    ctx->sourceIsRando = IS_RANDO;
-    if (ctx->sourceIsRando) {
-        // Get the seed from the randomizer context if available
-        auto randoContext = Rando::Context::GetInstance();
-        if (randoContext) {
-            ctx->sharedRandoSeed = randoContext->GetSeed();
-        }
-    }
-
-    fprintf(stderr, "[OoT] State frozen, return entrance: 0x%04X, isRando: %d, seed: %u\n", returnEntrance,
-            ctx->sourceIsRando, ctx->sharedRandoSeed);
-}
-
-/**
- * Resume OoT from a frozen state or start fresh from MM
- * Called by Context_ProcessSwitch() in switch.cpp
- *
- * If returning to OoT (has frozen state): restores SaveContext and spawns at return entrance
- * If first switch to OoT: this is the initial game, should already be initialized
- */
-void OoT_ResumeFromContext(ComboContext* ctx) {
-    fprintf(stderr, "[OoT] ResumeFromContext called\n");
-
-    if (Context_HasFrozenState(GAME_OOT)) {
-        // Returning to OoT - restore the frozen SaveContext
-        fprintf(stderr, "[OoT] Restoring frozen state\n");
-
-        Context_RestoreState(GAME_OOT, &gSaveContext, sizeof(gSaveContext));
-
-        // Get the return entrance from frozen state
-        uint16_t returnEntrance = Context_GetFrozenReturnEntrance(GAME_OOT);
-
-        // Apply the target entrance (either return entrance or startup entrance)
-        uint16_t targetEntrance = Combo_GetStartupEntrance();
-        if (targetEntrance == 0) {
-            targetEntrance = returnEntrance;
-        }
-        gSaveContext.entranceIndex = targetEntrance;
-
-        fprintf(stderr, "[OoT] State restored, entrance: 0x%04X\n", targetEntrance);
-    } else {
-        // First switch to OoT from MM - OoT should already be the initial game
-        // This case is rare (MM starting first), but handle it gracefully
-        fprintf(stderr, "[OoT] No frozen state (OoT should be initial game)\n");
-
-        // Apply startup entrance if set
-        uint16_t targetEntrance = Combo_GetStartupEntrance();
-        if (targetEntrance != 0) {
-            gSaveContext.entranceIndex = targetEntrance;
-            fprintf(stderr, "[OoT] Applied startup entrance: 0x%04X\n", targetEntrance);
-        }
-    }
-
-    // Clear the startup entrance now that we've used it
-    Combo_ClearStartupEntrance();
-
-    fprintf(stderr, "[OoT] ResumeFromContext complete\n");
-}
-
-} // extern "C"
-
-#endif // SINGLE_EXECUTABLE_BUILD
+//
+// DELIBERATELY EMPTY (#598). OoT_FreezeState / OoT_ResumeFromContext used to
+// live here behind `#ifdef SINGLE_EXECUTABLE_BUILD` — a macro this project
+// never defines for any target (SINGLE_EXECUTABLE_BUILD is a CMake *option*
+// name; the compile definition the single-exe build passes is
+// RSBS_SINGLE_EXECUTABLE), so the block had not been compiled, let alone
+// called, in any configuration. They were the last remains of the legacy
+// Context_ProcessSwitch() model; the live hot-swap freeze/consume policy is
+// Switch_PrepareHotSwap / Combo_ConsumeFrozenState in src/common/switch.cpp.
+//
+// WHY THE DELETION MATTERS DESPITE BEING A ZERO-BINARY CHANGE: OoT_FreezeState
+// wrote the master seed — `ctx->sourceIsRando` and `ctx->sharedRandoSeed` —
+// at FREEZE time. Under one-game semantics (#564) the combo identity is frozen
+// by ONE event, the file creation that authors it (3drando/playthrough.cpp
+// stamps sourceIsRando / sharedRandoSeed / sharedRandoSettingsHash /
+// mmProfileDigest there, and derives the reverse placement table from them in
+// the same breath). Any other writer re-stamps identity outside that event,
+// which #570's arrival compare would then read as corruption — and a
+// never-compiled writer is exactly the kind of thing a future revival copies
+// because it looks like precedent. The creation event is the ONLY sanctioned
+// stamp site; there is no second one to imitate now.

--- a/games/oot/soh/OTRGlobals.cpp
+++ b/games/oot/soh/OTRGlobals.cpp
@@ -2723,6 +2723,28 @@ extern "C" uint8_t Randomizer_IsSpoilerLoaded() {
     return OTRGlobals::Instance->gRandoContext->IsSpoilerLoaded() ? 1 : 0;
 }
 
+/**
+ * The identity of the rando world the process is currently holding — whichever
+ * way it got there. Generation publishes exactly this value as
+ * gComboCtx.sharedRandoSeed (3drando/playthrough.cpp passes ctx->GetSeed()),
+ * and a spoiler load restores exactly this value from the log's "finalSeed"
+ * field (Settings::ParseJson), so the two are directly comparable — which is
+ * what #597's file-creation KEEP test needs and the only reason this accessor
+ * exists.
+ *
+ * NOT ctx->GetHash()/the fill's finalHash: that mixes the settings string and
+ * the build version, and is not what the stamp carries.
+ *
+ * Returns 0 when no rando context exists, which the caller reads as "this
+ * process names no rando world" — the DROP direction.
+ */
+extern "C" uint32_t Randomizer_GetCurrentWorldSeed() {
+    if (OTRGlobals::Instance == nullptr || OTRGlobals::Instance->gRandoContext == nullptr) {
+        return 0;
+    }
+    return OTRGlobals::Instance->gRandoContext->GetSeed();
+}
+
 extern "C" void Randomizer_SetSpoilerLoaded(bool spoilerLoaded) {
     OTRGlobals::Instance->gRandoContext->SetSpoilerLoaded(spoilerLoaded);
 }

--- a/games/oot/soh/OTRGlobals.h
+++ b/games/oot/soh/OTRGlobals.h
@@ -125,6 +125,10 @@ GetItemEntry GetItemMystery();
 ItemObtainability Randomizer_GetItemObtainabilityFromRandomizerCheck(RandomizerCheck randomizerCheck);
 uint8_t Randomizer_IsSeedGenerated();
 uint8_t Randomizer_IsSpoilerLoaded();
+// The seed of the rando world this process currently holds, however it got
+// there (generated or spoiler-loaded) — the quantity gComboCtx.sharedRandoSeed
+// carries. Used by file creation to tell authorship from inheritance (#597).
+uint32_t Randomizer_GetCurrentWorldSeed();
 void Randomizer_SetSpoilerLoaded(bool spoilerLoaded);
 uint8_t Randomizer_GenerateRandomizer();
 void Randomizer_ShowRandomizerMenu();

--- a/games/oot/src/code/z_sram.c
+++ b/games/oot/src/code/z_sram.c
@@ -19,7 +19,7 @@ void BossRush_InitSave(void);
 // Cross-game session invalidation (#440). Declared locally: games/oot/src/**.c
 // does not have src/common on its include path (same convention z_play.c uses
 // for the Combo_* entry points). See src/common/context.h for the contract.
-extern void Context_InvalidateSessionOnNewGame(int isRandoFile);
+extern void Context_InvalidateSessionOnNewGame(int isRandoFile, uint32_t createdWorldSeed);
 // #533 armed-session latch: creating a file is one of the three legitimate
 // ways a slot becomes writable this session. See src/common/save.h.
 extern void RsbsSave_ArmSlotOnCreate(int slot);
@@ -299,11 +299,25 @@ void OoT_Sram_InitSave(FileChooseContext* fileChooseCtx) {
     // session authored still goes.
     //
     // isRandoFile is exactly the condition the branch below uses, so the seed
-    // stamp is kept precisely when generation has already authored it for this
-    // file and dropped for a vanilla file (where a surviving stamp would leave
+    // stamp is a candidate for keeping precisely when this file is a rando
+    // file, and dropped for a vanilla file (where a surviving stamp would leave
     // Combo_ForeignPairingActive() reporting a paired world that does not
     // exist).
-    Context_InvalidateSessionOnNewGame(isRandoFile);
+    //
+    // BUT IT IS ONLY A CANDIDATE (#597). isRandoFile counts
+    // Randomizer_IsSpoilerLoaded(), and Context::ParseSpoiler authors no combo
+    // identity — it re-seeds Rando::Context from the log and nothing else. So
+    // "generate seed A in the menu, load spoiler B, create the file" is a rando
+    // file whose world is B while the resident stamp still names A; keeping on
+    // isRandoFile alone handed world B identity A and, since #545, A's reverse
+    // placement table, pinning MM items into checks belonging to a different
+    // world. The second argument is what lets the context layer tell authorship
+    // from inheritance: the identity of the world THIS file will play, which is
+    // the same quantity the stamp carries whether generation or a spoiler load
+    // put it there. A mismatch discards; it never re-derives, because under
+    // one-game semantics (#564) an identity this file did not have authored for
+    // it is not this file's identity.
+    Context_InvalidateSessionOnNewGame(isRandoFile, isRandoFile ? Randomizer_GetCurrentWorldSeed() : 0);
 
     // ARM the unified slot for this create (#533). Save_SaveFile() below fires
     // OnSaveFile -> RsbsSave_Save, and the armed-session latch refuses writes

--- a/src/common/context.cpp
+++ b/src/common/context.cpp
@@ -441,11 +441,41 @@ int Context_InvalidateSessionOnReturnToTitle(void) {
     return 1;
 }
 
-void Context_InvalidateSessionOnNewGame(int isRandoFile) {
-    fprintf(stderr, "[Context] New file (rando=%d): retiring cross-game session state\n", isRandoFile);
-    // A rando file's stamp was authored by generation minutes ago and belongs
-    // to the file being created, not to the session being discarded.
-    Context_InvalidateSessionState(isRandoFile ? RSBS_SEED_STAMP_KEEP : RSBS_SEED_STAMP_DROP);
+void Context_InvalidateSessionOnNewGame(int isRandoFile, uint32_t createdWorldSeed) {
+    // The KEEP question is "did generation author this identity FOR the file
+    // being created?", and only an identity comparison answers it (#597).
+    // "Is this a rando file?" does not: the caller's test counts
+    // Randomizer_IsSpoilerLoaded(), and a spoiler load authors no identity at
+    // all — it only re-seeds Rando::Context from the log — so generate-A then
+    // spoiler-load-B then create used to hand world B identity A, and with it
+    // A's reverse placement table (#545). Nothing downstream can recover from
+    // that: #570's arrival compare validates the identity's INTERNAL
+    // consistency, and identity A is perfectly consistent with itself.
+    //
+    // sourceIsRando is part of the test because it is half of what makes a
+    // stamp real (Combo_ForeignPairingActive), and a zero seed is rejected
+    // outright so that "nothing was ever stamped" (a cold boot's all-zero
+    // gComboCtx) can never match a caller that has no world of its own.
+    const int identityIsThisFiles = gComboCtx.sourceIsRando && gComboCtx.sharedRandoSeed != 0 &&
+                                    gComboCtx.sharedRandoSeed == createdWorldSeed;
+    const int keep = (isRandoFile != 0) && identityIsThisFiles;
+
+    fprintf(stderr,
+            "[Context] New file (rando=%d, world seed=%u, resident stamp=%u): retiring cross-game session state\n",
+            isRandoFile, (unsigned)createdWorldSeed, (unsigned)gComboCtx.sharedRandoSeed);
+    if (isRandoFile && !identityIsThisFiles) {
+        // Loud on purpose: this is a refusal to inherit, and it is the only
+        // path where a rando file ends up deliberately unpaired. Silence here
+        // would be indistinguishable from the #597 corruption it replaces.
+        fprintf(stderr,
+                "[Context] New file: resident identity %u does not name this world (%u) — DISCARDING the stamp and "
+                "the reverse placement table rather than inheriting them (#597). This file is unpaired.\n",
+                (unsigned)gComboCtx.sharedRandoSeed, (unsigned)createdWorldSeed);
+    }
+
+    // A matching stamp was authored by generation minutes ago and belongs to
+    // the file being created, not to the session being discarded.
+    Context_InvalidateSessionState(keep ? RSBS_SEED_STAMP_KEEP : RSBS_SEED_STAMP_DROP);
 }
 
 void Context_InvalidateSessionOnSlotLoad(void) {

--- a/src/common/context.h
+++ b/src/common/context.h
@@ -930,10 +930,13 @@ bool Context_HasPendingSwitch(void);
 //   cold boot           | none (init)  | zeroed   | none      | none       | n/a until a seed exists
 //   reset -> same slot  | DROPPED      | reloaded | reloaded  | reloaded   | yes, from that slot's .redsave
 //   reset -> diff slot  | DROPPED      | reloaded | reloaded  | reloaded   | yes, from that slot's .redsave
-//   reset -> new file   | DROPPED      | zeroed   | DROPPED   | kept iff   | YES for a rando file (the
-//                       |              |          |           | rando file | operator's case); declines
-//                       |              |          |           |            | with no-paired-oot-world for
-//                       |              |          |           |            | a vanilla file, correctly
+//   reset -> new file   | DROPPED      | zeroed   | DROPPED   | kept iff   | YES for a file playing the
+//                       |              |          |           | the file   | world that was stamped (the
+//                       |              |          |           | plays the  | operator's case); declines
+//                       |              |          |           | stamped    | with no-paired-oot-world for
+//                       |              |          |           | world      | a vanilla file, and for a
+//                       |              |          |           | (#597)     | spoiler-loaded file that
+//                       |              |          |           |            | names a different world
 //   cross-game arrival  | PRESERVED    | preserved| preserved | preserved  | declines (existing save) —
 //                       |              |          |           |            | correct: it IS the player's
 //                       |              |          |           |            | own restored MM session
@@ -978,8 +981,11 @@ typedef enum {
      * Keep what the creation event authored for the file now being created:
      * the stamp, the reverse placement table (#534) — authored together and
      * only coherent together — and every creation-stamped identity term.
-     * Correct ONLY where generation has already authored them for THIS file
-     * (OoT_Sram_InitSave on a randomizer file).
+     * Correct ONLY where generation has already authored them for THIS file:
+     * OoT_Sram_InitSave on a randomizer file whose world IS the stamped world
+     * (#597 — "a randomizer file" alone is not the condition; see
+     * Context_InvalidateSessionOnNewGame, which is where that judgement is
+     * made, because this enum cannot express it).
      *
      * THE RULE, NOT THE LIST, IS THE CONTRACT (#564 V9). Under one-game
      * semantics the paired world's identity is frozen by the creation event,
@@ -1085,15 +1091,55 @@ int Context_InvalidateSessionOnReturnToTitle(void);
 /**
  * A new OoT file is being created (OoT_Sram_InitSave).
  *
+ * KEEP IS CONDITIONAL ON IDENTITY, NOT ON "IS THIS A RANDO FILE" (#597). The
+ * resident stamp is only this file's stamp when the world being created is the
+ * world generation stamped. Both facts have to reach this function or it cannot
+ * tell inheritance from authorship, which is exactly the hole #597 names: the
+ * caller's rando test counts Randomizer_IsSpoilerLoaded(), and ParseSpoiler
+ * authors NO combo identity, so "generate seed A, load spoiler B, create a
+ * file" used to take the KEEP path and hand world B the identity of world A —
+ * plus, since #545, A's reverse placement table, pinning MM items into checks
+ * that belong to a different world. #570's arrival compare cannot see it: the
+ * identity it validates is internally consistent, and the corruption is
+ * upstream of it.
+ *
+ * A mismatch DISCARDS. It never re-derives, re-stamps or otherwise heals the
+ * identity — under one-game semantics (#564) a file whose identity was not
+ * authored for it has no identity at all, and an identity-less file is an
+ * ordinary unpaired one (Combo_ForeignPairingActive() reads false), which is
+ * the same shape a vanilla file already has.
+ *
+ * WHY A SPOILER LOAD DOES NOT AUTHOR ONE INSTEAD (#597, decided here). It
+ * cannot, from today's spoiler format: of the four terms the creation event
+ * stamps, the log carries exactly one. `finalSeed` gives sharedRandoSeed;
+ * sharedRandoSettingsHash is Hash(settingsStr) built inside Playthrough_Init
+ * from the live option set and is NOT written to the log (recomputing it after
+ * Settings::ParseJson round-trips every option through GetOptionText/
+ * GetValueFromText, and one option that does not survive that trip is a
+ * different digest — i.e. a different world identity, which is the same
+ * mis-pairing arriving by a politer route); mmProfileDigest describes the MM
+ * half and has never been in an OoT spoiler at all; and foreignPlacementsOoT
+ * is not in the log either, because Playthrough_Init writes the spoiler BEFORE
+ * it stamps the identity and derives the reverse table from it. Authoring a
+ * faithful identity at spoiler load therefore requires writing the identity
+ * block into the spoiler at creation and hydrating it on load — a spoiler
+ * format change, and its own piece of work. Until then, spoiler-loaded files
+ * are honestly unpaired rather than dishonestly paired.
+ *
  * @param isRandoFile non-zero iff the file being created is a randomizer file
- *        whose seed has already been generated. That is the ONLY case where the
- *        seed stamp and the reverse placement table are kept: generation ran
- *        moments ago, in the menu, and authored both FOR this file (#534). A
- *        vanilla new file passes 0 and the stamp goes with the rest of the dead
- *        session — otherwise Combo_ForeignPairingActive() would still report a
- *        paired world.
+ *        (a generated seed OR a loaded spoiler). Necessary but NOT sufficient
+ *        for KEEP — see @p createdWorldSeed. A vanilla new file passes 0 and
+ *        the stamp goes with the rest of the dead session, or
+ *        Combo_ForeignPairingActive() would still report a paired world.
+ * @param createdWorldSeed the identity of the world THIS file will play —
+ *        Rando::Context::GetInstance()->GetSeed(), which is the exact quantity
+ *        Playthrough_Init publishes as gComboCtx.sharedRandoSeed and the exact
+ *        quantity a spoiler load restores from the log's "finalSeed". 0 means
+ *        "this file names no rando world" and always DROPS; a rando world that
+ *        genuinely hashes to 0 loses its pairing rather than risking a false
+ *        match, which is the safe direction (unpaired, never mis-paired).
  */
-void Context_InvalidateSessionOnNewGame(int isRandoFile);
+void Context_InvalidateSessionOnNewGame(int isRandoFile, uint32_t createdWorldSeed);
 
 /**
  * An existing slot is being loaded, BEFORE its .redsave is read back.

--- a/src/common/switch.cpp
+++ b/src/common/switch.cpp
@@ -29,7 +29,10 @@
  * which is excluded from the single-exe build — so this translation unit could
  * only stay linkable as long as nothing pulled it in. Its declarations in
  * context.h are now dangling; removing them is a context.h change and belongs
- * to whoever owns that file.
+ * to whoever owns that file. `OoT_FreezeState` itself is gone as of #598 (it
+ * was never compiled either: its `#ifdef SINGLE_EXECUTABLE_BUILD` guard names a
+ * CMake option, not a compile definition), so the only remaining copy of that
+ * shape is MM's, in the same never-compiled state.
  */
 
 #include "context.h"

--- a/src/common/tests/test_session_invalidation.c
+++ b/src/common/tests/test_session_invalidation.c
@@ -44,6 +44,16 @@
  *      nothing re-places the reverse table afterwards, so a wipe here is a
  *      permanent loss: #524's MM-items-in-OoT-checks never deliver and the
  *      zeroed table is persisted by the new slot's first .redsave.
+ *  5c. (#597) ...but ONLY when the file being created plays the world that
+ *      was stamped. Generate seed A, load a spoiler for world B, create the
+ *      file: still a "rando file" (the caller's test counts
+ *      Randomizer_IsSpoilerLoaded), yet nothing authored an identity for it,
+ *      so keeping would hand world B identity A and A's reverse placements —
+ *      MM items pinned into checks chosen for a different world. #570's
+ *      arrival compare cannot catch this; identity A is internally consistent
+ *      and the corruption is upstream of it.
+ *  5d. The boundary of 5c: an unstamped rando creation (both sides 0) must
+ *      not read as a match.
  *   6. A NON-rando new file drops the seed stamp too, or
  *      Combo_ForeignPairingActive() would keep reporting a paired world.
  *   7. A legitimate existing-slot load STILL restores that slot's .redsave.
@@ -353,7 +363,7 @@ TestResult Test_SessionInvalidation(void) {
     SeedSessionA(0x1234u, 0xABCDu);
     SESSION_ASSERT(Context_InvalidateSessionOnReturnToTitle() == 1);
     StampGeneratedSeed(0x99999999u, 0x5555u);
-    Context_InvalidateSessionOnNewGame(/*isRandoFile=*/1);
+    Context_InvalidateSessionOnNewGame(/*isRandoFile=*/1, /*createdWorldSeed=*/0x99999999u);
     {
         std::vector<uint8_t> arriving(kSessionBuf, kSessionBByte);
         const int hadFrozen = Combo_ConsumeFrozenState("mm", arriving.data(), arriving.size());
@@ -377,7 +387,7 @@ TestResult Test_SessionInvalidation(void) {
     // can be asked to preserve.
     SeedSessionA(0x1234u, 0xABCDu);
     StampGeneratedSeed(0x99999999u, 0x5555u);
-    Context_InvalidateSessionOnNewGame(/*isRandoFile=*/1);
+    Context_InvalidateSessionOnNewGame(/*isRandoFile=*/1, /*createdWorldSeed=*/0x99999999u);
     SESSION_ASSERT(SessionIsClear(/*expectSeedStamp=*/true));
     SESSION_ASSERT(gComboCtx.sharedRandoSeed == 0x99999999u);
     SESSION_ASSERT(gComboCtx.sharedRandoSettingsHash == 0x5555u);
@@ -416,9 +426,82 @@ TestResult Test_SessionInvalidation(void) {
     SESSION_ASSERT(Combo_CommitStagedSharedItems() == 0);
     SESSION_ASSERT(Combo_CountSharedItems(GAME_OOT, true) == 0);
 
+    // ---- 5c. #597: a rando file that plays a DIFFERENT world inherits ------
+    //          NOTHING. The corruption case, and the reason case 5's KEEP is
+    //          not simply "isRandoFile".
+    //
+    // The sequence, exactly as a player performs it: generate seed A from the
+    // menu (identity A stamped, A's reverse table authored), then load a
+    // SPOILER for a different world B and create a file from it. The caller's
+    // rando test counts Randomizer_IsSpoilerLoaded(), so isRandoFile is still
+    // 1 — but Context::ParseSpoiler authors no combo identity whatsoever, it
+    // only re-seeds Rando::Context from the log's "finalSeed". So the resident
+    // stamp still names A while the file plays B.
+    //
+    // Keeping here is silent, permanent corruption: world B would carry
+    // identity A, MM would generate its half against A's seed and settings,
+    // and A's reverse placements would pin MM items into OoT checks chosen for
+    // a world this file is not playing. #570's arrival compare is structurally
+    // unable to catch it — it validates that the identity is internally
+    // consistent, and identity A is perfectly consistent with itself; the
+    // corruption is upstream of everything it can see.
+    //
+    // FALSIFIABILITY: make Context_InvalidateSessionOnNewGame keep on
+    // isRandoFile alone again (the pre-#597 `isRandoFile ? KEEP : DROP`) and
+    // every assertion in this block goes red — the seed, the settings hash,
+    // the MM profile digest and A's reverse row all survive into world B.
+    SeedSessionA(0x1234u, 0xABCDu);
+    StampGeneratedSeed(/*seed=*/0x99999999u, /*settingsHash=*/0x5555u);
+    Context_InvalidateSessionOnNewGame(/*isRandoFile=*/1, /*createdWorldSeed=*/0x77777777u);
+    SESSION_ASSERT(SessionIsClear(/*expectSeedStamp=*/false));
+    SESSION_ASSERT(gComboCtx.sharedRandoSeed == 0);
+    SESSION_ASSERT(gComboCtx.sharedRandoSettingsHash == 0);
+    SESSION_ASSERT(gComboCtx.mmProfileDigest == 0);
+    // Neither generation's table nor the dead session's: an inherited reverse
+    // table is the half of this bug #545 added, and it is the half that puts
+    // wrong items in wrong checks rather than merely mislabelling the pair.
+    SESSION_ASSERT(Combo_CountForeignPlacementsOoT() == 0);
+    SESSION_ASSERT(Combo_GetForeignPlacementForOoTCheck(kGenReverseCheck) == nullptr);
+    SESSION_ASSERT(Combo_GetForeignPlacementForOoTCheck(kSessionAReverseCheck) == nullptr);
+    // The file is unpaired, which is the correct disposition for a file that
+    // has no identity of its own — the same shape a vanilla file has. It is
+    // NOT re-derived or re-stamped: under one-game semantics an identity this
+    // file did not have authored for it is not this file's identity.
+    SESSION_ASSERT(!Combo_ForeignPairingActive());
+    SESSION_ASSERT(ArrivalPairDecision(/*hadFrozenState=*/0) == PAIR_DECLINE_NO_WORLD);
+
+    // ---- 5d. #597 boundary: "both sides are 0" is NOT a match --------------
+    // The caller names no world — Randomizer_GetCurrentWorldSeed() returns 0
+    // when no rando context exists, and z_sram.c passes a literal 0 for a
+    // non-rando file — while the resident stamp's seed is also 0. Equality
+    // alone would call that a match and hand the file an identity nobody
+    // authored, so the seed test is `!= 0 && ==`, not `==`.
+    //
+    // WRITTEN TO BE FALSIFIABLE, WHICH THE OBVIOUS VERSION IS NOT: seeding this
+    // case with a bare ComboContext_Init() would assert nothing, because KEEP
+    // and DROP both leave an all-zero context and the assertions pass either
+    // way. So the resident state here is a REAL-looking identity whose seed
+    // happens to be 0 — settings hash, MM profile digest and a reverse row all
+    // populated — which makes the two policies observably different. Drop the
+    // `gComboCtx.sharedRandoSeed != 0` term from the KEEP test and this block
+    // goes red on the settings hash, the digest, the reverse row and the
+    // pairing flag.
+    SeedSessionA(0x1234u, 0xABCDu);
+    StampGeneratedSeed(/*seed=*/0u, /*settingsHash=*/0x5555u);
+    // Precondition: KEEP and DROP really are distinguishable from here.
+    SESSION_ASSERT(Combo_ForeignPairingActive());
+    SESSION_ASSERT(Combo_CountForeignPlacementsOoT() == 1);
+    Context_InvalidateSessionOnNewGame(/*isRandoFile=*/1, /*createdWorldSeed=*/0u);
+    SESSION_ASSERT(SessionIsClear(/*expectSeedStamp=*/false));
+    SESSION_ASSERT(!gComboCtx.sourceIsRando);
+    SESSION_ASSERT(gComboCtx.sharedRandoSettingsHash == 0);
+    SESSION_ASSERT(gComboCtx.mmProfileDigest == 0);
+    SESSION_ASSERT(Combo_CountForeignPlacementsOoT() == 0);
+    SESSION_ASSERT(!Combo_ForeignPairingActive());
+
     // ---- 6. New VANILLA file: the seed stamp goes too ----------------------
     SeedSessionA(0x1234u, 0xABCDu);
-    Context_InvalidateSessionOnNewGame(/*isRandoFile=*/0);
+    Context_InvalidateSessionOnNewGame(/*isRandoFile=*/0, /*createdWorldSeed=*/0u);
     SESSION_ASSERT(SessionIsClear(/*expectSeedStamp=*/false));
     SESSION_ASSERT(gComboCtx.sharedRandoSeed == 0);
     SESSION_ASSERT(gComboCtx.sharedRandoSettingsHash == 0);
@@ -553,7 +636,7 @@ TestResult Test_SessionInvalidation(void) {
         // case 8 so slot 2 is still unwritten where that case needs it.
         SeedSessionA(0x3333u, 0x4444u);
         StampGeneratedSeed(0x99999999u, 0x5555u);
-        Context_InvalidateSessionOnNewGame(/*isRandoFile=*/1);
+        Context_InvalidateSessionOnNewGame(/*isRandoFile=*/1, /*createdWorldSeed=*/0x99999999u);
         // #533: mirror z_sram.c's create seam, which arms the slot right after
         // the invalidation and before the file's first save.
         mgr.ArmSlotOnCreate(2);
@@ -578,7 +661,8 @@ TestResult Test_SessionInvalidation(void) {
     printf("[TEST] PASS: a dead session's frozen blobs, shadows and gComboCtx crossings do not "
            "survive a soft reset or a new game; the generation-authored seed stamp and reverse "
            "placement table survive rando file creation and reach the new slot's first .redsave "
-           "(#534); arrivals and existing-slot loads still restore\n");
+           "(#534) but ONLY for the file that plays the stamped world (#597); arrivals and "
+           "existing-slot loads still restore\n");
 
     // Leave global state clean for any subsequent test.
     Context_ClearAllFrozenStates();

--- a/src/common/tests/test_shared_state_roundtrip.c
+++ b/src/common/tests/test_shared_state_roundtrip.c
@@ -10,8 +10,11 @@
  *
  * Headless: this test only touches the shared ComboContext struct via its
  * public C API. It does NOT boot either game, allocate a SaveContext, or call
- * the game-port freeze/resume hooks (OoT_FreezeState / MM_ResumeFromContext),
- * which are unavailable in the headless --test path.
+ * the game-port freeze/resume hooks (MM_FreezeState / MM_ResumeFromContext),
+ * which are unavailable in the headless --test path. (OoT's counterparts used
+ * to be named here too; they were deleted by #598 — never compiled, never
+ * called, and a freeze-time writer of the seed stamp that the creation event
+ * is now the sole author of.)
  *
  * Included into test_runner.cpp inside an extern "C" block (mirrors
  * test_game_lifecycle.c). Only C-linkage ComboContext_* symbols and gComboCtx


### PR DESCRIPTION
One PR for both issues, deliberately: the #598 deletion is what makes the #597
comment true ("the creation event is the only sanctioned stamp site"), and both
edits land in `games/oot/soh/OTRGlobals.cpp`. Two commits, one per issue.

## #597 — a created file could inherit another world's identity

### Mechanism

`Context_InvalidateSessionOnNewGame` applied the `RSBS_SEED_STAMP_KEEP` policy
on `isRandoFile` alone. That flag (`games/oot/src/code/z_sram.c:272`) is

```c
u8 isRandoFile =
    (currentQuest == QUEST_RANDOMIZER && (Randomizer_IsSeedGenerated() || Randomizer_IsSpoilerLoaded()));
```

and `Rando::Context::ParseSpoiler` authors **no combo identity at all** — it
sets `mSeedGenerated=false`, `mSpoilerLoaded=true`, and re-seeds the context
from the log (`Settings::ParseJson` → `SetSeed(spoilerFileJson["finalSeed"])`,
`settings.cpp:3314`). So:

> generate seed A in the menu → load a spoiler for world B → create the file

is a rando file whose world is B while the resident stamp still names A. The
KEEP path handed world B **identity A**: A's seed, A's settings hash, A's
frozen MM profile digest, and — since #545 — **A's reverse placement table**,
pinning MM items into OoT checks chosen for a world this file is not playing.

#570's arrival compare-and-refuse cannot catch this. It validates that the
identity is *internally consistent*, and identity A is perfectly consistent
with itself; the corruption is upstream of everything it can see.

### Change

KEEP is now conditional on identity, not on "is this a rando file":

```c
const int identityIsThisFiles = gComboCtx.sourceIsRando && gComboCtx.sharedRandoSeed != 0 &&
                                gComboCtx.sharedRandoSeed == createdWorldSeed;
const int keep = (isRandoFile != 0) && identityIsThisFiles;
```

- `createdWorldSeed` is `Rando::Context::GetInstance()->GetSeed()`, reached from
  OoT's C side through a new `Randomizer_GetCurrentWorldSeed()` accessor
  (`OTRGlobals.cpp`, declared in `OTRGlobals.h`'s `#ifndef __cplusplus` block
  next to `Randomizer_IsSpoilerLoaded`). That is exactly the quantity
  `Playthrough_Init` publishes as `gComboCtx.sharedRandoSeed`
  (`playthrough.cpp:123`, where `seed == ctx->GetSeed()`) and exactly the
  quantity a spoiler load restores from `finalSeed`, so the two are directly
  comparable. Not `GetHash()`/`finalHash`, which mixes the settings string and
  the build version and is not what the stamp carries.
- A mismatch **DISCARDS**, loudly (stderr, tagged #597), and never re-derives or
  re-stamps. Under one-game semantics (#564) an identity a file did not have
  authored for it is not that file's identity, so the file is honestly unpaired
  — the same shape a vanilla file already has — rather than dishonestly paired.
- Seed `0` is "names no rando world" and always drops. A world that genuinely
  hashes to 0 loses its pairing rather than risking a false match: the safe
  direction is unpaired, never mis-paired.

### Blast radius is exactly the bug

- **Generate → create** still KEEPs. Nothing calls `ctx->SetSeed` between
  `Playthrough_Init`'s stamp and file creation (`Playthrough_Init` sets
  `SetHash`, a different field; `GenerateRandomizer` sets the seed *before*
  calling it).
- **Cold-boot spoiler load → create** is unchanged in effect: the resident
  stamp was already all-zero there, so KEEP and DROP were already
  indistinguishable.
- **Vanilla file** is unchanged (`isRandoFile == 0` → DROP, as before).
- The only behavior that changes is generate-then-load-a-*different*-spoiler-
  then-create. That is #597.

### Second half of the brief: can a spoiler-loaded file author its own identity?

**No — not from today's spoiler format.** Decided and recorded next to the KEEP
contract in `src/common/context.h`. Of the four creation-stamped terms, the log
carries exactly one:

| term | in the spoiler? |
| --- | --- |
| `sharedRandoSeed` | yes, as `finalSeed` |
| `sharedRandoSettingsHash` | **no** — `Hash(settingsStr)` is built inside `Playthrough_Init` from the live option set and never serialized. Recomputing it after `Settings::ParseJson` round-trips every option through `GetOptionText`/`GetValueFromText`; one option that does not survive that trip is a different digest, i.e. the same mis-pairing arriving by a politer route. |
| `mmProfileDigest` | **no** — has never been in an OoT spoiler. |
| `foreignPlacementsOoT` | **no** — structurally: `Playthrough_Init` writes the spoiler *before* it stamps the identity and derives the reverse table from it. |

Authoring a faithful identity at spoiler load therefore requires writing the
identity block into the spoiler at creation and hydrating it on load — a spoiler
**format** change, and its own piece of work. Until then, spoiler-loaded files
are honestly unpaired rather than dishonestly paired.

## #598 — delete OoT's freeze-time seed stamper

`OoT_FreezeState` wrote `ctx->sourceIsRando` and `ctx->sharedRandoSeed` at
freeze time — a second writer of an identity that #564 says exactly one event
authors.

**The issue's premise was that it is "dead-but-linked". It is deader than
that**, and the correction changes the disposition from "neuter it" to "delete
it": the block was guarded by `#ifdef SINGLE_EXECUTABLE_BUILD`, which is a CMake
*option* name and is never turned into a compile definition. The single-exe
define is `RSBS_SINGLE_EXECUTABLE` (`games/oot/CMakeLists.txt:279`).
`grep -rn SINGLE_EXECUTABLE_BUILD` over the tree finds it only in CMake files
and in two never-firing `#ifdef`s (this one and MM's mirror). So it was not in
any translation unit, not in `redship.map`, and had no callers.

Deleted outright, together with `OoT_ResumeFromContext` from the same block, and
replaced by a comment naming `3drando/playthrough.cpp`'s creation-event publish
as the only sanctioned stamp site — with the matching correction at that site.
This is a zero-binary change by construction, which is the point: a
never-compiled writer of the identity stamps is exactly the kind of thing a
future revival copies because it looks like precedent.

MM's identical mirror (`games/mm/2s2h/BenPort.cpp:2134-2273`) is **left in
place** deliberately: same never-defined macro, and the file is owned by PR
#543. The comments here name it so the remaining copy is documented rather than
forgotten.

Two stale in-tree references are corrected so a reader does not go hunting for a
symbol that no longer exists: the ADR 0002 §3 parenthetical (annotated, not
rewritten — the decision it records stands) and the header comment of
`src/common/tests/test_shared_state_roundtrip.c`.

## Changes

| file | why |
| --- | --- |
| `src/common/context.cpp` | the narrowed KEEP decision + the refusal log |
| `src/common/context.h` | two-arg contract, the KEEP enum doc, the transition-matrix row, and the "why a spoiler load cannot author one instead" finding |
| `games/oot/src/code/z_sram.c` | passes the created world's seed |
| `games/oot/soh/OTRGlobals.cpp` | `Randomizer_GetCurrentWorldSeed()` (#597); `OoT_FreezeState`/`OoT_ResumeFromContext` deleted (#598) |
| `games/oot/soh/OTRGlobals.h` | accessor declaration in the C-only block |
| `games/oot/soh/Enhancements/randomizer/3drando/playthrough.cpp` | comment: the one sanctioned stamp site (#598) |
| `src/common/switch.cpp` | comment: OoT's copy is gone, MM's mirror is the last one (#598) |
| `docs/adr/0002-origin-tagged-shared-items.md` | note correcting the "compiled, zero callers" parenthetical (#598) |
| `src/common/tests/test_shared_state_roundtrip.c` | header comment named a deleted symbol (#598) |
| `src/common/tests/test_session_invalidation.c` | the lock |

## Lock

ROM-free `redship` tier, ctest row `SessionInvalidation`
(`redship --test session-invalidation`).

**Case 5c — the operator sequence.** Seed session A, then stamp generation's
identity exactly as `Playthrough_Init` authors it (`StampGeneratedSeed(seed=
0x99999999, settingsHash=0x5555)` — plus the MM profile digest and one reverse
row), then create with `createdWorldSeed=0x77777777` (world B). The created file
must carry none of A:

```c
SESSION_ASSERT(SessionIsClear(/*expectSeedStamp=*/false));
SESSION_ASSERT(gComboCtx.sharedRandoSeed == 0);
SESSION_ASSERT(gComboCtx.sharedRandoSettingsHash == 0);
SESSION_ASSERT(gComboCtx.mmProfileDigest == 0);
SESSION_ASSERT(Combo_CountForeignPlacementsOoT() == 0);
SESSION_ASSERT(Combo_GetForeignPlacementForOoTCheck(kGenReverseCheck) == nullptr);
SESSION_ASSERT(Combo_GetForeignPlacementForOoTCheck(kSessionAReverseCheck) == nullptr);
SESSION_ASSERT(!Combo_ForeignPairingActive());
SESSION_ASSERT(ArrivalPairDecision(/*hadFrozenState=*/0) == PAIR_DECLINE_NO_WORLD);
```

**Case 5d — the zero boundary, written to be falsifiable.** The obvious version
of this case (`ComboContext_Init()` then create with seed 0) asserts *nothing*:
KEEP and DROP both leave an all-zero context, so it passes either way. So 5d
seeds a real-looking identity whose seed happens to be 0 — settings hash, MM
digest and a reverse row all populated — which makes the two policies observably
different, and asserts the preconditions before the call.

**Non-vacuity of the KEEP side.** Case 5 is unchanged in intent (it now passes
the *matching* seed) and still asserts the KEEP path preserves the stamp, the
settings hash, the MM profile digest and generation's reverse row. The fix
therefore cannot pass by dropping unconditionally.

**#598 has no lock, and there cannot be one** — the deleted text was never in a
translation unit, so no test can distinguish the tree before from the tree
after. The falsifiable claim is the deadness, checkable with
`grep -rn SINGLE_EXECUTABLE_BUILD` and the absence of any
`target_compile_definitions` that defines it.

## Verification

Local, ROM-staged, on the final state (branched from `e49c43ac`, i.e. with PR
#543 already merged in — `origin/main` advanced mid-review and was merged before
the final runs). Windows / MSVC / Ninja / Release, `-j4` at low priority per the
workstation cap.

**Both tiers green on the merged final state**

```
ctest -L "^redship$"   100% tests passed out of 73   (SessionInvalidation #28 Passed)
ctest -L "^rando$"     100% tests passed out of 18
```

The `rando` tier needed the archives staged (`ExtractAssets`, `ExtractMMAssets`,
then `oot.o2r`/`mm.o2r` copied next to `redship.exe`); before that,
`RandoGenFullInit` was the single red row and it is an archive-availability
failure, not a code one. `RandoDeterminism` and `SeedDeterminism` both pass —
nothing here moves an RNG stream.

**The refusal actually fires** (`redship --test session-invalidation`, verbatim):

```
[Context] New file: resident identity 2576980377 does not name this world (2004318071)
  — DISCARDING the stamp and the reverse placement table rather than inheriting them
  (#597). This file is unpaired.
[Context] New file: resident identity 0 does not name this world (0) — DISCARDING ...
```

(`2576980377` = `0x99999999`, `2004318071` = `0x77777777`.)

**Counterfactual A — restore the pre-#597 unconditional KEEP.** Replaced the
decision with `Context_InvalidateSessionState(isRandoFile ? KEEP : DROP)`,
rebuilt, re-ran:

```
1/1 Test #28: SessionInvalidation ...***Failed  2.45 sec
  FAIL: src/common/tests/test_session_invalidation.c:456: SessionIsClear( false)
```

Line 456 is case 5c. Restored, green again.

**Counterfactual B — drop the zero guard.** Changed the test to bare
`gComboCtx.sourceIsRando && gComboCtx.sharedRandoSeed == createdWorldSeed`,
rebuilt, re-ran:

```
1/1 Test #28: SessionInvalidation ...***Failed  2.39 sec
  FAIL: src/common/tests/test_session_invalidation.c:495: SessionIsClear( false)
```

Line 495 is case 5d — and 5c (line 456) **passed** under B, which is the point:
the two cases pin two different terms of the decision, and neither is carrying
the other. Restored, green again.

**Gates**: `./run-clang-format.sh` leaves the tree unmodified (`OTRGlobals.cpp`
is the only touched file on the enforced allowlist). `tools/tests/test_repo_invariants.py`
— new on main with #543 — passes 13/13. No submodule pointer moved; the
generated stamps (`games/{oot,mm}/src/boot/build.c`, `games/oot/properties.h`,
`games/mm/windows/properties.h`) were reverted before committing.

## Review note

This PR was opened by the reviewer for the lane, not the implementer. Two
changes were made to the implementation under review:

1. **Case 5d was vacuous and is rewritten.** As submitted it seeded the case with
   a bare `ComboContext_Init()`, which asserts nothing — KEEP and DROP both
   leave an all-zero context, so it passed under either policy and could not
   have caught the removal of the guard it was written to pin. Counterfactual B
   above is the evidence that the rewritten version is not vacuous.
2. **Two stale in-tree references to the deleted symbol** were corrected
   (ADR 0002 §3, `test_shared_state_roundtrip.c`) — the same
   grep-finds-a-ghost trap #598 exists to close.

Everything else was verified at source and stands as written, including the
implementer's correction of the #598 premise (never compiled, not merely
uncalled).

## Remaining risk, stated plainly

A spoiler-loaded file that does not match now creates **silently unpaired** —
the only signal is the stderr line above. That is strictly safer than the
corruption it replaces, and it is the honest disposition under #564, but the
player who loaded a spoiler expecting a paired combo gets no in-game notice.
ADR 0010 increment 2 moves the whole pair creation to this seam and makes
"cannot author the pair" fail the creation at file select; the spoiler case
should get its user-visible refusal there, together with the spoiler-format
change that would let it author an identity instead.

Part of #597
Part of #598

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!--- section:artifacts:start -->
### Build Artifacts
  - [rsbs-windows.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/8830480927.zip)
  - [rsbs-linux.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/8829792153.zip)
<!--- section:artifacts:end -->