### PR TITLE
Give MM's ShipInit map a CVar-change driver (#539); #497's pane verified already delivered

### DIFF
--- a/.github/clang-format-paths.txt
+++ b/.github/clang-format-paths.txt
@@ -35,6 +35,7 @@ games/mm/2s2h/Rando/Foreign.h
 games/mm/2s2h/Rando/ForeignItemsSingleExe.cpp
 games/mm/2s2h/Rando/TrackerAdapterSingleExe.cpp
 games/mm/2s2h/ShipInit.hpp
+games/mm/2s2h/ShipInitBridge_SingleExe.cpp
 games/mm/2s2h/TrackersGuiSingleExe.cpp
 games/mm/2s2h/TrackersGuiSingleExe.h
 games/mm/2s2h/mm_capture_harvest_gate_test.cpp
@@ -49,6 +50,7 @@ games/mm/2s2h/mm_notification_binding_test.cpp
 games/mm/2s2h/mm_notification_bridge.cpp
 games/mm/2s2h/mm_resume_state_test.cpp
 games/mm/2s2h/mm_save_manager_stubs.c
+games/mm/2s2h/mm_shipinit_driver_test.cpp
 games/mm/2s2h/mm_trackers_gui_test.cpp
 games/mm/2s2h/mm_unified_save_test.cpp
 games/mm/2s2h/z_scene_2SH.cpp
@@ -72,7 +74,9 @@ games/oot/soh/ResourceManagerHelpers.cpp
 games/oot/soh/ResourceManagerHelpers.h
 games/oot/soh/SaveManager.cpp
 games/oot/soh/SaveManager.h
+games/oot/soh/ShipInit.hpp
 games/oot/soh/mixer.c
+games/oot/soh/soh_shipinit_driver_test.cpp
 games/oot/soh/z_scene_otr.cpp
 games/oot/src/code/audio_load.c
 games/oot/src/code/code_800E4FE0.c

--- a/CMake/SingleExecutable.cmake
+++ b/CMake/SingleExecutable.cmake
@@ -665,6 +665,15 @@ if(BUILD_TESTING)
     # randomized while their models and dialog stayed vanilla. Display-free and
     # ROM-free, so it runs in this redship tier.
     redship_add_test(NAME MMHookDispatch COMMAND redship --test mm-hook-dispatch)
+    # One layer earlier than the row above (#539): a hook is only as armed as the
+    # registrar that (un)registers it, and MM's registrar map — S2H::ShipInit,
+    # separate from OoT's since the #375 COMDAT-fold split — had no CVar-change
+    # driver in the link. The unified menu's widgets call OoT's
+    # ShipInit::Init(cvar), so a converged key like
+    # gEnhancements.RememberSaveLocation re-armed OoT on the click and left MM
+    # latched at its first-boot value for the rest of the process.
+    # Display-free and ROM-free, so it runs in this redship tier.
+    redship_add_test(NAME MMShipInitDriver COMMAND redship --test mm-shipinit-driver)
     # filePlaytime epoch injection (#513): SavingEnhancements_AdvancePlaytime is
     # called from plain C (z_sram_NES.c, z_kaleido_scope_NES.c) regardless of
     # hook wiring, and accrued now - lastTimeLog with lastTimeLog unseeded (0) --

--- a/games/mm/2s2h/ShipInitBridge_SingleExe.cpp
+++ b/games/mm/2s2h/ShipInitBridge_SingleExe.cpp
@@ -1,0 +1,117 @@
+/**
+ * @file ShipInitBridge_SingleExe.cpp
+ * @brief #539 — the CVar-change driver for MM's `S2H::ShipInit` registrar map.
+ *
+ * THE BUG THIS CLOSES
+ * ===================
+ * `2s2h/ShipInit.hpp` puts MM's registrar map in `namespace S2H` (the #375
+ * COMDAT-fold fix), so MM owns a map that is disjoint from OoT's. Upstream MM
+ * re-runs entries out of that map whenever a CVar changes, from its own widget
+ * layer (`2s2h/BenGui/UIWidgets.cpp`) — but in single-exe that layer is drawn
+ * only by the tracker windows and only ever passes tracker CVar paths, so no
+ * converged enhancement key ever reaches it. The one live menu is OoT's
+ * `SohMenu`, whose widgets call OoT's `ShipInit::Init(cvar)`.
+ *
+ * Result before this TU existed: MM's map was driven EXACTLY ONCE per process,
+ * by `S2H::ShipInit::InitAll()` in `2s2h/GameExports_SingleExe.cpp`. A shared
+ * key like `gEnhancements.RememberSaveLocation` re-armed OoT's registrar the
+ * instant the player clicked, and left MM's latched at whatever the value had
+ * been at MM's first boot. Under the one-game ruling that divergence is
+ * corruption: one combo, two halves silently disagreeing about the same
+ * setting.
+ *
+ * THE CHOKE POINT
+ * ===============
+ * OoT's `ShipInit::Init(path)` (`games/oot/soh/ShipInit.hpp`) — every one of
+ * the menu's ~13 widget call sites funnels through it, so wiring it here is one
+ * edit instead of thirteen, and a widget added tomorrow is driven for free.
+ * That header calls the entry point below; the policy lives in this TU, next to
+ * MM's map, rather than in OoT's header.
+ *
+ * WHAT IS DELIBERATELY *NOT* FORWARDED
+ * ====================================
+ * The map is keyed by path string, and two of those keys are pseudo-paths with
+ * game-specific timing rather than CVar names:
+ *
+ *  - `"*"` — "every registrar". OoT drives it from boot (`OTRGlobals.cpp`) and
+ *    from preset loads (`Enhancements/Presets/Presets.cpp`). Forwarding it
+ *    would run MM's whole registrar set from OoT's boot, BEFORE MM's own
+ *    `InitAll()` has ever run, and again on every OoT preset load. MM drives
+ *    its own wildcard at MM bring-up and from `PresetManager.cpp`.
+ *  - `"IS_RANDO"` — "the rando arm-state may have changed". OoT drives it when
+ *    an OoT rando save loads (`Enhancements/randomizer/hook_handlers.cpp`);
+ *    MM drives its own from `Rando/Rando.cpp` on MM's save-load chain, which is
+ *    what the #439 arm-state locks assert. Forwarding OoT's would arm MM's
+ *    rando hooks against MM's *previous* save state on an OoT-only file load.
+ *
+ * Both exclusions are asserted by the `mm-shipinit-driver` lock, so "simplify
+ * the filter" is a red test rather than a silent behavior change.
+ *
+ * BLAST RADIUS
+ * ============
+ * Bounded by construction: the forward is keyed on the exact CVar name OoT's
+ * menu just wrote, and only fires when MM's map already holds a registrar under
+ * that name. A key MM does not register on is a lookup miss and nothing runs,
+ * so the set of MM registrars this can reach is exactly "MM registrars keyed on
+ * a CVar the unified menu writes" — i.e. the converged shared keys, which is
+ * precisely the set #539 is about. The `find()` guard also keeps the forward
+ * from growing MM's map: `ShipInit::Init` indexes with `operator[]`, which
+ * would insert an empty vector for every OoT-only key the player ever touched.
+ */
+
+#ifdef RSBS_SINGLE_EXECUTABLE
+
+#include "2s2h/ShipInit.hpp"
+
+#include <cstring>
+#include <string>
+
+extern "C" {
+
+/**
+ * Run MM's registrars keyed on `path`, if any. Called from OoT's
+ * `ShipInit::Init` — i.e. from the unified menu's widget layer — after OoT's
+ * own registrars for the same path have run.
+ */
+void MM_ShipInit_OnCVarChanged(const char* path) {
+    if (path == nullptr || path[0] == '\0') {
+        return;
+    }
+
+    // Pseudo-paths: MM owns their timing. See the header comment.
+    if (std::strcmp(path, "*") == 0 || std::strcmp(path, "IS_RANDO") == 0) {
+        return;
+    }
+
+    auto& shipInitFuncs = S2H::ShipInit::GetAll();
+    const auto it = shipInitFuncs.find(path);
+    if (it == shipInitFuncs.end() || it->second.empty()) {
+        // MM registers nothing on this key — the overwhelmingly common case,
+        // since most menu keys are OoT-only. Returning here (rather than
+        // calling Init) is what keeps operator[] from inserting an empty
+        // vector per key touched.
+        return;
+    }
+
+    S2H::ShipInit::Init(path);
+}
+
+/**
+ * How many MM registrars are keyed on `path`. Non-inserting, unlike
+ * `ShipInit::Init`'s `operator[]`. Exists so the `mm-shipinit-driver` lock can
+ * assert the converged keys really do have MM registrars behind them — the
+ * non-vacuity half of the fix, which is otherwise unobservable from outside
+ * MM's headers.
+ */
+int MM_ShipInit_RegistrarCountForPath(const char* path) {
+    if (path == nullptr) {
+        return 0;
+    }
+    auto& shipInitFuncs = S2H::ShipInit::GetAll();
+    const auto it = shipInitFuncs.find(path);
+    return it == shipInitFuncs.end() ? 0 : static_cast<int>(it->second.size());
+}
+
+} // extern "C"
+
+#endif // RSBS_SINGLE_EXECUTABLE

--- a/games/mm/2s2h/mm_shipinit_driver_test.cpp
+++ b/games/mm/2s2h/mm_shipinit_driver_test.cpp
@@ -1,0 +1,105 @@
+/**
+ * @file mm_shipinit_driver_test.cpp
+ * @brief MM-side half of the #539 lock: probes planted in MM's OWN registrar
+ *        map, so the OoT-side driver can be observed crossing the seam.
+ *
+ * The other half is games/oot/soh/soh_shipinit_driver_test.cpp, which drives
+ * OoT's `ShipInit::Init(path)` — the exact call every `SohMenu` widget makes.
+ * The split is forced, not stylistic: under `RSBS_SINGLE_EXECUTABLE` MM's
+ * `2s2h/ShipInit.hpp` ends with `using S2H::ShipInit;` at global scope, which
+ * collides with OoT's global `struct ShipInit`, so NO translation unit can see
+ * both headers. That is also exactly why the bug existed — the two maps cannot
+ * see each other either.
+ *
+ * The probes are registered through MM's real `RegisterShipInitFunc`, so they
+ * sit in the same map, under the same keys, with the same semantics as MM's
+ * production registrars. They are inert: they increment a counter.
+ *
+ * Keys chosen on purpose:
+ *  - `kProbeCVarPath` is SYNTHETIC. The driver leg must not depend on which
+ *    real MM enhancement TUs survived plain-archive linking this week (the
+ *    #516 elision class), and it must not re-run a production registrar with
+ *    live side effects inside a display-free harness.
+ *  - `"IS_RANDO"` is real, and the probe there is what makes the exclusion leg
+ *    non-vacuous: without a registrant under that key, "IS_RANDO did not
+ *    forward" would pass whether or not the filter existed.
+ *  - The `"*"` exclusion needs no probe of its own: `RegisterShipInitFunc`
+ *    pushes every registrant into `"*"` as well, so the CVar probe is already
+ *    under it.
+ *
+ * The converged-key reality check (does MM actually keep registrars under a
+ * shared enhancement key?) is asserted on the OoT side through
+ * `MM_ShipInit_RegistrarCountForPath`, which is production code in
+ * 2s2h/ShipInitBridge_SingleExe.cpp.
+ */
+
+#ifdef RSBS_SINGLE_EXECUTABLE
+
+#include "2s2h/ShipInit.hpp"
+
+#include <cstdio>
+#include <string>
+
+namespace {
+
+int gCVarProbeRuns = 0;
+int gRandoProbeRuns = 0;
+
+void CVarProbe() {
+    gCVarProbeRuns++;
+}
+
+void RandoProbe() {
+    gRandoProbeRuns++;
+}
+
+} // namespace
+
+// Kept in sync with the same literal on the OoT side; a typo on either side
+// shows up as FAIL(2) rather than a silent pass, because the probe count would
+// stay zero.
+#define MM_SHIPINIT_TEST_PROBE_PATH "gTest.ShipInitDriverProbe"
+
+static RegisterShipInitFunc sCVarProbe(CVarProbe, { MM_SHIPINIT_TEST_PROBE_PATH });
+static RegisterShipInitFunc sRandoProbe(RandoProbe, { "IS_RANDO" });
+
+extern "C" {
+
+void MMShipInitTest_ResetProbes(void) {
+    gCVarProbeRuns = 0;
+    gRandoProbeRuns = 0;
+}
+
+int MMShipInitTest_CVarProbeRuns(void) {
+    return gCVarProbeRuns;
+}
+
+int MMShipInitTest_RandoProbeRuns(void) {
+    return gRandoProbeRuns;
+}
+
+const char* MMShipInitTest_ProbePath(void) {
+    return MM_SHIPINIT_TEST_PROBE_PATH;
+}
+
+/**
+ * Print every CVar-shaped key MM's map holds, with its registrar count.
+ * Called only on a failure path: when the converged-key leg goes red the two
+ * plausible causes (a #516-class elision vs. the two games' spellings having
+ * drifted) look identical from the OoT side, and this tells them apart in the
+ * same run instead of costing a rebuild.
+ */
+void MMShipInitTest_DumpCVarKeys(void) {
+    auto& shipInitFuncs = S2H::ShipInit::GetAll();
+    printf("[TEST] MM S2H::ShipInit map: %d paths\n", (int)shipInitFuncs.size());
+    for (const auto& [path, funcs] : shipInitFuncs) {
+        if (path.find('.') == std::string::npos) {
+            continue; // "*", "IS_RANDO" and other pseudo-paths
+        }
+        printf("[TEST]   %s -> %d\n", path.c_str(), (int)funcs.size());
+    }
+}
+
+} // extern "C"
+
+#endif // RSBS_SINGLE_EXECUTABLE

--- a/games/oot/soh/ShipInit.hpp
+++ b/games/oot/soh/ShipInit.hpp
@@ -17,6 +17,20 @@ struct ShipInitEntry {
     std::source_location registeredAt;
 };
 
+#ifdef RSBS_SINGLE_EXECUTABLE
+/**
+ * #539: MM's registrar map is a SEPARATE map (`S2H::ShipInit`, the #375
+ * COMDAT-fold split), and in single-exe nothing drives it on a CVar change —
+ * MM's own widget layer is not the live menu. `SohMenu`'s widgets all funnel
+ * through `ShipInit::Init(cvar)` below, so forwarding from there is the one
+ * choke point that re-arms both games from one click.
+ *
+ * Defined in games/mm/2s2h/ShipInitBridge_SingleExe.cpp, which also owns the
+ * policy (which paths forward, and why `"*"` / `"IS_RANDO"` do not).
+ */
+extern "C" void MM_ShipInit_OnCVarChanged(const char* path);
+#endif
+
 struct ShipInit {
     static std::unordered_map<std::string, std::vector<ShipInitEntry>>& GetAll() {
         static std::unordered_map<std::string, std::vector<ShipInitEntry>> shipInitFuncs;
@@ -45,6 +59,14 @@ struct ShipInit {
             }
             entry.initFunc();
         }
+
+#ifdef RSBS_SINGLE_EXECUTABLE
+        // #539: re-arm MM's half of the combo on the same change. Runs AFTER
+        // OoT's own registrars so the ordering matches a standalone build of
+        // either game (its own registrars first), and unconditionally on every
+        // path — the bridge, not this header, decides what is forwarded.
+        MM_ShipInit_OnCVarChanged(path.c_str());
+#endif
     }
 };
 

--- a/games/oot/soh/soh_shipinit_driver_test.cpp
+++ b/games/oot/soh/soh_shipinit_driver_test.cpp
@@ -1,0 +1,151 @@
+/**
+ * @file soh_shipinit_driver_test.cpp
+ * @brief ROM-free, display-free lock for #539: a CVar change on the unified
+ *        menu path re-arms MM's registrars, not only OoT's.
+ *
+ * CTest label "redship", row `MMShipInitDriver` in CMake/SingleExecutable.cmake,
+ * dispatch `mm-shipinit-driver` in src/common/test_runner.cpp.
+ *
+ * WHAT WAS BROKEN
+ * ===============
+ * ADR 0003 converged `gEnhancements.RememberSaveLocation` (and Autosave) into
+ * single shared keys, but MM's registrar map is a separate map — `S2H::ShipInit`
+ * (2s2h/ShipInit.hpp, the #375 COMDAT-fold split). The one live menu is OoT's
+ * `SohMenu`, whose widgets call OoT's `ShipInit::Init(cvar)`. Nothing in the
+ * single-exe link ever called `S2H::ShipInit::Init()` with an enhancement key,
+ * so MM's map was driven exactly once per process by `InitAll()` at MM's first
+ * boot. One click re-armed OoT and left MM latched — one combo, two halves
+ * disagreeing about the same setting, which the one-game ruling calls
+ * corruption.
+ *
+ * WHY THIS FILE IS ON THE OoT SIDE
+ * ================================
+ * It must call the REAL production entry point the menu widgets call —
+ * `ShipInit::Init(path)`, which is an inline member of OoT's header, so it
+ * cannot be reached across a C boundary and cannot be re-derived without
+ * testing a copy instead of the code. The probes it observes must live in MM's
+ * map, which needs MM's header; and no TU can hold both headers, because MM's
+ * ends with `using S2H::ShipInit;` at global scope. Hence the split: probes in
+ * games/mm/2s2h/mm_shipinit_driver_test.cpp, driving here.
+ *
+ * NON-VACUITY
+ * ===========
+ * Every leg asserts its counter is zero before the drive and non-zero after
+ * (or stays zero, for the exclusion legs), so a probe that never registered
+ * cannot pass. Leg 1 is the reality check that keeps the whole lock honest: it
+ * asserts MM really does keep registrars under a CONVERGED key, so the bug
+ * being fixed is a bug about real registrars and not about a synthetic one.
+ *
+ * VERIFIED RED BEFORE GREEN: with the `MM_ShipInit_OnCVarChanged` call removed
+ * from ShipInit.hpp's `Init` (the whole fix), leg 2 fails FAIL(2). Legs 3 and 4
+ * pass in that state — they lock the deliberate scoping, and their
+ * counterfactual is deleting the pseudo-path filter in the bridge, which turns
+ * them red.
+ */
+
+#ifdef RSBS_SINGLE_EXECUTABLE
+
+#include "ShipInit.hpp"
+
+#include <cstdio>
+#include <cstring>
+
+// MM-side probe support (games/mm/2s2h/mm_shipinit_driver_test.cpp) and the
+// production bridge's non-inserting map query
+// (games/mm/2s2h/ShipInitBridge_SingleExe.cpp).
+extern "C" {
+void MMShipInitTest_ResetProbes(void);
+int MMShipInitTest_CVarProbeRuns(void);
+int MMShipInitTest_RandoProbeRuns(void);
+const char* MMShipInitTest_ProbePath(void);
+void MMShipInitTest_DumpCVarKeys(void);
+int MM_ShipInit_RegistrarCountForPath(const char* path);
+void MM_ShipInit_OnCVarChanged(const char* path);
+}
+
+namespace {
+
+// The converged key #539 names first. Spelled here rather than included from
+// MM's SavingEnhancements.cpp (which this TU must not see) — the point of the
+// leg is that BOTH games agree on this literal, so a divergence in either
+// game's spelling is exactly what should turn it red.
+constexpr const char* kConvergedKey = "gEnhancements.RememberSaveLocation";
+
+int Fail(int code, const char* msg) {
+    printf("[TEST] FAIL(%d): %s\n", code, msg);
+    return code;
+}
+
+} // namespace
+
+extern "C" int OoT_ShipInitMMDriver_RunHeadless(void) {
+    // ---- leg 1: the converged key really has MM registrars behind it -------
+    // If this is zero, either MM's SavingEnhancements TU was elided from the
+    // link (the #516 class) or the two games' spellings of the converged key
+    // drifted. Either way the driver would be re-arming nothing and every
+    // other leg here would be theatre.
+    const int convergedRegistrars = MM_ShipInit_RegistrarCountForPath(kConvergedKey);
+    if (convergedRegistrars <= 0) {
+        printf("[TEST] MM registrar count for '%s' is %d\n", kConvergedKey, convergedRegistrars);
+        MMShipInitTest_DumpCVarKeys();
+        return Fail(1, "no MM registrar is keyed on the converged enhancement key — either MM's TU is elided or the "
+                       "two games' spellings drifted, and re-arming MM would be a no-op (#539)");
+    }
+
+    const char* probePath = MMShipInitTest_ProbePath();
+
+    // ---- leg 2: THE FIX. OoT's Init reaches MM's map. ---------------------
+    // This is the exact call `UIWidgets::CVarCheckbox` and friends make after
+    // writing the CVar (games/oot/soh/SohGui/UIWidgets.cpp), so the lock rides
+    // the production path rather than a stand-in for it.
+    MMShipInitTest_ResetProbes();
+    ShipInit::Init(probePath);
+    if (MMShipInitTest_CVarProbeRuns() <= 0) {
+        return Fail(2, "a CVar change through OoT's ShipInit::Init did not run MM's registrar for the same key — "
+                       "MM's map still has no CVar-change driver (#539)");
+    }
+
+    // ---- leg 3: the "*" pseudo-path is NOT forwarded ----------------------
+    // Non-vacuous: RegisterShipInitFunc pushes every registrant into "*" too,
+    // so the CVar probe IS under it. OoT drives "*" from boot and from preset
+    // loads; forwarding it would run MM's whole registrar set before MM has
+    // booted and again on every OoT preset load.
+    MMShipInitTest_ResetProbes();
+    MM_ShipInit_OnCVarChanged("*");
+    if (MMShipInitTest_CVarProbeRuns() != 0) {
+        return Fail(3, "the '*' wildcard was forwarded to MM's map — OoT's boot and preset paths would run MM's "
+                       "whole registrar set, including before MM has booted (#539)");
+    }
+
+    // ---- leg 4: the "IS_RANDO" pseudo-path is NOT forwarded ---------------
+    // Non-vacuous via the MM-side IS_RANDO probe. MM drives its own IS_RANDO
+    // from Rando/Rando.cpp on MM's save-load chain; forwarding OoT's would arm
+    // MM's rando hooks against MM's previous save on an OoT-only file load,
+    // which is what the #439 arm-state locks exist to prevent.
+    MMShipInitTest_ResetProbes();
+    MM_ShipInit_OnCVarChanged("IS_RANDO");
+    if (MMShipInitTest_RandoProbeRuns() != 0) {
+        return Fail(4, "'IS_RANDO' was forwarded to MM's map — an OoT rando file load would re-arm MM's rando hooks "
+                       "off MM's stale save state (#539)");
+    }
+
+    // ---- leg 5: a key MM does not register on does not grow MM's map ------
+    // ShipInit::Init indexes with operator[], which inserts. Forwarding every
+    // OoT-only key a player ever touches through that would accrete one empty
+    // vector per key for the life of the process.
+    const char* oneOffKey = "gTest.ShipInitDriverKeyMMNeverRegisters";
+    MM_ShipInit_OnCVarChanged(oneOffKey);
+    if (MM_ShipInit_RegistrarCountForPath(oneOffKey) != 0) {
+        return Fail(5, "forwarding an unregistered key inserted it into MM's map");
+    }
+
+    // Leave the counters clean for whatever runs next in AllTests.
+    MMShipInitTest_ResetProbes();
+
+    printf("[TEST] PASS: a CVar change on the unified menu path re-arms MM's registrars (%d on the converged key), "
+           "while the '*' and 'IS_RANDO' pseudo-paths stay MM-driven\n",
+           convergedRegistrars);
+    return 0;
+}
+
+#endif // RSBS_SINGLE_EXECUTABLE

--- a/src/common/test_runner.cpp
+++ b/src/common/test_runner.cpp
@@ -50,6 +50,13 @@ int OoT_RegisterModelResourceFactoriesHeadless(void);
 // enters this translation unit; called through this C entry point, mirroring
 // MM_RegisterResourceFactoriesHeadless. Returns 0 on pass, non-zero on fail.
 int MM_SceneExecute_RunHeadless(void);
+// #539 — the CVar-change driver for MM's S2H::ShipInit map. The body lives in
+// an OoT TU (games/oot/soh/soh_shipinit_driver_test.cpp) because it must call
+// OoT's inline ShipInit::Init, the exact entry every SohMenu widget uses; its
+// probes live in an MM TU (games/mm/2s2h/mm_shipinit_driver_test.cpp) because
+// they must sit in MM's map. No TU can hold both games' ShipInit headers —
+// which is the same seam that let the bug exist. Returns 0 on pass.
+int OoT_ShipInitMMDriver_RunHeadless(void);
 // CosmeticEditor gfx-wrapper contract (games/mm/2s2h/CosmeticGfxSingleExe.cpp):
 // MM's HUD draw consumes these wrappers' Gfx* return as its display-list
 // write pointer; the old void stubs in mm_stubs.c fed it garbage (WRITE AV
@@ -351,6 +358,14 @@ extern "C" {
 // MM's umbrella headers out of this TU. Thin wrapper over the C entry point.
 static TestResult Test_MMSceneExecute(void) {
     return MM_SceneExecute_RunHeadless() == 0 ? TEST_PASS : TEST_FAIL;
+}
+
+// #539: a CVar change on the unified menu path must re-arm MM's registrars,
+// not only OoT's. Needs no Ship::Context — it touches the two registrar maps
+// and nothing else, and it drives only a synthetic key plus the two pseudo-
+// paths, so no production registrar with live side effects runs here.
+static TestResult Test_MMShipInitDriver(void) {
+    return OoT_ShipInitMMDriver_RunHeadless() == 0 ? TEST_PASS : TEST_FAIL;
 }
 
 // CosmeticEditor gfx-wrapper contract (see the extern decl above). Thin
@@ -2301,6 +2316,12 @@ const TestDescriptor gTests[] = {
     // dropped rebind #define fail here. Pure (no display, no ROM).
     {"mm-hook-dispatch", "ShouldActorInit/OnActorInit/OnActorDraw/OnOpenText dispatch reaches S2H::GameHooks (#511)",
      Test_MMHookDispatch},
+    // The sibling of the row above, one layer earlier: a hook is only as armed
+    // as the registrar that (un)registers it, and MM's registrar map had no
+    // CVar-change driver at all — the unified menu re-armed OoT and left MM
+    // latched at its first-boot value. Pure (no display, no ROM).
+    {"mm-shipinit-driver", "A unified-menu CVar change re-arms MM's ShipInit registrars, not only OoT's (#539)",
+     Test_MMShipInitDriver},
     // filePlaytime epoch injection: AdvancePlaytime accrued now-lastTimeLog with
     // lastTimeLog unseeded (0), writing a full Unix epoch into the persisted
     // playtime. Pure (no display), so it runs in the display-free suite.


### PR DESCRIPTION
Fixes #539.

**Read the first section before reviewing: the #497 half of this lane's brief was already delivered at `main`, and this PR deliberately does not redo it.**

## 1. #497 — verified delivered at head, no code change in this PR

The lane brief asked me to accept ADR 0004 and build the MM randomizer-options pane. Walked at `82d55a4a`, all of it is already in the tree, and re-landing it would have been destructive duplication:

| Asked for | State at head |
|---|---|
| ADR 0004 `Status: Proposed` → `Accepted` | Already `Accepted (2026-07-23, #497 step 1)`, `docs/adr/0004-menu-information-architecture.md:3`, with the §6/§4.1a amendments (#564/#565) and #579's ADR 0010 supersession note intact. Re-dating it to 2026-08-04 would falsify the record, so it is untouched. |
| A pane rendering all 47 options, data-driven from `Rando::StaticData::Options`, writing `gRando.*` | `games/mm/2s2h/Rando/OptionsUiSingleExe.cpp` (47 descriptors, labels + 5-group taxonomy + per-row liveness, `cvar`/`name`/`defaultValue` copied from the StaticData row), model `src/common/combo_mm_options_view.{h,c}`, window `src/common/ComboMmOptionsWindow.cpp`, reachable from the live `SohMenu` at `games/oot/soh/SohGui/SohMenuRandomizer.cpp` (`Randomizer → Cross-Game → Toggle MM Randomizer Options`). Writes land via `Combo_MMOptionSetValue` → `CVarSetInteger(desc->cvar, …)`. |
| The 47-vs-46 `RO_ACCESS_MAJORA_REMAINS` skew resolved | Resolved — 47 `RO(` rows, 47 descriptors. |
| Locks | `MMRandoOptions`, `MMPairedProfile`, `ComboMMOptionsWindow`, all `redship`-tier. |

**Logic-row reconciliation with #581 (the item the brief flagged as possibly stale):** consistent, no change needed. `Rando::StaticData::Options[RO_LOGIC]`'s default is `RO_LOGIC_GLITCHLESS` (`StaticData/Options.cpp:55`), the paired pin in `ResolveProfileValues` resolves an unset key to `RO_LOGIC_GLITCHLESS` (`Rando/Foreign.cpp:168-173`), and the pane's `kLogicLabels[0]` is `"Glitchless"` with the descriptor default `0` (`OptionsUiSingleExe.cpp:127-132,187-191`). The pane therefore *displays* exactly what the paired world *resolves to*, and #581's "an explicit choice of any mode still wins" is honoured by the same resolution the pane feeds. The attempt ladder is a generation-side retry, not an option, so it has no row to reconcile.

What is genuinely still open under #497 — steps 3 (`SohMenu` capability-gating infrastructure), 5 (shared-intent marker + the now-*four*-state presentation) and 6 (tier-4 Combo section), plus the "exactly one `SetMenu` survives the link" invariant — is `SohMenu`-side work that the brief did not scope to this lane. It stays open.

### Freeze-safety analysis (the brief's HARD CONSTRAINT), verified by construction

**Claim: a pane CVar write cannot mutate a live or frozen pairing.** Three independent facts, each measured at head rather than asserted:

1. **The writers refuse while frozen.** `Combo_MMOptionSetValue` and `Combo_MMOptionClear` both bail on `Combo_MMProfileFrozen()` (`src/common/combo_mm_options_view.c:120,164`) *before* touching the CVar store, with a logged rejection. The gate is in the writer, not only in the pane's rendering, so any future caller inherits it. Locked by `combo-mm-options-window`.
2. **No in-link consumer reads the option CVars mid-session.** Complete set of files referencing `Rando::StaticData::Options` or the `"gRando.Options."` literal at head: `Rando/StaticData/Options.cpp` (the table), `Rando/Foreign.cpp`, `Rando/MiscBehavior/OnFileCreate.cpp`, `Rando/OptionsUiSingleExe.cpp`, `Rando/Spoiler/Generate.cpp`, `Rando/Spoiler/Apply.cpp`, `Rando/Menu.cpp`, the two combo headers, and three test TUs. Of those:
   - the only code that **reads the CVars** is `Foreign.cpp`'s `ResolveProfileValues` (creation stamp + arrival compare — one shared computation, #564 V3) and the pane's own view model;
   - `Spoiler/Generate.cpp:18-20` and `Spoiler/Apply.cpp:215-217` use the row's `name` and read/write `RANDO_SAVE_OPTIONS`, i.e. the **frozen per-save array**, never the CVar;
   - `Rando/Menu.cpp` — the only other CVar writer — is **link-elided** (`games/mm/CMakeLists.txt:141,146`: it is a `2ship_rando_ui` member, a plain archive, and its tab bodies are file-local statics that would drag the uncompiled `BenMenu`).

   So the option CVars have exactly one runtime meaning: *input to the next profile resolution*. Nothing in gameplay reads them.
3. **Divergence is detected, not absorbed.** A pair whose inputs change between creation and arrival is refused at `MM_Rando_PairOnCrossGameArrival` (stamp left untouched, slot latched, `RSBS_REFUSE_IDENTITY` surfaced), with `ResolvePairedProfile` throwing as the class-level backstop for the non-arrival routes (PR #570).

**No consumer needed gating, so nothing was gated.** Residue, already recorded in ADR 0004 §4.1a and not introduced here: while frozen the pane still *renders* live CVar reads rather than the values the save was built from, so an out-of-band write (hand-edited config, console `cvar_set`) can make the display disagree with the world until the next arrival compare catches it.

---

## 2. #539 — MM's `ShipInit` map gets a CVar-change driver

### The bug

MM's registrar map is a *separate* map — `S2H::ShipInit` (`games/mm/2s2h/ShipInit.hpp:36`, the #375 COMDAT-fold split). Upstream MM re-runs entries out of it whenever a CVar changes, from its own widget layer; in single-exe that layer is drawn only by the tracker windows and only ever passes tracker CVar paths. The one live menu is OoT's `SohMenu`, whose widgets call **OoT's** `ShipInit::Init(cvar)`.

So MM's map was driven exactly once per process, by `S2H::ShipInit::InitAll()` at `games/mm/2s2h/GameExports_SingleExe.cpp:1419`. A converged key like `gEnhancements.RememberSaveLocation` re-armed OoT's registrar on the click and left MM's latched at its first-boot value for the rest of the session. Under the one-game ruling that divergence is corruption: one combo, two halves silently disagreeing about the same setting.

### The choke point

**OoT's `ShipInit::Init(path)`** (`games/oot/soh/ShipInit.hpp`). Every `SohMenu` widget funnels through it — `UIWidgets.cpp:381,612,743,820,872,932,962`, `UIWidgets.hpp:999,1013,1027`, `SohMenuEnhancements.cpp:19` — so this is one edit instead of eleven, and a widget added tomorrow is driven for free. The forward runs **after** OoT's own registrars, matching the ordering a standalone build of either game has (its own registrars first).

The *policy* deliberately does not live in OoT's header. It lives in a new MM-side TU, `games/mm/2s2h/ShipInitBridge_SingleExe.cpp`, next to MM's map.

### What is deliberately not forwarded

Two of the map's keys are pseudo-paths — timing signals, not CVar names — and each game owns its own:

- **`"*"`** — OoT drives it at boot (`OTRGlobals.cpp:2910`, `:1864`) and on preset loads (`Presets.cpp:131`). Forwarding it would run MM's whole registrar set from OoT's boot, *before* MM's own `InitAll()` has ever run, and again on every OoT preset load.
- **`"IS_RANDO"`** — OoT drives it when an OoT rando save loads (`hook_handlers.cpp:2736`); MM drives its own from `Rando/Rando.cpp:20` on MM's save-load chain, which is what the #439 arm-state locks assert. Forwarding OoT's would arm MM's rando hooks off MM's *stale* save state on an OoT-only file load.

Both exclusions are asserted, so "simplify the filter" is a red test rather than a silent behaviour change.

### Blast radius, bounded by construction

The forward is keyed on the exact CVar name the menu just wrote, and only fires when MM's map already holds a registrar under that name (a non-inserting `find()`). A key MM does not register on is a lookup miss and nothing runs. The reachable set is therefore exactly *"MM registrars keyed on a CVar the unified menu writes"* — the converged shared keys, which is precisely #539's subject. The `find()` guard also keeps the forward from growing MM's map: `ShipInit::Init` indexes with `operator[]`, which would otherwise insert one empty vector per OoT-only key a player ever touched.

Two hazards checked and cleared: MM's registrars cannot recurse back (no MM TU can see OoT's `ShipInit`), and `2s2h/DeveloperTools/*.cpp` — the registrars with CVar-writing side effects — are excluded from the link entirely (`games/mm/CMakeLists.txt:254`).

### `RegisterAutosave` — out of scope, and why

It is **not in MM's `ShipInit` map at all**, so no driver can reach it. Its three callers at head are `BenGui/BenMenu.cpp:1113` (TU in no target), `Enhancements/Enhancements.cpp:6` (elided), and the once-only `GameExports_SingleExe.cpp:1469`. Compare OoT, which *does* register it for re-arm (`Enhancements/QoL/Autosave.cpp:85`). Giving MM's a `RegisterShipInitFunc` is a separate change with its own arm-state question and is not attempted here; #539's Autosave leg therefore stays open even though its `RememberSaveLocation` leg closes.

### The lock: `mm-shipinit-driver` (redship tier, ROM-free, display-free)

Split across two TUs because **no translation unit can hold both games' `ShipInit` headers** — MM's ends with `using S2H::ShipInit;` at global scope, which collides with OoT's global `struct ShipInit`. That is the same seam that let the bug exist, so the test is shaped by it rather than around it:

- `games/oot/soh/soh_shipinit_driver_test.cpp` drives the **real** production entry, OoT's inline `ShipInit::Init(path)` — not a re-derivation of it;
- `games/mm/2s2h/mm_shipinit_driver_test.cpp` plants probes in MM's **real** map through MM's **real** `RegisterShipInitFunc`.

| Leg | Asserts | Counterfactual |
|---|---|---|
| 1 | A converged key really has MM registrars behind it (`MM_ShipInit_RegistrarCountForPath("gEnhancements.RememberSaveLocation") > 0`) | Red if MM's TU is elided (#516 class) or the two games' spellings drift. Keeps every other leg from being theatre. Dumps MM's whole CVar-keyed map on failure so elision and spelling-drift are distinguishable in one run. |
| 2 | **The fix.** OoT's `ShipInit::Init(path)` runs MM's registrar for the same key | Remove the forward → FAIL(2) |
| 3 | `"*"` is not forwarded | Non-vacuous: `RegisterShipInitFunc` pushes every registrant into `"*"`, so the probe *is* under it. Drop the filter → FAIL(3) |
| 4 | `"IS_RANDO"` is not forwarded | Non-vacuous via a second probe planted under `IS_RANDO`. Drop the filter → FAIL(4) |
| 5 | An unregistered key does not grow MM's map | Replace the `find()` guard with a bare `Init()` → FAIL(5) |

The driver leg uses a **synthetic** key on purpose: it must not depend on which MM enhancement TUs survived plain-archive linking this week, and it must not re-run a production registrar with live side effects inside a display-free harness. Leg 1 is what ties the synthetic mechanism back to the real converged keys.

## Verification (local, ROM-staged, this worktree, MSVC/Ninja Release)

**Failing-first, measured not asserted.** Same binary, same test, one file's body changed:

```
# driver body neutered (behaviourally identical to head, where no such call existed)
$ redship.exe --test mm-shipinit-driver
[TEST] FAIL(2): a CVar change through OoT's ShipInit::Init did not run MM's
       registrar for the same key — MM's map still has no CVar-change driver (#539)
EXITCODE=1

# driver restored
$ redship.exe --test mm-shipinit-driver
[TEST] PASS: a CVar change on the unified menu path re-arms MM's registrars
       (1 on the converged key), while the '*' and 'IS_RANDO' pseudo-paths stay MM-driven
EXITCODE=0
```

Leg 1 passed in **both** states: `gEnhancements.RememberSaveLocation` really does have an MM registrar behind it (count 1 — `Enhancements/Saving/SavingEnhancements.cpp:388` survives the `2ship_enh` plain-archive link, and the two games' spellings agree). So the red is the driver being absent, not the key being dead.

The header half of the fix has its own hard counterfactual, hit by accident during bring-up: with the new MM TU absent from the link, `MM_ShipInit_OnCVarChanged` is an **unresolved external** across every OoT TU that includes `ShipInit.hpp` (`LNK1120`). The forward cannot be silently dropped.

**Both tiers, on the final binary:**

- `ctest -L "^redship$"` — **100% tests passed, 78/78** (including the new `MMShipInitDriver` and the `TestRegistrationComplete` registration guard)
- `ctest -L "^rando$"` — **100% tests passed, 18/18** (including `MMPairSwitchEntry`, `MMPairedAttemptGen`, `MMPairedAttemptDeterminism`, `MMPairedExhaustion`, `MMReloadArmState`, `MMMoonCrashArmState`, `MMOwlSaveArmState`, `RandoDeterminism`, `SeedDeterminism`)

The three arm-state rows are the ones a mis-scoped forward would break: they assert MM's `IS_RANDO` hooks match the save on the non-arrival entry paths, which is exactly what leg 4's exclusion protects.

clang-format 14.0.6 clean on all four touched/added C++ paths. The three new files are added to `.github/clang-format-paths.txt`, plus `games/oot/soh/ShipInit.hpp` (already clean), so the gate now covers the choke point itself.

## Coordination

Touches to the two files other lanes own are minimal and additive: `src/common/test_runner.cpp` gains one extern declaration, one thin wrapper and one table row; `CMake/SingleExecutable.cmake` gains one `redship_add_test` row. `src/common/mm_stubs.c` is untouched. No `gameMode`/`fileNum` logic was needed — the driver has no "is a real file active" question to answer.

No submodule pointer and no generated stamp (`build.c`, `properties.h`) is in any commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!--- section:artifacts:start -->
### Build Artifacts
  - [rsbs-windows.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/8917425493.zip)
  - [rsbs-linux.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/8917231469.zip)
<!--- section:artifacts:end -->