### PR TITLE
Retire MM's DebugSaveFileMode clobber and share the key (#454)

### DIFF
--- a/docs/adr/0003-settings-namespace.md
+++ b/docs/adr/0003-settings-namespace.md
@@ -4,8 +4,12 @@
 - For: #34 (settings migration), gating #35; the settings decision in
   `docs/unified-surface-findings.md` §6.1
 - Corrected on acceptance: §4.1's `gDeveloperTools.DebugSaveFileMode` row was
-  **wrong** and is struck below; §5 gains the `TimeSavers` casing decision
-  ADR 0004 asked this document to make.
+  **wrong** for the tree as it then stood and was struck below (the key was
+  class (P) while MM's registrar clobbered it); §5 gains the `TimeSavers` casing
+  decision ADR 0004 asked this document to make.
+- Update 2026-08-02 (#454 fixed): MM's clobbering write was retired and its read
+  default aligned to OoT's `1`, so `DebugSaveFileMode` is genuine class (S)
+  again; the §4.1 row is restored and the class-(S) count is back to 26.
 - Measured against `origin/main` on 2026-07-21 by exhaustive grep of both
   trees (method and its one correction in Appendix A — the numbers below are
   reproducible, not quoted)
@@ -340,7 +344,7 @@ No action. Documented as deliberate; see the §2.3 guard.
 |---|---|
 | `gCheats.{InfiniteHealth, InfiniteMagic, MoonJumpOnL, NoClip, EasyFrameAdvance}` | Identical meaning in both games. Maintainer decision. |
 | `gDeveloperTools.{DebugEnabled, FrameAdvanceTick, LogLevel}` | Host/debug state. `FrameAdvanceTick` is a transient both games set and clear; only one game is active at a time, so no interleaving. |
-| ~~`gDeveloperTools.DebugSaveFileMode`~~ | **STRUCK 2026-07-23 — this row was wrong; the key is class (P).** It said: *"Value spaces align… only the unwritten fallback differs. Acceptable, worth knowing."* The value spaces do align, but the key is never left unwritten: `games/mm/2s2h/DeveloperTools/DeveloperTools.cpp`'s `RegisterDebugMode()` does `CVarSetInteger(CVAR_SAVE_FILE_MODE_NAME, DEBUG_SAVE_INFO_NONE)` whenever debug mode is off — the default state — so MM's registrar destroys OoT's `1` on every launch. ADR 0004 §2d holds the record; the key sits in `kDisputedClassificationKeys` until MM's write is retired and its read default aligned. Dormant today only because `2s2h/DeveloperTools/` is excluded from the single-exe link. **Class (S) count is 25 here, not 26.** |
+| `gDeveloperTools.DebugSaveFileMode` | **STRUCK 2026-07-23, RESTORED to (S) 2026-08-02 (#454 fixed).** The struck row's reasoning was correct for the tree as it stood: `games/mm/2s2h/DeveloperTools/DeveloperTools.cpp`'s `RegisterDebugMode()` did `CVarSetInteger(CVAR_SAVE_FILE_MODE_NAME, DEBUG_SAVE_INFO_NONE)` whenever debug mode was off — the default state — so MM's registrar destroyed OoT's `1` on every launch, which is what made the key class (P). #454 retired that write and aligned MM's read default to OoT's `1` (`DEBUG_SAVE_INFO_VANILLA_DEBUG`), so the key is now genuine (S): shared spelling, shared meaning, shared default, no writer. Moved back into `kSharedIntentKeys` in the same change. **Class (S) count is 26 again.** |
 | `gEnhancements.Graphics.{IncreaseActorDrawDistance, ActorCullingAccountsForWidescreen}` | Same multiplier semantics, same default (`1`), same widescreen-culling boolean. |
 | `gAudioEditor.{EnemyBGMDisable, LowHpAlarm, SeqNameNotification, SeqNameNotificationDuration}` | Same audio-editor behaviours. |
 | `gSettings.{CursorVisibility, DisableChanges}` | Host UI state. |

--- a/docs/adr/0004-menu-information-architecture.md
+++ b/docs/adr/0004-menu-information-architecture.md
@@ -113,10 +113,12 @@ resolving it"* — is discharged, provided MM's menu is never revived as a secon
 proviso is now load-bearing for both documents, which is the second reason §3 tier 1 flags the
 sidebar-name caveat.
 
-**~~One live disagreement, deliberately preserved.~~ RULED (P) on acceptance, 2026-07-23.** On
-`gDeveloperTools.DebugSaveFileMode`, ADR 0003 §4.1 classified (S) — value spaces align, only the
-unwritten fallback differs, "acceptable, worth knowing" — and this document classified it **(P)**,
-filed as [#454](https://github.com/spencerduncan/redshipblueship/issues/454).
+**~~One live disagreement, deliberately preserved.~~ RULED (P) on acceptance, 2026-07-23; FIXED and
+returned to (S), 2026-08-02 (#454).** On `gDeveloperTools.DebugSaveFileMode`, ADR 0003 §4.1 classified
+(S) — value spaces align, only the unwritten fallback differs, "acceptable, worth knowing" — and this
+document classified it **(P)**, filed as [#454](https://github.com/spencerduncan/redshipblueship/issues/454).
+The (P) reading was correct for the tree as it stood; #454 has since removed what made it (P) (see the
+resolution note at the end of this subsection), so the key is genuine (S) now.
 
 **#454 never decided it.** It was auto-closed by the squash-merge of PR #456, a docs-only change
 whose own text says #454 is the thing that will settle the question. The close is an artifact.
@@ -136,13 +138,15 @@ MM's registrar unconditionally writes `0` into the shared cell whenever debug mo
 the default state — so the key is never left unwritten once MM's devtools link, and OoT's `1` is
 destroyed on every launch. **ADR 0003 §4.1's row is therefore wrong and is corrected there.**
 
-Dormant but armed: `games/mm/CMakeLists.txt` excludes `2s2h/DeveloperTools/` from the single-exe
-build, so the clobber does not run today. It arms on the same un-elision work §5's gate 4
-schedules. The rename pass remains safe under either reading — the key name already matches — so
-this is a behaviour fix (retire MM's write, align MM's read default to OoT's `1`) owed by whichever
-lane un-elides `DeveloperTools`, not a namespace change. `kDisputedClassificationKeys` keeps the key
-until that fix lands, because the manifest must not claim (S) while the source still contains the
-write that makes it (P).
+**RESOLVED 2026-08-02 (#454).** The behaviour fix was made ahead of un-elision rather than deferred to
+it: `RegisterDebugMode()`'s `CVarSetInteger(CVAR_SAVE_FILE_MODE_NAME, DEBUG_SAVE_INFO_NONE)` write is
+retired, and MM's read default is aligned to OoT's `1` (`DEBUG_SAVE_INFO_VANILLA_DEBUG`). The rename
+pass was always safe under either reading — the key name already matched — so this was only ever a
+behaviour fix, and it is done. `games/mm/2s2h/DeveloperTools/` is still excluded from the single-exe
+build (so the clobber never ran there), but the source no longer contains the write, so whichever lane
+un-elides `DeveloperTools` inherits a key that is already (S). `kDisputedClassificationKeys` is now
+empty and `DebugSaveFileMode` sits in `kSharedIntentKeys`; the manifest claims (S) only against the
+fixed source.
 
 ### 3. The four tiers
 
@@ -464,11 +468,12 @@ kept so the decision trail stays legible.
    would silently switch a restoration on for players who asked for neither. Stays in
    `kMustStayDistinct`.
 3. **(P) row P5 — `gDeveloperTools.DebugSaveFileMode` defaults.**
-   **RESOLVED (P), against ADR 0003 §4.1 — see §2d for the evidence.** Not on the default
-   divergence: on MM's `DeveloperTools.cpp` write into the shared cell, which falsifies 0003's
-   "only the unwritten fallback differs" outright. The fix is a behaviour change owed by whichever
-   lane un-elides `2s2h/DeveloperTools/`; until then the key stays in
-   `kDisputedClassificationKeys`.
+   **RULED (P), against ADR 0003 §4.1 — see §2d for the evidence — then FIXED and returned to (S),
+   2026-08-02 (#454).** The (P) call was not on the default divergence but on MM's
+   `DeveloperTools.cpp` write into the shared cell, which falsified 0003's "only the unwritten
+   fallback differs" outright. #454 made the behaviour change ahead of un-elision: retired MM's
+   write and aligned its read default to OoT's `1`. `kDisputedClassificationKeys` is now empty and
+   the key lives in `kSharedIntentKeys`.
 4. **Group B rename confirmations.** *Was:* `InfiniteAmmo`/`InfiniteConsumables` and
    `NoRestrictItems`/`UnrestrictedItems` need a semantic check before renaming.
    **RESOLVED: neither converges. Both stay in `kMustStayDistinct`, and the recorded reasons are

--- a/docs/enhancement-classification.md
+++ b/docs/enhancement-classification.md
@@ -16,8 +16,10 @@
 > has already migrated away from, while this document includes it. Including it is what
 > surfaced the tunic desync (§3.3 BUG 1) — the key only looks shared *because* it appears in
 > the migrator — and ADR 0003 independently arrived at the same fix by a different route
-> (its §5.1 Tier-1 rename list). The two documents agree on every substantive row except
-> `DebugSaveFileMode`; see ADR 0004 §2d for that disagreement.
+> (its §5.1 Tier-1 rename list). The two documents originally disagreed on only one
+> substantive row — `DebugSaveFileMode`, which this document read (P) and ADR 0003 §4.1 read
+> (S). #454 has since removed what made it (P) (MM's clobbering write retired, read default
+> aligned to OoT's 1), so both now classify it (S); see ADR 0004 §2d for that history.
 
 ## 0. Governing principle
 
@@ -170,11 +172,16 @@ Currently inert only because `BenPort.cpp` is excluded from the single-exe link.
 moment MM's cosmetic surface is un-elided. **Classification: (S) shared-intent, CONVERGE →
 OoT's `gCosmetics.Link.{Kokiri,Goron,Zora}Tunic.Value`.**
 
-#### ❌ BUG 2 — `gDeveloperTools.DebugSaveFileMode`: shared key, divergent defaults
+#### ✅ BUG 2 (RESOLVED #454, 2026-08-02) — `gDeveloperTools.DebugSaveFileMode`: shared key, defaults now aligned
+
+> **Fixed by #454.** MM's `RegisterDebugMode()` clobbering write into the shared cell is retired and
+> MM's read default is aligned to OoT's `1` (`DEBUG_SAVE_INFO_VANILLA_DEBUG`), so the key is genuine
+> class (S). The measurement below is the pre-fix state, kept for the record. The MM default is now
+> **1**, not 0.
 
 | | OoT | MM |
 |---|---|---|
-| Default | **1** (`.DefaultIndex(1)`, `SaveManager.cpp:975` reads default `1`) | **0** (`DEBUG_SAVE_INFO_NONE`, `DeveloperTools.cpp:26`) |
+| Default | **1** (`.DefaultIndex(1)`, `SaveManager.cpp:975` reads default `1`) | **1** since #454 (`DEBUG_SAVE_INFO_VANILLA_DEBUG`, `DeveloperTools.cpp:26`); was `0` (`DEBUG_SAVE_INFO_NONE`) |
 | Value 0 | "Off — normal savefile" | `DEBUG_SAVE_INFO_NONE` — empty save |
 | Value 1 | "Vanilla debug save" | `DEBUG_SAVE_INFO_VANILLA_DEBUG` |
 | Value 2 | "Maxed — all items & upgrades" | `DEBUG_SAVE_INFO_COMPLETE` — 100% save |
@@ -184,13 +191,15 @@ The *enum ordering happens to align*, but the **defaults disagree**: unset, OoT 
 game's debug-save behaviour away from its own default. Low blast radius (debug-only, gated
 behind `DebugEnabled`) but it is a genuine accidental divergence on a shared key.
 
-**Classification: (P)** — the key already matches so nothing renames, but the defaults must be
-reconciled, which is a behaviour decision.
+**Classification: (S) — RESOLVED by #454.** The original reading here was (P): the key already
+matched so nothing renamed, but the divergent default had to be reconciled, which is a behaviour
+decision. #454 made that decision — MM's default was aligned to OoT's `1` and MM's clobbering
+write retired — so the key is now genuine (S). The pre-fix (P) framing is kept below for the record.
 
-> ⚠️ **ADR 0003 §4.1 classifies this (S)** — "value spaces align… only the unwritten fallback
-> differs. Acceptable, worth knowing." This document takes the more conservative (P) line. The
-> disagreement is narrow and safe (no rename either way); #454 decides it. Recorded rather than
-> reconciled so neither document silently overrides the other.
+> ⚠️ **ADR 0003 §4.1 always classified this (S)** — "value spaces align… only the unwritten
+> fallback differs." This document originally took the more conservative (P) line, and #454 then
+> decided it in favour of (S), aligning MM's default to OoT's 1 and retiring MM's clobbering
+> write. Recorded rather than silently overwritten so the route to the shared conclusion is legible.
 
 ## 4. (P) — per-game parallel: same idea, incompatible realisation
 
@@ -203,7 +212,7 @@ rename pass.**
 | P2 | **Infinite Sword Glitch** | `gCheats.EasyISG` (a **Cheat**) | `gEnhancements.Restorations.TatlISG` (a **Restoration**) | Taxonomy conflict *and* semantics: OoT treats ISG as a cheat to grant; MM treats restoring the Navi-ISG behaviour (via Tatl) as authenticity. Different menu sections, different framing. Needs a maintainer call before any merge. |
 | P3 | **Camera invert / sensitivity** | `gSettings.FreeLook.Invert{X,Y}Axis`, `gSettings.Controls.InvertAiming{X,Y}Axis`, `…InvertShieldAiming{X,Y}Axis`, `…InvertZAimingYAxis`, `gSettings.FirstPersonCameraSensitivity.{Enabled,X,Y}` | `gEnhancements.Camera.RightStick.Invert{X,Y}Axis`, `gEnhancements.Camera.FirstPerson.Invert{X,Y}`, `…RightStickInvert{X,Y}`, `…GyroInvert{X,Y}`, `…Sensitivity{X,Y}` | **Different axis decomposition.** OoT splits by *context* (free-look vs aiming vs shield-aiming vs Z-aiming); MM splits by *input device* (right stick vs gyro vs first-person). There is no 1:1 mapping — OoT has no gyro axis, MM has no shield-aim axis. Merging would drop settings on both sides. |
 | P4 | **Tunic / transformation colours** | `gCosmetics.Link.{Kokiri,Goron,Zora}Tunic.Value` | `gCosmetics.Link_{Kokiri,Goron,Zora}Tunic.Value` | See §3.3 BUG 1. Intent is shared; the *current keys* are desynced by an OoT migration MM never followed. Converge, but as a fix, not a plain rename. |
-| P5 | **Debug save file mode** | `gDeveloperTools.DebugSaveFileMode` (default 1) | `gDeveloperTools.DebugSaveFileMode` (default 0) | See §3.3 BUG 2. Same key, disagreeing defaults. |
+| P5 | **Debug save file mode** | `gDeveloperTools.DebugSaveFileMode` (default 1) | `gDeveloperTools.DebugSaveFileMode` (default 1 since #454) | **RESOLVED (#454): now (S).** See §3.3 BUG 2 — MM's clobbering write retired and read default aligned to OoT's 1. |
 | P6 | **Ocarina D-pad input** | `gEnhancements.DpadNoDropOcarinaInput`, `gSettings.OcarinaControl.Dpad`, `gSettings.CustomOcarina.Dpad` | `gEnhancements.Playback.DpadOcarina`, `…NoDropOcarinaInput`, `…RightStickOcarina` | Split across **different top-level namespaces** (OoT: partly `gSettings`, partly `gEnhancements`; MM: all `gEnhancements.Playback`) with different member sets — MM adds right-stick ocarina, OoT adds a custom-mapping layer. Structurally parallel, not identical. |
 | P7 | **Shield aim inversion** | `gSettings.Controls.InvertShieldAimingYAxis` (+ X axis) | `gEnhancements.Equipment.InvertShieldY` (Y only) | Different namespace *and* different axis coverage (OoT X+Y, MM Y only). Merging loses OoT's X axis. |
 
@@ -344,9 +353,9 @@ Scoped to the enhancement/cheat/cosmetic surface classified at **individual-sett
 
 | Class | Rows | Notes |
 |---|---:|---|
-| **(S) shared-intent** | **59** | 33 already MATCH + 26 need CONVERGE |
+| **(S) shared-intent** | **60** | 34 already MATCH + 26 need CONVERGE (DebugSaveFileMode joined MATCH via #454) |
 | — of which port-level MATCH | 19 | §3.1 |
-| — of which gameplay/tooling MATCH | 14 | §3.2 |
+| — of which gameplay/tooling MATCH | 15 | §3.2 (incl. DebugSaveFileMode since #454) |
 | — of which CONVERGE (→ rename list) | 26 | §5.3 |
 | **(P) per-game parallel** | **7** | §4 |
 | **(O) only-in-one (MM side)** | **~146** | of MM's 185 in-scope keys |
@@ -354,12 +363,15 @@ Scoped to the enhancement/cheat/cosmetic surface classified at **individual-sett
 
 **Collision set:** 35 exact + 2 by-design = **37 shared keys**.
 
-- 33 deliberate-and-correct — (S) (19 port-level, 14 shared-intent gameplay)
-- **2 accidental-divergence bugs** — the tunic stale-key desync (3 keys) and
-  `DebugSaveFileMode` default disagreement (1 key). Filed; see §3.3.
+- 34 deliberate-and-correct — (S) (19 port-level, 15 shared-intent gameplay/tooling — the
+  latter now including `DebugSaveFileMode`, reconciled to (S) by #454)
+- **1 accidental-divergence bug** — the tunic stale-key desync (3 keys). Filed; see §3.3.
+  (`DebugSaveFileMode`'s default disagreement was the second bug here; #454 resolved it —
+  MM's clobbering write retired and its read default aligned to OoT's 1 — so it is now (S).)
 
-**Bug list for filing:** exactly 2 issues, not the 5-cheat block a naive scan reports. Under
-decision (2) the cheat sharing is correct by design.
+**Bug list for filing:** 1 open issue (the tunic desync), not the 5-cheat block a naive scan
+reports; `DebugSaveFileMode` was the other and is resolved by #454. Under decision (2) the cheat
+sharing is correct by design.
 
 ## 8. Hazards surfaced in passing
 

--- a/games/mm/2s2h/BenGui/BenMenu.cpp
+++ b/games/mm/2s2h/BenGui/BenMenu.cpp
@@ -1814,7 +1814,12 @@ void BenMenu::AddDevTools() {
                               "- Empty Save: The default 3 heart save file in first cycle.\n"
                               "- Vanilla Debug Save: Uses the title screen save info (8 hearts, all items and masks).\n"
                               "- 100\% Save: All items, equipment, mask, quest status and Bombers' Notebook complete.")
-                     .ComboVec(&debugSaveOptions))
+                     .ComboVec(&debugSaveOptions)
+                     // #454: match the runtime read default (DeveloperTools.cpp,
+                     // DEBUG_SAVE_INFO_VANILLA_DEBUG == 1) and OoT's own menu
+                     // (SohMenuDevTools.cpp .DefaultIndex(1)), so the widget's
+                     // displayed default is not "Empty Save" while the game reads 1.
+                     .DefaultIndex(1))
         .PreFunc([](WidgetInfo& info) { info.isHidden = mBenMenu->disabledMap.at(DISABLE_FOR_DEBUG_MODE_OFF).active; });
     AddWidget(path, "Prevent Actor Update", WIDGET_CVAR_CHECKBOX)
         .CVar("gDeveloperTools.PreventActorUpdate")

--- a/games/mm/2s2h/DeveloperTools/DeveloperTools.cpp
+++ b/games/mm/2s2h/DeveloperTools/DeveloperTools.cpp
@@ -23,7 +23,12 @@ extern u16 sPersistentCycleWeekEventRegs[ARRAY_COUNT(gSaveContext.save.saveInfo.
 #define CVAR_DEBUG_MODE CVarGetInteger(CVAR_DEBUG_MODE_NAME, 0)
 
 #define CVAR_SAVE_FILE_MODE_NAME "gDeveloperTools.DebugSaveFileMode"
-#define CVAR_SAVE_FILE_MODE CVarGetInteger(CVAR_SAVE_FILE_MODE_NAME, DEBUG_SAVE_INFO_NONE)
+// Read default aligned with OoT's (#454): OoT reads this shared key with a
+// default of 1 (SaveManager.cpp), and MM's enumerators match value-for-value
+// (NONE=0, VANILLA_DEBUG=1, COMPLETE=2), so the two games now agree on the
+// unwritten fallback. This makes the key genuine class (S) — see
+// src/common/cvar_shared_keys.h's kSharedIntentKeys entry.
+#define CVAR_SAVE_FILE_MODE CVarGetInteger(CVAR_SAVE_FILE_MODE_NAME, DEBUG_SAVE_INFO_VANILLA_DEBUG)
 
 void SetSaveFileInfo() {
     u8 playerName[8];
@@ -146,9 +151,16 @@ void RegisterPreventActorInitHooks() {
 }
 
 void RegisterDebugMode() {
-    // Disable various debug options when toggled off
+    // Disable various debug options when toggled off.
+    //
+    // NOTE (#454): this used to also do
+    //   CVarSetInteger(CVAR_SAVE_FILE_MODE_NAME, DEBUG_SAVE_INFO_NONE);
+    // which is retired. In the single-shell combo, DebugSaveFileMode is ONE
+    // shared cell that OoT reads with a default of 1; writing 0 into it here on
+    // every launch (debug-off is the default state) destroyed OoT's default and
+    // is what made the key class (P). The other options below are MM-only cvars,
+    // so clearing them is correct and stays. See src/common/cvar_shared_keys.h.
     if (!CVAR_DEBUG_MODE) {
-        CVarSetInteger(CVAR_SAVE_FILE_MODE_NAME, DEBUG_SAVE_INFO_NONE);
         CVarSetInteger(CVAR_PREVENT_ACTOR_UPDATE_NAME, 0);
         CVarSetInteger(CVAR_PREVENT_ACTOR_DRAW_NAME, 0);
         CVarSetInteger(CVAR_PREVENT_ACTOR_INIT_NAME, 0);

--- a/src/common/cvar_shared_keys.h
+++ b/src/common/cvar_shared_keys.h
@@ -315,9 +315,13 @@ inline constexpr const char* kSharedIntentKeys[] = {
     "gCheats.InfiniteMagic",
     "gCheats.MoonJumpOnL",
     "gCheats.NoClip",
-    // Developer tooling. NOTE: gDeveloperTools.DebugSaveFileMode is
-    // deliberately ABSENT — see kDisputedClassificationKeys.
+    // Developer tooling. gDeveloperTools.DebugSaveFileMode joined this list when
+    // #454 was fixed: MM's clobbering write in RegisterDebugMode() was retired
+    // and its read default aligned to OoT's 1, so the key is now genuine class
+    // (S) — shared spelling, shared meaning, shared default, no writer. See the
+    // note where kDisputedClassificationKeys used to carry it.
     "gDeveloperTools.DebugEnabled",
+    "gDeveloperTools.DebugSaveFileMode",
     "gDeveloperTools.FrameAdvanceTick",
     "gDeveloperTools.LogLevel",
     // Graphics enhancements that describe the renderer, not the game.
@@ -354,49 +358,41 @@ inline constexpr const char* kDeliberateSharedCheatKeys[] = {
 };
 
 /**
- * Keys the two governing documents classified DIFFERENTLY. Kept as a table, and
- * asserted on only to the extent both readings agree: a key here is never swept
- * into the convergence set.
+ * Keys the two governing documents classified DIFFERENTLY. Kept as a named
+ * table so a future re-dispute has a home, and asserted on only to the extent
+ * both readings agree: a key here is never swept into the convergence set.
  *
- * `gDeveloperTools.DebugSaveFileMode`. ADR 0003 §4.1 called it (S) — "value
- * spaces align, only the unwritten fallback differs, acceptable". The inventory
- * §3.3 BUG 2 and ADR 0004 §2d took the (P) line on the strength of the
- * defaults disagreeing (OoT 1 = "vanilla debug save", MM 0 = "empty save").
+ * EMPTY as of #454's fix (2026-08-02). It carried exactly one key,
+ * `gDeveloperTools.DebugSaveFileMode`, which is now genuine class (S) and lives
+ * in kSharedIntentKeys.
  *
- * RULED (P), 2026-07-23 (#497 step 1, Lane 4) — and NOT on the defaults.
- * #454 was auto-closed by the merge of the docs-only PR #456, which itself says
- * #454 is the thing that will settle the question; nothing decided it. Lane 4
- * measured the tree instead and found the argument ADR 0003 §4.1 rests on is
- * false on its own terms:
+ * The history, because the resolution turned on it. ADR 0003 §4.1 first called
+ * the key (S) — "value spaces align, only the unwritten fallback differs,
+ * acceptable". ADR 0004 §2d and inventory §3.3 BUG 2 ruled it (P), and NOT on
+ * the defaults: the argument ADR 0003 rests on is false on its own terms,
+ * because MM did not merely READ the shared key with a different default — its
+ * registrar WROTE 0 into it whenever debug mode is off (the default state):
  *
  *   games/mm/2s2h/DeveloperTools/DeveloperTools.cpp, in RegisterDebugMode():
  *       if (!CVAR_DEBUG_MODE) {
  *           CVarSetInteger(CVAR_SAVE_FILE_MODE_NAME, DEBUG_SAVE_INFO_NONE);
  *
- * MM does not merely READ the shared key with a different default — it WRITES 0
- * into it at ShipInit whenever debug mode is off, which is the default state.
- * "Once written the shared value governs both; only the unwritten fallback
- * differs" is therefore not a benign observation: MM's registrar is the writer,
- * so the key is never left unwritten and OoT's default is destroyed on every
- * launch.
+ * so the key was never left unwritten and OoT's default was destroyed on every
+ * launch. That write is now RETIRED and MM's read default aligned to OoT's 1 in
+ * the same change that moved the key into kSharedIntentKeys — so the manifest
+ * only claims (S) against source that no longer contains the (P)-making write.
  *
- * DORMANT BUT ARMED. games/mm/CMakeLists.txt excludes 2s2h/DeveloperTools/
- * wholesale from the single-exe build, so the clobber does not run today. It
- * arms on the same un-elision work ADR 0004 §5 schedules — which is precisely
- * why it is recorded rather than left to be discovered then.
+ * An empty aggregate array literal (`= {}`) is ill-formed under MSVC (C2466: an
+ * array may not have zero size), so the empty table is expressed as a null
+ * pointer with an explicit zero count rather than an empty brace-init. The
+ * disputed-key loop in test_cvar_classification.c is bounded by the count and so
+ * never dereferences the pointer.
  *
- * The key stays HERE rather than moving into kSharedIntentKeys, because the
- * table should not claim (S) while games/mm still contains the write that makes
- * it (P). Retiring MM's clobber and aligning its read default is a BEHAVIOUR
- * change in a different lane's file; when it lands, move this key into
- * kSharedIntentKeys (count 25 -> 26) in the same commit as the fix, so the diff
- * is verifiable against the fixed source.
- *
- * Do not converge, split, or re-default this key as a side effect of other work.
+ * Do not converge, split, or re-default DebugSaveFileMode as a side effect of
+ * other work; it is a deliberate (S) now, not an accident.
  */
-inline constexpr const char* kDisputedClassificationKeys[] = {
-    "gDeveloperTools.DebugSaveFileMode",
-};
+inline constexpr const char* const* kDisputedClassificationKeys = nullptr;
+inline constexpr std::size_t kDisputedClassificationKeyCount = 0;
 
 /**
  * Menu-index keys: shared spelling, and the value names or indexes into a
@@ -427,8 +423,8 @@ inline constexpr std::size_t kMustStayDistinctCount = sizeof(kMustStayDistinct) 
 inline constexpr std::size_t kSharedIntentKeyCount = sizeof(kSharedIntentKeys) / sizeof(kSharedIntentKeys[0]);
 inline constexpr std::size_t kDeliberateSharedCheatKeyCount =
     sizeof(kDeliberateSharedCheatKeys) / sizeof(kDeliberateSharedCheatKeys[0]);
-inline constexpr std::size_t kDisputedClassificationKeyCount =
-    sizeof(kDisputedClassificationKeys) / sizeof(kDisputedClassificationKeys[0]);
+// kDisputedClassificationKeyCount is defined at the (now-empty) table itself,
+// because that table is a null pointer with no sizeof to divide — see there.
 inline constexpr std::size_t kMenuIndexKeyCount = sizeof(kMenuIndexKeys) / sizeof(kMenuIndexKeys[0]);
 
 // Tier 1 (#34) landed 9 keys — 6 audio + 3 tunic. #462 adds 23 of the inventory
@@ -437,20 +433,20 @@ inline constexpr std::size_t kMenuIndexKeyCount = sizeof(kMenuIndexKeys) / sizeo
 // silently dropped or double-added row a compile error.
 static_assert(kConvergedKeyCount == 32, "tier 1 (9) + inventory §5.3 remainder (23 of 26; 3 held out) = 32");
 
-// ADR 0003 Appendix B measured 26 class-(S) collisions. This table carries 25:
-// DebugSaveFileMode was pulled out into kDisputedClassificationKeys because the
-// inventory reclassified it (P) and #454 has not settled it. Pinning the count
-// makes a silent drop a compile error rather than a quietly weaker lock.
-static_assert(kSharedIntentKeyCount == 25,
-              "ADR 0003 Appendix B's 26 class-(S) keys, less DebugSaveFileMode — ruled (P) by #497 step 1 on "
-              "MM's DeveloperTools.cpp write, not on the default divergence");
+// ADR 0003 Appendix B measured 26 class-(S) collisions, and this table now
+// carries all 26: DebugSaveFileMode rejoined when #454 was fixed (MM's clobber
+// retired, read default aligned to OoT's 1). Pinning the count makes a silent
+// drop a compile error rather than a quietly weaker lock.
+static_assert(kSharedIntentKeyCount == 26,
+              "ADR 0003 Appendix B's 26 class-(S) keys, including DebugSaveFileMode — restored to (S) by #454 "
+              "once MM's DeveloperTools.cpp write was retired and its read default aligned to OoT's 1");
 static_assert(kMenuIndexKeyCount == 4, "four menu-index keys — #451");
-// The disputed table had no pinned count, so a silent drop would have retired
-// the one thing both readings agree on (never converge this key) with no
-// compile error. Pinned like every other table here.
-static_assert(kDisputedClassificationKeyCount == 1,
-              "one disputed key — gDeveloperTools.DebugSaveFileMode, ruled (P) and held here until MM's "
-              "clobber is retired (#497 step 1)");
+// The disputed table is empty since #454's fix. Pinned at 0 like every other
+// table here, so a key silently re-added to it is a compile error rather than a
+// quietly reopened dispute.
+static_assert(kDisputedClassificationKeyCount == 0,
+              "no disputed keys — gDeveloperTools.DebugSaveFileMode was resolved to (S) and moved into "
+              "kSharedIntentKeys by #454");
 
 } // namespace RSBS
 

--- a/src/common/tests/test_cvar_classification.c
+++ b/src/common/tests/test_cvar_classification.c
@@ -260,6 +260,27 @@ TestResult Test_CVarClassification(void) {
         CVARCLASS_CHECK(covers, "a retired family prefix covers no converged legacy key — it is stale");
     }
 
+    // #454: gDeveloperTools.DebugSaveFileMode is now genuine class (S). The
+    // count static_asserts in cvar_shared_keys.h pin the SIZES (26 shared, 0
+    // disputed), but not the identity — 26 could be reached by adding some other
+    // key while this one silently vanished. Pin the identity too: the key is IN
+    // kSharedIntentKeys and NOT in the disputed table.
+    {
+        bool sharedHasDebugSave = false;
+        for (std::size_t i = 0; i < RSBS::kSharedIntentKeyCount; i++) {
+            if (strcmp(RSBS::kSharedIntentKeys[i], "gDeveloperTools.DebugSaveFileMode") == 0) {
+                sharedHasDebugSave = true;
+                break;
+            }
+        }
+        CVARCLASS_CHECK(sharedHasDebugSave,
+                        "gDeveloperTools.DebugSaveFileMode must be in kSharedIntentKeys after #454 (S) resolution");
+        for (std::size_t d = 0; d < RSBS::kDisputedClassificationKeyCount; d++) {
+            CVARCLASS_CHECK(strcmp(RSBS::kDisputedClassificationKeys[d], "gDeveloperTools.DebugSaveFileMode") != 0,
+                            "gDeveloperTools.DebugSaveFileMode is back in the disputed table — #454 reopened");
+        }
+    }
+
     // ------------------------------------------------------------------
     // (2) The migrator's decision rules (ADR 0003 §6.3).
     //


### PR DESCRIPTION
## What

Executes the fix specified by the header comment in `cvar_shared_keys.h:383-399`.

`gDeveloperTools.DebugSaveFileMode` was ruled class (P) — but **not** on its divergent defaults. It was ruled (P) because MM's registrar *writes* into the shared cell:

```c
// games/mm/2s2h/DeveloperTools/DeveloperTools.cpp, RegisterDebugMode()
if (!CVAR_DEBUG_MODE) {
    CVarSetInteger(CVAR_SAVE_FILE_MODE_NAME, DEBUG_SAVE_INFO_NONE);
```

Debug-off is the default state, so the key was never left unwritten and OoT's `1` was destroyed on every launch — falsifying ADR 0003 §4.1's "only the unwritten fallback differs" on its own terms.

This change:

1. **Retires that write.** The other `CVarSetInteger` calls in the block are MM-only cvars and stay.
2. **Aligns MM's read default to OoT's `1`** (`DEBUG_SAVE_INFO_VANILLA_DEBUG`). The enumerators already match value-for-value (NONE=0, VANILLA_DEBUG=1, COMPLETE=2), so the two games now agree on the unwritten fallback.
3. **Moves the key into `kSharedIntentKeys` (25 → 26)** in the same change, as the header instructed, so the diff is verifiable against the fixed source and the manifest never claims (S) while the (P)-making write still exists.
4. **Updates the ADR rows to match**: ADR 0003 §4.1 (row restored, count back to 26) and §Status; ADR 0004 §2d + §5 row P5; plus the `enhancement-classification.md` inventory (BUG 2, P5, intro, and the §7 counts — DebugSaveFileMode moves from the bug bucket into (S): MATCH 33→34, (S) total 59→60, bugs 2→1).
5. **`BenMenu.cpp` gains `.DefaultIndex(1)`** on the Debug Save File Mode combobox, matching OoT's `SohMenuDevTools.cpp` — without it the widget would display "Empty Save" while the game reads `1`.

## Dormancy

`games/mm/CMakeLists.txt:254` elides `2s2h/DeveloperTools/` (and `2s2h/BenGui/`) from the single-exe build, so the clobber never ran in `redship` and this is not a live behaviour change there. It is fixed ahead of un-elision rather than deferred to it, so whichever lane un-elides `DeveloperTools` inherits a key that is already (S).

## The MSVC zero-size-array problem

Emptying `kDisputedClassificationKeys` cannot be done with `= {}` — an empty aggregate array literal is ill-formed under MSVC (C2466, "array may not have zero size"). The empty table is expressed instead as a **null pointer with an explicit zero count**, and `kDisputedClassificationKeyCount` is defined at the table rather than via `sizeof`. The disputed-key loop in `test_cvar_classification.c` is bounded by that count, so it never dereferences the pointer. Both static_asserts are re-pinned (shared 26, disputed 0) so a silent re-add is a compile error.

The test also gains a positive identity lock: the counts alone could be satisfied by adding some other key while this one vanished, so it now asserts DebugSaveFileMode is *in* `kSharedIntentKeys` and *not* in the disputed table.

## Testing

- Local ROM-staged build (MSVC/Ninja, `--parallel 4`): clean, compiles under MSVC with the empty table.
- `ctest -L "^redship$"`: **77/77 passed** (`CVarClassification` included), baseline on `main` also 77/77.
- Reviewed by a 5-lens adversarial pass; its confirmed findings (doc self-contradictions in `enhancement-classification.md`, and the missing `BenMenu` `.DefaultIndex`) are fixed in this PR.

Fixes #454.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!--- section:artifacts:start -->
### Build Artifacts
  - [rsbs-windows.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/8837668180.zip)
  - [rsbs-linux.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/8837547286.zip)
<!--- section:artifacts:end -->