### PR TITLE
Whole-file commit: a durable save commits both halves, and the newest whole commit wins (#589, #531)

### DIFF
--- a/CMake/SingleExecutable.cmake
+++ b/CMake/SingleExecutable.cmake
@@ -555,6 +555,16 @@ if(BUILD_TESTING)
     redship_add_test(NAME CommitGenerationMonotonic COMMAND redship --test commit-generation-monotonic)
     redship_add_test(NAME CommitTornWrite COMMAND redship --test commit-torn-write)
     redship_add_test(NAME CommitGenerationSkew COMMAND redship --test commit-generation-skew)
+    # Whole-file commit (#589, operator ruling 2026-08-04) — the read half of
+    # the same machinery. A durable save-and-quit in EITHER half commits BOTH
+    # halves at ONE generation, and on load the newest WHOLE commit wins: its
+    # Tier-2 is armed and delivered over OoT's older .sav. That is what
+    # structurally retires #531 (a durable RSBS_SHARED_ITEM_REDEEMED record
+    # outliving the item it accounts for = permanent loss of a progression
+    # item). Counterfactual: drop the Tier-2 arming from LoadSlot and
+    # WholeFileRedeemedItem goes red on the assertion that names the loss.
+    redship_add_test(NAME WholeFileCommit COMMAND redship --test whole-file-commit)
+    redship_add_test(NAME WholeFileRedeemedItem COMMAND redship --test whole-file-redeemed-item)
     redship_add_test(NAME Context COMMAND redship --test context)
     # F10 hot-swap freeze/consume contract (#364): the hotkey path must freeze
     # the DEPARTING game (or refuse the switch), and a consumed frozen state

--- a/docs/adr/0009-combo-settings-and-reverse-pool.md
+++ b/docs/adr/0009-combo-settings-and-reverse-pool.md
@@ -2,7 +2,8 @@
 
 - Status: **Accepted** (2026-07-22); **decisions 1 and 2 amended 2026-07-30**
   under the one-game-semantics ruling; **decision 4 added 2026-08-04** (#589,
-  whole-file commit) under the same ruling
+  whole-file commit) and **decision 4a decided 2026-08-05** (#589,
+  quit-to-title is a durable commit) under the same ruling
 - For: #498 (combo-level settings), gating #493 (MM -> OoT foreign items); Phase
   3.1 tracker #492, Lane 1
 - Amended: **2026-07-30, #564** (the one-game ruling is recorded on
@@ -21,7 +22,9 @@
   retires [#531](https://github.com/spencerduncan/redshipblueship/issues/531).
   Decisions 1-3 are unchanged. Added rather than amended because it decides a
   question none of them addressed: not what a save file *identifies*, but what
-  a save *commits*.
+  a save *commits*. **Decision 4a (2026-08-05)** closes the one question
+  decision 4 left open: quit-to-title is a durable commit — deliberate
+  autosave-on-quit, not a side effect.
 - Depends on:
   - **[ADR 0002](0002-origin-tagged-shared-items.md)** (Accepted) — the origin-tag
     invariant and the `ComboContext` growth contract every carve below obeys.
@@ -408,25 +411,53 @@ effect, by construction.
    erase, create, session reset) clears the claim with it. The #533 invariant
    that detection must never become data loss is unchanged.
 
-**Consequence to state plainly: OoT's exit-time commit becomes durable.**
-OoT's `OnExitGame` hook already committed on quit-to-title (`SaveManager.cpp`),
-and its Tier-2 — previously inert, because Tier-2 was never armed — is now the
-newest whole commit's OoT half. So a quit-to-title now resumes from the state
-at the quit, including the branch a player reaches by declining the death
-prompt's "Save?". That is the *atomic* answer and it is strictly better than
-the status quo ante, where that same quit already persisted Tier-1's REDEEMED
-records while discarding the world they accounted for — #531 by a second route.
-The alternative atomic answer is that a quit-without-saving should commit
-NOTHING, which means suppressing the exit-time commit rather than scoping the
-authority; that belongs to whoever owns that hook and is recorded as an open
-question on #589 rather than decided here.
-
 **Locks.** `whole-file-commit` and `whole-file-redeemed-item`
 (`src/common/tests/test_whole_file_commit.c`, CTest label `redship`) own the
 atomicity and authority claims and the #531 scenario end to end;
 `commit-generation-skew` keeps the detection claims;
 `mm-unified-save-capture` check 12 locks that a real MM route commits OoT's
 half too.
+
+### Decision 4a — quit-to-title is a DURABLE COMMIT (decided, not a consequence)
+
+> **2026-08-05, operator ruling on #589.** *Durable commit — keep the shipped
+> behavior. Quit-to-title commits the whole file at one generation; reload
+> resumes from the quit state. This is deliberate autosave-on-quit under the
+> one-game ruling, chosen over "commit nothing" partly because it atomically
+> closes #531's second route.*
+
+This shipped as a *consequence* of decision 4 and was raised as an open
+question; the ruling above **settles it as intended semantics**. The rationale
+below is the analysis that was put to the operator, kept verbatim as the
+reasoning behind the decision rather than as an argument still in flight.
+
+OoT's `OnExitGame` hook already committed on quit-to-title (`SaveManager.cpp`),
+and its Tier-2 — previously inert, because Tier-2 was never armed — is now the
+newest whole commit's OoT half. So a quit-to-title now resumes from the state
+at the quit, including the branch a player reaches by declining the death
+prompt's "Save?". That is the *atomic* answer and it is strictly better than
+the status quo ante, where that same quit already persisted Tier-1's REDEEMED
+records while discarding the world they accounted for — **#531's second route**,
+and the reason the ruling names it: an unsaved OoT leg that follows an MM leg
+would otherwise durably keep the REDEEMED records while discarding the items
+they account for, reproducing the exact loss decision 4 exists to retire.
+
+The alternative atomic answer — a quit-without-saving commits NOTHING, by
+suppressing the exit-time commit rather than scoping the authority — was
+**considered and rejected**. It is atomic too, but it leaves #531's second
+route open until the exit-time commit is restructured, and it trades a
+player-visible improvement (progress since the last save point survives a quit)
+for fidelity to a vanilla affordance that one-game semantics has already
+superseded elsewhere. Scoping the *authority* instead (e.g. by `sourceGame`)
+was rejected outright and must not be revisited: it reintroduces the loss —
+play past a save point after an MM leg, then quit without saving, and the
+REDEEMED records survive while the world does not.
+
+**What this obliges.** Quit-to-title is now a save route in every sense that
+matters, so it inherits the same rules as one: it commits through the #569
+choke point, it respects the #533/#568 write latch, and it must never commit a
+half. Anyone touching that hook (the #606 lane's region) is changing a *save*,
+not a teardown.
 
 ---
 

--- a/docs/adr/0009-combo-settings-and-reverse-pool.md
+++ b/docs/adr/0009-combo-settings-and-reverse-pool.md
@@ -1,7 +1,8 @@
 # ADR 0009: Combo settings author in CVars and identify by digest; the reverse pool is a second origin-keyed table behind a pre-generation gate
 
 - Status: **Accepted** (2026-07-22); **decisions 1 and 2 amended 2026-07-30**
-  under the one-game-semantics ruling
+  under the one-game-semantics ruling; **decision 4 added 2026-08-04** (#589,
+  whole-file commit) under the same ruling
 - For: #498 (combo-level settings), gating #493 (MM -> OoT foreign items); Phase
   3.1 tracker #492, Lane 1
 - Amended: **2026-07-30, #564** (the one-game ruling is recorded on
@@ -14,6 +15,13 @@
   claim 3's *rationale* is restated where it leaned on decision 1. Each
   amendment sits at the end of its decision, with the original reasoning kept
   above it so the decision trail stays legible.
+- Extended: **2026-08-04, [#589](https://github.com/spencerduncan/redshipblueship/issues/589)**
+  — decision 4 applies the same one-game ruling to durable commits (a commit is
+  the WHOLE file; on load the newest whole commit wins), which structurally
+  retires [#531](https://github.com/spencerduncan/redshipblueship/issues/531).
+  Decisions 1-3 are unchanged. Added rather than amended because it decides a
+  question none of them addressed: not what a save file *identifies*, but what
+  a save *commits*.
 - Depends on:
   - **[ADR 0002](0002-origin-tagged-shared-items.md)** (Accepted) — the origin-tag
     invariant and the `ComboContext` growth contract every carve below obeys.
@@ -330,6 +338,95 @@ state by calling `ComboContext_Init()`, which `memset`s the whole struct
 automatically. The sites that genuinely need pairing are the explicit
 `Combo_ClearForeignPlacements` callers, the spoiler write/read pair, and the
 determinism digest.
+
+## Decision 4 — a durable commit is the WHOLE file; on load, the newest whole commit wins
+
+> **2026-08-04, operator ruling on [#589](https://github.com/spencerduncan/redshipblueship/issues/589).**
+> *Whole-file commit: any half's save-and-quit commits BOTH halves at one
+> generation, in one instant, through the existing #569 commit choke point; on
+> load, the newest whole commit wins.* Recorded here rather than in a new ADR
+> because it is the same one-game ruling decisions 1 and 2 were amended under
+> (#500/#564), applied to the durable-commit space instead of the identity
+> space: a paired OoT+MM slot is ONE save, so divergence between its halves is
+> corruption, not choice.
+
+**The question.** #589 asked what a save-and-quit in one half of a cross-game
+session commits. Before this ruling the honest answer was "half the file": MM's
+owl save captured MM's half into the `.redsave` while OoT's half stayed at
+OoT's last durable write, and OoT's `file{N+1}.sav` was never rewritten because
+an MM-side commit cannot reach OoT's own save flow. #569 made that divergence
+*visible* — a monotonic commit generation stamped into both artifacts, compared
+at load, rendered as `[STALE: cross-game progress is newer than the OoT save]`
+— without making it *correct*.
+
+**The decision, in two halves.**
+
+*Write.* Every durable commit carries the whole file: the saving half live
+(refreshed from its own `gSaveContext` on the game thread immediately before
+staging) and the other half from its frozen shadow, which is that half's true
+state as of when it was last live. One monotonic generation, one instant, one
+choke point (`rsbs::SaveManager::StageCommit`). No route commits a half.
+
+*Read.* The generation names which artifact holds the newest WHOLE commit, and
+every tier of that commit wins together. When the `.redsave`'s generation is
+newer than the one OoT's `.sav` mirrors, the `.redsave`'s Tier-2 is OoT's half
+at that commit: `LoadSlot` arms it and OoT's load seam consumes it into the
+live `SaveContext` before `Sram_OpenSave` interprets the file. Detection
+becomes authority.
+
+**What this retires.** [#531](https://github.com/spencerduncan/redshipblueship/issues/531)
+(P1, permanent loss of cross-game progression items) is retired
+*structurally*, not patched. Its mechanism was a durable
+`RSBS_SHARED_ITEM_REDEEMED` record outliving the world state it accounted for:
+the record rode Tier-1 into the `.redsave`, the item rode only OoT's live
+`SaveContext`, the load committed the former and discarded the latter, and the
+redeem loop skips a REDEEMED entry forever. Under whole-file commit the record
+and the world it was redeemed into are tiers of the same commit — they are
+restored together or not at all, so the shape has no representation. Note what
+this is *not*: it is not the redemption-staging residue #531's own comment
+sketched (flags staged until a commit whose world tier contains the effect).
+Staging was the right fix for a world where commits were partial. Once a commit
+is whole, the record is already in a commit whose world tier contains its
+effect, by construction.
+
+**Boundaries — three things the ruling does NOT say.**
+
+1. **It is not "the `.redsave` always wins".** Equal generations, and either
+   artifact at the pre-stamp 0, claim no authority: the `.sav` delivers OoT's
+   half exactly as before. An unconditional arm would race a redundant or
+   legacy copy of OoT's world against the file the engine just loaded — the
+   original reason Tier-2 was left unarmed, which is correct for those cases
+   and only those.
+2. **It is not freshness arbitration in both directions.** The inverse skew
+   (OoT's `.sav` newer, i.e. a `.redsave` commit is MISSING) still REFUSES at
+   full #533 strength: no commit, evidence quarantined, slot write-latched.
+   Committing a rolled-back Tier-1 would resurrect already-consumed shared-item
+   records and roll MM's only persistence back. "Newest whole commit wins"
+   presumes both artifacts are intact; a missing commit is corruption.
+3. **A REFUSED slot has no authoritative half.** Refusal is checked before any
+   authority is claimed, and every release event (successful load, explicit
+   erase, create, session reset) clears the claim with it. The #533 invariant
+   that detection must never become data loss is unchanged.
+
+**Consequence to state plainly: OoT's exit-time commit becomes durable.**
+OoT's `OnExitGame` hook already committed on quit-to-title (`SaveManager.cpp`),
+and its Tier-2 — previously inert, because Tier-2 was never armed — is now the
+newest whole commit's OoT half. So a quit-to-title now resumes from the state
+at the quit, including the branch a player reaches by declining the death
+prompt's "Save?". That is the *atomic* answer and it is strictly better than
+the status quo ante, where that same quit already persisted Tier-1's REDEEMED
+records while discarding the world they accounted for — #531 by a second route.
+The alternative atomic answer is that a quit-without-saving should commit
+NOTHING, which means suppressing the exit-time commit rather than scoping the
+authority; that belongs to whoever owns that hook and is recorded as an open
+question on #589 rather than decided here.
+
+**Locks.** `whole-file-commit` and `whole-file-redeemed-item`
+(`src/common/tests/test_whole_file_commit.c`, CTest label `redship`) own the
+atomicity and authority claims and the #531 scenario end to end;
+`commit-generation-skew` keeps the detection claims;
+`mm-unified-save-capture` check 12 locks that a real MM route commits OoT's
+half too.
 
 ---
 

--- a/games/mm/2s2h/mm_unified_save_test.cpp
+++ b/games/mm/2s2h/mm_unified_save_test.cpp
@@ -138,6 +138,34 @@
  *      invariant in tools/tests/test_repo_invariants.py
  *      (test_titlesetup_transitions_are_guarded_or_marked_exempt). Neither
  *      lock is sufficient alone; together they cover decision and wiring.
+ *
+ * ---------------------------------------------------------------------------
+ * #589 EXTENSION: an MM save commits the WHOLE file, not MM's half of it.
+ *
+ * Checks 1-11 are all about MM's own half. The operator's 2026-08-04 ruling on
+ * #589 says a durable save-and-quit in EITHER half commits BOTH halves, at one
+ * generation, in one instant: the saving half live, the other half from its
+ * frozen shadow. Check 12 locks that from MM's side, where it is checkable
+ * against a REAL route rather than against the choke point in isolation.
+ *
+ *  12. An MM owl-shaped marshal commits OoT's half too. The OoT shadow is
+ *      stamped with a pattern of its own before the marshal; the reloaded
+ *      Tier-2 must carry it back WHOLE, alongside MM's Tier-3, at the single
+ *      generation the commit advanced. Two ways this goes red: a commit that
+ *      captured only the saving half (Tier-2 comes back zeroed or stale), and
+ *      a commit that took a generation per half.
+ *
+ *      This is also where #589's SIBLING concern is settled: func_8014546C's
+ *      owl branch memcpys only offsetof(SaveContext, fileNum) bytes. That
+ *      truncation is REAL and it is vanilla MM behaviour — but its destination
+ *      is sramCtx->saveBuf, MM's N64 flash staging buffer, whose writer is a
+ *      no-op stub in single-exe builds. The .redsave capture is a separate,
+ *      full-width Context_UpdateShadowCopy of sizeof(SaveContext), so the
+ *      truncation cannot reach the unified commit. The check asserts that
+ *      relationship instead of asserting the absence of a bug: the route probe
+ *      must sit PAST offsetof(SaveContext, fileNum), so a commit that ever
+ *      inherited the owl memcpy's width would fail checks 6 and 12 rather than
+ *      pass them by accident.
  */
 
 #include "global.h"
@@ -210,6 +238,27 @@ void ArmCrossGameSaveContext(u8 stamp) {
 void PoisonMMShadow(uint8_t value) {
     std::vector<uint8_t> poison(MM_SAVE_CONTEXT_SIZE, value);
     Context_UpdateShadowCopy(GAME_MM, poison.data(), poison.size());
+}
+
+// The OoT half, as the frozen shadow a cross-game MM session leaves behind it
+// (#589 check 12). Filled uniformly so "came back WHOLE" is a scan, not a
+// spot check.
+void FillOoTShadow(uint8_t value) {
+    std::vector<uint8_t> oot(OOT_SAVE_CONTEXT_SIZE, value);
+    Context_UpdateShadowCopy(GAME_OOT, oot.data(), oot.size());
+}
+
+bool OoTShadowIsUniform(uint8_t value) {
+    const uint8_t* oot = static_cast<const uint8_t*>(Context_GetOoTSaveContext());
+    if (oot == nullptr) {
+        return false;
+    }
+    for (size_t i = 0; i < OOT_SAVE_CONTEXT_SIZE; i++) {
+        if (oot[i] != value) {
+            return false;
+        }
+    }
+    return true;
 }
 
 // Did `what` produce a real durable commit? Requires: the monotonic #537
@@ -492,6 +541,49 @@ extern "C" int MM_UnifiedSaveCapture_RunHeadless(void) {
                      "the committed blob must carry the rolled-over cycle's reset count too");
     }
 
+    // ---- 12. An MM save commits the WHOLE file (#589) ---------------------
+    // Runs here, on the owl-shaped marshal, because the owl statue is the
+    // route the ruling was written about ("a save-and-quit in one half"). The
+    // OoT half is stamped with a pattern of its own before the marshal — that
+    // is what a cross-game MM session actually has resident: the frozen shadow
+    // the crossing left behind. The commit must carry it, whole, at the SAME
+    // single generation advance CommitReached already requires.
+    //
+    // Without this, an MM save is a HALF-file commit: MM's half persists, OoT's
+    // half stays at whatever the .redsave last held, and the two halves of the
+    // ONE save drift apart — which is #589's title and #531's mechanism.
+    {
+        const uint8_t kOoTHalfPattern = 0x6D;
+        ArmCrossGameSaveContext(0xB8);
+        gSaveContext.save.isOwlSave = true;
+        PoisonMMShadow(0x00);
+        FillOoTShadow(kOoTHalfPattern);
+
+        const uint32_t gen = gComboCtx.commitGeneration;
+        func_8014546C(&sramCtx);
+        // CommitReached clears every shadow and reloads from the FILE, so both
+        // assertions below are about what reached disk, not about memory.
+        USAVE_ASSERT(CommitReached(kSlot, gen, 0xB8, "func_8014546C (owl branch, whole-file commit)"),
+                     "the owl route must still commit MM's half (#530)");
+        USAVE_ASSERT(OoTShadowIsUniform(kOoTHalfPattern),
+                     "an MM-side save must commit OoT's half too, WHOLE, at the same generation -- a save "
+                     "that persists only the saving half is a half-file commit (#589)");
+
+        // #589's sibling concern, settled by construction rather than by
+        // assertion-of-absence. func_8014546C's owl branch memcpys only
+        // offsetof(SaveContext, fileNum) bytes into sramCtx->saveBuf -- real,
+        // vanilla, and confined to MM's N64 flash staging buffer, whose writer
+        // is a no-op stub in single-exe. The unified capture is a separate
+        // full-width Context_UpdateShadowCopy(sizeof(SaveContext)). Pinning the
+        // route probe PAST that width is what makes the distinction
+        // falsifiable: if the commit ever inherited the owl memcpy's bound, the
+        // stamp check inside CommitReached above would fail rather than pass by
+        // accident.
+        USAVE_ASSERT(RouteProbeOffset() > offsetof(SaveContext, fileNum),
+                     "the route probe must sit past the owl marshal's truncated memcpy width, or check 12 "
+                     "cannot distinguish a full-width commit from an owl-width one (#589)");
+    }
+
     // ---- 8. The commit gates hold at the NEW call sites --------------------
     // (a) #533/#568 write latch: a slot this session never loaded, created, or
     //     erased stays unwritten, and the monotonic generation must not move --
@@ -519,10 +611,10 @@ extern "C" int MM_UnifiedSaveCapture_RunHeadless(void) {
         USAVE_ASSERT(RsbsSave_IsSlotWritable(kSlot) == 0, "an identity refusal must latch the slot (#570)");
 
         ArmCrossGameSaveContext(0xB6);
-        // A day the last PERMITTED commit (7b's new cycle) cannot have, so the
-        // reload below can tell the refused world from the kept one. 7b's
-        // end-of-cycle zeroed masksGivenOnMoon, so the tail stamp alone can no
-        // longer distinguish them.
+        // A day the last PERMITTED commit (check 12's, day 0) cannot have, so
+        // the reload below can tell the refused world from the kept one. The
+        // tail stamp alone cannot: 7b's end-of-cycle zeroes masksGivenOnMoon,
+        // so the probe field is not a reliable discriminator here.
         const s32 kRefusedDay = 9;
         gSaveContext.save.day = kRefusedDay;
         PoisonMMShadow(0x00);
@@ -542,9 +634,8 @@ extern "C" int MM_UnifiedSaveCapture_RunHeadless(void) {
         s32 keptDay = -1;
         memcpy(&keptDay, mm + offsetof(SaveContext, save.day), sizeof(keptDay));
         USAVE_ASSERT(keptDay != kRefusedDay, "an identity-refused slot must not have absorbed the refused world");
-        USAVE_ASSERT(keptDay == 0,
-                     "an identity-refused slot must still hold the LAST permitted commit (7b's new cycle), "
-                     "not the refused one");
+        USAVE_ASSERT(keptDay == 0, "an identity-refused slot must still hold the LAST permitted commit (check 12's), "
+                                   "not the refused one");
         USAVE_ASSERT(mm[RouteProbeOffset()] != 0xB6, "the refused commit's tail must not have reached the file either");
     }
 

--- a/games/oot/soh/SaveManager.cpp
+++ b/games/oot/soh/SaveManager.cpp
@@ -43,6 +43,12 @@ extern "C" SaveContext gSaveContext;
 // surface; it is called immediately before each .redsave write below so the
 // pool never lags the OoT blob stored beside it.
 extern "C" void OoT_HarvestSharedResources(void);
+// Whole-file commit, read side (#589/#531), defined in src/common/switch.cpp.
+// Restores the armed OoT blob into the live gSaveContext and RETIRES it in the
+// same call (#364's single-use contract). Declared rather than included for the
+// same narrow-surface reason as the harvest above; z_play.c declares it the
+// same way.
+extern "C" int Combo_ConsumeFrozenState(const char* gameId, void* saveContext, size_t size);
 using namespace std::string_literals;
 
 void SaveManager::WriteSaveFile(const std::filesystem::path& savePath, const uintptr_t addr, void* dramAddr,
@@ -227,10 +233,40 @@ SaveManager::SaveManager() {
         // A .sav-newer mismatch (a .redsave commit is missing) refuses
         // through the full #533 machinery — quarantine, write latch, file
         // panel — because committing the rolled-back Tier-1 would resurrect
-        // consumed shared-item records; a .redsave-newer mismatch (an MM-side
-        // commit landed after OoT's last save point, the #531 loss shape)
-        // loads and is surfaced as SlotMeta.commitSkew.
+        // consumed shared-item records; a .redsave-newer mismatch means the
+        // .redsave holds a WHOLE commit this .sav does not, and the newest
+        // whole commit wins (#589).
         RsbsSave_LoadSlotChecked(fileNum, this->GetLoadedCommitGeneration());
+
+        // WHOLE-FILE COMMIT, delivery seam (#589/#531, operator ruling
+        // 2026-08-04). This hook fires at the TAIL of LoadFile — every section
+        // has already been applied to the live gSaveContext — so it is the one
+        // point that is both after the .sav is fully in memory and before
+        // Sram_OpenSave interprets it (entrance fixups, health floor, spoiling
+        // items). If the load found a newer whole commit in the .redsave, its
+        // Tier-2 is OoT's half at that commit and is now armed; consume it
+        // here so the file resumes from the newest whole commit rather than
+        // from a .sav that predates it.
+        //
+        // Without this, the load is the #531 machine: Tier-1's REDEEMED
+        // shared-item records commit (they ride the same Tier-1 the choke
+        // point just restored) while the OoT world they were redeemed INTO
+        // does not, the redeem loop skips those entries forever, and the item
+        // is permanently gone.
+        //
+        // fileNum is carried across the restore deliberately. The blob is
+        // OoT's own SaveContext from this same slot, so its fileNum agrees —
+        // but "agrees" is an inference about how the blob was captured, and
+        // every later save addresses the file through this field. Re-asserting
+        // the slot the player actually opened costs two lines and removes the
+        // inference.
+        if (RsbsSave_TakeOoTHalfAuthority()) {
+            const int32_t openedFileNum = gSaveContext.fileNum;
+            Combo_ConsumeFrozenState("oot", &gSaveContext, sizeof(gSaveContext));
+            gSaveContext.fileNum = openedFileNum;
+            SPDLOG_INFO("RSBS: applied the .redsave's OoT half over file{}.sav (newer whole commit, #589)",
+                        fileNum + 1);
+        }
     });
 
     GameInteractor::Instance->RegisterGameHook<GameInteractor::OnDeleteFile>([](int32_t fileNum) {

--- a/src/common/ComboMenuBar.cpp
+++ b/src/common/ComboMenuBar.cpp
@@ -409,16 +409,19 @@ void ComboMenuBar::DrawFileSelect() {
             ImGui::TextUnformatted(meta.mmStarted ? "[MM v]" : "[MM _]");
 
             if (meta.commitSkew > 0) {
-                // #531/#537: the last load of this slot observed the .redsave
-                // carrying a NEWER commit generation than OoT's own save — an
-                // MM-side commit landed after OoT's last save point, so OoT's
-                // world resumed older than the cross-game records that account
-                // for it. Loading proceeds (this is the designed post-MM-commit
-                // state), but the divergence must be player-visible, not
-                // stderr-only.
-                ImGui::TextColored(ImVec4(0.95f, 0.75f, 0.25f, 1.0f),
-                                   "[STALE: cross-game progress is newer than the OoT save]");
-                ImGui::TextDisabled("Items delivered to OoT after its last save point may be missing.");
+                // #531/#589: the last load of this slot observed the .redsave
+                // carrying a NEWER whole commit than OoT's own save — a commit
+                // landed after OoT's file was last written (an MM-side save,
+                // or OoT's exit snapshot). Under the 2026-08-04 whole-file
+                // commit ruling that is no longer a loss warning: the commit
+                // captured OoT's half too, and the load applies it, so the two
+                // halves resume at ONE instant. Reported rather than dropped
+                // because the player's OoT file on disk really is older than
+                // what they just resumed from, and that is worth knowing
+                // before they go looking for it with an external tool.
+                ImGui::TextColored(ImVec4(0.55f, 0.85f, 0.55f, 1.0f),
+                                   "[SYNCED: cross-game progress newer than the OoT save, applied]");
+                ImGui::TextDisabled("Resumed from the newest whole commit; both halves at one instant.");
             }
         }
 

--- a/src/common/context.h
+++ b/src/common/context.h
@@ -643,7 +643,11 @@ typedef struct {
     // lost or the file was replaced from elsewhere. Detection lives in the
     // load itself (rsbs::SaveManager::LoadSlot, via CompareCommitGenerations):
     // a .sav-newer mismatch REFUSES through the #533 machinery, a
-    // .redsave-newer mismatch loads and surfaces as SlotMeta.commitSkew.
+    // .redsave-newer mismatch loads and — since the 2026-08-04 whole-file
+    // commit ruling (#589) — makes the .redsave's Tier-2 the AUTHORITY for
+    // OoT's half of that load, not merely a warning on SlotMeta.commitSkew.
+    // That is what retires #531: the generation names which artifact holds the
+    // newest WHOLE commit, and every tier of that commit wins together.
     //
     // Zero == unset (no commit has ever been stamped), the growth contract's
     // required meaning: a zero-extended legacy record reads 0 and is exempt

--- a/src/common/save.cpp
+++ b/src/common/save.cpp
@@ -184,6 +184,17 @@ uint32_t SaveManager::StageCommit() {
     // point (#537). Serialization source = the context-layer shadow copies.
     // Both must be present (Context_InitFrozenStates run); otherwise there is
     // nothing to capture and we refuse rather than stage a half-empty commit.
+    //
+    // WHOLE-FILE COMMIT (#589, operator ruling 2026-08-04). Reading BOTH
+    // shadows here is not an implementation convenience, it is the ruling:
+    // a durable save-and-quit in either half commits the WHOLE file — the
+    // saving half live (its caller refreshed its own shadow from the live
+    // gSaveContext immediately before staging, on this thread) and the other
+    // half from its frozen shadow, which is that half's true state as of when
+    // it was last live. One generation, one instant, both halves. That is what
+    // makes the REDEEMED shared-item records in Tier-1 and the world they were
+    // redeemed INTO inseparable, and it is why a partial stage is a refusal
+    // rather than a best-effort write.
     const void* ootShadow = Context_GetOoTSaveContext();
     const void* mmShadow = Context_GetMMSaveContext();
     if (ootShadow == nullptr || mmShadow == nullptr) {
@@ -575,8 +586,13 @@ RsbsLoadOutcome SaveManager::LoadSlot(int slot, uint32_t ootSavGeneration) {
         return RSBS_LOAD_REFUSED;
     }
     // The skew record describes what THIS load attempt observed; stale
-    // observations from an earlier load of the slot do not carry over.
+    // observations from an earlier load of the slot do not carry over. The
+    // whole-file authority signal (#589) is dropped for the same reason, and
+    // for a second one: it is dropped BEFORE the read, so every early return
+    // below — absent, refused, sticky-refused, commit-skew — leaves no
+    // authority claim behind. A refused slot has no authoritative half.
     mSlotSkew[slot] = 0;
+    mOoTHalfAuthoritySlot = -1;
 
     SlotFileData data;
     RsbsRefuseReason reason = RSBS_REFUSE_NONE;
@@ -645,18 +661,30 @@ RsbsLoadOutcome SaveManager::LoadSlot(int slot, uint32_t ootSavGeneration) {
         return RSBS_LOAD_REFUSED;
     }
     if (skew > 0) {
-        // The .redsave is NEWER than OoT's .sav: an MM-side commit (owl save,
-        // exit capture) landed after OoT's last save point. This is the
-        // designed post-MM-commit state — an MM-side commit cannot rewrite
-        // OoT's own file — so the load proceeds, but it is exactly the #531
-        // loss shape: OoT's world resumes older than the cross-game records
-        // that account for it (an item delivered to OoT after its last save
-        // may be missing while marked REDEEMED). Recorded and surfaced in the
-        // file panel via SlotMeta.commitSkew; the record-staging fix that
-        // retires the loss itself is #531's residue.
+        // The .redsave carries a whole commit OoT's own file does not: a
+        // commit landed after OoT's .sav was last written (an MM-side owl
+        // save / new cycle / autosave, or OoT's own exit-time snapshot). An
+        // MM-side commit cannot rewrite OoT's file, so this is the designed
+        // post-commit state and refusing it would refuse every ordinary MM
+        // session's reload.
+        //
+        // WHOLE-FILE COMMIT (#589, 2026-08-04): this used to be a warning and
+        // nothing more — the load proceeded, Tier-2 was left unarmed, and OoT
+        // resumed from its older .sav while Tier-1's RSBS_SHARED_ITEM_REDEEMED
+        // records (which the same commit made durable) stood. That is #531
+        // exactly: the record outlives the item it accounts for, the redeem
+        // loop skips the entry forever, and a progression item is gone.
+        //
+        // Under the ruling the detection becomes AUTHORITY. The commit that
+        // stamped this generation captured OoT's half in Tier-2 at the same
+        // instant — the frozen shadow, i.e. OoT's true state as of when it was
+        // last live — so the newest whole commit's Tier-2 IS OoT's half. Arm
+        // it, record the authority, and let OoT's load seam deliver it over
+        // the .sav the engine just applied. Record and world travel together;
+        // the loss becomes unrepresentable rather than merely visible.
         std::fprintf(stderr,
-                     "[RsbsSave] slot %d COMMIT SKEW: .redsave generation %u is NEWER than OoT's .sav "
-                     "generation %u — OoT's world is stale relative to the cross-game records (#531).\n",
+                     "[RsbsSave] slot %d WHOLE-FILE COMMIT: .redsave generation %u is NEWER than OoT's .sav "
+                     "generation %u — the .redsave's OoT half is the authority for this load (#531/#589).\n",
                      slot, combo.commitGeneration, ootSavGeneration);
         mSlotSkew[slot] = 1;
     }
@@ -687,11 +715,36 @@ RsbsLoadOutcome SaveManager::LoadSlot(int slot, uint32_t ootSavGeneration) {
     // the next crossing produced. That is the read-side half of "MM will be
     // reset after game restart".
     //
-    // MM ONLY, deliberately. OoT's own file{N+1}.sav is the authority for OoT
-    // state and is applied by Sram_OpenSave on the normal load path; arming
-    // Tier-2 as well would race a second, staler copy of OoT's world against
-    // it. MM has no such per-game file in single-exe — the unified slot is its
-    // only persistence — so Tier-3 is the one that needs delivering.
+    // MM ALWAYS; OoT only when the whole commit is newer than OoT's own file.
+    //
+    // RENEGOTIATED by the 2026-08-04 whole-file-commit ruling (#589). The
+    // original rule here was "MM only, deliberately: OoT's own file{N+1}.sav
+    // is the authority for OoT state, arming Tier-2 too would race a second,
+    // staler copy of OoT's world against it". The staleness argument is
+    // exactly right for the case it was written for and exactly backwards for
+    // the case below it:
+    //
+    //   - generations AGREE (or either artifact predates the stamp): Tier-2
+    //     and the .sav were authored by the same commit, or the .redsave makes
+    //     no authority claim at all. Arming would at best duplicate the .sav
+    //     and at worst race a legacy copy. Stay unarmed — unchanged.
+    //   - the .redsave is NEWER: there is no second, staler copy to race. The
+    //     .sav is the stale one, by a generation the same commit stamped into
+    //     both artifacts, and Tier-2 is the only record of OoT's half at that
+    //     commit. Arming it is what makes the file whole again.
+    //
+    // The safety property the second case rests on, stated because it is an
+    // invariant of OTHER code and would break silently: the OoT shadow is
+    // refreshed at every point where OoT stops being live (both crossing paths
+    // and the F10 hot swap freeze it) AND at every OoT save (SaveSection
+    // refreshes it in the same breath as writing the .sav). So a committed
+    // Tier-2 is never OLDER than the .sav it is being compared against, and
+    // "newer generation" cannot deliver a rolled-back OoT world. A future
+    // commit route that stages without refreshing OoT's shadow first would
+    // violate that and must not exist.
+    //
+    // MM has no per-game file in single-exe at all — the unified slot is its
+    // only persistence — so Tier-3 is delivered unconditionally, as before.
     //
     // Arming is refused for an all-zero tier (see Context_ArmShadowAsFrozen),
     // which is exactly a slot saved before the player ever entered MM: that
@@ -712,6 +765,41 @@ RsbsLoadOutcome SaveManager::LoadSlot(int slot, uint32_t ootSavGeneration) {
     const int armed = Context_ArmShadowAsFrozen(GAME_MM, MM_ENTR_SOUTH_CLOCK_TOWN_0);
     std::fprintf(stderr, "[RsbsSave] slot %d loaded; MM half %s\n", slot,
                  armed ? "armed for restore" : "empty (MM will cold-boot)");
+
+    // The OoT half of the newest whole commit (#589). Same machinery, same
+    // all-zero refusal (a slot that never held an OoT world has nothing to
+    // deliver, and restoring a zeroed SaveContext over the file the engine
+    // just loaded would be strictly worse than the .sav it replaces).
+    //
+    // The return entrance is the OoT-side twin of the MM arming's floor: the
+    // .redsave does not serialize either game's frozen return entrance, so use
+    // the same cross-game arrival entrance the real freeze records for this
+    // direction (out of the Happy Mask Shop). It is a floor, not a policy —
+    // the seam below consumes this blob immediately, before any consumer of
+    // the return entrance runs, and a slot-resume that wants its own spawn
+    // policy overrides it later. What it must NOT be is 0: entrance presence
+    // is tracked by a separate flag, so 0 is a real consumable id (see the MM
+    // arming above, where 0 spawned Link inside the Mayor's Residence).
+    if (mSlotSkew[slot] > 0) {
+        if (Context_ArmShadowAsFrozen(GAME_OOT, OOT_ENTR_MARKET_FROM_MASK_SHOP)) {
+            mOoTHalfAuthoritySlot = slot;
+            std::fprintf(stderr,
+                         "[RsbsSave] slot %d OoT half armed from the .redsave: the whole commit in the "
+                         ".redsave is newer than OoT's own .sav, so its Tier-2 is the authority (#531/#589)\n",
+                         slot);
+        } else {
+            // An all-zero Tier-2 with a newer generation is not a state any
+            // commit this build authors can produce (StageCommit copies the
+            // OoT shadow whole, and a slot only reaches a non-zero generation
+            // through a commit). Name it rather than silently falling back:
+            // the .sav delivers OoT's half, which is the pre-ruling behaviour
+            // and still safe.
+            std::fprintf(stderr,
+                         "[RsbsSave] slot %d has a newer whole commit but an EMPTY OoT half; falling back to "
+                         "OoT's own .sav for this load (#589)\n",
+                         slot);
+        }
+    }
 
     // A successful load is one of the three legitimate arming events, and it
     // retires any earlier refusal record — if a loadable file is back at the
@@ -768,6 +856,9 @@ void SaveManager::DeleteSave(int slot) {
     mSlotArmed[slot] = true;
     mSlotRefused[slot] = RSBS_REFUSE_NONE;
     mSlotSkew[slot] = 0;
+    if (mOoTHalfAuthoritySlot == slot) {
+        mOoTHalfAuthoritySlot = -1;
+    }
 }
 
 void SaveManager::ArmSlotOnCreate(int slot) {
@@ -788,6 +879,11 @@ void SaveManager::ArmSlotOnCreate(int slot) {
     mSlotArmed[slot] = true;
     mSlotRefused[slot] = RSBS_REFUSE_NONE;
     mSlotSkew[slot] = 0;
+    if (mOoTHalfAuthoritySlot == slot) {
+        // A brand-new file authors its own OoT half; nothing loaded can be
+        // authoritative over it (#589).
+        mOoTHalfAuthoritySlot = -1;
+    }
 }
 
 bool SaveManager::IsSlotWritable(int slot) const {
@@ -898,10 +994,25 @@ void SaveManager::ResetSlotSessionState() {
         mSlotRefused[i] = RSBS_REFUSE_NONE;
         mSlotSkew[i] = 0;
     }
+    mOoTHalfAuthoritySlot = -1;
 }
 
 int SaveManager::GetSlotCommitSkew(int slot) const {
     return SlotInRange(slot) ? mSlotSkew[slot] : 0;
+}
+
+bool SaveManager::OoTHalfIsAuthoritative() const {
+    return mOoTHalfAuthoritySlot >= 0;
+}
+
+bool SaveManager::TakeOoTHalfAuthority() {
+    // One-shot (#589). The armed Tier-2 blob is single-use by the #364 frozen
+    // -blob contract, so the signal that drives its consumption retires with
+    // it: a second caller must not be told to re-apply a blob that has already
+    // been consumed and retired.
+    const bool authoritative = mOoTHalfAuthoritySlot >= 0;
+    mOoTHalfAuthoritySlot = -1;
+    return authoritative;
 }
 
 void SaveManager::RegisterGameMeta(GameId game, const RsbsGameMetaDesc* desc) {
@@ -1092,6 +1203,14 @@ int RsbsSave_GetSlotCommitSkew(int slot) {
 
 int RsbsSave_CompareCommitGenerations(uint32_t redsaveGeneration, uint32_t ootSavGeneration) {
     return rsbs::SaveManager::CompareCommitGenerations(redsaveGeneration, ootSavGeneration);
+}
+
+int RsbsSave_TakeOoTHalfAuthority(void) {
+    return rsbs::SaveManager::Instance().TakeOoTHalfAuthority() ? 1 : 0;
+}
+
+int RsbsSave_OoTHalfIsAuthoritative(void) {
+    return rsbs::SaveManager::Instance().OoTHalfIsAuthoritative() ? 1 : 0;
 }
 
 int RsbsSave_Load(int slot) {

--- a/src/common/save.h
+++ b/src/common/save.h
@@ -167,15 +167,18 @@ struct SlotMeta {
     RsbsRefuseReason refuseReason;
     bool             hasQuarantine;
 
-    // #531/#564 V16 interim: the freshness relation the LAST checked load of
-    // this slot observed between the two durable artifacts of the ONE save.
+    // #531/#589 (whole-file commit, operator ruling 2026-08-04): the freshness
+    // relation the LAST checked load of this slot observed between the two
+    // durable artifacts of the ONE save.
     // 0 = agreed (or never compared / either artifact predates the stamp);
-    // +1 = the .redsave was NEWER than OoT's .sav — an MM-side commit landed
-    // after OoT's last save point, so OoT's world resumed older than the
-    // cross-game records that account for it (the #531 loss shape). The file
-    // panel renders this as a staleness warning. (-1, the .sav-newer case,
-    // never appears here: that load REFUSES instead — see
-    // RSBS_REFUSE_COMMIT_SKEW.) Session state, reset by erase/create/reset.
+    // +1 = the .redsave carried a NEWER whole commit than OoT's .sav — a
+    // commit landed after OoT's own file was last written (an MM-side owl
+    // save, or OoT's exit-time snapshot). Under whole-file commit that is not
+    // a warning any more: the .redsave's Tier-2 IS OoT's half at that commit,
+    // so the load ARMS it and OoT's load seam takes it (see LoadSlot and
+    // OoTHalfIsAuthoritative). (-1, the .sav-newer case, never appears here:
+    // that load REFUSES instead — see RSBS_REFUSE_COMMIT_SKEW.) Session state,
+    // reset by erase/create/reset.
     int commitSkew;
 };
 
@@ -274,23 +277,57 @@ public:
      * mirrors ("rsbsCommitGeneration"; 0 when absent/unknown — 0 exempts the
      * comparison entirely). The commit choke point stamps the same monotonic
      * generation into BOTH durable artifacts of the ONE save, so load is
-     * where their freshness is compared (#531/#564 V16 interim):
+     * where their freshness is compared — and, since the 2026-08-04 whole-file
+     * commit ruling (#589), where AUTHORITY is decided (#531):
      *
-     *   - equal, or either side pre-stamp (0): agreement; load proceeds.
-     *   - .redsave NEWER (an MM-side commit landed after OoT's last save
-     *     point): load proceeds — this is the designed post-MM-commit state,
-     *     refusing it would refuse every ordinary MM session's reload — but
-     *     the skew is RECORDED and surfaced in the file panel (SlotMeta
-     *     .commitSkew / GetSlotCommitSkew): OoT's world resumed older than
-     *     the cross-game records, the #531 loss shape. (The record-staging
-     *     residue that retires the loss itself is tracked in #531.)
+     *   - equal, or either side pre-stamp (0): agreement; load proceeds and
+     *     OoT's own .sav delivers OoT's half, exactly as before. A pre-stamp
+     *     artifact makes no authority claim: legacy files stay on the old
+     *     path rather than being adjudicated on evidence they do not carry.
+     *   - .redsave NEWER: the .redsave carries a whole commit that OoT's own
+     *     file does not. Under the ruling a durable commit is the WHOLE file
+     *     — the saving half live, the other half from its frozen shadow, one
+     *     generation — so its Tier-2 IS OoT's half at that commit, and the
+     *     newest whole commit wins. The load therefore ARMS Tier-2 as well as
+     *     Tier-3 and reports OoTHalfIsAuthoritative() so OoT's load seam
+     *     takes it into the live SaveContext. This is what structurally
+     *     retires #531: the REDEEMED shared-item records in Tier-1 and the
+     *     world they were redeemed INTO now travel together, so a record can
+     *     no longer outlive the item it accounts for. Still recorded on the
+     *     slot (SlotMeta.commitSkew / GetSlotCommitSkew) — the panel now
+     *     reads it as "cross-game progress newer than the OoT save, applied"
+     *     rather than as a loss warning.
      *   - .sav NEWER (a .redsave commit is MISSING — lost write or foreign
      *     file): REFUSED before committing, through the full #533 machinery
      *     (quarantine + write latch + panel surface), because committing the
      *     rolled-back Tier-1 would resurrect consumed shared-item records
-     *     and roll back MM's world.
+     *     and roll back MM's world. UNCHANGED by the ruling: "the newest
+     *     whole commit wins" is not "arbitrate freshness in both directions"
+     *     — a missing commit is corruption to refuse, and a refused slot must
+     *     never lose to, or clobber, anything.
      */
     RsbsLoadOutcome LoadSlot(int slot, uint32_t ootSavGeneration = 0);
+
+    /**
+     * Whole-file commit, read side (#589/#531). True iff the load that just
+     * ran found the .redsave's whole commit NEWER than OoT's .sav and
+     * therefore armed Tier-2 — i.e. OoT's half must come from the .redsave,
+     * not from the .sav that OoT's own loader just applied.
+     *
+     * TakeOoTHalfAuthority() is the ONE-SHOT form the load seam uses: it
+     * returns the same answer and clears the flag, so the authoritative half
+     * is delivered exactly once per load. One-shot on purpose — the armed
+     * Tier-2 blob is single-use (#364: a frozen blob that survives its own
+     * consumption is indistinguishable, on the next return leg, from one that
+     * was just frozen, and re-applying it rolls the player back), so the
+     * signal that drives the consumption has to retire with it.
+     *
+     * Cleared by every load attempt (including a refusal), by erase, by
+     * create, and by ResetSlotSessionState: a slot that was REFUSED has no
+     * authoritative half to deliver.
+     */
+    bool OoTHalfIsAuthoritative() const;
+    bool TakeOoTHalfAuthority();
 
     /** Compatibility wrapper: LoadSlot(slot) == RSBS_LOAD_OK. */
     bool Load(int slot);
@@ -523,10 +560,17 @@ private:
     bool             mSlotArmed[RSBS_SAVE_MAX_SLOTS]{};
     RsbsRefuseReason mSlotRefused[RSBS_SAVE_MAX_SLOTS]{};
 
-    // #531/#564 V16: the freshness relation the last checked load observed
+    // #531/#589: the freshness relation the last checked load observed
     // (see LoadSlot / GetSlotCommitSkew). 0 or +1; the -1 case refuses
     // through mSlotRefused instead.
     int mSlotSkew[RSBS_SAVE_MAX_SLOTS]{};
+
+    // #589 whole-file commit: the slot whose loaded Tier-2 is the
+    // authoritative OoT half and has been armed for restore, or -1 for none.
+    // One-shot: TakeOoTHalfAuthority clears it. Not per-slot storage — a
+    // session has at most one load in flight and exactly one live OoT
+    // SaveContext to deliver into.
+    int mOoTHalfAuthoritySlot = -1;
 
     // Game-side metadata descriptors, indexed by GameId (GAME_OOT / GAME_MM).
     // mMetaPresent[i] guards mMetaDescs[i]; an unset descriptor causes
@@ -561,19 +605,33 @@ uint32_t RsbsSave_StageCommit(void);
 int      RsbsSave_WriteStagedCommit(int slot);
 
 /**
- * Load with the cross-artifact freshness check (#531/#564 V16 interim; see
+ * Load with the cross-artifact freshness check (#531/#589; see
  * SaveManager::LoadSlot). `ootSavGeneration` is the commit generation the OoT
  * .sav JSON mirrors ("rsbsCommitGeneration", 0 when absent — exempt). Returns
  * the RsbsLoadOutcome as an int; a .sav-newer skew refuses through the full
  * #533 machinery (quarantine + latch + RSBS_REFUSE_COMMIT_SKEW), a
- * .redsave-newer skew loads and is surfaced via RsbsSave_GetSlotCommitSkew /
- * SlotMeta.commitSkew (0 agreed, +1 the #531 loss shape).
- * RsbsSave_CompareCommitGenerations is the pure comparison, exposed for the
- * headless locks.
+ * .redsave-newer skew loads, ARMS the .redsave's OoT half as the authority for
+ * this load (RsbsSave_TakeOoTHalfAuthority) and is surfaced via
+ * RsbsSave_GetSlotCommitSkew / SlotMeta.commitSkew (0 agreed, +1 the newest
+ * whole commit came from the .redsave). RsbsSave_CompareCommitGenerations is
+ * the pure comparison, exposed for the headless locks.
  */
 int RsbsSave_LoadSlotChecked(int slot, uint32_t ootSavGeneration);
 int RsbsSave_GetSlotCommitSkew(int slot);
 int RsbsSave_CompareCommitGenerations(uint32_t redsaveGeneration, uint32_t ootSavGeneration);
+
+/**
+ * Whole-file commit, read side (#589/#531; see SaveManager::TakeOoTHalfAuthority).
+ * RsbsSave_TakeOoTHalfAuthority returns 1 exactly once after a load whose
+ * .redsave carried a newer whole commit than OoT's .sav, and 0 otherwise. The
+ * caller — OoT's OnLoadFile seam, which runs after OoT's own sections have
+ * been applied to the live gSaveContext — answers a 1 by consuming the armed
+ * OoT blob (Combo_ConsumeFrozenState("oot", ...)) so the newest whole commit's
+ * OoT half is the one the file resumes from. RsbsSave_OoTHalfIsAuthoritative
+ * is the non-consuming peek, for panels and tests.
+ */
+int RsbsSave_TakeOoTHalfAuthority(void);
+int RsbsSave_OoTHalfIsAuthoritative(void);
 
 /**
  * #533 REFUSED-state surface. LoadSlot is RsbsSave_Load with the three-way

--- a/src/common/test_runner.cpp
+++ b/src/common/test_runner.cpp
@@ -220,6 +220,13 @@ extern "C" {
 // C++), same reason as above.
 #include "tests/test_commit_generation.c"
 
+// WHOLE-FILE COMMIT (#589, operator ruling 2026-08-04) — the read half of the
+// same machinery, and what structurally retires #531: one commit carries BOTH
+// halves at ONE generation, and on load the newest whole commit's OoT half is
+// the AUTHORITY rather than a warning. FILE SCOPE (compiled as C++), same
+// reason as above.
+#include "tests/test_whole_file_commit.c"
+
 // Lane C1 foreign-item pipeline locks (#392, ADR 0002): give-path tagging,
 // round-trip survival with a real pool entry, and the foreignPlacements carve
 // serialization. FILE SCOPE (compiled as C++) for rsbs::SaveManager; the
@@ -2254,8 +2261,15 @@ const TestDescriptor gTests[] = {
      Test_CommitGenerationMonotonic},
     {"commit-torn-write", "Post-stage mutation cannot reach the .redsave; the #537 tear is unrepresentable",
      Test_CommitTornWrite},
-    {"commit-generation-skew", "Load detects .redsave/.sav freshness divergence (#531/#564 V16)",
+    {"commit-generation-skew", "Load detects .redsave/.sav freshness divergence (#531/#589)",
      Test_CommitGenerationSkew},
+    // Whole-file commit (#589): a durable save in either half commits BOTH
+    // halves at one generation, and on load the newest whole commit wins —
+    // which is what retires #531's permanent item loss.
+    {"whole-file-commit", "One commit carries both halves; the newest whole commit is the authority (#589)",
+     Test_WholeFileCommit},
+    {"whole-file-redeemed-item", "A REDEEMED record and the world it was redeemed into survive together (#531)",
+     Test_WholeFileRedeemedItem},
     {"mm-scene-parse", "MM scene commands parse via the S2H factory (#344)", Test_MMSceneParse},
     {"seq-map-bounds", "Sequence-map capacity covers the id range + custom slack (#371, #378)", Test_SeqMapBounds},
     {"cvar-classification", "Cross-game CVar classification matches ADR 0003 + the inventory (#34)",

--- a/src/common/tests/test_commit_generation.c
+++ b/src/common/tests/test_commit_generation.c
@@ -20,13 +20,23 @@
  *   post-stage mutations would then be serialized.
  *
  *   commit-generation-skew — the load-time freshness comparison between the
- *   two durable artifacts, surfaced through the #533 machinery: agreement and
- *   the pre-stamp (0) exemptions load cleanly; a .redsave NEWER than the .sav
- *   (the #531 loss shape) loads but records +1 on the slot's panel surface;
- *   a .sav NEWER than the .redsave (a missing .redsave commit) REFUSES before
- *   committing — quarantine, write latch, RSBS_REFUSE_COMMIT_SKEW — because
- *   committing the rolled-back Tier-1 would resurrect consumed shared-item
- *   records and roll back MM's only persistence.
+ *   two durable artifacts: agreement and the pre-stamp (0) exemptions load
+ *   cleanly; a .redsave NEWER than the .sav loads and records +1 on the slot's
+ *   panel surface; a .sav NEWER than the .redsave (a missing .redsave commit)
+ *   REFUSES before committing — quarantine, write latch,
+ *   RSBS_REFUSE_COMMIT_SKEW — because committing the rolled-back Tier-1 would
+ *   resurrect consumed shared-item records and roll back MM's only
+ *   persistence.
+ *
+ *   DOCTRINE NOTE (2026-08-04, #589). What the +1 direction MEANS changed with
+ *   the whole-file-commit ruling: it used to be "the #531 loss shape, load and
+ *   warn", and is now "the .redsave holds the newest WHOLE commit, so its OoT
+ *   half is the authority for this load". This file still owns the DETECTION
+ *   claims — the comparison and its two exemptions, both directions' outcomes,
+ *   and the #533 refusal — while the AUTHORITY claims that detection now feeds
+ *   live in test_whole_file_commit.c. Splitting them that way is deliberate:
+ *   a regression in the comparison and a regression in what is done with it
+ *   are different bugs and should fail different tests.
  *
  * Linkage note: like test_save_roundtrip.c, this file is #included into
  * test_runner.cpp at FILE SCOPE (compiled as C++) so it can call the C++
@@ -273,17 +283,39 @@ TestResult Test_CommitGenerationSkew(void) {
     CG_ASSERT(RsbsSave_LoadSlotChecked(0, 0) == RSBS_LOAD_OK, "a pre-stamp .sav must be exempt at load");
     CG_ASSERT(RsbsSave_GetSlotCommitSkew(0) == 0, "the exemption must record no skew");
 
-    // ---- .redsave newer (+1): the #531 loss shape — load, but SURFACE it -
-    // An MM-side commit landed after OoT's last save point. Refusing here
-    // would refuse every ordinary MM session's reload, so the load proceeds;
-    // the divergence is recorded on the slot and reaches the file panel.
+    // ---- .redsave newer (+1): the newest WHOLE commit — load and SURFACE it
+    // A commit landed after OoT's last save point (an MM-side save, or OoT's
+    // exit snapshot). Refusing here would refuse every ordinary MM session's
+    // reload, so the load proceeds; the divergence is recorded on the slot and
+    // reaches the file panel.
+    //
+    // RENEGOTIATED 2026-08-04 (#589). This block used to assert only that the
+    // divergence was RECORDED, and its comment called it "the #531 loss shape"
+    // — i.e. it encoded ".sav always wins for OoT's half, so the load is lossy
+    // but visible" as required behaviour. Under the whole-file-commit ruling
+    // the same +1 means the .redsave carries a whole commit the .sav does not,
+    // and its Tier-2 is OoT's half at that commit. The recording assertions
+    // below are unchanged and still load-bearing (the panel surface and the
+    // slot's writability are both about detection); what this file no longer
+    // claims is that the detection ENDS there. test_whole_file_commit.c owns
+    // the authority claims.
     mgr.ResetSlotSessionState();
     ComboContext_Init();
     CG_ASSERT(RsbsSave_LoadSlotChecked(0, 1) == RSBS_LOAD_OK, "a redsave-newer slot must still load");
-    CG_ASSERT(RsbsSave_GetSlotCommitSkew(0) == 1, "the #531 loss shape must be recorded (+1)");
+    CG_ASSERT(RsbsSave_GetSlotCommitSkew(0) == 1, "the newer whole commit must be recorded (+1)");
     CG_ASSERT(mgr.ReadMeta(0).commitSkew == 1, "the skew must surface on the file-panel meta");
     CG_ASSERT(RsbsSave_IsSlotWritable(0) == 1, "a redsave-newer slot stays writable (next commit heals forward)");
     CG_ASSERT(mgr.GetSlotState(0) == RSBS_SLOT_VALID, "a redsave-newer slot is VALID, not REFUSED");
+    // The detection now hands off to the authority path (#589/#531): this load
+    // must have armed the .redsave's OoT half. Asserted here as well as in
+    // test_whole_file_commit.c because it is the ONE consequence of a +1 that
+    // must never silently disappear — a +1 that arms nothing is #531 restored.
+    CG_ASSERT(RsbsSave_OoTHalfIsAuthoritative() == 1,
+              "a redsave-newer load must claim OoT-half authority — detection without authority is #531");
+    // Retire the claim (and the armed blob) so the refusal case below starts
+    // from a clean session, exactly as the production load seam would.
+    CG_ASSERT(RsbsSave_TakeOoTHalfAuthority() == 1, "taking the authority must report it");
+    Context_ClearAllFrozenStates();
 
     // ---- .sav newer (-1): a .redsave commit is MISSING — REFUSE (#533) ---
     // Committing the rolled-back Tier-1 would resurrect consumed shared-item

--- a/src/common/tests/test_session_invalidation.c
+++ b/src/common/tests/test_session_invalidation.c
@@ -585,10 +585,17 @@ TestResult Test_SessionInvalidation(void) {
         // is 0, which put Link inside the Mayor's Residence. Must match what
         // the real hot-swap freeze records.
         SESSION_ASSERT(Context_GetFrozenReturnEntrance(GAME_MM) == MM_ENTR_SOUTH_CLOCK_TOWN_0);
-        // OoT stays unarmed on purpose: OoT's own file{N+1}.sav is the
-        // authority for OoT state and Sram_OpenSave applies it on the normal
-        // load path. Arming Tier-2 too would race a second, staler copy of
-        // OoT's world against it.
+        // OoT stays unarmed HERE, and the reason is narrower than it used to
+        // be. The original reason — "OoT's own file{N+1}.sav is the authority
+        // for OoT state, full stop" — was retired by the 2026-08-04 whole-file
+        // commit ruling (#589): when the .redsave carries a NEWER whole commit
+        // than the .sav, its Tier-2 IS OoT's half and the load arms it (see
+        // test_whole_file_commit.c). This load is the other case: mgr.Load()
+        // passes no .sav generation, so the comparison takes the pre-stamp
+        // exemption, the .redsave makes no authority claim, and Tier-2 must
+        // stay unarmed so it cannot race the copy of OoT's world that
+        // Sram_OpenSave is about to apply. Keeping this assertion is what
+        // stops the ruling from being implemented as a blanket "always arm".
         SESSION_ASSERT(Context_HasFrozenState(GAME_OOT) == 0);
 
         // ...and the complement, which is what stops the arming from being a

--- a/src/common/tests/test_whole_file_commit.c
+++ b/src/common/tests/test_whole_file_commit.c
@@ -1,0 +1,402 @@
+/**
+ * @file test_whole_file_commit.c
+ * @brief Headless locks for WHOLE-FILE COMMIT semantics (#589), which is what
+ *        structurally retires the #531 permanent-loss bug.
+ *
+ * THE RULING (operator, 2026-08-04, on #589). A paired OoT+MM slot is ONE save
+ * (#500/#564 one-game semantics). Therefore a durable save-and-quit in EITHER
+ * half commits BOTH halves — the saving half live, the other half from its
+ * frozen shadow, at ONE generation, in one instant, through the #569 commit
+ * choke point — and on load, the newest WHOLE commit wins.
+ *
+ * WHAT #531 WAS. The write half of that was already true: StageCommit copies
+ * Tier-1 + both shadows. The READ half was not. Load deliberately left Tier-2
+ * unarmed ("OoT's own file{N+1}.sav is the authority for OoT state"), so after
+ * an MM-side commit that landed later than OoT's last save point:
+ *
+ *   - Tier-1 committed, carrying RSBS_SHARED_ITEM_REDEEMED for a foreign item
+ *     that had been awarded to OoT's LIVE save on a cross-game arrival, and
+ *   - OoT resumed from its older .sav, which never contained that item.
+ *
+ * The redeem loop skips a REDEEMED entry unconditionally and forever
+ * (shared_items.c), so the record outlived the item it accounted for: the item
+ * was permanently gone and a paired seed could dead-end. The pre-ruling code
+ * DETECTED this (the commit-generation comparison from #569) and printed a
+ * warning. Detection is not authority; these locks are about authority.
+ *
+ * TWO LOCKS:
+ *
+ *   whole-file-commit — ATOMICITY and AUTHORITY as separable claims.
+ *     (a) One commit carries BOTH halves, full width, at ONE generation — not
+ *         one generation per half, and not a partial capture of either.
+ *     (b) A load whose .redsave carries a NEWER whole commit than OoT's .sav
+ *         ARMS the OoT half and reports it authoritative EXACTLY ONCE (the
+ *         armed blob is single-use, #364).
+ *     (c) Agreement and the pre-stamp (0) exemptions claim NO authority: the
+ *         .sav delivers OoT's half, exactly as before the ruling. This is the
+ *         check that stops the fix from being a blanket "the .redsave always
+ *         wins", which would race a legacy or equal-instant copy of OoT's
+ *         world against the file the engine just loaded.
+ *     (d) A REFUSED load (#533 / the .sav-newer direction) claims no authority
+ *         and commits nothing. The ruling is "the newest whole commit wins",
+ *         NOT "arbitrate freshness in both directions" — a missing .redsave
+ *         commit is still corruption to refuse.
+ *
+ *   whole-file-redeemed-item — the #531 scenario, end to end at the unit
+ *     level, with its own counterfactual built in: the test asserts that the
+ *     freshly-loaded .sav world does NOT contain the item (that is the losing
+ *     state, reproduced) and then that the whole-commit delivery puts it back
+ *     and leaves the REDEEMED record consistent with the world.
+ *     COUNTERFACTUAL: delete the Tier-2 arming from SaveManager::LoadSlot (or
+ *     the delivery seam this test mirrors from OoT's OnLoadFile hook) and this
+ *     test goes red on exactly the assertion that names the loss.
+ *
+ * Linkage note: like test_commit_generation.c, this file is #included into
+ * test_runner.cpp at FILE SCOPE (compiled as C++) so it can call the C++
+ * rsbs::SaveManager API.
+ */
+
+#include "../context.h"
+#include "../entrance.h"
+#include "../game.h"
+#include "../save.h"
+#include "../shared_items.h"
+#include "../test_runner.h"
+
+#include <cstdint>
+#include <cstdio>
+#include <cstring>
+#include <vector>
+
+// The delivery half of the whole-file commit lives in src/common/switch.cpp
+// (restore + retire in one call, #364). No header declares it — z_play.c and
+// OoT's SaveManager.cpp both take it by extern, and so does this file.
+extern "C" int Combo_ConsumeFrozenState(const char* gameId, void* saveContext, size_t size);
+
+#define WFC_ASSERT(cond, msg)                   \
+    do {                                        \
+        if (!(cond)) {                          \
+            printf("[TEST] FAIL: %s\n", (msg)); \
+            return TEST_FAIL;                   \
+        }                                       \
+    } while (0)
+
+namespace {
+
+const char* const kWholeFileTestDir = "rsbs_test_whole_file_commit";
+
+// A whole SaveContext-sized buffer standing in for a game's LIVE gSaveContext.
+// The headless tier cannot include either game's z64save.h (that is the whole
+// point of src/common), so a half is modelled as its blob: the same bytes the
+// context layer's shadow holds and the same bytes the .redsave stores.
+using HalfBlob = std::vector<uint8_t>;
+
+HalfBlob MakeOoTHalf(uint8_t fill) {
+    return HalfBlob(OOT_SAVE_CONTEXT_SIZE, fill);
+}
+
+HalfBlob MakeMMHalf(uint8_t fill) {
+    return HalfBlob(MM_SAVE_CONTEXT_SIZE, fill);
+}
+
+// "Full width" means EVERY byte, so this scans rather than spot-checking. A
+// prefix capture (the shape that has bitten this codebase twice: MM's excluded
+// SaveManager mirroring only sizeof(Save), and the owl marshal's
+// offsetof(SaveContext, fileNum) memcpy) leaves the tail at whatever a
+// different instant put there, which a first/last/middle sample can miss.
+bool HalfIsUniform(const void* blob, size_t size, uint8_t value) {
+    if (blob == nullptr) {
+        return false;
+    }
+    const uint8_t* bytes = static_cast<const uint8_t*>(blob);
+    for (size_t i = 0; i < size; i++) {
+        if (bytes[i] != value) {
+            return false;
+        }
+    }
+    return true;
+}
+
+// ---- #531 scenario scaffolding -------------------------------------------
+
+// Byte offset inside the OoT half standing in for the inventory slot a foreign
+// item lands in. Well past any header, and NOT byte 0, so a zeroed or
+// wrong-length blob cannot satisfy the "item present" check by accident.
+constexpr size_t kOoTBowSlot = 0x1200;
+constexpr uint8_t kOoTBowPresent = 0x3B;
+constexpr uint16_t kFairyBowId = 0x2A;
+
+// The award callback the arrival hook supplies to Combo_RedeemSharedItemsForGame:
+// it mutates only the LIVE save, which is precisely the asymmetry #531 lives
+// on — the flag it sets afterwards is durable, the mutation is not.
+void WholeFileAwardToLiveOoT(const SharedItem* item, void* ctx) {
+    if (item == nullptr || ctx == nullptr) {
+        return;
+    }
+    if (item->id != kFairyBowId) {
+        return;
+    }
+    static_cast<uint8_t*>(ctx)[kOoTBowSlot] = kOoTBowPresent;
+}
+
+}  // namespace
+
+TestResult Test_WholeFileCommit(void) {
+    printf("[TEST] whole-file-commit: one commit carries both halves; the newest whole commit wins (#589)\n");
+
+    rsbs::SaveManager& mgr = rsbs::SaveManager::Instance();
+    mgr.SetSaveDirectory(kWholeFileTestDir);
+
+    Context_InitFrozenStates();
+    Context_ClearAllFrozenStates();
+    ComboContext_Init();
+    mgr.ResetSlotSessionState();
+    mgr.DeleteSave(0);
+
+    // A warm-up commit first, so the whole commit below lands at a generation
+    // whose PREDECESSOR is a real stamp rather than the pre-stamp 0. The
+    // ".redsave newer" case has to be tested against a .sav that makes a
+    // claim; against 0 it would take the legacy exemption instead and the
+    // authority assertions would pass for the wrong reason.
+    {
+        HalfBlob warm = MakeOoTHalf(0x01);
+        HalfBlob warmMM = MakeMMHalf(0x02);
+        Context_UpdateShadowCopy(GAME_OOT, warm.data(), warm.size());
+        Context_UpdateShadowCopy(GAME_MM, warmMM.data(), warmMM.size());
+    }
+    WFC_ASSERT(mgr.Save(0), "the warm-up commit failed");
+
+    // ---- (a) ATOMICITY: both halves, full width, at ONE generation --------
+    // Distinct fills per half so a commit that captured one half twice, or
+    // captured either half short, is visible rather than plausible.
+    const uint8_t kOoTFill = 0x71;
+    const uint8_t kMMFill = 0x2E;
+    {
+        HalfBlob oot = MakeOoTHalf(kOoTFill);
+        HalfBlob mm = MakeMMHalf(kMMFill);
+        Context_UpdateShadowCopy(GAME_OOT, oot.data(), oot.size());
+        Context_UpdateShadowCopy(GAME_MM, mm.data(), mm.size());
+    }
+    gComboCtx.sourceGame = GAME_MM;  // an MM-side durable route, the #531 shape
+    gComboCtx.sharedFlags[2] = 0xFEEDFACEu;
+
+    const uint32_t genBefore = gComboCtx.commitGeneration;
+    WFC_ASSERT(mgr.Save(0), "the whole-file commit failed");
+    const uint32_t wholeGen = gComboCtx.commitGeneration;
+    WFC_ASSERT(wholeGen == genBefore + 1,
+               "a whole-file commit is ONE commit: both halves must share a single generation advance, "
+               "not take one each");
+
+    // The file, not the memory: wipe both shadows and Tier-1 before reloading.
+    Context_ClearAllFrozenStates();
+    ComboContext_Init();
+    WFC_ASSERT(HalfIsUniform(Context_GetOoTSaveContext(), OOT_SAVE_CONTEXT_SIZE, 0),
+               "test setup: the clear must have zeroed the OoT shadow");
+
+    WFC_ASSERT(RsbsSave_LoadSlotChecked(0, wholeGen) == RSBS_LOAD_OK, "the whole commit must load back");
+    WFC_ASSERT(gComboCtx.commitGeneration == wholeGen, "Tier-1 must carry the commit's generation");
+    WFC_ASSERT(gComboCtx.sharedFlags[2] == 0xFEEDFACEu, "Tier-1 content must survive the whole commit");
+    WFC_ASSERT(HalfIsUniform(Context_GetOoTSaveContext(), OOT_SAVE_CONTEXT_SIZE, kOoTFill),
+               "the OoT half must come back WHOLE from a commit authored while MM was live — this is the "
+               "other half the ruling requires every commit to carry");
+    WFC_ASSERT(HalfIsUniform(Context_GetMMSaveContext(), MM_SAVE_CONTEXT_SIZE, kMMFill),
+               "the MM half must come back whole from the same commit");
+
+    // ---- (c) AGREEMENT claims no authority --------------------------------
+    // The commit that stamped this generation also wrote OoT's .sav, so Tier-2
+    // and the .sav describe one instant. Arming here would race a redundant
+    // copy of OoT's world against the file the engine just loaded.
+    WFC_ASSERT(RsbsSave_OoTHalfIsAuthoritative() == 0,
+               "agreeing artifacts must claim NO OoT-half authority: the .sav delivers OoT's half");
+    WFC_ASSERT(Context_HasFrozenState(GAME_OOT) == 0, "agreement must leave Tier-2 unarmed");
+    WFC_ASSERT(Context_HasFrozenState(GAME_MM) == 1, "the MM half is armed unconditionally (#528), as before");
+
+    // Pre-stamp (0) .sav: a legacy artifact makes no claim either way, so it
+    // must not be adjudicated on evidence it does not carry.
+    Context_ClearAllFrozenStates();
+    ComboContext_Init();
+    mgr.ResetSlotSessionState();
+    WFC_ASSERT(RsbsSave_LoadSlotChecked(0, 0) == RSBS_LOAD_OK, "a pre-stamp .sav must still load");
+    WFC_ASSERT(RsbsSave_OoTHalfIsAuthoritative() == 0, "a pre-stamp .sav must claim no OoT-half authority");
+    WFC_ASSERT(Context_HasFrozenState(GAME_OOT) == 0, "the pre-stamp exemption must leave Tier-2 unarmed");
+
+    // ---- (b) NEWER whole commit: authority, armed, delivered ONCE ---------
+    Context_ClearAllFrozenStates();
+    ComboContext_Init();
+    mgr.ResetSlotSessionState();
+    WFC_ASSERT(RsbsSave_LoadSlotChecked(0, wholeGen - 1) == RSBS_LOAD_OK,
+               "a .redsave carrying a newer whole commit must load");
+    WFC_ASSERT(RsbsSave_GetSlotCommitSkew(0) == 1, "the newer whole commit must be recorded on the slot");
+    WFC_ASSERT(Context_HasFrozenState(GAME_OOT) == 1,
+               "the newest whole commit's OoT half must be ARMED — leaving it unarmed is #531 exactly");
+    WFC_ASSERT(RsbsSave_OoTHalfIsAuthoritative() == 1, "the newer whole commit must claim OoT-half authority");
+
+    // The delivery seam, mirrored from OoT's OnLoadFile hook: take the
+    // authority (one-shot) and consume the armed blob into the live half.
+    {
+        HalfBlob live = MakeOoTHalf(0x00);
+        WFC_ASSERT(RsbsSave_TakeOoTHalfAuthority() == 1, "taking the authority must report it");
+        WFC_ASSERT(RsbsSave_TakeOoTHalfAuthority() == 0,
+                   "the authority is ONE-SHOT: the armed blob is single-use (#364), so a second taker must "
+                   "not be told to re-apply a blob that has already been retired");
+        WFC_ASSERT(Combo_ConsumeFrozenState("oot", live.data(), live.size()) == 1,
+                   "consuming the armed OoT half must restore it");
+        WFC_ASSERT(HalfIsUniform(live.data(), live.size(), kOoTFill),
+                   "the delivered OoT half must be the .redsave's Tier-2, whole");
+        WFC_ASSERT(Context_HasFrozenState(GAME_OOT) == 0,
+                   "consumption must RETIRE the blob (#364): a surviving blob rolls the player back on the "
+                   "next return leg");
+    }
+
+    // ---- (d) A REFUSED load claims no authority ---------------------------
+    // The .sav-newer direction is unchanged by the ruling: a MISSING .redsave
+    // commit is corruption to refuse, not freshness to arbitrate. Nothing may
+    // be committed, nothing armed, nothing claimed.
+    Context_ClearAllFrozenStates();
+    ComboContext_Init();
+    mgr.ResetSlotSessionState();
+    gComboCtx.saveSlot = 0x5AFE0007;  // sentinel: a refusal must not touch live state
+    WFC_ASSERT(RsbsSave_LoadSlotChecked(0, wholeGen + 5) == RSBS_LOAD_REFUSED,
+               "a .sav newer than the .redsave must still REFUSE (#533/#569)");
+    WFC_ASSERT(gComboCtx.saveSlot == 0x5AFE0007, "the refusal clobbered live ComboContext");
+    WFC_ASSERT(RsbsSave_OoTHalfIsAuthoritative() == 0,
+               "a REFUSED slot has no authoritative half — the ruling must never hand a quarantined file's "
+               "world to the live session");
+    WFC_ASSERT(Context_HasFrozenState(GAME_OOT) == 0, "a refused load must arm nothing");
+    WFC_ASSERT(RsbsSave_IsSlotWritable(0) == 0, "the skew refusal must still latch writes (#533)");
+
+    // ---- The three release events also release the authority --------------
+    // A stale authority claim is a rollback waiting for a consumer, so the same
+    // events that clear a refusal clear it too.
+    mgr.DeleteSave(0);
+    WFC_ASSERT(RsbsSave_OoTHalfIsAuthoritative() == 0, "erase must clear any authority claim");
+    mgr.ResetSlotSessionState();
+    WFC_ASSERT(RsbsSave_OoTHalfIsAuthoritative() == 0, "a fresh session must claim nothing");
+
+    Context_ClearAllFrozenStates();
+    ComboContext_Init();
+    printf("[TEST] PASS: one commit, both halves, one generation; the newest whole commit is the authority\n");
+    return TEST_PASS;
+}
+
+TestResult Test_WholeFileRedeemedItem(void) {
+    printf("[TEST] whole-file-redeemed-item: a REDEEMED record and the world it was redeemed into survive "
+           "together (#531)\n");
+
+    rsbs::SaveManager& mgr = rsbs::SaveManager::Instance();
+    mgr.SetSaveDirectory(kWholeFileTestDir);
+
+    Context_InitFrozenStates();
+    Context_ClearAllFrozenStates();
+    ComboContext_Init();
+    mgr.ResetSlotSessionState();
+    mgr.DeleteSave(0);
+
+    // The two artifacts of the ONE save. `savGeneration` stands in for the
+    // "rsbsCommitGeneration" key OoT's file{N+1}.sav mirrors: it advances only
+    // when OoT's OWN save flow runs, which is the entire asymmetry #531 lives
+    // on. `savWorld` stands in for the OoT world that .sav holds.
+    uint32_t savGeneration = 0;
+    HalfBlob savWorld = MakeOoTHalf(0x11);
+
+    // ---- 1. OoT plays and saves at a save point ---------------------------
+    // Both artifacts authored by one commit: the .redsave's Tier-2 and the
+    // .sav agree, and the .sav mirrors the generation.
+    HalfBlob ootLive = savWorld;
+    Context_UpdateShadowCopy(GAME_OOT, ootLive.data(), ootLive.size());
+    {
+        HalfBlob mmCold = MakeMMHalf(0x00);
+        Context_UpdateShadowCopy(GAME_MM, mmCold.data(), mmCold.size());
+    }
+    gComboCtx.sourceGame = GAME_OOT;
+    WFC_ASSERT(mgr.Save(0), "OoT's own save must commit");
+    savGeneration = gComboCtx.commitGeneration;
+    WFC_ASSERT(ootLive[kOoTBowSlot] != kOoTBowPresent, "test setup: the saved OoT world must NOT hold the item");
+
+    // ---- 2. The MM leg produces a foreign OoT item ------------------------
+    WFC_ASSERT(Combo_RecordSharedItem(GAME_OOT, kFairyBowId) >= 0, "recording the foreign OoT item failed");
+    WFC_ASSERT(Combo_CountSharedItems(GAME_OOT, false) == 1, "the item must be pending for OoT");
+
+    // ---- 3. Arrival in OoT: the item is awarded to the LIVE save ----------
+    // This is the asymmetry: the award mutates only the live SaveContext,
+    // while RSBS_SHARED_ITEM_REDEEMED goes into durable Tier-1.
+    WFC_ASSERT(Combo_RedeemSharedItemsForGame(GAME_OOT, WholeFileAwardToLiveOoT, ootLive.data()) == 1,
+               "the arrival must redeem the pending item");
+    WFC_ASSERT(ootLive[kOoTBowSlot] == kOoTBowPresent, "the award must have reached the live OoT save");
+    WFC_ASSERT(Combo_CountSharedItems(GAME_OOT, false) == 0, "the entry must now be REDEEMED (skipped forever)");
+
+    // ---- 4. The player walks straight back into the portal ----------------
+    // No OoT save point in between: file{N+1}.sav still holds the pre-item
+    // world and still mirrors the OLD generation. The crossing freezes OoT's
+    // half — which is where the whole commit later reads it from.
+    Context_FreezeState(GAME_OOT, OOT_ENTR_MARKET_FROM_MASK_SHOP, ootLive.data(), ootLive.size());
+
+    // ---- 5. MM owl-saves: a WHOLE commit, at a new generation -------------
+    {
+        HalfBlob mmLive = MakeMMHalf(0x9C);
+        Context_UpdateShadowCopy(GAME_MM, mmLive.data(), mmLive.size());
+    }
+    gComboCtx.sourceGame = GAME_MM;
+    WFC_ASSERT(mgr.Save(0), "the MM-side owl commit failed");
+    const uint32_t owlGeneration = gComboCtx.commitGeneration;
+    WFC_ASSERT(owlGeneration > savGeneration,
+               "test setup: an MM-side commit cannot rewrite OoT's .sav, so it must be the newer generation");
+
+    // ---- 6. Process exit, relaunch, load the slot -------------------------
+    // Everything in memory goes; OoT's engine loads file{N+1}.sav into its
+    // live SaveContext (savWorld, WITHOUT the item) and only then does the
+    // OnLoadFile hook run.
+    Context_ClearAllFrozenStates();
+    ComboContext_Init();
+    mgr.ResetSlotSessionState();
+
+    HalfBlob resumed = savWorld;
+    WFC_ASSERT(resumed[kOoTBowSlot] != kOoTBowPresent,
+               "THE LOSING STATE, reproduced: the .sav world OoT resumes from does not contain the item. "
+               "Everything below is about whether it stays that way");
+
+    WFC_ASSERT(RsbsSave_LoadSlotChecked(0, savGeneration) == RSBS_LOAD_OK,
+               "the slot must load (an MM-side commit after OoT's save point is the DESIGNED state)");
+    WFC_ASSERT(gComboCtx.commitGeneration == owlGeneration, "Tier-1 must come from the newest whole commit");
+
+    // The REDEEMED record came back — durable, as it always was.
+    WFC_ASSERT(Combo_CountSharedItems(GAME_OOT, true) == 1, "the shared-item record must have survived");
+    WFC_ASSERT(Combo_CountSharedItems(GAME_OOT, false) == 0, "it must still be REDEEMED, i.e. never redelivered");
+
+    // ---- 7. The delivery seam (OoT's OnLoadFile hook, mirrored) -----------
+    WFC_ASSERT(RsbsSave_TakeOoTHalfAuthority() == 1,
+               "the .redsave holds a newer WHOLE commit, so its OoT half is the authority for this load");
+    WFC_ASSERT(Combo_ConsumeFrozenState("oot", resumed.data(), resumed.size()) == 1,
+               "the authoritative OoT half must be consumable");
+
+    // ---- 8. Record and world are consistent -------------------------------
+    // This is the assertion that names the bug. Before the ruling, the load
+    // left Tier-2 unarmed, `resumed` kept the .sav's pre-item world, and the
+    // REDEEMED record above blocked redelivery forever: the item was gone and
+    // the seed could dead-end.
+    WFC_ASSERT(resumed[kOoTBowSlot] == kOoTBowPresent,
+               "#531: the item the REDEEMED record accounts for must be present in the resumed OoT world. "
+               "A durable record whose effect did not survive with it is permanent loss of a progression "
+               "item — the record and the world it was redeemed into commit together or not at all");
+
+    // The redeem loop legitimately skips the entry now — and that is CORRECT,
+    // because the world it accounts for is the one we are standing in. Assert
+    // both halves of that: no redelivery, AND the item still present after the
+    // pass (a redelivery here would be cross-game duplication, the failure the
+    // REDEEMED flag exists to prevent).
+    WFC_ASSERT(Combo_RedeemSharedItemsForGame(GAME_OOT, WholeFileAwardToLiveOoT, resumed.data()) == 0,
+               "a REDEEMED entry must not redeliver");
+    WFC_ASSERT(resumed[kOoTBowSlot] == kOoTBowPresent, "and the item must still be there after the pass");
+
+    // The MM half of the same commit came back too — it is one file.
+    WFC_ASSERT(HalfIsUniform(Context_GetMMSaveContext(), MM_SAVE_CONTEXT_SIZE, 0x9C),
+               "the MM half of the newest whole commit must have loaded with it");
+    WFC_ASSERT(Context_HasFrozenState(GAME_MM) == 1, "the MM half must be armed for its own arrival (#528)");
+
+    mgr.DeleteSave(0);
+    mgr.ResetSlotSessionState();
+    Context_ClearAllFrozenStates();
+    ComboContext_Init();
+    printf("[TEST] PASS: the REDEEMED record and the item it accounts for survive the reload together\n");
+    return TEST_PASS;
+}


### PR DESCRIPTION
Fixes #531. Fixes #589.

## The ruling

> **2026-08-04, operator, on #589.** Whole-file commit: any half's save-and-quit
> commits BOTH halves at one generation, in one instant, through the existing
> #569 commit choke point; on load, the newest whole commit wins.

This is the one-game ruling (#500/#564 — "a paired OoT+MM slot is ONE save;
divergence between its halves is corruption, not choice") applied to the
durable-commit space rather than the identity space. Recorded as **decision 4
of ADR 0009**, following the precedent #565 set for the identity amendments.

## The mechanism it retires (#531, P1)

The WRITE half of the ruling was already true on `main`: `StageCommit` copies
Tier-1 + both shadows in one game-thread marshal, at one monotonic generation.
The READ half was not:

1. `MM_Combo_CaptureSaveToUnifiedSlot` commits on MM's owl-save path — a moment
   at which OoT's `file{N+1}.sav` is *not* rewritten (`Combo_CheckEntranceSwitch`
   freezes the OoT shadow at the crossing but never calls `Save_SaveFile`).
2. So the `.redsave` carries generation N and the `.sav` carries N-1.
3. On load, `save.cpp` restored Tier-1 wholesale — including
   `RSBS_SHARED_ITEM_REDEEMED` records — while **deliberately leaving Tier-2
   unarmed** ("OoT's own `file{N+1}.sav` is the authority for OoT state").
4. `Combo_RedeemSharedItemsForGame` skips a REDEEMED entry unconditionally and
   forever (`shared_items.c:277`).

Net: the durable record outlived the world it accounted for. A foreign OoT
progression item awarded on a cross-game arrival after OoT's last save point
was **permanently gone**, with the record that says "already delivered" intact.
The seed could dead-end.

#569 made this *visible* (`[STALE: cross-game progress is newer than the OoT
save]`). This PR makes it *impossible*: detection becomes authority.

## The change

**`src/common/save.cpp` — `LoadSlot`.** When the `.redsave`'s commit generation
is newer than the one OoT's `.sav` mirrors, the `.redsave` holds a whole commit
the `.sav` does not, so its Tier-2 **is** OoT's half at that commit. The load
arms Tier-2 (`Context_ArmShadowAsFrozen(GAME_OOT, OOT_ENTR_MARKET_FROM_MASK_SHOP)`)
and records a one-shot authority claim. Record and world now travel together, so
the #531 shape has no representation.

**`games/oot/soh/SaveManager.cpp` — `OnLoadFile` delivery seam (that hook only).**
The hook fires at the tail of `LoadFile`, after every section has been applied
to the live `gSaveContext` and before `Sram_OpenSave` interprets it. If the
load claimed authority, the seam consumes the armed blob
(`Combo_ConsumeFrozenState("oot", …)` — restore *and retire*, #364's single-use
contract) and re-asserts the opened `fileNum`. **Deliberately kept to that one
hook**: the parallel #606 lane owns the `OnExitGame` region of this file, which
this diff does not touch.

**`src/common/ComboMenuBar.cpp`.** The `[STALE: …]` warning becomes
`[SYNCED: cross-game progress newer than the OoT save, applied]`. The fact is
still worth reporting (the player's `.sav` on disk really is older than what
they resumed from); it is no longer a loss.

### What the ruling does NOT say — three boundaries, each locked by a test

1. **Not "the `.redsave` always wins".** Equal generations, and either artifact
   at the pre-stamp `0`, claim no authority; the `.sav` delivers OoT's half
   exactly as before. An unconditional arm would race a redundant or legacy
   copy of OoT's world against the file the engine just loaded — which is the
   original, still-correct reason Tier-2 was left unarmed for those cases.
2. **Not freshness arbitration in both directions.** The inverse skew (`.sav`
   newer ⇒ a `.redsave` commit is MISSING) still REFUSES at full #533 strength:
   no commit, evidence quarantined, slot write-latched, reason surfaced.
3. **A REFUSED slot has no authoritative half.** The claim is dropped before the
   file is read, so every early return (absent, refused, sticky-refused,
   commit-skew) leaves nothing behind; erase / create / session reset clear it
   too.

### Safety property the authority rests on (stated in-code)

The OoT shadow is refreshed at **every** point where OoT stops being live (both
crossing paths and the F10 hot swap freeze it) **and** at every OoT save
(`SaveSection` refreshes it in the same breath as writing the `.sav`). A
committed Tier-2 is therefore never *older* than the `.sav` it is compared
against, so "newer generation" can never deliver a rolled-back OoT world. A
future commit route that stages without refreshing OoT's shadow first would
break that; the comment says so.

### Not broken

Torn-write protection (#537 — commits stay on the game-thread choke point), the
write latch (#568/#533), slot-session scoping (#536/#541), and the #543
bootstrap guards are all untouched. `mm_stubs.c` untouched.

## The #589 sibling concern: `func_8014546C`'s owl memcpy

The truncation is **real and needs no fix**. `func_8014546C`'s owl branch does
`memcpy(sramCtx->saveBuf, &gSaveContext, offsetof(SaveContext, fileNum))` —
0x3CA0 of a 0x48C8+ struct — but its destination is MM's **N64 flash staging
buffer**, whose writer is a no-op stub in single-exe (`mm_save_manager_stubs.c`,
because `games/mm/CMakeLists.txt` filters out `2s2h/SaveManager/*.cpp`). The
`.redsave` capture is a separate, full-width
`Context_UpdateShadowCopy(GAME_MM, &gSaveContext, sizeof(gSaveContext))`.
Rather than assert the absence of a bug, check 12 pins the relationship: the
route probe (`masksGivenOnMoon`, 0x48CA) must sit **past** `offsetof(SaveContext,
fileNum)`, so a commit that ever inherited the owl memcpy's width would fail
checks 6 and 12 instead of passing by accident.

## Doctrine assertions changed, and why the ruling requires each

| Where | Was | Now | Why |
|---|---|---|---|
| `src/common/tests/test_session_invalidation.c:588` | `Context_HasFrozenState(GAME_OOT) == 0`, justified as *"OoT's own `file{N+1}.sav` is the authority for OoT state; arming Tier-2 would race a staler copy"* | **assertion unchanged**, justification narrowed to the pre-stamp case | The blanket claim is retired by the ruling, but this load passes no `.sav` generation, so it takes the legacy exemption and must still not arm. Keeping the assertion is what stops the fix from being implemented as "always arm". |
| `src/common/tests/test_commit_generation.c` (skew, `+1` arm) | comment: *"the #531 loss shape — load, but SURFACE it"*; assertions stopped at "recorded" | same recording assertions **plus** `RsbsSave_OoTHalfIsAuthoritative() == 1` | A `+1` that arms nothing **is** #531. The file keeps the DETECTION claims; the AUTHORITY claims move to `test_whole_file_commit.c`, because a regression in the comparison and a regression in what is done with it are different bugs. |
| `src/common/tests/test_commit_generation.c` (header + dispatch text) | *"#531/#564 V16 interim"*, *"the #531 loss shape"* | *"#531/#589"*, "the newest whole commit" | The `+1` direction changed meaning, not detection. |
| `src/common/save.cpp` (`LoadSlot` arming block) | *"MM ONLY, deliberately"* | *"MM ALWAYS; OoT only when the whole commit is newer"* | The staleness argument is right for agreement and backwards for the newer case — when the `.redsave` is newer there is no second, staler copy to race; the `.sav` is the stale one. |
| `src/common/save.h`, `src/common/context.h` (`commitGeneration`, `SlotMeta.commitSkew`, `LoadSlot` contract) | *"loads and is surfaced as a staleness warning"* | *"loads and its half is the authority"* | Same. |
| `src/common/ComboMenuBar.cpp` | `[STALE: …]` + *"items delivered to OoT after its last save point may be missing"* | `[SYNCED: … applied]` + *"resumed from the newest whole commit"* | The warning described a loss that no longer happens; leaving it would send players hunting a bug that was fixed. |
| `games/mm/2s2h/mm_unified_save_test.cpp` check 8(b) | *"the LAST permitted commit (7b's new cycle)"* | *"(check 12's)"* | Bookkeeping: check 12 now commits after 7b. Both have `day == 0`, so the assertion is unchanged. |

## Quit-to-title is a durable commit — RULED, not a side effect

> **2026-08-05, operator ruling on #589.** *Durable commit — keep the shipped
> behavior. Quit-to-title commits the whole file at one generation; reload
> resumes from the quit state. This is deliberate autosave-on-quit under the
> one-game ruling, chosen over "commit nothing" partly because it atomically
> closes #531's second route.*

This shipped as a consequence and was raised as an open question; the ruling
settles it as **intended semantics**. Recorded as **ADR 0009 decision 4a**.

`OnExitGame` already committed on quit-to-title, and its Tier-2 — previously
inert, because Tier-2 was never armed — is now the newest whole commit's OoT
half. So a quit-to-title (including the branch reached by declining the death
prompt's "Save?") now resumes from the state at the quit.

**#531's second route** is what makes this the atomic answer rather than merely
a tolerable one: without it, an unsaved OoT leg following an MM leg durably
keeps the REDEEMED records while discarding the items they account for —
reproducing the exact loss this PR exists to retire, by a different path.

Two alternatives considered and rejected, recorded so they are not re-litigated:

- **Quit-without-saving commits nothing** (suppress the exit-time commit). Also
  atomic, but leaves #531's second route open until that hook is restructured,
  and trades a player-visible improvement for fidelity to a vanilla affordance
  one-game semantics has already superseded elsewhere.
- **Scope the authority by `sourceGame`.** Rejected outright — it reintroduces
  the loss: play past a save point after an MM leg, quit without saving, and
  the REDEEMED records survive while the world does not.

**What it obliges going forward:** quit-to-title is now a save route in every
sense that matters — it commits through the #569 choke point and respects the
#533/#568 write latch. Anyone touching that hook (the #606 lane's region) is
changing a *save*, not a teardown.

## Tests

New (`redship` tier, `src/common/tests/test_whole_file_commit.c`):

- **`whole-file-commit`** — atomicity and authority as separable claims:
  one commit carries both halves full-width at ONE generation advance;
  a newer whole commit arms Tier-2 and reports authority exactly once
  (one-shot, per #364); agreement and the pre-stamp exemption claim none;
  a REFUSED load claims none and commits nothing; erase/create/reset release
  the claim.
- **`whole-file-redeemed-item`** — the #531 scenario end to end, with its
  counterfactual built in: the test first asserts the freshly-loaded `.sav`
  world does NOT contain the item (the losing state, reproduced), then that
  the whole-commit delivery puts it back, then that the redeem loop correctly
  declines to redeliver *and* the item is still present after that pass.

Extended (`mm-unified-save-capture`, check 12): an MM owl-shaped marshal must
commit OoT's half too — the OoT shadow is stamped before the marshal and the
reloaded Tier-2 must come back whole, at the same single generation advance
`CommitReached` already requires. Plus the `offsetof(SaveContext, fileNum)`
probe-placement assertion above.

### Counterfactual, executed

The Tier-2 arming was disabled in `LoadSlot` (`if (false && mSlotSkew[slot] > 0)`),
rebuilt, run, then reverted and re-verified green. All three affected locks go
red, each on the assertion that names the loss:

```
[TEST] whole-file-commit: one commit carries both halves; the newest whole commit wins (#589)
[TEST] FAIL: the newest whole commit's OoT half must be ARMED — leaving it unarmed is #531 exactly

[TEST] whole-file-redeemed-item: a REDEEMED record and the world it was redeemed into survive together (#531)
[TEST] FAIL: the .redsave holds a newer WHOLE commit, so its OoT half is the authority for this load

[TEST] commit-generation-skew: cross-artifact freshness at load, surfaced via #533
[TEST] FAIL: a redsave-newer load must claim OoT-half authority — detection without authority is #531
```

Nothing else fired, which is the point: the detection claims in
`commit-generation-skew` stayed green under the counterfactual (the comparison
still works), and only the new authority assertion in that file went red. That
is the separation of concerns the doctrine note describes, made falsifiable.

## Verification

Local ROM-staged build (MSVC/Ninja Release, Windows, fresh worktree, submodules
initialized, port archives staged into the build root, OpenGL backend pinned),
on the final head:

```
ctest -L "^redship$"        : 100% tests passed out of 79
ctest -L "^rando$"          : 100% tests passed out of 18
ctest -L "^integration$"    : 100% tests passed out of 6
ctest -L integration-soak   : 100% tests passed out of 1
```

The new locks, verbatim:

```
[RsbsSave] slot 0 WHOLE-FILE COMMIT: .redsave generation 2 is NEWER than OoT's .sav generation 1 —
  the .redsave's OoT half is the authority for this load (#531/#589).
[RsbsSave] slot 0 loaded; MM half armed for restore
[RsbsSave] slot 0 OoT half armed from the .redsave: the whole commit in the .redsave is newer than
  OoT's own .sav, so its Tier-2 is the authority (#531/#589)
[RsbsSave] slot 0 REFUSED: COMMIT SKEW — OoT's .sav mirrors commit generation 7 but the .redsave
  carries 2 (a .redsave commit is missing). ... Evidence quarantined
[TEST] PASS: one commit, both halves, one generation; the newest whole commit is the authority

[SharedItem] recorded origin=oot id=42 in slot 0
[SharedItem] redeemed 1 item(s) for oot
[TEST] PASS: the REDEEMED record and the item it accounts for survive the reload together
```

**Two tier results worth flagging independently of this PR:**

- `IntSwitchOoTHmsToMm` **passed** (84.5s). It is documented as permanently red
  unattended (#544); it was green on this run.
- `integration-soak` (`IntGameplayRoundtripSoak`) **passed** (64.2s). It was
  permanently red via #557, whose fix merged 2026-08-02 — this is the first
  green soak I have observed.

`clang-format` 14.0.6 (the version the CI gate pins) reports no changes on the
two touched files on `.github/clang-format-paths.txt`
(`games/oot/soh/SaveManager.cpp`, `games/mm/2s2h/mm_unified_save_test.cpp`).
No submodule pointer changes; the build-regenerated stamps
(`games/{mm,oot}/src/boot/build.c`, `games/mm/windows/properties.h`,
`games/oot/properties.h`) were restored before the commit.

## Coordination

`games/oot/soh/SaveManager.cpp` is touched in exactly two places — the include
block and the `OnLoadFile` hook body. The `OnExitGame` hook the #606 lane owns
is untouched, and `src/common/mm_stubs.c` is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!--- section:artifacts:start -->
### Build Artifacts
  - [rsbs-windows.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/8919610468.zip)
  - [rsbs-linux.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/8919403025.zip)
<!--- section:artifacts:end -->