### PR TITLE
Record 2026-08-04 rulings: retire ADR 0009's stale netplay claim (#584), lock increment-2 fill budget (#582)

### DIFF
--- a/docs/adr/0009-combo-settings-and-reverse-pool.md
+++ b/docs/adr/0009-combo-settings-and-reverse-pool.md
@@ -1,7 +1,8 @@
 # ADR 0009: Combo settings author in CVars and identify by digest; the reverse pool is a second origin-keyed table behind a pre-generation gate
 
 - Status: **Accepted** (2026-07-22); **decisions 1 and 2 amended 2026-07-30**
-  under the one-game-semantics ruling
+  under the one-game-semantics ruling; **the `reserved[]` byte budget amended
+  2026-08-04** under the #584 operator ruling
 - For: #498 (combo-level settings), gating #493 (MM -> OoT foreign items); Phase
   3.1 tracker #492, Lane 1
 - Amended: **2026-07-30, #564** (the one-game ruling is recorded on
@@ -14,6 +15,15 @@
   claim 3's *rationale* is restated where it leaned on decision 1. Each
   amendment sits at the end of its decision, with the original reasoning kept
   above it so the decision trail stays legible.
+- Amended: **2026-08-04, #584** (operator ruling: claim 4, "Netplay grant
+  fields, 64 B", double-counted a carve **PR #473**/ADR 0005 already spent
+  the day before this ADR was created; the claim is retired as already spent,
+  not reduced. Two carves that landed after this ADR shipped and were never
+  recorded — `commitGeneration` (#569) and `mmPairedAttempt` (#581) — are
+  added so the table reconciles to `src/common/context.h`'s actual
+  `reserved[124]`.) See the amendment inside "The `reserved[264]` byte
+  budget" below; the table's original rows are kept for the trail and marked,
+  not deleted.
 - Depends on:
   - **[ADR 0002](0002-origin-tagged-shared-items.md)** (Accepted) — the origin-tag
     invariant and the `ComboContext` growth contract every carve below obeys.
@@ -345,10 +355,12 @@ Publishing the allocation once beats five sequential re-versions:
 | 1 | `foreignPlacementsOoT[8]` (#493 step 2, Lane 1) | 48 B | **carved by this arc** |
 | 2 | `comboSettingsHash` (#498 decision 1, Lane 1) | 4 B | reserved |
 | 3 | MM option-profile digest (#497 step 7 / #499 step 4, Lane 4) | 4 B | **carved by Lane 4; size CONFIRMED at 4 B** |
-| 4 | Netplay grant fields (#460, ADR 0005/0007) | 64 B | reserved |
+| 4 | Netplay grant fields (#460, ADR 0005/0007) | 64 B | ~~reserved~~ **RETIRED 2026-08-04 (#584)** — already spent by PR #473, see amendment below |
 | 5 | `sharedResources[8]` (#525, shared rupees + hearts + magic) | 32 B | **carved by #525** |
 | 6 | `sharedResourcesExt[12]` (#525 optional tier, shared ammo) | 48 B | **carved by #525** |
 | 7 | Unallocated floor | 84 B | must not drop below 64 |
+| 8 | `commitGeneration` (#569, one-game-persistence commit-generation stamp) | 4 B | **carved** — PR #569, merged 2026-07-31; missing from this table until the 2026-08-04 (#584) amendment |
+| 9 | `mmPairedAttempt` (#581, ADR 0010 increment 1.2 / accepted answer O3) | 4 B | **carved** — PR #581, merged 2026-08-02; missing from this table until the 2026-08-04 (#584) amendment |
 
 Total reserved-against: 152 B of 284. After claims 1, 3, 5 and 6 land, `reserved[]`
 is 132 bytes and 152 B of capacity remain.
@@ -423,6 +435,47 @@ Nothing here re-opens the floor or the table. It records that "a save-side recor
 would be a second settings store" must not be re-used as an argument against
 freezing identity — it is the sentence #564 struck.
 
+### Amendment — claim 4 retired, table reconciled to `context.h` (2026-08-04, #584)
+
+**Claim 4, retired 2026-08-04 (#584 operator ruling).** This claim
+double-counted a carve that had already landed. `grantCursors[8]` (64 B,
+offset 672) and `sharedItemOverflowCount` (4 B, offset 736) were carved by
+**PR #473** (ADR 0005), merged **2026-07-21T20:46:51Z** — one day before this
+ADR was created (2026-07-22, per the Status line above). The `reserved[264]`
+baseline / 284-byte capacity this section opens with is measured *after* that
+carve (ADR 0005 §5: `reserved[332]` shrinks to `reserved[264]`), so claim 4's
+"Netplay grant fields … 64 B … reserved" row asked for the same 64 bytes a
+second time — once implicitly, by starting the count at 264 rather than 332,
+and once explicitly, as an outstanding line in this table. ADR 0007 (the
+grant-relay transport that actually shipped netplay) confirms this from the
+consumer side: its §5.2 states plainly that it carves "**nothing** from
+`reserved[]`" and that "`reserved[264]` at offset 740 is left wholly to ADR
+0005's successors." There is no further netplay carve to make. Claim 4 is
+retired, not reduced — the work it named was already done, by a different
+ADR, before this one existed.
+
+**Reconciling the table to `src/common/context.h` (re-derived 2026-08-04).**
+Two carves landed after this ADR shipped and were never recorded here:
+`commitGeneration` (**#569**, one-game-persistence commit-generation stamp, 4
+B, offset 872) and `mmPairedAttempt` (**#581** / ADR 0010 increment 1.2,
+accepted answer O3, 4 B, offset 876) — rows 8-9 above. Following the table
+from its 264-byte start: 264 − 48 (claim 1) − 4 (claim 3) − 32 (claim 5) − 48
+(claim 6) − 4 (claim 8, #569) − 4 (claim 9, #581) = **124**, matching
+`reserved[124]` at `context.h:705` exactly (its start offset, 880, is
+876 + 4 — the byte immediately after `mmPairedAttempt`).
+
+**Corrected arithmetic: outstanding claims vs. the 64-byte floor.** With
+claim 4 retired, the only claim still outstanding against `reserved[]` is
+**claim 2** (`comboSettingsHash`, 4 B — not yet carved as of this amendment;
+verified absent from `context.h`). `124 − 4 = 120`, which clears the 64-byte
+floor with 56 bytes to spare. This retires the alarm both `context.h:701-704`
+and issue #584 raised — that outstanding claims "2 and 4 (4 + 64) would leave
+56, UNDER the 64-byte floor" — because that arithmetic depended on claim 4
+still being live. It is not. No format-version bump, no
+`RSBS_COMBO_CONTEXT_RECORD_SIZE` raise, and no record-size change are owed by
+this correction; it is bookkeeping only, and nothing in decisions 1-3 above
+changes.
+
 Two constraints on anyone spending from this:
 
 - **Keep `reserved[]` at 64 bytes or more.** `Test_SaveComboRecordFixed`'s
@@ -481,3 +534,17 @@ Added by the 2026-07-30 amendments (#564):
   vanilla-Termina revert with nowhere to live; the refusal surface is shared
   with #533's refused-load surface rather than invented per producer (#564's
   one-authority persistence model, REFUSAL).
+
+Added by the 2026-08-04 amendment (#584):
+
+- **Claim 4 ("Netplay grant fields, 64 B") is retired, not reduced.** It was
+  already spent by PR #473/ADR 0005 the day before this ADR was created; the
+  264-byte baseline the budget table opens with was already computed after
+  that carve, so counting it again as an outstanding claim double-counted the
+  same 64 bytes.
+- **The table now carries rows 8-9** (`commitGeneration` #569,
+  `mmPairedAttempt` #581) so it reconciles to `reserved[124]`, the figure
+  actually in `src/common/context.h` as of this amendment.
+- **Only claim 2 remains outstanding.** `comboSettingsHash` (4 B) is the sole
+  unspent claim; landing it leaves `reserved[120]`, clear of the 64-byte
+  floor by 56 bytes.

--- a/docs/adr/0010-cross-game-logic-and-beatability.md
+++ b/docs/adr/0010-cross-game-logic-and-beatability.md
@@ -583,6 +583,24 @@ and is "option 1 with the bytes thrown away"):
 - Cost acknowledged: SeedDeterminism / MMRandoGen / HeadlessForeignDigest
   digests re-pin.
 
+**2026-08-04 operator decision (#582) — the fill budget.** PR #581's
+increment-1 review measured the open question this section's "Creation-time
+compute budget" cost flagged as owed: under the heavy Glitchless profile, 14
+of 66 master seeds' first attempts failed, and every one of those 14 was the
+fill's 10-second wall-clock abort — zero were deterministic dead-ends
+(100% wall-clock abort, 0% dead-ends). The operator ruled on that evidence:
+**increment 2 ships with a visible generation-progress surface and a ~30
+second cap as the floor, layered with a per-attempt adaptive budget
+calibrated to host speed.** This preserves PR #581 §2a's determinism rule —
+a timeout never climbs a ladder rung, because a wall-clock abort is a
+function of machine speed, not of the seed, and letting it advance the
+ladder would hand two players on different hardware two different worlds
+under one frozen identity. The adaptive per-attempt budget changes how long
+a slow host waits before that rule fires; it does not change the rule. Sizing
+the ~30s floor, the adaptive calibration, and the progress surface's copy is
+left to the increment-2 implementer; #582 stays open as that epic's
+implementation tracker.
+
 Increment 2 is the **prerequisite of increment 3**: a single-bag fill is a
 single generation event by definition — both worlds' placements must be
 decided at one seam before either spoiler exists.
@@ -598,7 +616,10 @@ union bag and places across both games' shuffled check sets, per Decisions
   unimplemented; #493's named gap); the ADR-0002-clean boundary language
   (origin-tagged `SharedItem` + host check id + game-neutral bounds — exact
   scalars and carve budget: accepted answer O7, the increment-3 epic sizes
-  the carve against `reserved[132]` under the append-only second-block rule);
+  the carve against `reserved[132]` [corrected 2026-08-04, #584: now
+  `reserved[124]` — two carves (#569, #581) landed after this ADR was
+  accepted; see ADR 0009's byte-budget amendment] under the append-only
+  second-block rule);
   the negation-ban and constraint-bitset disciplines in force in both graphs
   (Decision 2.3, enforcement: answer O6, all three mechanisms); MM's
   crawl join-fix landed (increment 1.3); the solver-inventory audit and the
@@ -650,7 +671,7 @@ bidirectional), license mechanics (→ D10).)
 | O3 | **Attempt-ladder spec**: hash recipe and separator, max attempts, where the attempt index is recorded in save + spoiler, terminal-failure UX copy on the #533 surface | **Accepted as recommended**: the implementer picks the hash recipe/separator, the attempt maximum and the save+spoiler recording sites, bound by this ADR's determinism rules (the world stays a pure function of the frozen identity) and the #533/#568 terminal-failure surface |
 | O5 | **Canonical MM time-slice list**: redship has 45 (`Logic.h:20+`), OoTMM has 46 (missing `NIGHT2_AM_05_30`); adopt the u64 representation, add the slice or justify its absence, pin the list where both the crawl and any data port read it | **Accepted**: adopt the 46 slices — add `NIGHT2_AM_05_30` — with the u64 representation, pinned where both the crawl and any data port read it, **unless** the increment epic's source review justifies otherwise |
 | O6 | **Monotonicity enforcement mechanism** for lambda logic: review rule + grep/clang-tidy probe + a CI check that adds items and asserts the reachable set never shrinks — which combination, and where it runs | **Accepted: all three mechanisms**, not a choice among them — the review rule, the static probe (grep/clang-tidy over the lambda logic), and the CI grow-check that adds items and asserts the reachable set never shrinks |
-| O7 | **Boundary/constraint carrier scalars and carve budget**: exactly which game-neutral fields cross (SharedItem + host check id + earliness bound?), sized against `reserved[132]` under the append-only second-block rule and the 64-byte floor | **Accepted**: the increment-3 epic sizes the carve, against `reserved[132]` under the append-only second-block rule and the 64-byte floor |
+| O7 | **Boundary/constraint carrier scalars and carve budget**: exactly which game-neutral fields cross (SharedItem + host check id + earliness bound?), sized against `reserved[132]` under the append-only second-block rule and the 64-byte floor | **Accepted**: the increment-3 epic sizes the carve, against `reserved[132]` under the append-only second-block rule and the 64-byte floor [corrected 2026-08-04, #584: the live figure is `reserved[124]`, not 132 — the #569 and #581 carves landed after this answer was ratified; the append-only rule and the 64-byte floor are unaffected, and this correction does not reopen O7's answer] |
 | O8 | **Shared-item classification authority**: one owner per shared item's junk/progression/renewable classification (OoTMM's `SHARED_BOMBCHU` two-settings wart is the cautionary tale) | **Accepted**: a single-owner classification table, one owner per shared item, living in the sanctioned ADR 0002 TU pair (`src/common/shared_items.h` / `src/common/shared_items.c`, deliberately free of game headers) — never a per-game duplicate that can disagree with itself |
 | O10 | **Combo triforce-hunt accounting**: one shared piece count across both worlds (a shared-resource-style carrier) vs per-half counts ANDed/ORed; both engines' existing piece machinery is the substrate | **Decided: ONE shared triforce piece count across both worlds**, carried shared-resource-style — not per-half composition. Both engines' existing piece machinery (OoT `RSK_TRIFORCE_HUNT_PIECES_*`, MM `RO_TRIFORCE_PIECES_*`) is the substrate feeding that one combo-level count |
 | O11 | **Shipped default rung** of the logic ladder (`beatable(T = ∅)` is the conservative candidate; base `none` is the operator's named audience) — and whether the default GOAL stays `beat-both` | **Decided: "copy what ship has for the rando settings."** At source, Ship of Harkinian defaults logic to Glitchless (`RSK_LOGIC_RULES` → `RO_LOGIC_GLITCHLESS`, `settings.cpp:1282`), every trick to "Disabled" (`TrickOption`'s default index 0, `option.cpp:361-364`), and `RSK_ALL_LOCATIONS_REACHABLE` to `RO_GENERIC_ON` (`settings.cpp:1283`). The combo's shipped default follows those defaults: the **proved, no-tricks rung** — `beatable(T = ∅)` — and **never** the base `none` rung, despite `none` being the operator's named audience. SoH's all-locations-reachable default carries through on the strictness axis §1.2 keeps per-half, which in ladder terms presents as `all-reachable(T = ∅)` if the combo surfaces strictness as a rung rather than as the per-half axis; that presentation choice is the increment epic's, and either way the default is the strictest SoH ships. Consistent with increment 1.1's paired-MM flip to Glitchless. **Default GOAL stays `beat-both`**: SoH has no combo-GOAL precedent to copy, and OoTMM's own `goal` likewise defaults to `'both'` (§1.1) |
@@ -728,14 +749,21 @@ is accepted (listed here; deliberately not filed by this ADR):
   fixpoint itself is cheap — but MM's 10s Glitchless wall-clock abort
   (`GlitchlessLogic.cpp:64`) is unmeasured under creation flow and must be
   measured, not assumed, before increment 2 ships. Re-roll time is a
-  budgeted product cost.
+  budgeted product cost. **Measured and decided 2026-08-04 (#582, PR #581):**
+  14/66 heavy-profile first attempts failed, 100% of those by wall-clock
+  abort and 0% by dead-end — the abort is the *dominant* failure mode, not a
+  tail case. The operator decision (see increment 2 above) is a visible
+  generation-progress surface plus a ~30s floor, layered with a per-attempt
+  adaptive budget keyed to host speed; #582 remains open as the
+  implementation tracker.
 - **Determinism re-pins, twice**: increment 2 re-pins the
   SeedDeterminism/MMRandoGen/HeadlessForeignDigest rows; increment 3 re-pins
   everything again when the fill unifies. Batched deliberately; never
   silently.
 - **Increment 3's blast radius is the largest in the phase**: both fills'
   ordering, the spoiler identity (one artifact, both worlds — #564 V23),
-  boundary carve bytes against a 132-byte budget with a 64-byte floor, and
+  boundary carve bytes against a 132-byte budget [corrected 2026-08-04, #584:
+  now a 124-byte budget — see ADR 0009's amendment] with a 64-byte floor, and
   the CI tier cost (MM logic needs registrars + a live save; the `rando`
   label runs under a display and is skipped by `--test all`). Budget for
   slower feedback.


### PR DESCRIPTION
Records two 2026-08-04 operator rulings as dated ADR amendments. Docs-only.

## Ruling A — #584: the 64-byte netplay claim is stale bookkeeping

ADR 0009 claim 4 ("Netplay grant fields, 64 B") double-counted a carve PR #473 (ADR 0005, merged `2026-07-21T20:46:51Z`) already spent — one day *before* ADR 0009 was created (`2026-07-22`). ADR 0009's `reserved[264]` / 284-byte starting capacity is computed *after* that carve, so counting claim 4 again as an outstanding line item asked for the same 64 bytes twice.

- Re-derived the live figure directly from `src/common/context.h:705`: `reserved[124]` (verified, not copied from the issue).
- ADR 0009: claim 4 marked **retired** (original row kept, struck through, for the trail — not deleted); added the two carve line items missing from the table (`commitGeneration` #569, `mmPairedAttempt` #581); added a full dated amendment section reconciling `264 − 48 − 4 − 32 − 48 − 4 − 4 = 124`; corrected the outstanding-claims-vs-floor arithmetic (only claim 2 remains, `124 − 4 = 120`, clear of the 64-byte floor by 56 bytes — not under it, as `context.h`'s own comment and #584 feared).
- ADR 0010: fixed the three now-stale `reserved[132]` references (~:601, the O7 ratified answer at ~:653, ~:738) with bracketed dated correction notes citing #584. The O7 ratified text itself is left intact per instruction — only a correction note is appended after it.

## Ruling B — #582: increment-2 fill budget

Operator ruling: ADR 0010 increment 2 ships with a visible generation-progress surface and a ~30s cap as the floor, layered with a per-attempt adaptive budget calibrated to host speed — preserving PR #581 §2a's "a timeout never climbs a ladder rung" determinism rule. Basis: PR #581's measurement of 14/66 heavy-profile first-attempt failures, 100% wall-clock abort, 0% dead-ends.

- Recorded as a dated decision in ADR 0010's increment-2 section and cross-referenced from the Consequences → "Creation-time compute budget" bullet.
- #582 stays **open** — it remains the increment-2 epic's implementation tracker.

## Scope

Docs-only: `docs/adr/0009-combo-settings-and-reverse-pool.md` and `docs/adr/0010-cross-game-logic-and-beatability.md`. Nothing outside `docs/` touched; rides the docs-bypass CI path.

Fixes #584
Refs #582

🤖 Generated with [Claude Code](https://claude.com/claude-code)
