### PR TITLE
Gate the spoiler-drop path's cross-game commit on the pairing identity (#610)

### DIFF
--- a/.github/clang-format-paths.txt
+++ b/.github/clang-format-paths.txt
@@ -54,6 +54,7 @@ games/mm/2s2h/mm_notification_bridge.cpp
 games/mm/2s2h/mm_resume_state_test.cpp
 games/mm/2s2h/mm_save_manager_stubs.c
 games/mm/2s2h/mm_shipinit_driver_test.cpp
+games/mm/2s2h/mm_spoiler_identity_test.cpp
 games/mm/2s2h/mm_trackers_gui_test.cpp
 games/mm/2s2h/mm_unified_save_test.cpp
 games/mm/2s2h/z_scene_2SH.cpp

--- a/CMake/SingleExecutable.cmake
+++ b/CMake/SingleExecutable.cmake
@@ -436,6 +436,14 @@ if(BUILD_TESTING)
     redship_add_test(NAME MMRandoOptions COMMAND redship --test mm-rando-options)
     redship_add_test(NAME MMPairedProfile COMMAND redship --test mm-paired-profile)
     redship_add_test(NAME ComboMMOptionsWindow COMMAND redship --test combo-mm-options-window)
+    # Spoiler-drop identity gate (#610). MM's spoiler-LOAD path rebuilt
+    # gComboCtx.foreignPlacements from ANY dropped spoiler with no comparison
+    # against the #570 identity terms, and the pickup that followed authored a
+    # durable shared-item record a later genuine pair would redeem. Display-free
+    # for the same reasons as the two rows above — the spoiler writer/loader and
+    # the placement table need no fill, no display, and no ROM.
+    redship_add_test(NAME MMSpoilerIdentity COMMAND redship --test mm-spoiler-identity)
+    redship_add_test(NAME MMForeignPickupGate COMMAND redship --test mm-foreign-pickup-gate)
     # Cross-game session invalidation (#440). A soft reset or a new game must
     # retire the previous session's frozen blobs, shadows and gComboCtx
     # crossings — while a cross-game arrival and a legitimate existing-slot

--- a/games/mm/2s2h/Rando/Foreign.cpp
+++ b/games/mm/2s2h/Rando/Foreign.cpp
@@ -636,6 +636,30 @@ bool RecordForeignPickup(RandoCheckId randoCheckId) {
     if (item == nullptr) {
         return false;
     }
+    // #610, DEFENSE IN DEPTH for a placement table populated by any route.
+    //
+    // Combo_RecordSharedItem takes no identity argument and performs no
+    // identity check (src/common/shared_items.c): whatever it records is
+    // redeemed by whichever paired OoT world arrives next, blind to which world
+    // authored it. So the ONE place that can refuse to author a record for a
+    // world that does not exist is here, before the record is written.
+    //
+    // With no live pairing there is no such world. The spoiler-LOAD gate
+    // (Spoiler/Apply.cpp) is what stops the table being populated in this state
+    // in the first place; this is the second lock on the same door, for any
+    // future route that reaches the table without going through it. The check
+    // degrades to the junk-class MM item it physically holds — the documented
+    // absent-placement behavior (foreign_items.h) — rather than to a crossing
+    // nobody can receive.
+    if (!PairingActive()) {
+        fprintf(stderr,
+                "[MM] foreign pickup REFUSED: MM check %u holds a foreign placement, but this session has no live "
+                "cross-game pairing (sourceIsRando=%d settingsHash=%08X). No durable shared-item record is "
+                "authored — there is no paired world it could belong to (#610)\n",
+                (unsigned)randoCheckId, gComboCtx.sourceIsRando ? 1 : 0, gComboCtx.sharedRandoSettingsHash);
+        fflush(stderr);
+        return false;
+    }
     // Durable immediately (Combo_RecordSharedItem writes the serialized array,
     // so an MM save+quit before the next switch cannot lose the pickup — the
     // stage/commit outbox is RAM-only, see shared_items.h). The producer

--- a/games/mm/2s2h/Rando/Foreign.h
+++ b/games/mm/2s2h/Rando/Foreign.h
@@ -191,7 +191,13 @@ const char* ForeignArticleForCheck(RandoCheckId randoCheckId);
 /** Give-path core: record the check's foreign item into the shared structure
  *  (durable immediately; de-duped by the A1 producer). Returns true if a
  *  foreign item was recorded. The CheckQueue lambda calls this and layers the
- *  generic presentation on top; the ROM-free unit test drives it directly. */
+ *  generic presentation on top; the ROM-free unit test drives it directly.
+ *
+ *  Returns false — authoring NOTHING — when the check hosts no foreign item OR
+ *  when PairingActive() is false (#610). The second case is defense in depth:
+ *  Combo_RecordSharedItem carries no identity and is redeemed by whichever
+ *  paired world arrives next, so a record authored with no live pairing is an
+ *  item injected into a world that never placed it. */
 bool RecordForeignPickup(RandoCheckId randoCheckId);
 
 } // namespace Foreign

--- a/games/mm/2s2h/Rando/Spoiler/Apply.cpp
+++ b/games/mm/2s2h/Rando/Spoiler/Apply.cpp
@@ -5,10 +5,18 @@
 
 #ifdef RSBS_SINGLE_EXECUTABLE
 #include <cstdio>
+#include <cstring>
 #include <stdexcept>
+#include <string>
 #include <vector>
 #include "foreign_items.h" // src/common — placement table + pinned-pool reverse lookup (Lane C1, #392)
 #include "Rando/Foreign.h" // Rando::Foreign::IsEligibleHost — the host rule the LOAD path must reapply (#488)
+// The #533/#568 REFUSED machinery and its player-visible half. The identity
+// gate below reports through exactly the surface #570's arrival refusal uses
+// (#610) — a divergent spoiler and a divergent arrival are the same class of
+// corruption and must not be surfaced two different ways.
+#include "save.h"
+#include "notification_bridge.h"
 #endif
 
 extern "C" {
@@ -54,6 +62,173 @@ namespace Spoiler {
 //      ApplyToSaveContext's existing throw-on-malformed-check and LoadFromFile's
 //      throw-on-bad-type-tag). An ABSENT section is not an error: a solo or
 //      pre-C1 world legitimately hosts no foreign items.
+// ---------------------------------------------------------------------------
+// The spoiler-LOAD identity gate (#610).
+//
+// A spoiler is an UNTRUSTED FILE. Rando::Spoiler::HandleFileDropped copies
+// whatever was dragged onto the window into the spoiler folder and selects it,
+// and OnFileCreate's LOAD branch then applies it. Everything that branch does
+// to MM's OWN world is upstream behavior and is deliberately left alone.
+//
+// The "foreign" section is different in kind: it is not a description of MM's
+// world, it is a COMBO COMMIT. Reconstructing it writes
+// gComboCtx.foreignPlacements, and every durable cross-game record flows from
+// there — Rando::Foreign::RecordForeignPickup -> Combo_RecordSharedItem ->
+// redeemed by whatever paired OoT world arrives next (foreign_items.h's
+// give-time flow, which carries no evidence of where a record came from). So
+// committing a section out of a file that names a DIFFERENT world injects items
+// into a world whose fill never placed them and whose logic graph never
+// accounted for them.
+//
+// Under one-game semantics (#564) the pairing identity freezes at creation, so
+// the question this gate answers is #601's: was this spoiler authored FOR the
+// world this session is playing? Only an identity comparison answers it, and
+// the terms compared are exactly the ones #570 freezes at creation — which is
+// why the writer now stamps them into the spoiler (Spoiler/Generate.cpp's
+// "rsbsPairing" block).
+//
+// Divergence REFUSES rather than absorbing: nothing is committed, nothing is
+// re-derived, and the refusal surfaces through the #533/#568 machinery exactly
+// as #570's arrival refusal does. The MM world itself still loads — the gate is
+// on the combo commit, not on the spoiler feature.
+// ---------------------------------------------------------------------------
+
+/** Read one identity term. False when it is missing or not an unsigned number —
+ *  an unreadable term is treated as absent, never as zero. */
+static bool ReadIdentityTerm(const nlohmann::json& identity, const char* key, uint32_t& out) {
+    if (!identity.contains(key) || !identity[key].is_number_unsigned()) {
+        return false;
+    }
+    out = identity[key].get<uint32_t>();
+    return true;
+}
+
+static std::string IdentityMismatchDetail(const char* label, uint32_t spoilerValue, uint32_t sessionValue) {
+    char buf[160];
+    snprintf(buf, sizeof(buf), "%s: spoiler names %08X, this session is playing %08X", label, (unsigned)spoilerValue,
+             (unsigned)sessionValue);
+    return buf;
+}
+
+/**
+ * True when the spoiler's foreign section must NOT be committed. `outTerm`
+ * receives the divergent term's NAME (the machine term, so the refusal points
+ * at one thing rather than saying "something is different") and `outDetail` the
+ * numbers behind it.
+ */
+static bool ForeignIdentityDiverges(const nlohmann::json& spoiler, std::string& outTerm, std::string& outDetail) {
+    // (1) There must be a live pairing at all. These are the two halves of
+    //     Combo_ForeignPairingActive(), split apart so the refusal can name
+    //     WHICH one is missing. Both-false is the issue's exact scenario: MM's
+    //     default/boot state, or the state after a vanilla OoT session, where
+    //     there is no world these crossings could possibly belong to.
+    if (!gComboCtx.sourceIsRando) {
+        outTerm = "sourceIsRando";
+        outDetail = "this session is not playing a generated cross-game world";
+        return true;
+    }
+    if (gComboCtx.sharedRandoSettingsHash == 0) {
+        outTerm = "sharedRandoSettingsHash";
+        outDetail = "this session recorded no settings profile, so the worlds must not pair";
+        return true;
+    }
+
+    // (2) The spoiler must NAME a world. A foreign section with no identity
+    //     block was written by a build predating this stamp, or by hand: it
+    //     cannot be SHOWN to describe this world, and "cannot be shown" is
+    //     refused rather than assumed. A pre-stamp paired spoiler is therefore
+    //     no longer loadable as a paired world — regenerate it; the alternative
+    //     is keeping the hole open for every file that omits the block.
+    if (!spoiler.contains("rsbsPairing") || !spoiler["rsbsPairing"].is_object()) {
+        outTerm = "rsbsPairing";
+        outDetail = "the spoiler carries no cross-game identity, so it cannot be shown to name this world";
+        return true;
+    }
+    const nlohmann::json& identity = spoiler["rsbsPairing"];
+
+    uint32_t spoilerSeed = 0;
+    if (!ReadIdentityTerm(identity, "sharedRandoSeed", spoilerSeed)) {
+        outTerm = "sharedRandoSeed";
+        outDetail = "the spoiler's identity omits the shared master seed";
+        return true;
+    }
+    if (spoilerSeed != gComboCtx.sharedRandoSeed) {
+        outTerm = "sharedRandoSeed";
+        outDetail = IdentityMismatchDetail("shared master seed", spoilerSeed, gComboCtx.sharedRandoSeed);
+        return true;
+    }
+
+    uint32_t spoilerSettings = 0;
+    if (!ReadIdentityTerm(identity, "sharedRandoSettingsHash", spoilerSettings)) {
+        outTerm = "sharedRandoSettingsHash";
+        outDetail = "the spoiler's identity omits the shared settings digest";
+        return true;
+    }
+    if (spoilerSettings != gComboCtx.sharedRandoSettingsHash) {
+        outTerm = "sharedRandoSettingsHash";
+        outDetail =
+            IdentityMismatchDetail("shared settings digest", spoilerSettings, gComboCtx.sharedRandoSettingsHash);
+        return true;
+    }
+
+    // #570's own term. ZERO on either side means "that world froze no MM
+    // profile" — a legacy pre-freeze pair, which #570's arrival gate treats as
+    // legacy rather than as divergent — so it is not compared instead of being
+    // declared a mismatch. The seed and settings terms above have already
+    // matched by the time this runs.
+    uint32_t spoilerProfile = 0;
+    if (ReadIdentityTerm(identity, "mmProfileDigest", spoilerProfile) && spoilerProfile != 0 &&
+        gComboCtx.mmProfileDigest != 0 && spoilerProfile != gComboCtx.mmProfileDigest) {
+        outTerm = "mmProfileDigest";
+        outDetail = IdentityMismatchDetail("frozen MM option profile", spoilerProfile, gComboCtx.mmProfileDigest);
+        return true;
+    }
+
+    return false;
+}
+
+static void RefuseForeignReconstruction(const std::string& term, const std::string& detail) {
+    const int slot = RsbsSave_GetActiveSlot();
+    fprintf(stderr,
+            "[MM] spoiler-load: REFUSED — this spoiler's cross-game section does not name the world this session is "
+            "playing (divergent term: %s; %s). No foreign placement is committed, so no durable cross-game record "
+            "can be authored from it; unified-save slot %d is latched against writes this session. The Majora's "
+            "Mask world itself still loads.\n",
+            term.c_str(), detail.c_str(), slot);
+    fflush(stderr);
+    // Latch WITHOUT quarantining, the same shape #570's arrival refusal uses:
+    // the on-disk .redsave is healthy — it is this SESSION that is holding a
+    // spoiler for somebody else's world — so the file is left untouched and only
+    // this session's writes are stopped. RsbsSave_RefuseSlotIdentity treats a
+    // -1 slot as "nothing durable to protect" and is a no-op there.
+    RsbsSave_RefuseSlotIdentity(slot);
+
+    // Player-visible, immediately, on the shared overlay. stderr is not a
+    // surface, and a refusal nobody sees reads as "the cross-game items just
+    // silently did nothing" — #564 V7's silent vanilla revert wearing a fix's
+    // clothes.
+    const std::string message = "This spoiler's cross-game items were placed for a different world (divergent term: " +
+                                term + "). They will not appear here, and this session will not be saved to the pair.";
+    ComboNotification refusalToast;
+    memset(&refusalToast, 0, sizeof(refusalToast));
+    refusalToast.prefix = "Cross-game pairing REFUSED:";
+    refusalToast.prefixColor[0] = 0.9f;
+    refusalToast.prefixColor[1] = 0.35f;
+    refusalToast.prefixColor[2] = 0.3f;
+    refusalToast.prefixColor[3] = 1.0f;
+    refusalToast.message = message.c_str();
+    refusalToast.messageColor[0] = 1.0f;
+    refusalToast.messageColor[1] = 1.0f;
+    refusalToast.messageColor[2] = 1.0f;
+    refusalToast.messageColor[3] = 1.0f;
+    refusalToast.remainingTime = 15.0f;
+    // Muted for the same reason #570's refusal toast is: the overlay's ding is
+    // OoT's Audio_PlaySoundGeneral, and this runs on MM's file-create seam (and
+    // in the display-free locks) where OoT's audio session is not a given.
+    refusalToast.mute = 1;
+    OoT_Notification_Emit(&refusalToast);
+}
+
 int ReconstructForeignPlacements(const nlohmann::json& spoiler) {
     // (2) Never silently overwrite a live session's placement table.
     if (Combo_CountForeignPlacements() > 0) {
@@ -70,6 +245,25 @@ int ReconstructForeignPlacements(const nlohmann::json& spoiler) {
     }
     if (!spoiler["foreign"].is_object()) {
         throw std::runtime_error("Spoiler 'foreign' section is not an object");
+    }
+    if (spoiler["foreign"].empty()) {
+        // A paired world that placed nothing. There is no commit to gate, so
+        // there is nothing to refuse either — refusing here would latch a slot
+        // over a section that could not corrupt anything.
+        return 0;
+    }
+
+    // (2b) #610 IDENTITY GATE. Runs BEFORE the shape validation below, because
+    // a spoiler for another world is refused whether or not its section is
+    // well-formed — and because refusing must not depend on how far the parse
+    // happened to get.
+    {
+        std::string divergentTerm;
+        std::string divergentDetail;
+        if (ForeignIdentityDiverges(spoiler, divergentTerm, divergentDetail)) {
+            RefuseForeignReconstruction(divergentTerm, divergentDetail);
+            return -2;
+        }
     }
 
     // (3) Stage-and-validate every entry before committing anything.

--- a/games/mm/2s2h/Rando/Spoiler/Generate.cpp
+++ b/games/mm/2s2h/Rando/Spoiler/Generate.cpp
@@ -2,6 +2,10 @@
 #include "Rando/Rando.h"
 #ifdef RSBS_SINGLE_EXECUTABLE
 #include "Rando/Foreign.h" // Lane C1 (#392): foreign-check lookup for the spoiler
+// src/common — gComboCtx, for the pairing identity the spoiler now stamps
+// alongside its cross-game section (#610). Included OUTSIDE any extern "C"
+// block: context.h manages its own linkage (see its header comment).
+#include "context.h"
 #endif
 
 namespace Rando {
@@ -61,6 +65,24 @@ nlohmann::json GenerateFromSaveContext() {
     // it". Only present (possibly empty) when this world was generated as the
     // MM half of a paired world.
     if (Rando::Foreign::PairingActive()) {
+        // #610: the "foreign" section below is a COMBO COMMIT, not a
+        // description — reloading it writes gComboCtx.foreignPlacements, from
+        // which every durable cross-game record flows. A spoiler is an
+        // untrusted file on disk (HandleFileDropped copies in whatever was
+        // dragged onto the window), so it has to NAME the world it was authored
+        // for or the LOAD path has nothing to compare against and must refuse.
+        //
+        // These are exactly the terms #570 freezes at creation, in exactly the
+        // form the arrival gate compares. They are written HERE rather than
+        // unconditionally because an unpaired world has no cross-game identity
+        // to name, and stamping a zeroed one would make "no pairing" look like
+        // a pairing that happens to be all zeros.
+        spoiler["rsbsPairing"] = {
+            { "sharedRandoSeed", gComboCtx.sharedRandoSeed },
+            { "sharedRandoSettingsHash", gComboCtx.sharedRandoSettingsHash },
+            { "mmProfileDigest", gComboCtx.mmProfileDigest },
+        };
+
         spoiler["foreign"] = nlohmann::json::object();
         for (auto& [randoCheckId, randoStaticCheck] : Rando::StaticData::Checks) {
             if (randoStaticCheck.randoCheckId == RC_UNKNOWN || !Rando::Foreign::IsForeignCheck(randoCheckId)) {

--- a/games/mm/2s2h/Rando/Spoiler/Spoiler.h
+++ b/games/mm/2s2h/Rando/Spoiler/Spoiler.h
@@ -45,12 +45,14 @@ bool HandleFileDropped(char* path);
 // junk-class MM host item. Called by ApplyToSaveContext; exposed for the
 // MMRandoGen CTest lock.
 //
-// Returns the number of placements reconstructed (>= 0), 0 for an absent
-// "foreign" section, or -1 when it PRESERVES an already-populated (live-
-// session) table rather than overwriting it. Throws std::runtime_error on a
-// malformed section (validate-then-commit; the table is left untouched). Never
-// reads or writes gComboCtx.sharedItemsTagged, so redeemed crossings survive.
-// See Apply.cpp for the full overwrite semantics.
+// Returns the number of placements reconstructed (>= 0), 0 for an absent or
+// empty "foreign" section, -1 when it PRESERVES an already-populated (live-
+// session) table rather than overwriting it, or -2 when the spoiler's cross-game
+// IDENTITY does not name the world this session is playing (#610) — refused
+// through the #533 surface, nothing committed, MM's own world still applied.
+// Throws std::runtime_error on a malformed section (validate-then-commit; the
+// table is left untouched). Never reads or writes gComboCtx.sharedItemsTagged,
+// so redeemed crossings survive. See Apply.cpp for the full semantics.
 int ReconstructForeignPlacements(const nlohmann::json& spoiler);
 #endif
 

--- a/games/mm/2s2h/mm_spoiler_identity_test.cpp
+++ b/games/mm/2s2h/mm_spoiler_identity_test.cpp
@@ -1,0 +1,539 @@
+/**
+ * ROM-free locks for the spoiler-drop identity gate (#610).
+ * CTest label "redship" (display-free); rows `mm-spoiler-identity` and
+ * `mm-foreign-pickup-gate` in src/common/test_runner.cpp.
+ *
+ * Lives MM-side because the surfaces under test need MM's headers:
+ * `Rando::Spoiler::LoadFromFile` / `ApplyToSaveContext` (the two calls
+ * OnFileCreate's LOAD branch makes, OnFileCreate.cpp:439-441) and
+ * `Rando::Foreign::RecordForeignPickup`.
+ *
+ * ============================================================================
+ * WHAT #610 IS
+ * ============================================================================
+ *
+ * `Rando::Spoiler::HandleFileDropped` stages ANY file dragged onto the window
+ * that parses as a `2S2H_RANDO_SPOILER` into MM's spoiler folder and selects it
+ * (`gRando.SpoilerFile` / `gRando.SpoilerFileIndex`). That staging is correctly
+ * identity-free — it is a file copy. The hole was downstream: on an UNPAIRED MM
+ * file `Rando::MiscBehavior::OnFileCreate` takes the LOAD branch, and
+ * `ApplyToSaveContext` called `ReconstructForeignPlacements` unconditionally,
+ * committing whatever the dropped file's `"foreign"` section claimed straight
+ * into `gComboCtx.foreignPlacements` — with no comparison against the terms
+ * #570 freezes at creation (`sourceIsRando` / `sharedRandoSeed` /
+ * `sharedRandoSettingsHash` / `mmProfileDigest`). From there `RecordForeignPickup`
+ * fired on every collected check with no `Combo_ForeignPairingActive()` gate and
+ * `Combo_RecordSharedItem` durably recorded a pickup that a LATER, genuine
+ * paired-OoT arrival redeems — injecting an item from an unrelated world into a
+ * world whose fill never placed it.
+ *
+ * Under one-game semantics (#564) the identity freezes at creation: a spoiler
+ * that names a different world is corruption to REFUSE, never state to absorb.
+ * That is #601's rule ("an identity a file did not have authored for it is not
+ * that file's identity") applied to MM's spoiler entry path.
+ *
+ * ============================================================================
+ * mm-spoiler-identity — the commit gate
+ * ============================================================================
+ *
+ * Drives the REAL consumer pair (`LoadFromFile` + `ApplyToSaveContext`) over a
+ * spoiler produced by the REAL writer (`GenerateFromSaveContext`) and staged
+ * through the REAL path (`SaveToFile` into `SpoilerDirectory()`, selected with
+ * the same two CVars `HandleFileDropped` sets). Nothing here is a paraphrase of
+ * the shipping code.
+ *
+ * The divergence is modelled by moving the LIVE session's identity, never by
+ * hand-editing the spoiler's: that keeps the staged file byte-authentic output
+ * of the shipping writer, so leg 5 below is a genuine lock on the writer
+ * EMITTING an identity at all (without it, every real paired spoiler would be
+ * refused as unidentified and leg 5 goes red).
+ *
+ *   1. unpaired session (the issue's exact scenario) -> NOT committed, refused
+ *   2. paired, divergent sharedRandoSeed            -> NOT committed, refused
+ *   3. paired, divergent sharedRandoSettingsHash    -> NOT committed, refused
+ *   4. paired, divergent mmProfileDigest            -> NOT committed, refused
+ *   5. paired, identity matches                     -> COMMITTED, no refusal
+ *   6. standalone spoiler, no "foreign" section     -> loads, no refusal
+ *
+ * Leg 5 is the non-vacuity leg: a gate that refuses everything would pass 1-4
+ * and prove nothing. Leg 6 is the scope leg: upstream's standalone spoiler-load
+ * capability must survive — the gate is on the COMBO commit, not on the spoiler
+ * feature — so a spoiler that touches neither gComboCtx nor the shared records
+ * must load exactly as before and latch nothing.
+ *
+ * Every refusal leg asserts the surface, not just the absence: the #533/#568
+ * machinery latches the active slot with `RSBS_REFUSE_IDENTITY` (the same
+ * reason #570's arrival gate uses — the slot FILE is healthy, the SESSION
+ * diverged, so nothing is quarantined), and the shared overlay carries a toast
+ * that NAMES the divergent term. A refusal the player cannot see is #564 V7's
+ * silent vanilla revert wearing a fix's clothes.
+ *
+ * ============================================================================
+ * mm-foreign-pickup-gate — the durable-record gate
+ * ============================================================================
+ *
+ * Defense in depth for a placement table populated by ANY route: with no live
+ * pairing, collecting a foreign-hosted check must author no durable
+ * `sharedItemsTagged` record, because there is no world for that record to
+ * belong to. Includes the matching non-vacuity leg (pairing active -> the
+ * record IS authored), so "gate everything off" cannot pass.
+ */
+
+#ifdef RSBS_SINGLE_EXECUTABLE
+
+#include <cstdarg>
+#include <cstdio>
+#include <cstring>
+#include <filesystem>
+#include <stdexcept>
+#include <string>
+
+#include <libultraship/bridge/consolevariablebridge.h>
+
+#include "Rando/Rando.h"
+#include "Rando/Foreign.h"
+#include "Rando/Spoiler/Spoiler.h"
+#include "Rando/StaticData/StaticData.h"
+
+// src/common — outside any extern "C" block; these headers manage their own
+// linkage (matching Foreign.cpp / mm_rando_options_test.cpp).
+#include "foreign_items.h"
+#include "shared_items.h"
+#include "save.h"                // the #533 REFUSED surface this gate reports through
+#include "notification_bridge.h" // the player-visible half of that surface
+
+extern "C" {
+#include "variables.h"
+}
+
+namespace {
+
+int Fail(int code, const char* fmt, ...) {
+    va_list args;
+    va_start(args, fmt);
+    fprintf(stderr, "[MM-SPOILER-ID] FAIL(%d): ", code);
+    vfprintf(stderr, fmt, args);
+    fprintf(stderr, "\n");
+    va_end(args);
+    fflush(stderr);
+    return code;
+}
+
+// The slot the refusal latches. Nothing is written to it — RefuseSlotIdentity
+// deliberately never quarantines, because the FILE is healthy. The SaveManager
+// is pointed at a scratch directory first all the same: ArmSlotOnCreate reads
+// (and would quarantine) whatever .redsave sits at the slot path, and a lock
+// has no business touching the operator's real saves.
+constexpr int kSlot = 0;
+const char* const kScratchSaveDir = "rsbs_test_saves_spoiler_identity";
+
+// Planted as the "last toast" before every leg, so a refusal assertion can
+// never be satisfied by a toast an EARLIER leg emitted. The overlay's store has
+// no drain entry point, and "the last toast still exists" is exactly the vacuous
+// pass this sentinel closes.
+const char* const kToastSentinel = "rsbs610-no-toast-was-emitted";
+
+// The world the staged spoiler is authored for.
+constexpr uint32_t kSeedA = 0x0610A11Au;
+constexpr uint32_t kHashA = 0x5EED0610u;
+constexpr uint32_t kDigestA = 0xD16E5701u;
+
+/** Publish a live pairing carrier (the shape Playthrough_Init stamps). */
+void ArmPairing(uint32_t seed, uint32_t settingsHash, uint32_t profileDigest) {
+    gComboCtx.sourceIsRando = true;
+    gComboCtx.sharedRandoSeed = seed;
+    gComboCtx.sharedRandoSettingsHash = settingsHash;
+    gComboCtx.mmProfileDigest = profileDigest;
+}
+
+/** Re-arm the slot so each leg observes ITS OWN refusal, not the previous one's. */
+void ResetRefusalSurface() {
+    RsbsSave_ResetSlotSessionState();
+    RsbsSave_SetActiveSlot(kSlot);
+    RsbsSave_ArmSlotOnCreate(kSlot);
+
+    ComboNotification sentinel;
+    memset(&sentinel, 0, sizeof(sentinel));
+    sentinel.prefix = "";
+    sentinel.message = kToastSentinel;
+    sentinel.remainingTime = 1.0f;
+    // Muted for the same reason #570's refusal toast is: the overlay's ding is
+    // OoT's Audio_PlaySoundGeneral, and this runs in a display-free harness
+    // where OoT's audio session is not a given.
+    sentinel.mute = 1;
+    OoT_Notification_Emit(&sentinel);
+}
+
+/**
+ * The refusal surface, asserted as a whole: latched slot, RSBS_REFUSE_IDENTITY,
+ * no quarantine (the .redsave is healthy), and a toast naming `term`.
+ */
+int AssertRefused(int baseCode, const char* leg, const char* term) {
+    if (RsbsSave_IsSlotWritable(kSlot) != 0) {
+        return Fail(baseCode,
+                    "%s: the active slot was not latched — this session's captures can still reach the "
+                    "pair's .redsave",
+                    leg);
+    }
+    if (RsbsSave_GetSlotRefuseReason(kSlot) != (int)RSBS_REFUSE_IDENTITY) {
+        return Fail(baseCode + 1, "%s: refusal reason is %d, expected RSBS_REFUSE_IDENTITY", leg,
+                    RsbsSave_GetSlotRefuseReason(kSlot));
+    }
+    if (RsbsSave_HasQuarantine(kSlot) != 0) {
+        return Fail(baseCode + 2,
+                    "%s: an identity refusal quarantined the slot file — the file is healthy, the "
+                    "session diverged (#570)",
+                    leg);
+    }
+    ComboNotification toast;
+    memset(&toast, 0, sizeof(toast));
+    if (OoT_Notification_PeekLastForTest(&toast) != 1) {
+        return Fail(baseCode + 3, "%s: no toast reached the shared overlay — stderr is not a player-visible surface",
+                    leg);
+    }
+    const std::string message = toast.message != nullptr ? toast.message : "";
+    const std::string prefix = toast.prefix != nullptr ? toast.prefix : "";
+    if (message == kToastSentinel) {
+        return Fail(baseCode + 3, "%s: the overlay still holds this leg's sentinel — no refusal toast was emitted",
+                    leg);
+    }
+    if (prefix.find("REFUSED") == std::string::npos) {
+        return Fail(baseCode + 3, "%s: the toast's prefix ('%s') does not read as a refusal", leg, prefix.c_str());
+    }
+    if (message.find(term) == std::string::npos) {
+        return Fail(baseCode + 4, "%s: the refusal does not name the divergent term '%s' (message: '%s')", leg, term,
+                    message.c_str());
+    }
+    return 0;
+}
+
+} // namespace
+
+extern "C" int MM_SpoilerIdentity_RunHeadless(void) {
+    printf("[TEST] mm-spoiler-identity: a dropped spoiler's cross-game section reaches gComboCtx only when its "
+           "identity names the live pairing (#610)\n");
+
+    // ---- Stage a spoiler for world A, through the real writer --------------
+    {
+        std::error_code ec;
+        std::filesystem::create_directories(kScratchSaveDir, ec);
+        rsbs::SaveManager::Instance().SetSaveDirectory(kScratchSaveDir);
+    }
+    memset(&gSaveContext, 0, sizeof(gSaveContext));
+    ComboContext_Init();
+    ArmPairing(kSeedA, kHashA, kDigestA);
+    if (!Combo_ForeignPairingActive()) {
+        return Fail(1, "the staging carrier did not read as an active pairing");
+    }
+
+    // A host the CURRENT rule accepts (Rando::Foreign::IsEligibleHost): an
+    // allowed check class holding a legal junk-class MM item, shuffled and not
+    // user-excluded. Found by driving the REAL predicate one candidate at a
+    // time and reverting the ones it rejects, so this lock neither pins a check
+    // name a future table edit could remove nor paraphrases the host rule. Only
+    // the winner is left shuffled, so the staged spoiler describes exactly one
+    // check.
+    RandoCheckId host = RC_UNKNOWN;
+    for (auto& [randoCheckId, randoStaticCheck] : Rando::StaticData::Checks) {
+        if (randoStaticCheck.randoCheckId == RC_UNKNOWN) {
+            continue;
+        }
+        const RandoSaveCheck previous = RANDO_SAVE_CHECKS[randoCheckId];
+        RANDO_SAVE_CHECKS[randoCheckId].randoItemId = RI_JUNK;
+        RANDO_SAVE_CHECKS[randoCheckId].shuffled = true;
+        RANDO_SAVE_CHECKS[randoCheckId].skipped = false;
+        if (Rando::Foreign::IsEligibleHost(randoCheckId)) {
+            host = randoCheckId;
+            break;
+        }
+        RANDO_SAVE_CHECKS[randoCheckId] = previous;
+    }
+    if (host == RC_UNKNOWN) {
+        return Fail(2, "no eligible foreign host exists in the check table — the fixture cannot be built");
+    }
+    const char* hostName = Rando::StaticData::Checks.at(host).name;
+
+    const ComboForeignItemDef* pool = nullptr;
+    const int poolCount = Combo_GetForeignItemPoolFor((uint8_t)GAME_OOT, &pool);
+    if (poolCount <= 0 || pool == nullptr) {
+        return Fail(3, "the OoT foreign pool is not registered in this build");
+    }
+    const SharedItem placed = pool[0].item;
+
+    Combo_ClearForeignPlacements();
+    if (Combo_SetForeignPlacement((uint16_t)host, placed) < 0) {
+        return Fail(4, "could not seed the fixture placement on host check %s", hostName);
+    }
+
+    gSaveContext.save.shipSaveInfo.rando.finalSeed = 0xABCD0610u;
+    nlohmann::json staged = Rando::Spoiler::GenerateFromSaveContext();
+    if (!staged.contains("foreign") || !staged["foreign"].is_object() || staged["foreign"].size() != 1) {
+        return Fail(5, "the real writer did not emit a one-entry 'foreign' section for the fixture world");
+    }
+
+    // Stage it exactly as HandleFileDropped does: the file lands in the spoiler
+    // folder and the two CVars select it. Reading the index back proves the
+    // LOAD-branch precondition (OnFileCreate.cpp:83) is genuinely satisfied.
+    const std::string stagedName = "rsbs610-staged.json";
+    try {
+        Rando::Spoiler::SaveToFile(stagedName, staged);
+        CVarSetString("gRando.SpoilerFile", stagedName.c_str());
+        Rando::Spoiler::RefreshOptions();
+    } catch (const std::exception& e) { return Fail(6, "staging the spoiler threw: %s", e.what()); }
+    if (CVarGetInteger("gRando.SpoilerFileIndex", 0) == 0) {
+        return Fail(7, "the staged spoiler is not selected (SpoilerFileIndex == 0) — OnFileCreate would GENERATE, "
+                       "so this fixture would not exercise the LOAD branch at all");
+    }
+    const std::string selected = CVarGetString("gRando.SpoilerFile", "");
+
+    // A standalone (unpaired) spoiler for leg 6, written by the same real
+    // writer while nothing is paired: it carries no "foreign" section at all.
+    ComboContext_Init();
+    const std::string soloName = "rsbs610-solo.json";
+    gSaveContext.save.shipSaveInfo.rando.finalSeed = 0x501050A0u;
+    nlohmann::json solo = Rando::Spoiler::GenerateFromSaveContext();
+    if (solo.contains("foreign")) {
+        return Fail(8, "an unpaired world's spoiler carries a 'foreign' section");
+    }
+    try {
+        Rando::Spoiler::SaveToFile(soloName, solo);
+    } catch (const std::exception& e) { return Fail(8, "staging the solo spoiler threw: %s", e.what()); }
+
+    // One helper for the four refusal legs and the two accepting ones: reload
+    // through the REAL validator and apply through the REAL entry point.
+    auto driveLoad = [&](const std::string& fileName, int code, const char** err) -> int {
+        *err = nullptr;
+        Combo_ClearForeignPlacements();
+        try {
+            nlohmann::json loaded = Rando::Spoiler::LoadFromFile(fileName);
+            Rando::Spoiler::ApplyToSaveContext(loaded);
+        } catch (const std::exception& e) {
+            static std::string held;
+            held = e.what();
+            *err = held.c_str();
+            return code;
+        }
+        return 0;
+    };
+    const char* err = nullptr;
+
+    // ---- Leg 1: the issue's scenario — no live pairing at all --------------
+    // A player who never generated a paired OoT world this session drops a
+    // spoiler and creates a file. There is no identity to compare against, so
+    // there is no world these crossings can belong to.
+    memset(&gSaveContext, 0, sizeof(gSaveContext));
+    ComboContext_Init();
+    ResetRefusalSurface();
+    if (int rc = driveLoad(selected, 10, &err)) {
+        return Fail(rc, "unpaired load threw instead of refusing the foreign section: %s", err);
+    }
+    if (Combo_CountForeignPlacements() != 0) {
+        return Fail(11,
+                    "UNPAIRED session committed %d foreign placement(s) from a dropped spoiler — every check "
+                    "collected there would author a durable shared-item record for a world that does not exist "
+                    "(#610)",
+                    Combo_CountForeignPlacements());
+    }
+    if (int rc = AssertRefused(12, "unpaired", "sourceIsRando")) {
+        return rc;
+    }
+    // The MM world itself still loaded: the gate is on the combo commit, not on
+    // the spoiler feature.
+    if (gSaveContext.save.shipSaveInfo.rando.finalSeed != staged["finalSeed"].get<uint32_t>()) {
+        return Fail(17, "the refusal took the MM world down with it (finalSeed %08X != spoiler's %08X)",
+                    gSaveContext.save.shipSaveInfo.rando.finalSeed, staged["finalSeed"].get<uint32_t>());
+    }
+
+    // ---- Leg 2: paired, but a DIFFERENT world's seed -----------------------
+    memset(&gSaveContext, 0, sizeof(gSaveContext));
+    ComboContext_Init();
+    ArmPairing(kSeedA ^ 0x00BADBADu, kHashA, kDigestA);
+    ResetRefusalSurface();
+    if (int rc = driveLoad(selected, 20, &err)) {
+        return Fail(rc, "divergent-seed load threw instead of refusing: %s", err);
+    }
+    if (Combo_CountForeignPlacements() != 0) {
+        return Fail(21, "a spoiler naming seed %08X committed %d placement(s) into a session pairing seed %08X", kSeedA,
+                    Combo_CountForeignPlacements(), kSeedA ^ 0x00BADBADu);
+    }
+    if (int rc = AssertRefused(22, "divergent seed", "sharedRandoSeed")) {
+        return rc;
+    }
+
+    // ---- Leg 3: paired, divergent settings digest --------------------------
+    memset(&gSaveContext, 0, sizeof(gSaveContext));
+    ComboContext_Init();
+    ArmPairing(kSeedA, kHashA ^ 0x00BADBADu, kDigestA);
+    ResetRefusalSurface();
+    if (int rc = driveLoad(selected, 30, &err)) {
+        return Fail(rc, "divergent-settings load threw instead of refusing: %s", err);
+    }
+    if (Combo_CountForeignPlacements() != 0) {
+        return Fail(31, "a spoiler naming settings %08X committed %d placement(s) into a session pairing %08X", kHashA,
+                    Combo_CountForeignPlacements(), kHashA ^ 0x00BADBADu);
+    }
+    if (int rc = AssertRefused(32, "divergent settings", "sharedRandoSettingsHash")) {
+        return rc;
+    }
+
+    // ---- Leg 4: paired, divergent frozen MM profile ------------------------
+    // The #570 term. Same seed and settings, different frozen MM profile: the
+    // spoiler describes a world built from options this pair was not created
+    // with.
+    memset(&gSaveContext, 0, sizeof(gSaveContext));
+    ComboContext_Init();
+    ArmPairing(kSeedA, kHashA, kDigestA ^ 0x00BADBADu);
+    ResetRefusalSurface();
+    if (int rc = driveLoad(selected, 40, &err)) {
+        return Fail(rc, "divergent-profile load threw instead of refusing: %s", err);
+    }
+    if (Combo_CountForeignPlacements() != 0) {
+        return Fail(41, "a spoiler naming profile %08X committed %d placement(s) into a pair frozen at %08X", kDigestA,
+                    Combo_CountForeignPlacements(), kDigestA ^ 0x00BADBADu);
+    }
+    if (int rc = AssertRefused(42, "divergent profile", "mmProfileDigest")) {
+        return rc;
+    }
+
+    // ---- Leg 5: NON-VACUITY — the identity matches, so it commits ----------
+    memset(&gSaveContext, 0, sizeof(gSaveContext));
+    ComboContext_Init();
+    ArmPairing(kSeedA, kHashA, kDigestA);
+    ResetRefusalSurface();
+    if (int rc = driveLoad(selected, 50, &err)) {
+        return Fail(rc, "the matching-identity load threw: %s", err);
+    }
+    if (Combo_CountForeignPlacements() != 1) {
+        return Fail(51,
+                    "a spoiler whose identity NAMES this session's pairing reconstructed %d placement(s), expected "
+                    "1 — the gate refuses everything and locks nothing",
+                    Combo_CountForeignPlacements());
+    }
+    {
+        const SharedItem* got = Combo_GetForeignPlacementForCheck((uint16_t)host);
+        if (got == nullptr || got->originGame != placed.originGame || got->id != placed.id) {
+            return Fail(52, "the matching load did not rebuild host %s's placement", hostName);
+        }
+    }
+    if (RsbsSave_IsSlotWritable(kSlot) != 1 || RsbsSave_GetSlotRefuseReason(kSlot) != (int)RSBS_REFUSE_NONE) {
+        return Fail(53, "a matching identity latched the slot anyway (writable=%d reason=%d)",
+                    RsbsSave_IsSlotWritable(kSlot), RsbsSave_GetSlotRefuseReason(kSlot));
+    }
+
+    // ---- Leg 6: SCOPE — upstream's standalone spoiler load is untouched ----
+    // No "foreign" section means nothing that could reach gComboCtx or the
+    // shared records, so an unpaired session must load it exactly as before:
+    // no refusal, no latch, and the world applied.
+    memset(&gSaveContext, 0, sizeof(gSaveContext));
+    ComboContext_Init();
+    ResetRefusalSurface();
+    if (int rc = driveLoad(soloName, 60, &err)) {
+        return Fail(rc, "a standalone (non-combo) spoiler failed to load: %s", err);
+    }
+    if (Combo_CountForeignPlacements() != 0) {
+        return Fail(61, "a spoiler with no foreign section produced %d placement(s)", Combo_CountForeignPlacements());
+    }
+    if (RsbsSave_IsSlotWritable(kSlot) != 1 || RsbsSave_GetSlotRefuseReason(kSlot) != (int)RSBS_REFUSE_NONE) {
+        return Fail(62,
+                    "a standalone spoiler load latched the slot (writable=%d reason=%d) — the gate must sit on the "
+                    "COMBO commit, not on the spoiler feature",
+                    RsbsSave_IsSlotWritable(kSlot), RsbsSave_GetSlotRefuseReason(kSlot));
+    }
+    if (gSaveContext.save.shipSaveInfo.rando.finalSeed != solo["finalSeed"].get<uint32_t>()) {
+        return Fail(63, "the standalone spoiler's world was not applied");
+    }
+
+    // Leave process-global state clean for whatever test runs next.
+    RsbsSave_ResetSlotSessionState();
+    RsbsSave_SetActiveSlot(-1);
+    memset(&gSaveContext, 0, sizeof(gSaveContext));
+    ComboContext_Init();
+    CVarSetString("gRando.SpoilerFile", "");
+    CVarSetInteger("gRando.SpoilerFileIndex", 0);
+
+    printf("[TEST] PASS: the spoiler foreign section commits only under a matching pairing identity; every "
+           "divergent term refuses through the #533 surface; standalone spoiler loads untouched\n");
+    return 0;
+}
+
+extern "C" int MM_ForeignPickupGate_RunHeadless(void) {
+    printf("[TEST] mm-foreign-pickup-gate: an unpaired session authors no durable shared-item record, whatever the "
+           "placement table holds (#610)\n");
+
+    memset(&gSaveContext, 0, sizeof(gSaveContext));
+    ComboContext_Init();
+    Combo_ClearSharedItemOutbox();
+
+    const ComboForeignItemDef* pool = nullptr;
+    const int poolCount = Combo_GetForeignItemPoolFor((uint8_t)GAME_OOT, &pool);
+    if (poolCount <= 0 || pool == nullptr) {
+        return Fail(70, "the OoT foreign pool is not registered in this build");
+    }
+
+    RandoCheckId host = RC_UNKNOWN;
+    for (auto& [randoCheckId, randoStaticCheck] : Rando::StaticData::Checks) {
+        if (randoStaticCheck.randoCheckId == RC_UNKNOWN) {
+            continue;
+        }
+        const RandoSaveCheck previous = RANDO_SAVE_CHECKS[randoCheckId];
+        RANDO_SAVE_CHECKS[randoCheckId].randoItemId = RI_JUNK;
+        RANDO_SAVE_CHECKS[randoCheckId].shuffled = true;
+        RANDO_SAVE_CHECKS[randoCheckId].skipped = false;
+        if (Rando::Foreign::IsEligibleHost(randoCheckId)) {
+            host = randoCheckId;
+            break;
+        }
+        RANDO_SAVE_CHECKS[randoCheckId] = previous;
+    }
+    if (host == RC_UNKNOWN) {
+        return Fail(71, "no eligible foreign host exists in the check table");
+    }
+
+    // The corrupted state the rest of #610 exists to prevent, reached here
+    // directly: a populated placement table with NO live pairing. Whatever
+    // route put it there, collecting the check must not author a durable
+    // record — `Combo_RecordSharedItem` has no identity parameter, so the
+    // record a later genuine pair redeems would carry no evidence of where it
+    // came from.
+    if (Combo_SetForeignPlacement((uint16_t)host, pool[0].item) < 0) {
+        return Fail(72, "could not seed the fixture placement");
+    }
+    if (Combo_ForeignPairingActive()) {
+        return Fail(73, "the unpaired fixture reads as paired");
+    }
+
+    if (Rando::Foreign::RecordForeignPickup(host)) {
+        return Fail(74, "an UNPAIRED session recorded a foreign pickup as a durable shared item (#610)");
+    }
+    if (Combo_CountSharedItems(GAME_OOT, /*includeRedeemed=*/true) != 0) {
+        return Fail(75,
+                    "an unpaired pickup left %d durable shared-item record(s) — a later genuine paired OoT arrival "
+                    "would redeem them into a world whose fill never placed them",
+                    Combo_CountSharedItems(GAME_OOT, /*includeRedeemed=*/true));
+    }
+
+    // ---- NON-VACUITY: the same pickup under a live pairing DOES record -----
+    gComboCtx.sourceIsRando = true;
+    gComboCtx.sharedRandoSeed = 0x0610C0DEu;
+    gComboCtx.sharedRandoSettingsHash = 0x0610FEEDu;
+    if (!Combo_ForeignPairingActive()) {
+        return Fail(76, "the paired fixture does not read as paired");
+    }
+    if (!Rando::Foreign::RecordForeignPickup(host)) {
+        return Fail(77, "a PAIRED session failed to record a foreign pickup — the gate is not a gate, it is an off "
+                        "switch");
+    }
+    if (Combo_CountSharedItems(GAME_OOT, /*includeRedeemed=*/false) != 1) {
+        return Fail(78, "a paired pickup recorded %d un-redeemed shared item(s), expected 1",
+                    Combo_CountSharedItems(GAME_OOT, /*includeRedeemed=*/false));
+    }
+
+    Combo_ClearSharedItemOutbox();
+    memset(&gSaveContext, 0, sizeof(gSaveContext));
+    ComboContext_Init();
+
+    printf("[TEST] PASS: foreign pickups author durable shared-item records only under a live pairing\n");
+    return 0;
+}
+
+#endif // RSBS_SINGLE_EXECUTABLE

--- a/src/common/save.cpp
+++ b/src/common/save.cpp
@@ -129,7 +129,14 @@ const char* SaveManager::RefuseReasonLabel(RsbsRefuseReason reason) {
         case RSBS_REFUSE_COMMIT_SKEW:
             return "older than the OoT save (a commit is missing)";
         case RSBS_REFUSE_IDENTITY:
-            return "options differ from this pair's creation";
+            // Deliberately names the CLASS, not one producer's instance of it.
+            // Two paths latch this reason now: #570's arrival gate (the live MM
+            // options no longer resolve to the frozen profile) and #610's
+            // spoiler-load gate (the loaded spoiler's cross-game section names
+            // a different world). "Options differ from this pair's creation"
+            // was true of the first and actively misleading about the second.
+            // Each producer's own stderr line carries the specific term.
+            return "this session diverges from this pair's creation identity";
         case RSBS_REFUSE_GENERATION:
             return "the paired Termina world could not be generated";
         case RSBS_REFUSE_NONE:

--- a/src/common/test_runner.cpp
+++ b/src/common/test_runner.cpp
@@ -182,6 +182,13 @@ int Combo_TrackerWindow_RunHeadless(void);
 // need MM's headers — this file must never acquire them. Return 0 on pass.
 int MM_RandoOptions_RunHeadless(void);
 int MM_PairedProfile_RunHeadless(void);
+// games/mm/2s2h/mm_spoiler_identity_test.cpp (#610): the spoiler-drop identity
+// gate on the cross-game commit, and the foreign-pickup durable-record gate.
+// MM-side for the same reason as the two above — they drive
+// Rando::Spoiler::LoadFromFile/ApplyToSaveContext and
+// Rando::Foreign::RecordForeignPickup. Return 0 on pass.
+int MM_SpoilerIdentity_RunHeadless(void);
+int MM_ForeignPickupGate_RunHeadless(void);
 // VB-affinity regression: MM's GameInteractor_* calls resolve to OoT's
 // extern "C" wrappers in single-exe builds, and the two games' vanilla-
 // behavior ordinals alias each other. The wrappers gate on the active game;
@@ -2025,6 +2032,44 @@ TestResult Test_MMPairedProfile(void) {
     return MM_PairedProfile_RunHeadless() == 0 ? TEST_PASS : TEST_FAIL;
 }
 
+// Spoiler-drop identity gate (#610). Drives the REAL spoiler-LOAD consumer pair
+// (Rando::Spoiler::LoadFromFile + ApplyToSaveContext — the two calls
+// OnFileCreate's LOAD branch makes) over a spoiler written by the real writer
+// and staged the way HandleFileDropped stages one. Needs the shared bring-up:
+// the spoiler path resolves against the live Ship::Context's app directory and
+// the refusal surfaces through the shared notification overlay.
+TestResult Test_MMSpoilerIdentity(void) {
+    auto ctx = CreateHarnessStyleContext();
+    if (!ctx) {
+        printf("[TEST] FAIL: could not create Ship::Context singleton\n");
+        return TEST_FAIL;
+    }
+    if (OoT_InitSharedContextSubsystems() != 0) {
+        printf("[TEST] FAIL: shared bring-up reported failure\n");
+        return TEST_FAIL;
+    }
+
+    return MM_SpoilerIdentity_RunHeadless() == 0 ? TEST_PASS : TEST_FAIL;
+}
+
+// Foreign-pickup durable-record gate (#610), the defense-in-depth half: a
+// populated placement table with no live pairing must author no shared-item
+// record. Same bring-up as its sibling for consistency; the gate itself reads
+// only gComboCtx.
+TestResult Test_MMForeignPickupGate(void) {
+    auto ctx = CreateHarnessStyleContext();
+    if (!ctx) {
+        printf("[TEST] FAIL: could not create Ship::Context singleton\n");
+        return TEST_FAIL;
+    }
+    if (OoT_InitSharedContextSubsystems() != 0) {
+        printf("[TEST] FAIL: shared bring-up reported failure\n");
+        return TEST_FAIL;
+    }
+
+    return MM_ForeignPickupGate_RunHeadless() == 0 ? TEST_PASS : TEST_FAIL;
+}
+
 TestResult Test_RoundtripIntegrity(void) {
     printf("[TEST] roundtrip-integrity: OoT SaveContext byte-integrity across roundtrip (issue #262)\n");
     int failures = TestRoundtripIntegrity_Run();
@@ -2250,6 +2295,14 @@ const TestDescriptor gTests[] = {
      Test_MMRandoOptions},
     {"mm-paired-profile", "The paired MM profile honours explicit choices and publishes a moving digest (#499)",
      Test_MMPairedProfile},
+    // Spoiler-drop identity gate (#610): a dropped spoiler's cross-game section
+    // is a COMBO commit, so it reaches gComboCtx only when its identity names
+    // the live pairing; divergence refuses through the #533 surface.
+    {"mm-spoiler-identity",
+     "A spoiler's foreign section commits only when its identity names the live pairing (#610)",
+     Test_MMSpoilerIdentity},
+    {"mm-foreign-pickup-gate", "An unpaired session authors no durable shared-item record on a foreign pickup (#610)",
+     Test_MMForeignPickupGate},
     {"combo-mm-options-window",
      "Common-owned MM options pane registers de-collided; inert under every active game (#497)",
      Test_ComboMMOptionsWindow},


### PR DESCRIPTION
Fixes #610.

## Mechanism, verified at current main (f9e1a8b8)

The issue's trace holds line-for-line; nothing had drifted.

`Rando::Spoiler::HandleFileDropped` (the whole file) is correctly identity-free — it copies any JSON that parses as a `2S2H_RANDO_SPOILER` into MM's spoiler folder and points `gRando.SpoilerFile` / `SpoilerFileIndex` at it. The hole is downstream:

- `OnFileCreate.cpp:32` reads `rsbsPaired`; `:71` clears `foreignPlacements` unconditionally; `:83` takes the GENERATE branch when paired, so the paired leg is safe by never consulting the spoiler. `:437-441` is the UNPAIRED leg: `LoadFromFile` → `ApplyToSaveContext`.
- `Apply.cpp:265` (pre-fix) called `ReconstructForeignPlacements` unconditionally. Its only cross-session guard was "refuse if the table is already populated" (`:59-65`) — which `:71`'s clear makes structurally unreachable on this path. No identity term was read anywhere in the chain.
- `Foreign.cpp:634` `RecordForeignPickup` had no `Combo_ForeignPairingActive()` gate; `shared_items.c:109` `Combo_RecordSharedItem` takes no identity argument at all, and per `foreign_items.h:24-29` a later genuine paired-OoT arrival redeems every un-redeemed record blind to which world authored it.

Both halves are now reproduced by tests that were **measured RED before the fix**:

```
[MM-SPOILER-ID] FAIL(11): UNPAIRED session committed 1 foreign placement(s) from a
  dropped spoiler — every check collected there would author a durable shared-item
  record for a world that does not exist (#610)

[MM-SPOILER-ID] FAIL(74): an UNPAIRED session recorded a foreign pickup as a durable
  shared item (#610)
```

One correction to the issue's write-up: the reverse direction is **not** exposed. `gComboCtx.foreignPlacementsOoT` has no spoiler-load reconstruction — its only producer is `OoT_PlaceForeignItems`, which already requires an active pairing.

## The refusal surface

Identity-gated on the **combo commit**, not on the spoiler feature.

**1. The writer stamps the identity** (`Spoiler/Generate.cpp`). Alongside the `"foreign"` section it already writes only for a paired world, the spoiler now carries:

```json
"rsbsPairing": {
  "sharedRandoSeed": ...,
  "sharedRandoSettingsHash": ...,
  "mmProfileDigest": ...
}
```

— the three terms #570 freezes at creation, in the form the arrival gate compares. A spoiler that claims cross-game placements now names the world it was authored for. Written only when paired: stamping a zeroed identity would make "no pairing" look like a pairing that happens to be all zeros.

**2. The loader compares and refuses** (`Spoiler/Apply.cpp`). A non-empty `"foreign"` section is gated *before* shape validation and before the table is touched. Refusal reports through the #533/#568 machinery in exactly the shape #570's arrival refusal uses — `RsbsSave_RefuseSlotIdentity` latches the active slot **without quarantining** (the `.redsave` is healthy; the *session* diverged) plus an immediate muted toast on the shared overlay. Each refusal names the specific divergent term:

```
[MM] spoiler-load: REFUSED — this spoiler's cross-game section does not name the world
this session is playing (divergent term: sharedRandoSeed; shared master seed: spoiler
names 0610A11A, this session is playing 06AA7AB7). No foreign placement is committed,
so no durable cross-game record can be authored from it; unified-save slot 0 is latched
against writes this session. The Majora's Mask world itself still loads.
```

Returns `-2` and **does not throw**, so MM's own world still loads — upstream's standalone spoiler-load capability is untouched, and a spoiler with no `"foreign"` section (or an empty one) takes no new code path and latches nothing.

`mmProfileDigest` is skipped when zero on either side, matching #570's legacy pre-freeze handling.

**3. Defense in depth** (`Foreign.cpp`). `RecordForeignPickup` gains the `PairingActive()` gate. `Combo_RecordSharedItem` has no identity parameter, so this is the last place that can refuse to author a record for a world that does not exist — for any future route that reaches the placement table without going through (2).

**4. Shared label corrected** (`src/common/save.cpp`). `RSBS_REFUSE_IDENTITY` now has two producers, so its file-panel label moved from "options differ from this pair's creation" (true of #570, actively misleading about #610) to "this session diverges from this pair's creation identity". Each producer's own stderr line still carries the specific term.

### Known consequence, stated rather than discovered later

A **pre-stamp paired spoiler is refused as unidentified** rather than trusted. Regenerating it is the recovery. The alternative — trusting a foreign section that cannot be shown to name this world — is the hole itself, kept open for every file that omits the block. Recorded in Apply.cpp next to the check.

## Locks

Two new display-free rows in the `redship` tier, `games/mm/2s2h/mm_spoiler_identity_test.cpp`.

`mm-spoiler-identity` drives the **real** consumer pair (`LoadFromFile` + `ApplyToSaveContext` — the two calls `OnFileCreate.cpp:439-441` makes) over a spoiler produced by the **real** writer and staged through the **real** path (`SaveToFile` into `SpoilerDirectory()`, selected with the same two CVars `HandleFileDropped` sets, with `SpoilerFileIndex != 0` asserted so the LOAD-branch precondition is genuinely satisfied). Divergence is modelled by moving the **live** identity, never by hand-editing the spoiler, so the staged file stays byte-authentic writer output — which is what makes leg 5 a real lock on the writer emitting an identity at all.

| Lock | Counterfactual that goes red |
|---|---|
| Unpaired session (the issue's scenario): not committed, refused, term named | **Measured: FAIL(11)** without the gate |
| Divergent `sharedRandoSeed` / `sharedRandoSettingsHash` / `mmProfileDigest`: not committed, refused, each naming its own term | Drop any one comparison from `ForeignIdentityDiverges` |
| Matching identity **commits** (non-vacuity) | A gate that refuses everything; also red without `Generate.cpp`'s stamp, since a genuine paired spoiler would then be unidentified |
| Standalone spoiler (no `"foreign"` section) loads, latches nothing, world applied | Gating the spoiler feature instead of the combo commit |
| Refusal is player-visible and reasoned | Each leg plants a sentinel toast first, so "the previous leg's toast is still there" cannot pass. Drop the toast or the latch → red |
| `mm-foreign-pickup-gate`: unpaired pickup authors no durable record | **Measured: FAIL(74)** without the gate |
| ...and the paired pickup still records | An off switch rather than a gate |

## Verification

Full local build (Ninja/MSVC Release, submodules initialized, ROM-staged archives, isolated worktree at `f9e1a8b8`):

- `ctest -L "^redship$"` — **100% tests passed out of 84** (82 before; +2 new rows), including `TestRegistrationComplete` and `AllTests`
- `ctest -L "^rando$"` — **100% tests passed out of 18**, including `MMRandoGen` (whose spoiler-LOAD reconstruction legs now run against the newly-stamped identity), `MMPairSwitchEntry`, `ForeignPlacementOoT`, `RandoDeterminism` and `SeedDeterminism` — the last two confirming the added spoiler key perturbs no generation stream
- clang-format 14.0.6 clean on every enforced path touched; the new test TU is added to `.github/clang-format-paths.txt`
- No submodule pointer and no generated stamp (`build.c`, `properties.h`) in the commit

Both failing-first results above were captured from a build containing the tests but not the fix, then re-run green on the build containing both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!--- section:artifacts:start -->
### Build Artifacts
  - [rsbs-windows.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/8949292608.zip)
  - [rsbs-linux.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/8948992184.zip)
<!--- section:artifacts:end -->