### PR TITLE
Show the item icon on OoT's cross-game arrival toast (#494)

### DIFF
--- a/games/oot/soh/Enhancements/randomizer/ForeignItemsSingleExe.cpp
+++ b/games/oot/soh/Enhancements/randomizer/ForeignItemsSingleExe.cpp
@@ -94,11 +94,24 @@ void GiveLinkRupees(int numOfRupees);
 // inventory items whose give falls through OoT_Item_Give's generic tail — save
 // writes only, no PlayState deref — which is what makes them safe on the
 // NULL-play redemption path the pool is given through.
+// The `iconName` column is the ITEM_* texture-map key each item's OoT arrival
+// toast renders (#494) — the exact string GetTextureForItemId returns for that
+// item's GetItemEntry.itemId, which is what the Notification overlay resolves
+// through GetTextureByName. Verified against item_list.cpp's item table and the
+// Plandomizer itemImageMap: GI_LENS -> ITEM_LENS, GI_BOOMERANG -> ITEM_BOOMERANG,
+// GI_HAMMER -> ITEM_HAMMER. Progressive Strength has no single item id (it
+// resolves per-tier at give time), so it takes the base-tier bracelet icon as a
+// stable representative rather than a per-tier lookup on the NULL-play redemption
+// path — a decoration, not the give. src/common serves these back verbatim via
+// Combo_GetForeignItemIconName; it never has to translate an RG_* itself.
 static const ComboForeignItemDef kForeignPoolV1[] = {
-    { { (uint8_t)GAME_OOT, 0, (uint16_t)RG_PROGRESSIVE_STRENGTH }, "Progressive Strength Upgrade", "a " },
-    { { (uint8_t)GAME_OOT, 0, (uint16_t)RG_LENS_OF_TRUTH }, "Lens of Truth", "the " },
-    { { (uint8_t)GAME_OOT, 0, (uint16_t)RG_BOOMERANG }, "Boomerang", "the " },
-    { { (uint8_t)GAME_OOT, 0, (uint16_t)RG_MEGATON_HAMMER }, "Megaton Hammer", "the " },
+    { { (uint8_t)GAME_OOT, 0, (uint16_t)RG_PROGRESSIVE_STRENGTH },
+      "Progressive Strength Upgrade",
+      "a ",
+      "ITEM_BRACELET" },
+    { { (uint8_t)GAME_OOT, 0, (uint16_t)RG_LENS_OF_TRUTH }, "Lens of Truth", "the ", "ITEM_LENS" },
+    { { (uint8_t)GAME_OOT, 0, (uint16_t)RG_BOOMERANG }, "Boomerang", "the ", "ITEM_BOOMERANG" },
+    { { (uint8_t)GAME_OOT, 0, (uint16_t)RG_MEGATON_HAMMER }, "Megaton Hammer", "the ", "ITEM_HAMMER" },
 };
 
 static constexpr int kForeignPoolCount = sizeof(kForeignPoolV1) / sizeof(kForeignPoolV1[0]);

--- a/games/oot/soh/GameExports_SingleExe.cpp
+++ b/games/oot/soh/GameExports_SingleExe.cpp
@@ -1092,10 +1092,15 @@ static void OoT_AwardSharedItem(const SharedItem* item, void* ctx) {
     // surface the arrival ALREADY renders over — MM's rando pickups cross-bind
     // to this exact Emit (#427 item 1).
     //
-    // No .itemIcon: resolving one needs a per-item icon-name accessor that
-    // src/common does not have yet (the Combo_GetForeignItemIconName tier of
-    // #494). Emitting text-only is an existing idiom, not a degradation — the
-    // MOD_RANDOMIZER branch in hook_handlers.cpp omits the icon too.
+    // .itemIcon comes from Combo_GetForeignItemIconName (#494): the pinned pool
+    // now carries each OoT item's ITEM_* texture-map key alongside its name and
+    // article, and the accessor serves it back origin-keyed, so src/common never
+    // translates an RG_* into a texture. It may still return NULL (an entry with
+    // no icon, or an id outside the pool), and a NULL icon is text-only, not a
+    // degradation — the MOD_RANDOMIZER branch in hook_handlers.cpp omits the icon
+    // too. The overlay stores the pointer and dereferences it at draw time, well
+    // after the item icons are registered, and the pool's key is a string literal
+    // that outlives the toast.
     //
     // WORDING (#510): "You got the Fairy Bow", not "Received from Termina: …".
     // The arrival IS the moment the player receives it in OoT, so the native
@@ -1115,6 +1120,7 @@ static void OoT_AwardSharedItem(const SharedItem* item, void* ctx) {
     const char* foreignName = Combo_GetForeignItemName(*item);
     const char* foreignArticle = Combo_GetForeignItemArticle(*item);
     Notification::Emit({
+        .itemIcon = Combo_GetForeignItemIconName(*item),
         .message = "You got ",
         .suffix = std::string(foreignArticle != nullptr ? foreignArticle : "") +
                   (foreignName != nullptr ? foreignName : "a foreign item"),

--- a/src/common/foreign_items.c
+++ b/src/common/foreign_items.c
@@ -107,6 +107,21 @@ const char* Combo_GetForeignItemArticle(SharedItem item) {
     return NULL;
 }
 
+const char* Combo_GetForeignItemIconName(SharedItem item) {
+    // The icon column of the SAME origin-keyed walk. A pool entry may carry a
+    // NULL icon (its origin's toast renders text-only), so a NULL result here
+    // means either "not in the pool" or "no icon for this entry" — both of which
+    // the arrival toast treats identically, so they need not be distinguished.
+    const ComboForeignItemDef* pool = NULL;
+    const int poolCount = Combo_GetForeignItemPoolFor(item.originGame, &pool);
+    for (int i = 0; i < poolCount; i++) {
+        if (pool[i].item.originGame == item.originGame && pool[i].item.id == item.id) {
+            return pool[i].iconName;
+        }
+    }
+    return NULL;
+}
+
 bool Combo_GetForeignItemByNameFor(uint8_t originGame, const char* name, SharedItem* outItem) {
     // The spoiler-LOAD inverse. Reused (not re-derived) so reconstruction shares
     // one source of truth with generation, and so a raw RG_*/RI_* is never

--- a/src/common/foreign_items.h
+++ b/src/common/foreign_items.h
@@ -48,6 +48,14 @@ typedef struct {
     SharedItem item;     // originGame == GAME_OOT, flags == 0, id == the RG_* value
     const char* name;    // e.g. "Megaton Hammer"
     const char* article; // "the ", "a ", "an " or "" — see below
+    // The host game's texture-map key for this item's arrival-toast icon, or
+    // NULL for a text-only toast. Like `name`, it is filled in by the pool's
+    // defining TU (where the item's icon is known) and served back through this
+    // header, so src/common never has to translate a foreign id into a texture.
+    // The OoT pool carries the `ITEM_*` key its Notification overlay resolves via
+    // GetTextureByName (the same string GetTextureForItemId returns); see
+    // Combo_GetForeignItemIconName.
+    const char* iconName;
 } ComboForeignItemDef;
 
 // WHY THE ARTICLE IS PART OF THE DESCRIPTOR (#510). A cross-game item is
@@ -144,6 +152,22 @@ const char* Combo_GetForeignItemName(SharedItem item);
  * full "the Lens of Truth" phrase. See the note on ComboForeignItemDef.article.
  */
 const char* Combo_GetForeignItemArticle(SharedItem item);
+
+/**
+ * The arrival-toast icon for a foreign item — the host game's texture-map key,
+ * or NULL if (originGame, id) is not in that origin's pinned pool OR the pool
+ * entry carries no icon. NULL is not a defect: Notification::Emit renders a
+ * text-only toast for a null icon, the same idiom the native pickup paths use.
+ *
+ * The returned string is the pool's own static storage (a string literal in the
+ * defining TU), so it outlives any toast that stores it as a bare pointer and
+ * dereferences it at draw time (see notification_bridge.h). Origin-aware by the
+ * same construction as Combo_GetForeignItemName: the tag on the SharedItem
+ * selects which pool is walked, so an OoT-origin item resolves an OoT `ITEM_*`
+ * key and nothing else. This is the accessor GameExports' OoT_AwardSharedItem
+ * needs so the cross-game arrival toast can show the item's icon (#494).
+ */
+const char* Combo_GetForeignItemIconName(SharedItem item);
 
 /**
  * The inverse of Combo_GetForeignItemName, keyed on (originGame, name). Used by

--- a/src/common/tests/test_foreign_items.c
+++ b/src/common/tests/test_foreign_items.c
@@ -166,6 +166,14 @@ TestResult Test_ForeignItemGive(void) {
         if (pool[i].article[0] != '\0') {
             FI_ASSERT(pool[i].article[strlen(pool[i].article) - 1] == ' ');
         }
+        // #494: the arrival-toast icon accessor serves the pool's own iconName
+        // pointer back verbatim (identity, not a copy), origin-keyed like the
+        // name/article lookups. Every OoT pool entry carries an ITEM_* key, so
+        // none is NULL here — but a NULL entry would be a text-only toast, not a
+        // defect, so the contract asserted is "serves the column exactly", not
+        // "always non-NULL".
+        FI_ASSERT(Combo_GetForeignItemIconName(pool[i].item) == pool[i].iconName);
+        FI_ASSERT(pool[i].iconName != NULL && pool[i].iconName[0] == 'I'); // ITEM_* texture-map key
     }
     // (originGame, name) uniqueness WITHIN a pool. Two entries sharing a name
     // in one id-space would make that origin's inverse ambiguous, which no
@@ -282,12 +290,14 @@ TestResult Test_ForeignItemGive(void) {
         const char* ootName = Combo_GetForeignItemName(ootSameId);
         FI_ASSERT(ootName == NULL || strcmp(ootName, mmProbe.name) != 0);
 
-        // An untagged item resolves to no pool and therefore to no name.
+        // An untagged item resolves to no pool and therefore to no name — and,
+        // by the same walk, to no icon (#494).
         SharedItem untaggedName;
         untaggedName.originGame = (uint8_t)GAME_NONE;
         untaggedName.flags = 0;
         untaggedName.id = mmProbe.item.id;
         FI_ASSERT(Combo_GetForeignItemName(untaggedName) == NULL);
+        FI_ASSERT(Combo_GetForeignItemIconName(untaggedName) == NULL);
     }
 
     // ------------------------------------------------------------------


### PR DESCRIPTION
## What

The #494 icon tier, **clean wins only**: a cross-game item arriving in OoT now shows its icon on the arrival toast.

`src/common` had no way to name an OoT item's icon without OoT's headers, which is exactly what the blocker comment at `GameExports_SingleExe.cpp:1095` said. This adds that accessor:

- **`ComboForeignItemDef` gains an `iconName` column** — the host game's texture-map key, filled in by the pool's defining TU (where the item's icon is known), served back through the header. Same shape as the existing `name`/`article` columns, for the same ADR 0002 reason: `src/common` never translates a foreign id into a texture.
- **`Combo_GetForeignItemIconName(SharedItem)`** — the origin-keyed walk that returns it, or `NULL`. Origin-aware by the same construction as the name lookup: the tag on the `SharedItem` selects which pool is walked.
- **OoT's pinned pool carries the real `ITEM_*` keys**, verified against `item_list.cpp` and the Plandomizer `itemImageMap`: `GI_LENS → ITEM_LENS`, `GI_BOOMERANG → ITEM_BOOMERANG`, `GI_HAMMER → ITEM_HAMMER`. Progressive Strength has no single item id (it resolves per-tier at give time), so it takes the base-tier `ITEM_BRACELET` icon as a stable representative — a decoration, not the give.
- **`OoT_AwardSharedItem` sets `.itemIcon`** from the accessor. `NULL` stays valid: `Notification::Emit` renders text-only, the same idiom the `MOD_RANDOMIZER` branch in `hook_handlers.cpp` already uses.

Pointer lifetime is safe by construction: the accessor returns the pool's own string literals, and the overlay stores `itemIcon` as a bare pointer dereferenced at draw time (`notification_bridge.h`).

## What this deliberately does NOT do

**MM's blue pickup textbox is left exactly as-is.** Its `.icon` is a `uint8_t` N64 message-header GI-index (`CustomMessage.cpp:124`, copied into `buff[2]` at `:142`), so it cannot carry a texture path — there is no in-range byte that names a foreign OoT item. Making that work needs vendored `z_message.c` surgery, which is #494 **Tier 2b** and out of scope here.

Filed as **#607**, including the `uint8_t` GI-index constraint and the Lane-6 upstream-conflict landmine (`z_message.c` is vendored 2ship/decomp code, so in-place edits collide with upstream merges).

## Testing

- Local ROM-staged build (MSVC/Ninja, `--parallel 4`): clean.
- `ctest -L "^redship$"`: **77/77 passed**, baseline on `main` also 77/77.
- New assertions in `test_foreign_items.c`: the accessor serves the pool's `iconName` column by **pointer identity** (not a copy), every OoT pool entry carries an `ITEM_*` key, and an untagged item resolves to no icon.
- Reviewed by a 5-lens adversarial pass (correctness, completeness sweep, test vacuity); zero findings against this change.

Part of #494. Tier 2b tracked in #607.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!--- section:artifacts:start -->
### Build Artifacts
  - [rsbs-windows.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/8837716930.zip)
  - [rsbs-linux.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/8837593010.zip)
<!--- section:artifacts:end -->