### PR TITLE
Lock MM's re-homed registrar list at runtime, not just at link (#516)

### DIFF
--- a/.github/clang-format-paths.txt
+++ b/.github/clang-format-paths.txt
@@ -44,6 +44,7 @@ games/mm/2s2h/mm_fb_effects_test.cpp
 games/mm/2s2h/mm_flash_filenum_test.cpp
 games/mm/2s2h/mm_hook_dispatch_test.cpp
 games/mm/2s2h/mm_playtime_seed_test.cpp
+games/mm/2s2h/mm_registrar_coverage_test.cpp
 games/mm/2s2h/mm_framebuffer_effects.c
 games/mm/2s2h/mm_gi_shim_test.cpp
 games/mm/2s2h/mm_notification_binding_test.cpp

--- a/.github/scripts/check-registrar-elision.sh
+++ b/.github/scripts/check-registrar-elision.sh
@@ -309,6 +309,25 @@ main() {
     fi
 
     local overall=0
+    # WHY 2ship_enh AND 2ship_rando_ui STAY report-only -- do not "fix" this by
+    # flipping them to required (#516 asked the question twice; the answer is
+    # the same both times).
+    #
+    # `required` means EVERY registrar TU in the archive must survive the link.
+    # For 2ship_enh that is the wrong assertion, not a stricter one: most of its
+    # members must legitimately stay dead in single-exe. BenGui::SetupGuiElements
+    # would bring up a second menu surface; DebugConsole_Init ODR-collides with
+    # OoT's and, since AddCommand is first-wins, would be inert anyway;
+    # GameInteractor::RegisterOwnHooks writes into OoT's instance through
+    # poisoned names; OTRAudio_Init would spawn a second SDL audio thread;
+    # ConfigVersion1Updater would corrupt OoT's config migration at ordinal 1.
+    # Requiring the archive whole would demand exactly those link. 2ship_rando_ui
+    # is the same shape -- it is compiled only for bit-rot protection and is
+    # meant to be elided until MM's menu surface is ported.
+    #
+    # Enforcement for this archive therefore has to be PER-SYMBOL, which is what
+    # the required_mm_registrars allowlist below does, backed by the
+    # MMRegistrarCoverage ctest row for the half a symbol grep cannot see.
     run_elision_gate "$bin" \
         "$build_dir/games/oot/libsoh_rando.a:required" \
         "$build_dir/games/oot/libsoh_enh.a:required" \
@@ -347,10 +366,26 @@ main() {
     # dropped the hard call and re-elided a required MM feature.
     #
     # Same plain-grep-not-`-q` discipline as the probes above (pipefail + SIGPIPE).
-    # RegisterAutosave is deliberately ABSENT: its symbol ODR-folds with OoT's
-    # soh_enh Autosave.cpp twin (a static void RegisterAutosave()), so a presence
-    # probe cannot attribute a hit to MM's copy. RegisterSavingEnhancements has no
-    # such twin and is gated here (#516 Phase 2).
+    # RegisterAutosave is deliberately ABSENT: OoT ships a static
+    # RegisterAutosave (games/oot/soh/Enhancements/QoL/Autosave.cpp:80), whose
+    # symbol nm still lists, so a presence probe cannot attribute a hit to MM's
+    # copy. RegisterSavingEnhancements has no such twin and is gated here.
+    #
+    # RegisterAutosave is instead gated at RUNTIME by the MMRegistrarCoverage
+    # ctest row (games/mm/2s2h/mm_registrar_coverage_test.cpp), which attributes
+    # by registry content rather than by symbol name: OnGameStateDrawFinish has
+    # exactly one registrant in the whole MM tree, inside RegisterAutosave's
+    # CVar-gated branch, so a non-empty registry after the real MM_Rando_Init is
+    # an exact tell. That closes #516's open question 1 without renaming
+    # upstream-tracked code.
+    #
+    # NOTE ON WHAT THIS LOOP CAN AND CANNOT SEE. A name found here proves only
+    # that the symbol LINKED. It does not prove the registrar RAN -- a call
+    # moved under a never-true condition, or a once-guard that latches before
+    # it, keeps the symbol and leaves the registry as empty as full elision did.
+    # MMRegistrarCoverage covers that half for all four. Keep both: the grep
+    # catches re-elision at link time on every CI build, the ctest row catches
+    # the silent-no-op failure this whole issue class is made of.
     local required_mm_registrars=(
         "CustomItem::RegisterHooks"                 # cross-game + rando item delivery (critical)
         "S2H::CustomMessage::RegisterHooks"         # custom rando/hint message text 0x4B (critical)

--- a/CMake/SingleExecutable.cmake
+++ b/CMake/SingleExecutable.cmake
@@ -688,6 +688,23 @@ if(BUILD_TESTING)
     # gSaveContext storage means an ungated MM tracker reads OoT bytes through
     # MM's SaveContext layout.
     redship_add_test(NAME MMTrackersGui COMMAND redship --test mm-trackers-gui)
+    # Registrar coverage (#516): games/mm/2s2h/BenPort.cpp is excluded from the
+    # single exe and was the SOLE caller of InitOTR's registration sequence, so
+    # 2ship_enh (a plain STATIC archive) lost the TUs entirely -- CustomItem and
+    # CustomMessage's RegisterHooks, RegisterSavingEnhancements and
+    # RegisterAutosave were all 0-hit in redship.map, leaving every randomized
+    # custom item uncollectable and every rando textbox on vanilla message
+    # 0x004B. They are re-homed into MM_Rando_Init; this row drives that real
+    # entry point and asserts each registry actually filled.
+    #
+    # It is NOT redundant with check-registrar-elision.sh's per-symbol
+    # allowlist: that grep proves the symbols LINKED, which a call moved under a
+    # never-true condition would still satisfy. It is also the only possible
+    # gate on RegisterAutosave, whose name the script cannot attribute (OoT
+    # ships a static twin at Enhancements/QoL/Autosave.cpp). Display-free and
+    # ROM-free -- MM_Rando_Init gates its one asset-dependent call behind
+    # MM_Rando_AssetsReady() -- so it runs in this redship tier.
+    redship_add_test(NAME MMRegistrarCoverage COMMAND redship --test mm-registrar-coverage)
     redship_add_test(NAME MMResumeArena COMMAND redship --test mm-resume-arena)
     redship_add_test(NAME MMStartupRestore COMMAND redship --test mm-startup-restore)
     redship_add_test(NAME AllTests COMMAND redship --test all)

--- a/games/mm/2s2h/GameExports_SingleExe.cpp
+++ b/games/mm/2s2h/GameExports_SingleExe.cpp
@@ -1442,6 +1442,12 @@ extern "C" void MM_Rando_Init(void) {
     // MM ShouldActorInit and OnOpenText execute points their bodies were written
     // against; before that, reviving them here would have registered into a
     // registry nothing dispatched.
+    //
+    // LOCKED. The four calls below are asserted at runtime by the
+    // MMRegistrarCoverage ctest row (games/mm/2s2h/mm_registrar_coverage_test.cpp),
+    // which drives this function and fails if any of their registries is still
+    // empty afterwards. Deleting or condition-gating one turns that row red --
+    // which is the point, since the #516 failure mode is otherwise silent.
     CustomItem::RegisterHooks();    // ShouldActorInit[EN_ITEM00]: the swap that
                                     // makes CustomItem::Spawn's placeholder a
                                     // real item — cross-game arrivals + every

--- a/games/mm/2s2h/mm_registrar_coverage_test.cpp
+++ b/games/mm/2s2h/mm_registrar_coverage_test.cpp
@@ -1,0 +1,234 @@
+/**
+ * @file mm_registrar_coverage_test.cpp
+ * ROM-free, display-free lock for #516: MM's single-exe bring-up must actually
+ * POPULATE the hook registries that BenPort.cpp's exclusion emptied.
+ * CTest label "redship", row MMRegistrarCoverage in CMake/SingleExecutable.cmake,
+ * dispatch "mm-registrar-coverage" in src/common/test_runner.cpp.
+ *
+ * WHAT WAS BROKEN (#516). games/mm/2s2h/BenPort.cpp is excluded from the single
+ * exe (games/mm/CMakeLists.txt), and it was the SOLE caller of InitOTR's
+ * registration sequence. 2ship_enh is a plain STATIC archive, so with no
+ * inbound reference those TUs were link-elided outright: CustomItem::
+ * RegisterHooks, S2H::CustomMessage::RegisterHooks, InitEnhancements (and
+ * through it RegisterSavingEnhancements / RegisterAutosave) and
+ * GfxPatcher_ApplyNecessaryAuthenticPatches were all 0-hit in redship.map.
+ * Player-visible: every randomized custom item uncollectable, every rando/hint
+ * textbox rendering vanilla message 0x004B, no owl-save persistence, no
+ * autosave. The registrars have since been re-homed into MM_Rando_Init
+ * (games/mm/2s2h/GameExports_SingleExe.cpp).
+ *
+ * WHY THIS ROW EXISTS ALONGSIDE THE CI SYMBOL GATE. .github/scripts/
+ * check-registrar-elision.sh greps the linked binary for a per-symbol
+ * allowlist. That proves the registrars LINKED. It cannot prove they RAN --
+ * a call moved under a condition that is never true, or a once-guard that
+ * latches before the call, both keep the symbol in the binary and leave every
+ * registry as empty as full elision did. This row closes that gap the way the
+ * script's own header recommends for ForeignItemsSingleExe.cpp: "ask the
+ * running binary whether MM's pool actually registered. A dropped initializer
+ * is a red test, not a subtle count."
+ *
+ * It is also the ONLY possible gate for RegisterAutosave. That symbol cannot
+ * be allowlisted in the CI script: OoT ships a static RegisterAutosave
+ * (games/oot/soh/Enhancements/QoL/Autosave.cpp:80), so a demangled-name grep
+ * is satisfied by OoT's copy whether or not MM's ever links. Attribution by
+ * name is impossible; attribution by REGISTRY CONTENT is exact, because
+ * OnGameStateDrawFinish has exactly one registrant in the whole MM tree
+ * (SavingEnhancements.cpp, inside RegisterAutosave's CVar-gated branch).
+ * That closes #516's open question 1 without renaming upstream-tracked code.
+ *
+ * ATTRIBUTION -- why each probe names exactly one registrar.
+ *   - BeforeMoonCrashSaveReset: sole registrant in all of games/mm is
+ *     SavingEnhancements.cpp (RegisterSavingEnhancements). Non-empty => it ran.
+ *   - OnGameStateDrawFinish:    sole registrant is SavingEnhancements.cpp
+ *     (RegisterAutosave, CVar-gated). Non-empty => it ran.
+ *   - OnOpenText[0x004B]:       sole registrant for that id is
+ *     CustomMessage.cpp (CustomMessage::RegisterHooks).
+ *   - ShouldActorInit[EN_ITEM00]: FOUR registrants exist -- CustomItem.cpp
+ *     (unconditional) plus ChuDrops.cpp, JPGrottos.cpp (each CVar-gated) and
+ *     Rando/ActorBehavior/EnItem00.cpp (IS_RANDO-gated). The two CVar-gated
+ *     ones are forced OFF below, so a non-empty bucket can only be
+ *     CustomItem's. Without that forcing this probe could pass on a default
+ *     flip while CustomItem::RegisterHooks stayed dead -- the exact vacuity
+ *     #516 is about. The IS_RANDO one cannot be forced from here without
+ *     touching gSaveContext (MM's z64save.h carries no extern "C" guard, so a
+ *     C++ TU that includes global.h at file scope cannot also take a C-linkage
+ *     declaration of it), so it is caught rather than prevented: the bucket is
+ *     asserted to hold EXACTLY ONE registrant, and a second one fails loudly as
+ *     a precondition violation instead of silently propping up the probe.
+ *
+ * NON-VACUITY. Every probe asserts its registry is EMPTY before MM_Rando_Init
+ * and non-empty after, so a registry populated by something else, or by an
+ * earlier phase of the harness, cannot satisfy it. Verified red before green:
+ * commenting out any one of the four calls in MM_Rando_Init fails this row at
+ * that probe's own FAIL code, and re-adding it turns it green.
+ *
+ * DELIBERATELY NOT REFERENCED HERE. This row drives only the production entry
+ * point MM_Rando_Init(); it never calls CustomItem::RegisterHooks and friends
+ * directly. That is load-bearing, not stylistic: a direct call from this
+ * always-linked test TU would itself be an inbound reference that keeps those
+ * symbols in the binary, which would make the CI symbol gate pass on a build
+ * where production had dropped every call. The test must not prop up what the
+ * gate measures.
+ *
+ * WHAT THIS DOES NOT COVER. GfxPatcher_ApplyNecessaryAuthenticPatches is a
+ * one-shot resource patcher, not a hook registrar, and MM_Rando_Init gates it
+ * behind MM_Rando_AssetsReady() because its ResourceMgr_Load*ByName helpers
+ * null-deref with no mm.o2r. It therefore does not run in this ROM-free row and
+ * has no registry to probe; it stays covered by the CI symbol allowlist alone.
+ * Nor does this row prove the registered handlers are ever DISPATCHED -- that
+ * is MMHookDispatch's invariant (#511/#512), and the two rows are complementary:
+ * dispatch without registration and registration without dispatch are both
+ * silent, and each was a real shipped bug.
+ */
+
+#include "global.h"
+
+#include <cstdio>
+
+#if !defined(RSBS_SINGLE_EXECUTABLE)
+/**
+ * The S2H::GameHooks registry and the BenPort exclusion that motivates this
+ * lock both exist only in the single-exe build. Outside it MM runs its own
+ * InitOTR and there is nothing to re-home, so the row reports pass rather than
+ * failing to link. test_runner.cpp declares this unconditionally.
+ */
+extern "C" int MM_RegistrarCoverage_RunHeadless(void) {
+    printf("[TEST] mm-registrar-coverage: PASS (not applicable outside RSBS_SINGLE_EXECUTABLE)\n");
+    return 0;
+}
+#else
+
+#include <libultraship/bridge/consolevariablebridge.h>
+#include <ship/Context.h>
+
+#include "2s2h/GameInteractor/GameInteractor.h"
+#include "2s2h/CustomMessage/CustomMessage.h"
+#include "mm_game_hooks.h"
+
+extern "C" {
+// The production bring-up under test. Declared, never defined here.
+void MM_Rando_Init(void);
+}
+
+namespace {
+
+#define RC_ASSERT(cond, code, msg)                                                      \
+    do {                                                                                \
+        if (!(cond)) {                                                                  \
+            printf("[TEST] FAIL(%d): %s (%s:%d)\n", (code), (msg), __FILE__, __LINE__); \
+            return (code);                                                              \
+        }                                                                               \
+    } while (0)
+
+// Settled counts. Unregistration in S2H::GameHooks is DEFERRED -- Unregister
+// only queues an id, and the queue is drained at the next Execute of that hook
+// type. RegisterAutosave in particular unregisters-then-registers on every
+// call, so counting the raw maps without draining first could credit a hook
+// that is already slated for removal. Flushing makes each count the state a
+// real dispatch would see.
+template <typename H> size_t SettledUnkeyedCount() {
+    S2H::GameHooks::FlushPendingUnregistrations<H>();
+    return S2H::GameHooks::Registry<H>::functions.size();
+}
+
+template <typename H> size_t SettledCountForId(int32_t forId) {
+    S2H::GameHooks::FlushPendingUnregistrations<H>();
+    auto& buckets = S2H::GameHooks::Registry<H>::functionsForID;
+    auto it = buckets.find(forId);
+    return it == buckets.end() ? 0u : it->second.size();
+}
+
+// The two CVar-gated OTHER ShouldActorInit[ACTOR_EN_ITEM00] registrants, forced
+// off so the probe can only be satisfied by CustomItem's unconditional one.
+// (The third competitor, EnItem00.cpp's IS_RANDO leg, is caught by the
+// exactly-one assertion rather than prevented -- see the file header.)
+constexpr const char* kChuDropsCVar = "gEnhancements.Equipment.ChuDrops";
+constexpr const char* kJPGrottosCVar = "gEnhancements.Restorations.JPGrottos";
+
+// RegisterAutosave registers nothing unless this is set -- it is a runtime
+// toggle, not an unconditional registrar. Forced ON so its absence is a real
+// failure rather than a configuration artifact.
+constexpr const char* kAutosaveCVar = "gEnhancements.Autosave";
+
+} // namespace
+
+extern "C" int MM_RegistrarCoverage_RunHeadless(void) {
+    printf("[TEST] mm-registrar-coverage: MM bring-up populates the registries BenPort's exclusion emptied (#516)\n");
+
+    auto ctx = Ship::Context::GetInstance();
+    RC_ASSERT(ctx != nullptr, 1, "Ship::Context singleton missing — run the shared bring-up first");
+    RC_ASSERT(ctx->GetConsoleVariables() != nullptr, 1,
+              "ConsoleVariables missing — ShipInit registrars and the CVar forcing below need them");
+
+    // ---- Harness configuration, before any registration runs ---------------
+    // Competing EN_ITEM00 registrants off and autosave on (see ATTRIBUTION in
+    // the file header). These must be set before MM_Rando_Init, because
+    // COND_ID_HOOK evaluates its gate once, at ShipInit::InitAll time.
+    CVarSetInteger(kChuDropsCVar, 0);
+    CVarSetInteger(kJPGrottosCVar, 0);
+    CVarSetInteger(kAutosaveCVar, 1);
+
+    // ---- Non-vacuity: every probed registry starts empty -------------------
+    // If any of these is already populated, the "non-empty after" assertions
+    // below prove nothing, so refuse to run rather than pass vacuously.
+    RC_ASSERT(SettledCountForId<GameInteractor::ShouldActorInit>(ACTOR_EN_ITEM00) == 0, 2,
+              "ShouldActorInit[EN_ITEM00] was already populated before MM_Rando_Init — probe would be vacuous");
+    RC_ASSERT(SettledCountForId<GameInteractor::OnOpenText>(CUSTOM_MESSAGE_ID) == 0, 2,
+              "OnOpenText[0x004B] was already populated before MM_Rando_Init — probe would be vacuous");
+    RC_ASSERT(SettledUnkeyedCount<GameInteractor::BeforeMoonCrashSaveReset>() == 0, 2,
+              "BeforeMoonCrashSaveReset was already populated before MM_Rando_Init — probe would be vacuous");
+    RC_ASSERT(SettledUnkeyedCount<GameInteractor::OnGameStateDrawFinish>() == 0, 2,
+              "OnGameStateDrawFinish was already populated before MM_Rando_Init — probe would be vacuous");
+
+    // ---- The production bring-up -------------------------------------------
+    // Once-only guarded internally; this row is the only caller in its process.
+    MM_Rando_Init();
+
+    // ---- CustomItem::RegisterHooks (#516 critical) -------------------------
+    // Without it CustomItem::Spawn's ACTOR_EN_ITEM00/ITEM00_NOTHING placeholder
+    // is never swapped for the real item: every rando reward and every
+    // cross-game arrival delivers nothing.
+    const size_t enItem00Registrants = SettledCountForId<GameInteractor::ShouldActorInit>(ACTOR_EN_ITEM00);
+    RC_ASSERT(enItem00Registrants > 0, 3,
+              "ShouldActorInit[EN_ITEM00] empty after MM_Rando_Init — CustomItem::RegisterHooks never ran, "
+              "every randomized custom item is uncollectable (#516)");
+    // Attribution integrity, not a feature assertion. With ChuDrops and
+    // JPGrottos forced off, CustomItem's unconditional registrant is the only
+    // one that may be here. A second means a competing gate came on -- most
+    // likely EnItem00.cpp's IS_RANDO leg, if a shared-process `--test all`
+    // ordering left saveType == SAVETYPE_RANDO -- and the probe above would no
+    // longer be evidence that CustomItem ran. Fail loudly rather than pass on
+    // someone else's registrant; if a fifth registrant is added deliberately,
+    // update the ATTRIBUTION note in this file's header along with this count.
+    RC_ASSERT(enItem00Registrants == 1, 7,
+              "ShouldActorInit[EN_ITEM00] has a competing registrant — the CustomItem probe above is no longer "
+              "attributable; see ATTRIBUTION in this file's header (#516)");
+
+    // ---- CustomMessage::RegisterHooks (#516 critical) ----------------------
+    // Its registrant is the only code that clears loadFromMessageTable and
+    // loads the staged custom message; without it MM falls through to the real
+    // vanilla message table and every rando/hint textbox renders entry 0x004B.
+    RC_ASSERT(SettledCountForId<GameInteractor::OnOpenText>(CUSTOM_MESSAGE_ID) > 0, 4,
+              "OnOpenText[0x004B] empty after MM_Rando_Init — CustomMessage::RegisterHooks never ran, "
+              "every rando/hint textbox renders vanilla message 0x004B (#516)");
+
+    // ---- RegisterSavingEnhancements (#516 Phase 2) -------------------------
+    // Sole registrant of BeforeMoonCrashSaveReset. Also carries the OnSaveLoad
+    // leg that seeds shipSaveContext.lastTimeLog — the seeder whose absence
+    // injected a full Unix epoch into filePlaytime (#513).
+    RC_ASSERT(SettledUnkeyedCount<GameInteractor::BeforeMoonCrashSaveReset>() > 0, 5,
+              "BeforeMoonCrashSaveReset empty after MM_Rando_Init — RegisterSavingEnhancements never ran, "
+              "owl-save persistence and moon-crash cleanup are inert (#516)");
+
+    // ---- RegisterAutosave (#516 Phase 2; ungateable by symbol name) --------
+    // Sole registrant of OnGameStateDrawFinish, and the reason this row exists
+    // at all: OoT's static twin makes the CI name-grep unattributable.
+    RC_ASSERT(SettledUnkeyedCount<GameInteractor::OnGameStateDrawFinish>() > 0, 6,
+              "OnGameStateDrawFinish empty after MM_Rando_Init — RegisterAutosave never ran, "
+              "MM has no periodic autosave and no autosave icon (#516)");
+
+    printf("[TEST] mm-registrar-coverage: PASS (4 re-homed registrars all populated their registries)\n");
+    return 0;
+}
+
+#endif /* RSBS_SINGLE_EXECUTABLE */

--- a/src/common/test_runner.cpp
+++ b/src/common/test_runner.cpp
@@ -134,6 +134,15 @@ int MM_HookDispatch_RunHeadless(void);
 // a full Unix epoch -- into the persisted filePlaytime. The fix treats the zero
 // as the seed. Returns 0 on pass, non-zero on fail.
 int MM_PlaytimeSeed_RunHeadless(void);
+// MM registrar coverage (games/mm/2s2h/mm_registrar_coverage_test.cpp, #516):
+// BenPort.cpp's exclusion elided InitOTR's whole registration list, so
+// CustomItem / CustomMessage / RegisterSavingEnhancements / RegisterAutosave
+// were absent from the binary. They are re-homed into MM_Rando_Init; this row
+// drives that production entry point and asserts each one's registry actually
+// filled. Complements the CI symbol allowlist, which can only prove the
+// symbols LINKED -- and which cannot attribute RegisterAutosave at all, since
+// OoT ships a static twin of that name. Returns 0 on pass, non-zero on fail.
+int MM_RegistrarCoverage_RunHeadless(void);
 // MM tracker registration surface (games/mm/2s2h/mm_trackers_gui_test.cpp,
 // #392): the four MM tracker windows must register on a Gui under
 // "MM "-prefixed names (SoH owns the unprefixed ones and Gui::AddGuiWindow
@@ -1871,6 +1880,25 @@ TestResult Test_MMTrackersGui(void) {
     return MM_TrackersGui_RunHeadless() == 0 ? TEST_PASS : TEST_FAIL;
 }
 
+// MM registrar coverage (#516). Needs the same display-free shared bring-up as
+// the Gui rows above, for a different reason: it drives the real MM_Rando_Init,
+// whose ShipInit registrars and CVar-gated legs read the Ship::Context
+// singleton's ConsoleVariables. Without it MM_Rando_Init dereferences a null
+// singleton rather than reporting a clean failure.
+TestResult Test_MMRegistrarCoverage(void) {
+    auto ctx = CreateHarnessStyleContext();
+    if (!ctx) {
+        printf("[TEST] FAIL: could not create Ship::Context singleton\n");
+        return TEST_FAIL;
+    }
+    if (OoT_InitSharedContextSubsystems() != 0) {
+        printf("[TEST] FAIL: shared bring-up reported failure\n");
+        return TEST_FAIL;
+    }
+
+    return MM_RegistrarCoverage_RunHeadless() == 0 ? TEST_PASS : TEST_FAIL;
+}
+
 // Cross-game spoiler window (#496, ADR 0008). Same bring-up as the MM tracker
 // bridge above and for the same reason: the test constructs real
 // Ship::GuiWindow objects on a standalone Ship::Gui, and the GuiWindow ctor
@@ -2329,6 +2357,14 @@ const TestDescriptor gTests[] = {
      Test_MMPlaytimeSeed},
     {"mm-trackers-gui", "MM tracker windows register de-collided on the shared Gui + gate on the active game (#392)",
      Test_MMTrackersGui},
+    // Registrar coverage: BenPort.cpp's exclusion elided InitOTR's whole
+    // registration list, so the re-homed registrars in MM_Rando_Init must be
+    // shown to POPULATE their registries, not merely to link. Runs the real
+    // MM_Rando_Init, which is irreversible in-process, so `--test all` skips
+    // this entry and it is exercised only through its own CTest row (see the
+    // skip block in TestRunner_Run for the full reasoning).
+    {"mm-registrar-coverage", "MM_Rando_Init populates the registries BenPort's exclusion emptied (#516)",
+     Test_MMRegistrarCoverage},
     // The two MM resume-contract tests below mutate process-global state
     // (mm-resume-arena re-inits the MM system arena + heaps; mm-startup-restore
     // scribbles and re-zeroes the unified gSaveContext). Both clean up after
@@ -2422,6 +2458,35 @@ int TestRunner_Run(const char* testName) {
                 strcmp(gTests[i].name, "mm-owl-save-arm-state") == 0 ||
                 strcmp(gTests[i].name, "foreign-placement-oot") == 0) {
                 printf("\n--- Skipping: %s (needs display; runs as a rando-label CTest) ---\n", gTests[i].name);
+                continue;
+            }
+            // mm-registrar-coverage is display-free, but it is the only row that
+            // runs the real MM_Rando_Init, and that is IRREVERSIBLE in-process:
+            // the once-guard cannot be cleared, and InitAll + Rando::Init leave
+            // registrants across dozens of S2H::GameHooks types, far more than a
+            // row could plausibly reset. Those registrations are correct
+            // production state, but later rows in this shared process were
+            // written against a process where MM's registrars had never run.
+            //
+            // Concretely: mm-startup-restore freezes a byte-patterned save and
+            // asserts an exact restore, and MM_Play_ConsumeStartupEntrance ends
+            // in GameInteractor_ExecuteOnSaveLoad. With RegisterSavingEnhancements
+            // live, that hook seeds shipSaveContext.lastTimeLog -- and
+            // shipSaveContext is the LAST member of SaveContext, so the seed
+            // overwrites the very tail byte that row checks.
+            //
+            // Worth stating plainly, because it is a latent finding rather than
+            // a quirk of this row: in a real MM boot MM_Rando_Init runs before
+            // any restore, so that seeder IS live, and mm-startup-restore's
+            // byte-exact tail assertion passes today only because its isolated
+            // process never registered it. Re-examining that assertion against
+            // production is its own change, not this one's.
+            //
+            // Skipping here costs no coverage: MMRegistrarCoverage has its own
+            // CTest row in the redship tier, which is what CI enforces.
+            if (strcmp(gTests[i].name, "mm-registrar-coverage") == 0) {
+                printf("\n--- Skipping: %s (runs MM_Rando_Init irreversibly; has its own CTest row) ---\n",
+                       gTests[i].name);
                 continue;
             }
             printf("\n--- Running: %s ---\n", gTests[i].name);


### PR DESCRIPTION
Fixes #516

## What this closes, and what it does not

#516 asked for two things: restore the registration list BenPort.cpp's exclusion elided, and **lock it** so the next elided registrar fails CI instead of shipping.

The list is already restored — Phases 1 and 2 (PRs #518, #520) re-homed every salvageable entry into `MM_Rando_Init`. **What was missing is the lock's second half.** `check-registrar-elision.sh`'s per-symbol allowlist greps the linked binary, which proves the registrars **linked**. It cannot prove they **ran**: a call moved under a never-true condition, or a once-guard that latches before it, keeps the symbol in the binary and leaves the registry as empty as full elision did. That is the same silent shape as the original bug — this issue class is made of "the symbol is there, the behaviour isn't".

So this PR adds the runtime half, and audits the list entry-by-entry to confirm nothing is still silently missing.

## Entry-by-entry audit of BenPort.cpp's `InitOTR` (`:849-905`)

| BenPort entry | Status | Where / why |
|---|---|---|
| `ShipInit::InitAll()` | already present | `MM_Rando_Init` |
| `InitEnhancements()` | already present | Its whole body is `RegisterSavingEnhancements` + `RegisterAutosave`, both called directly |
| `Rando::Init()` | already present | `MM_Rando_Init` |
| `CustomItem::RegisterHooks()` | already present → **now runtime-gated** | Phase 1; probe added here |
| `CustomMessage::RegisterHooks()` | already present → **now runtime-gated** | Phase 1; probe added here |
| `RegisterSavingEnhancements()` | already present → **now runtime-gated** | Phase 2; probe added here |
| `RegisterAutosave()` | already present → **now gated for the first time** | Phase 2 left it wired but **ungateable**; see below |
| `GfxPatcher_ApplyNecessaryAuthenticPatches()` | already present | Phase 1, gated on `MM_Rando_AssetsReady()`. Not a hook registrar and asset-dependent, so no ROM-free registry to probe — stays covered by the symbol allowlist alone |
| `Rando::StaticData::PopulateCheckNames()` | already present | `TrackersGuiSingleExe.cpp:274`, `TrackerAdapterSingleExe.cpp:94` |
| `MM_OTRMessage_Init()` | already present | `GameExports_SingleExe.cpp:1308` |
| ~28 × `RegisterResourceFactory` | already present **by design** | OoT registers the shared types; MM registers only its 7 MM-specific/conflicting ones (`RegisterMMResourceFactories`), incl. the per-archive Path/Room/Cutscene dispatchers. Not a shortfall |
| `AudioCollection::Instance` | already present | `GameExports_SingleExe.cpp:161` |
| `BenGui::SetupGuiElements()` | **excluded — deliberate** | Second menu surface; trackers re-homed via `TrackersGuiSingleExe.cpp` |
| `DebugConsole_Init()` | **excluded — deliberate** | ODR-collides with OoT's; `AddCommand` is first-wins, so it would be inert anyway |
| `GameInteractor::RegisterOwnHooks()` | **excluded — deliberate** | Poisoned names; OOB write into OoT's instance. Pump already via `MM_GameEvents_RegisterPump` |
| `OTRAudio_Init()` | **excluded — deliberate** | Would spawn a second SDL audio thread; OoT's already serves MM |
| `ConfigVersion1Updater` | **excluded — deliberate** | Ordinal-1 collision on OoT-owned config; superseded by `SOH::ImportTwoShipConfig` |
| `OTRExtScanner()` | **still absent — Phase 3** | Needs a shared-ExtensionCache rescan after MM archives mount. Cosmetic (MM HD gfxprint fonts) |
| `PlayerCustomFlipbooks_Patch()` | **still absent — Phase 3** | Same ExtensionCache dependency. Cosmetic (static FD/Deku/Goron faces) |
| `MM_gIrqMgrRetraceTime` seed | not a registrar | Self-seeds at `irqmgr.c:129` |

Net: the list is complete except the two cosmetic Phase 3 entries, which share one prerequisite (an `MM_Game_Init` ordering change) and want their own "did the rescan actually land MM paths" verification. Not folded in here.

## The new lock — `MMRegistrarCoverage`

Drives the real `MM_Rando_Init` and asserts each re-homed registrar's registry actually filled:

| Registrar | Probed registry | Why it is attributable |
|---|---|---|
| `CustomItem::RegisterHooks` | `ShouldActorInit[EN_ITEM00]` | 4 possible registrants; the 2 CVar-gated ones forced off and the bucket asserted to hold **exactly one** |
| `CustomMessage::RegisterHooks` | `OnOpenText[0x004B]` | Sole registrant for that id |
| `RegisterSavingEnhancements` | `BeforeMoonCrashSaveReset` | Sole registrant in all of `games/mm` |
| `RegisterAutosave` | `OnGameStateDrawFinish` | Sole registrant in all of `games/mm` |

**This closes #516's open question 1.** `RegisterAutosave` could not be allowlisted in CI because OoT ships a `static RegisterAutosave` (`Enhancements/QoL/Autosave.cpp:80`) whose symbol `nm` still lists — a demangled-name grep is satisfied by OoT's copy whether or not MM's ever links. Attribution *by name* is impossible; attribution *by registry content* is exact. No upstream-tracked file had to be renamed, which was the alternative on the table.

**The row deliberately calls only `MM_Rando_Init`, never the registrars directly.** That is load-bearing, not stylistic: a direct call from this always-linked test TU would itself be an inbound reference keeping those symbols in the binary, making the CI symbol gate pass on a build where production had dropped every call. The test must not prop up what the gate measures.

### Non-vacuity

Every probe asserts its registry is **empty before** `MM_Rando_Init` and non-empty after. Falsified before trusted, two builds:

- all four calls commented out → **`FAIL(3)`** at the CustomItem probe
- only `RegisterAutosave` commented out → **`FAIL(6)`**, with the other five probes still green — so that probe is independently attributable, not riding on its neighbours

## Why `2ship_enh` is *not* flipped to `required`

This was proposed twice on #516. It is the wrong assertion, not a stricter one: `required` demands every registrar TU in the archive survive the link, and most of `2ship_enh` must legitimately stay dead (the five deliberate exclusions above). Flipping it would demand `BenGui`/`DebugConsole`/`RegisterOwnHooks`/`OTRAudio_Init`/`ConfigVersion1Updater` all link. Enforcement there has to be **per-symbol** — which the existing allowlist plus this new row now provide. The reasoning is recorded in the script so the next reader doesn't re-litigate it.

## A latent finding, surfaced not fixed

`--test all` skips this entry. It is display-free, but `MM_Rando_Init` is irreversible in-process, and later rows in that shared process were written against a process where MM's registrars had never run.

Concretely: `mm-startup-restore` freezes a byte-patterned save and asserts an exact restore, and `MM_Play_ConsumeStartupEntrance` ends in `GameInteractor_ExecuteOnSaveLoad`. With `RegisterSavingEnhancements` live, that hook seeds `shipSaveContext.lastTimeLog` — and `shipSaveContext` is the **last member of `SaveContext`**, so the seed overwrites the exact tail byte that row checks.

Worth stating plainly: **in a real MM boot that seeder is live before any restore**, so `mm-startup-restore`'s byte-exact tail assertion passes today only because its isolated process never registered it. Re-examining that assertion against production is its own change, not this one's. No coverage is lost here — `MMRegistrarCoverage` has its own CTest row, which is what CI enforces.

## Verification

Rebased onto `6544f9a4` (carries both the #539 ShipInit driver and the libultraship/ZAPDTR fork bump), rebuilt, all three tiers run locally:

- **redship 79/79** (78 on main + this row)
- **rando 18/18** — including `MMMoonCrashArmState`, the row that caught the first attempt at reviving these registrars
- **integration 5/6** — the one red is `IntSwitchOoTHmsToMm`, the known permanently-red unattended row (#544), not a regression

Refs #513, #438

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!--- section:artifacts:start -->
### Build Artifacts
  - [rsbs-windows.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/8919756121.zip)
  - [rsbs-linux.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/8919582189.zip)
<!--- section:artifacts:end -->