### PR TITLE
Carve the frozen combo record and refuse divergence by name (#498)

### DIFF
--- a/.github/clang-format-paths.txt
+++ b/.github/clang-format-paths.txt
@@ -41,6 +41,7 @@ games/mm/2s2h/ShipInitBridge_SingleExe.cpp
 games/mm/2s2h/TrackersGuiSingleExe.cpp
 games/mm/2s2h/TrackersGuiSingleExe.h
 games/mm/2s2h/mm_capture_harvest_gate_test.cpp
+games/mm/2s2h/mm_combo_settings_test.cpp
 games/mm/2s2h/mm_culling_test.cpp
 games/mm/2s2h/mm_fb_effects_test.cpp
 games/mm/2s2h/mm_flash_filenum_test.cpp

--- a/CMake/SingleExecutable.cmake
+++ b/CMake/SingleExecutable.cmake
@@ -444,6 +444,15 @@ if(BUILD_TESTING)
     # the placement table need no fill, no display, and no ROM.
     redship_add_test(NAME MMSpoilerIdentity COMMAND redship --test mm-spoiler-identity)
     redship_add_test(NAME MMForeignPickupGate COMMAND redship --test mm-foreign-pickup-gate)
+    # Combo-level arrival identity gate (#498, ADR 0011 increment 1). Drives the
+    # REAL MM_Rando_PairOnCrossGameArrival. A divergent frozen combo record must
+    # refuse through the #533/#568 surface AND NAME the diverged rule — the
+    # capability that justifies carving a 12-byte record instead of spending ADR
+    # 0009 claim 2's 4-byte digest alone; without it the record buys display
+    # only. The legacy legs pass hadFrozenState=1 so the gate returns before any
+    # generation dispatch, which keeps this row ROM-free while exercising the
+    # exact early-return path the O5 transitional writer has to sit ahead of.
+    redship_add_test(NAME MMComboSettingsGate COMMAND redship --test mm-combo-settings-gate)
     # Cross-game session invalidation (#440). A soft reset or a new game must
     # retire the previous session's frozen blobs, shadows and gComboCtx
     # crossings — while a cross-game arrival and a legitimate existing-slot
@@ -586,6 +595,18 @@ if(BUILD_TESTING)
     # WholeFileRedeemedItem goes red on the assertion that names the loss.
     redship_add_test(NAME WholeFileCommit COMMAND redship --test whole-file-commit)
     redship_add_test(NAME WholeFileRedeemedItem COMMAND redship --test whole-file-redeemed-item)
+    # The frozen COMBO-LEVEL rule record (#498, ADR 0011 increment 1): 16 bytes
+    # out of reserved[124] -> reserved[108], carved at .redsave offsets 880
+    # (comboSettingsHash, ADR 0009 claim 2 spent exactly as reserved) and 884
+    # (ComboSettingsRecord, ADR 0011 claim 10). ComboSettingsCanonical is the
+    # golden-vector row and it is the one #574's cross-peer identity handshake
+    # will inherit: the digest input is pinned byte-for-byte precisely so a
+    # struct-layout or endianness change is a red test rather than a silently
+    # different world identity on one peer's build.
+    redship_add_test(NAME ComboSettingsFormat COMMAND redship --test combo-settings-format)
+    redship_add_test(NAME ComboSettingsCanonical COMMAND redship --test combo-settings-canonical)
+    redship_add_test(NAME ComboSettingsDivergence COMMAND redship --test combo-settings-divergence)
+    redship_add_test(NAME ComboSettingsLegacyFreeze COMMAND redship --test combo-settings-legacy-freeze)
     redship_add_test(NAME Context COMMAND redship --test context)
     # F10 hot-swap freeze/consume contract (#364): the hotkey path must freeze
     # the DEPARTING game (or refuse the switch), and a consumed frozen state

--- a/docs/adr/0009-combo-settings-and-reverse-pool.md
+++ b/docs/adr/0009-combo-settings-and-reverse-pool.md
@@ -488,7 +488,7 @@ Publishing the allocation once beats five sequential re-versions:
 | # | Claimant | Size | Status |
 |---|---|---|---|
 | 1 | `foreignPlacementsOoT[8]` (#493 step 2, Lane 1) | 48 B | **carved by this arc** |
-| 2 | `comboSettingsHash` (#498 decision 1, Lane 1) | 4 B | reserved |
+| 2 | `comboSettingsHash` (#498 decision 1, Lane 1) | 4 B | **carved 2026-08-05** — ADR 0011 increment 1, offset **880**; spent exactly as reserved |
 | 3 | MM option-profile digest (#497 step 7 / #499 step 4, Lane 4) | 4 B | **carved by Lane 4; size CONFIRMED at 4 B** |
 | 4 | Netplay grant fields (#460, ADR 0005/0007) | 64 B | ~~reserved~~ **RETIRED 2026-08-04 (#584)** — already spent by PR #473, see amendment below |
 | 5 | `sharedResources[8]` (#525, shared rupees + hearts + magic) | 32 B | **carved by #525** |
@@ -496,6 +496,7 @@ Publishing the allocation once beats five sequential re-versions:
 | 7 | Unallocated floor | 84 B | must not drop below 64 |
 | 8 | `commitGeneration` (#569, one-game-persistence commit-generation stamp) | 4 B | **carved** — PR #569, merged 2026-07-31; missing from this table until the 2026-08-04 (#584) amendment |
 | 9 | `mmPairedAttempt` (#581, ADR 0010 increment 1.2 / accepted answer O3) | 4 B | **carved** — PR #581, merged 2026-08-02; missing from this table until the 2026-08-04 (#584) amendment |
+| **10 (new, 2026-08-05)** | `comboSettings` (`ComboSettingsRecord`, ADR 0011 decision 1 / accepted answer O1) | 12 B | **carved 2026-08-05** — ADR 0011 increment 1, offset **884** |
 
 Total reserved-against: 152 B of 284. After claims 1, 3, 5 and 6 land, `reserved[]`
 is 132 bytes and 152 B of capacity remain.
@@ -611,6 +612,35 @@ still being live. It is not. No format-version bump, no
 this correction; it is bookkeeping only, and nothing in decisions 1-3 above
 changes.
 
+### Amendment — claims 2 and 10 carved; the outstanding list is EMPTY (2026-08-05, ADR 0011 increment 1)
+
+**Claim 2 is spent, and claim 10 is the row ADR 0011 adds.** ADR 0011 decision
+1 (accepted answer O1) carves both in one change: `uint32_t comboSettingsHash`
+at `.redsave` byte offset **880** — claim 2, exactly the 4 bytes this table
+reserved — and `ComboSettingsRecord comboSettings` (12 B) at offset **884**,
+the new claim 10. `RSBS_SAVE_VERSION`, `RSBS_COMBO_CONTEXT_RECORD_SIZE` and
+`RSBS_COMBO_CONTEXT_PRECARVE_SIZE` are all unmoved; `sizeof(ComboContext)`
+stays 1004 against the 1024 budget.
+
+**Reconciling to `src/common/context.h` (re-derived 2026-08-05).** Following
+the table from its 264-byte start: `264 − 48` (claim 1) `− 4` (claim 3) `− 32`
+(claim 5) `− 48` (claim 6) `− 4` (claim 8, #569) `− 4` (claim 9, #581) `− 4`
+(claim 2) `− 12` (claim 10) = **108**, matching `reserved[108]` in
+`context.h` exactly. Its start offset is **896** (884 + 12 — the byte
+immediately after `comboSettings`), and both new offsets carry literal-integer
+`RSBS_CTX_STATIC_ASSERT`s in the style of 672/736/740/788/792/824/872/876, so a
+field growing in place ahead of either one is a build error rather than a
+silent reinterpretation of every shipped save.
+
+**108 clears the 64-byte floor by 44 bytes, and no claim remains outstanding.**
+Claim 4 was retired as already spent by the 2026-08-04 (#584) amendment above,
+and claims 2 and 10 are now carved, so the next carver starts from 108 with the
+append-only second-block rule in force. The stale warning in `context.h`'s
+`reserved[]` comment — that claims 2 and 4 "would leave 56, UNDER the 64-byte
+floor" — is removed by the same change, because leaving it in place invites the
+next carver to raise the record size to solve a problem that no longer exists
+(ADR 0011 increment 0).
+
 Two constraints on anyone spending from this:
 
 - **Keep `reserved[]` at 64 bytes or more.** `Test_SaveComboRecordFixed`'s
@@ -683,3 +713,19 @@ Added by the 2026-08-04 amendment (#584):
 - **Only claim 2 remains outstanding.** `comboSettingsHash` (4 B) is the sole
   unspent claim; landing it leaves `reserved[120]`, clear of the 64-byte
   floor by 56 bytes.
+
+Added by the 2026-08-05 amendment (ADR 0011 increment 1):
+
+- **Claim 2 is carved (offset 880) and claim 10 is added and carved (offset
+  884, 12 B).** `reserved[124]` becomes `reserved[108]`, beginning at offset
+  896. The bullet above is superseded on its arithmetic only: ADR 0011 spends
+  16 bytes rather than claim 2's 4, because combo-level terms have no per-half
+  tier to live in the way MM's options did, so O1 chose a frozen record plus
+  the digest over the digest alone.
+- **The outstanding-claim list against `reserved[]` is now empty.**
+- **`Rando_HeadlessSeedDeterminismDigest` folds `comboSettingsHash`**, paying
+  decision 1's stated consequence: "changing a combo setting changes the
+  derived world" is assertable from that increment on. `MixPairedFinalSeed()`
+  is deliberately NOT widened with it — ADR 0011 decision 1.4 forbids it,
+  because folding an identity term into the SEED derivation would re-derive
+  every already-generated paired world.

--- a/games/mm/2s2h/GameExports_SingleExe.cpp
+++ b/games/mm/2s2h/GameExports_SingleExe.cpp
@@ -2986,6 +2986,28 @@ void MM_Rando_PairOnCrossGameArrival(int hadFrozenState) {
         return;
     }
 
+    // ------------------------------------------------------------------------
+    // The O5 TRANSITIONAL WRITER (ADR 0011 decision 4.4), placed here — under a
+    // live pairing and ahead of every "this MM save already exists" early
+    // return below — because ALL of those returns are still crossings, and a
+    // legacy pair that always has an existing MM save would otherwise never
+    // freeze at all: permanently exempt from comparison, with 4.4 describing a
+    // behaviour nothing builds.
+    //
+    // A pair whose record reads absent predates this carve and was generated
+    // when there was only one rule set, so it freezes the SHIPPED DEFAULTS and
+    // compares normally thereafter. Refusing it instead would orphan every
+    // already-written paired .redsave to detect a divergence that cannot have
+    // happened. No-op for an already-frozen record — a second crossing COMPARES
+    // rather than re-freezes, which is what keeps this a transitional writer and
+    // not a self-healing overwrite.
+    //
+    // On a pre-freeze pair whose mmProfileDigest is ALSO still 0, the
+    // fingerprint stamped here folds that 0; ResolvePairedProfile re-stamps it
+    // immediately after it freezes the profile, which is decision 4.1's order
+    // restored.
+    Combo_FreezeLegacyComboSettings();
+
     if (hadFrozenState) {
         // Self-heal a save that is INTERNALLY INCONSISTENT before accepting it.
         //
@@ -3097,6 +3119,79 @@ void MM_Rando_PairOnCrossGameArrival(int hadFrozenState) {
         // (ResolvePairedProfile stamps it during the generation below).
         fprintf(stderr, "[MM] pairing: no creation-time profile stamp (pre-freeze pair); the profile freezes at "
                         "this arrival\n");
+    }
+
+    // ------------------------------------------------------------------------
+    // The COMBO-LEVEL arrival identity gate (ADR 0011 decision 4).
+    //
+    // Same surface, same call, same semantics as the MM-profile gate above —
+    // with one thing the profile gate cannot do, and which is the whole reason
+    // twelve bytes were carved instead of four: THIS REFUSAL NAMES THE RULE.
+    // "Your combo rules do not match this save" with no ability to say WHICH is
+    // the un-repairable case ADR 0009 accepted only because it had no
+    // alternative. A digest could never have been shown or diffed; a record can.
+    //
+    // Divergence is corruption to refuse, never a choice to honor: no world is
+    // generated, the frozen record is left untouched (NEVER self-healed — a
+    // self-heal would make every divergence disappear the instant it was
+    // detected), the slot is latched against writes so the divergent session
+    // cannot capture its rules into the healthy pair's .redsave, and the file
+    // panel renders the slot REFUSED.
+    //
+    // An ABSENT record yields no bits (decision 4.2's exemption), so a legacy
+    // pair passes here and is repaired by the transitional writer above.
+    // ------------------------------------------------------------------------
+    {
+        const uint32_t comboDiverged = Combo_ComboSettingsDivergence();
+        if (comboDiverged != 0) {
+            char fields[192];
+            Combo_ComboSettingsDivergenceDescribe(comboDiverged, fields, sizeof(fields));
+            const int slot = RsbsSave_GetActiveSlot();
+            fprintf(stderr,
+                    "[MM] pairing: REFUSED — the CROSS-GAME RULES resolved at this arrival do not match the ones "
+                    "frozen when this file was created. Diverged: %s. (frozen: dir=%u poolOoT=%u poolMM=%u "
+                    "classOoT=%04X classMM=%04X goal=%u rung=%u fingerprint=%08X). No MM world is generated; the "
+                    "frozen record is left untouched; unified-save slot %d is latched against writes this "
+                    "session\n",
+                    fields, (unsigned)gComboCtx.comboSettings.direction, (unsigned)gComboCtx.comboSettings.poolSizeOoT,
+                    (unsigned)gComboCtx.comboSettings.poolSizeMM, (unsigned)gComboCtx.comboSettings.itemClassOoT,
+                    (unsigned)gComboCtx.comboSettings.itemClassMM, (unsigned)gComboCtx.comboSettings.goal,
+                    (unsigned)gComboCtx.comboSettings.logicRung, (unsigned)gComboCtx.comboSettingsHash, slot);
+            fflush(stderr);
+            RsbsSave_RefuseSlotIdentity(slot);
+
+            // Player-visible, immediately, on the shared overlay, and it NAMES
+            // THE FIELD — the capability decision 1.1 justification 2 claims,
+            // built rather than promised.
+            static char refusalMessage[320];
+            snprintf(refusalMessage, sizeof(refusalMessage),
+                     "Cross-game rules changed since this file was created (%s). "
+                     "Termina stays un-randomized and progress here will not be saved to the pair.",
+                     fields);
+            ComboNotification refusalToast;
+            memset(&refusalToast, 0, sizeof(refusalToast));
+            refusalToast.prefix = "Cross-game pairing REFUSED:";
+            refusalToast.prefixColor[0] = 0.9f;
+            refusalToast.prefixColor[1] = 0.35f;
+            refusalToast.prefixColor[2] = 0.3f;
+            refusalToast.prefixColor[3] = 1.0f;
+            refusalToast.message = refusalMessage;
+            refusalToast.messageColor[0] = 1.0f;
+            refusalToast.messageColor[1] = 1.0f;
+            refusalToast.messageColor[2] = 1.0f;
+            refusalToast.messageColor[3] = 1.0f;
+            refusalToast.remainingTime = 15.0f;
+            // Muted for the same reason the profile refusal above is: the
+            // overlay's ding is OoT's Audio_PlaySoundGeneral, and this call site
+            // runs on MM's boot path (and in the display-free rando tier).
+            refusalToast.mute = 1;
+            OoT_Notification_Emit(&refusalToast);
+            return;
+        }
+        if (Combo_ComboSettingsFrozen()) {
+            fprintf(stderr, "[MM] pairing: arrival combo rules match the creation-frozen record (fingerprint %08X)\n",
+                    (unsigned)gComboCtx.comboSettingsHash);
+        }
     }
 
     fprintf(stderr, "[MM] pairing: armed on switch-entry (masterSeed=%u settingsHash=%08X) — dispatching OnSaveInit\n",

--- a/games/mm/2s2h/Rando/Foreign.cpp
+++ b/games/mm/2s2h/Rando/Foreign.cpp
@@ -292,6 +292,17 @@ uint32_t ResolvePairedProfile(bool paired) {
                 "generation (digest %08X)\n",
                 (unsigned)digest);
         gComboCtx.mmProfileDigest = digest;
+        // ADR 0011 decision 4.4: the combo fingerprint FOLDS this digest, and on
+        // a doubly-legacy pair the transitional combo writer ran at the arrival
+        // gate while it was still 0. Re-stamp it here — "recomputes
+        // comboSettingsHash in the order of 4.1 immediately after" — or the next
+        // arrival's cross-check would see a fingerprint that disagrees with its
+        // own record and refuse a healthy pair.
+        if (Combo_ComboSettingsFrozen()) {
+            const uint32_t refreshed = Combo_StampComboSettingsHash();
+            fprintf(stderr, "[MM] combo settings: fingerprint re-stamped over the freshly frozen MM profile (%08X)\n",
+                    (unsigned)refreshed);
+        }
     }
     return digest;
 }
@@ -509,7 +520,21 @@ int PlaceForeignItems() {
     if (poolCount <= 0 || pool == nullptr) {
         return 0;
     }
-    sLastPlacementStats.requested = poolCount;
+    // How many crossings this direction may make comes from the FROZEN COMBO
+    // RECORD (ADR 0011 decision 1, accepted answer O4). Combo_ComboPoolSizeFor
+    // clamps to RSBS_FOREIGN_PLACEMENT_CAP and falls back to it for an unfrozen
+    // record, so with the shipped defaults `wanted` is poolCount exactly as
+    // before and no generated world moves. `requested` follows `wanted` rather
+    // than `poolCount` so the shortfall alarm below stays honest: placing fewer
+    // than the pool BECAUSE THE RULES SAY SO is not a host-supply shortfall.
+    const int poolSize = Combo_ComboPoolSizeFor((uint8_t)GAME_OOT);
+    const int wanted = (poolCount < poolSize) ? poolCount : poolSize;
+    // Read and reported here; ADR 0011 increment 4 is where an unarmed direction
+    // makes this pass a no-op (deliberately last — it is the only increment that
+    // can change a generated world).
+    fprintf(stderr, "[MM] foreign placement: combo rules direction=%u poolSizeOoT=%d (frozen=%d)\n",
+            (unsigned)Combo_ComboDirection(), poolSize, Combo_ComboSettingsFrozen() ? 1 : 0);
+    sLastPlacementStats.requested = wanted;
 
     // The reachability gate (ADR 0010 increment 1.3, #500 work item 2): the
     // closure of everything MM's own logic can reach in THIS world, under its
@@ -565,7 +590,7 @@ int PlaceForeignItems() {
     }
 
     int placed = 0;
-    for (int i = 0; i < poolCount && !candidates.empty(); i++) {
+    for (int i = 0; i < wanted && !candidates.empty(); i++) {
         const size_t pick = (size_t)(SelectNext() % (uint32_t)candidates.size());
         const RandoCheckId hostCheck = candidates[pick];
         candidates.erase(candidates.begin() + (std::ptrdiff_t)pick);
@@ -586,7 +611,7 @@ int PlaceForeignItems() {
     }
     sLastPlacementStats.placed = placed;
 
-    if (placed < poolCount) {
+    if (placed < wanted) {
         // Under-supply (ADR 0010 increment 1.3; cap ≠ promise): fewer
         // reachable eligible hosts than pool items means fewer placements —
         // NEVER an unreachable placement, and (while crossings are duplicate
@@ -596,9 +621,9 @@ int PlaceForeignItems() {
         // (foreignShortfall, Spoiler/Generate.cpp); this line is the log-side
         // alarm.
         fprintf(stderr,
-                "[MM] foreign placement SHORTFALL: only %d of %d pool items placed — reachable eligible hosts "
+                "[MM] foreign placement SHORTFALL: only %d of %d wanted placements made — reachable eligible hosts "
                 "exhausted (%d eligible, %d reachable); recorded in the spoiler\n",
-                placed, poolCount, sLastPlacementStats.eligibleHosts, sLastPlacementStats.reachableEligibleHosts);
+                placed, wanted, sLastPlacementStats.eligibleHosts, sLastPlacementStats.reachableEligibleHosts);
     }
     return placed;
 }

--- a/games/mm/2s2h/mm_combo_settings_test.cpp
+++ b/games/mm/2s2h/mm_combo_settings_test.cpp
@@ -1,0 +1,290 @@
+/**
+ * ROM-free lock for the COMBO-LEVEL arrival identity gate (ADR 0011 increment
+ * 1, #498). CTest label "redship" (display-free); row `mm-combo-settings-gate`
+ * in src/common/test_runner.cpp.
+ *
+ * Lives MM-side because the surface under test is `MM_Rando_PairOnCrossGameArrival`
+ * — the REAL arrival gate, the one the Happy Mask Shop hand-off runs through
+ * (games/mm/2s2h/GameExports_SingleExe.cpp, called from
+ * MM_Play_ConsumeStartupEntrance) — and because reaching its combo leg means
+ * first satisfying its MM-profile leg, which needs MM's option tables.
+ *
+ * ============================================================================
+ * WHAT THIS LOCKS, AND WHY IT IS THE POINT OF THE CARVE
+ * ============================================================================
+ *
+ * ADR 0011 spends 16 bytes on a RECORD instead of ADR 0009's reserved 4-byte
+ * digest, and one of the two justifications is that a refusal can then say
+ * WHICH rule diverged. The ADR itself records the disposition: that
+ * justification only stands if something BUILDS the capability, so
+ * `Combo_ComboSettingsDivergence` is a scheduled increment-1 task with a test
+ * lock that asserts the refusal NAMES the diverged field rather than merely
+ * refusing. This is that lock. Without it the twelve bytes buy display alone.
+ *
+ *   leg 1 — direction alone diverges  -> REFUSED, and the toast names
+ *                                        "direction"; the frozen record is NOT
+ *                                        self-healed and no world is generated
+ *   leg 2 — a legacy (formatVersion 0) paired file taken through one crossing
+ *                                     -> comes back at formatVersion 1 with the
+ *                                        shipped defaults and a nonzero
+ *                                        fingerprint, and is NOT refused
+ *   leg 3 — the same file taken through a SECOND crossing
+ *                                     -> compares rather than re-freezing
+ *
+ * NON-VACUITY. A gate that refused everything would pass leg 1 and prove
+ * nothing. Two things close that, in different places and deliberately so:
+ * leg 2 drives the same gate to completion WITHOUT a refusal, and the
+ * `combo-settings-divergence` row (src/common/tests/test_combo_settings.c)
+ * proves the diff returns 0 for a healthy pair — which is decisive here
+ * because the gate's condition is literally
+ * `Combo_ComboSettingsDivergence() != 0`.
+ *
+ * WHY LEG 2/3 PASS hadFrozenState = 1. The transitional writer sits ahead of
+ * every "this MM save already exists" early return on purpose (all of them are
+ * still crossings, and a legacy pair that always has a restored MM session
+ * would otherwise never freeze at all). Passing 1 exercises exactly that
+ * placement AND keeps this row ROM-free: with a restored session the gate
+ * returns before `GameInteractor_ExecuteOnSaveInit`, so no MM fill is
+ * dispatched.
+ */
+
+#ifdef RSBS_SINGLE_EXECUTABLE
+
+#include <cstdarg>
+#include <cstdio>
+#include <cstring>
+#include <string>
+
+#include "Rando/Rando.h"
+
+// src/common — outside any extern "C" block; these headers manage their own
+// linkage (matching Foreign.cpp / mm_spoiler_identity_test.cpp).
+#include "foreign_items.h"
+#include "save.h"                  // the #533 REFUSED surface this gate reports through
+#include "notification_bridge.h"   // the player-visible half of that surface
+#include "combo_mm_options_view.h" // MM_Rando_ComputeProfileStamp — the profile leg's input
+
+extern "C" {
+#include "variables.h"
+void MM_Rando_PairOnCrossGameArrival(int hadFrozenState);
+}
+
+namespace {
+
+int Fail(int code, const char* fmt, ...) {
+    va_list args;
+    va_start(args, fmt);
+    fprintf(stderr, "[MM-COMBO-SETTINGS] FAIL(%d): ", code);
+    vfprintf(stderr, fmt, args);
+    fprintf(stderr, "\n");
+    va_end(args);
+    fflush(stderr);
+    return code;
+}
+
+constexpr int kSlot = 0;
+const char* const kScratchSaveDir = "rsbs_test_saves_combo_settings";
+
+// Planted as the "last toast" before every leg: the overlay's store has no
+// drain entry point, so "a toast exists" would otherwise be satisfiable by an
+// earlier leg's — the exact vacuous pass mm_spoiler_identity_test.cpp closes
+// the same way.
+const char* const kToastSentinel = "rsbs498-no-toast-was-emitted";
+
+constexpr uint32_t kSeed = 0x0498C0DEu;
+constexpr uint32_t kSettingsHash = 0x5E770011u;
+
+/** Publish the live pairing carrier the way Playthrough_Init stamps it, with an
+ *  MM profile digest that MATCHES what this session resolves — otherwise the
+ *  profile leg refuses first and the combo leg is never reached. */
+void ArmPairing() {
+    gComboCtx.sourceIsRando = true;
+    gComboCtx.sharedRandoSeed = kSeed;
+    gComboCtx.sharedRandoSettingsHash = kSettingsHash;
+    gComboCtx.mmProfileDigest = MM_Rando_ComputeProfileStamp();
+}
+
+/** The bootstrap state the arrival gate expects: a vanilla MM save with no
+ *  rando world under it (what TitleSetup's MM_Sram_InitNewSave authors). */
+void ArmVanillaBootstrapSave() {
+    gSaveContext.save.shipSaveInfo.saveType = SAVETYPE_VANILLA;
+    gSaveContext.save.shipSaveInfo.rando.finalSeed = 0;
+}
+
+void ResetRefusalSurface() {
+    RsbsSave_ResetSlotSessionState();
+    RsbsSave_SetActiveSlot(kSlot);
+    RsbsSave_ArmSlotOnCreate(kSlot);
+
+    ComboNotification sentinel;
+    memset(&sentinel, 0, sizeof(sentinel));
+    sentinel.prefix = "";
+    sentinel.message = kToastSentinel;
+    sentinel.remainingTime = 1.0f;
+    // Muted for the same reason the refusal toasts are: the overlay's ding is
+    // OoT's Audio_PlaySoundGeneral, and this runs display-free.
+    sentinel.mute = 1;
+    OoT_Notification_Emit(&sentinel);
+}
+
+/** The refusal surface as a whole: latched slot, RSBS_REFUSE_IDENTITY, no
+ *  quarantine (the .redsave FILE is healthy — the SESSION diverged), and a
+ *  toast that NAMES @p term. */
+int AssertRefusedNaming(int baseCode, const char* leg, const char* term) {
+    if (RsbsSave_IsSlotWritable(kSlot) != 0) {
+        return Fail(baseCode,
+                    "%s: the active slot was not latched — a session running different cross-game rules can still "
+                    "capture itself into the healthy pair's .redsave",
+                    leg);
+    }
+    if (RsbsSave_GetSlotRefuseReason(kSlot) != (int)RSBS_REFUSE_IDENTITY) {
+        return Fail(baseCode + 1, "%s: refusal reason is %d, expected RSBS_REFUSE_IDENTITY", leg,
+                    RsbsSave_GetSlotRefuseReason(kSlot));
+    }
+    if (RsbsSave_HasQuarantine(kSlot) != 0) {
+        return Fail(baseCode + 2, "%s: an identity refusal quarantined the slot file — the file is healthy", leg);
+    }
+
+    ComboNotification toast;
+    memset(&toast, 0, sizeof(toast));
+    if (OoT_Notification_PeekLastForTest(&toast) != 1) {
+        return Fail(baseCode + 3, "%s: no toast reached the shared overlay — stderr is not a player-visible surface",
+                    leg);
+    }
+    const std::string message = toast.message != nullptr ? toast.message : "";
+    const std::string prefix = toast.prefix != nullptr ? toast.prefix : "";
+    if (message == kToastSentinel) {
+        return Fail(baseCode + 3, "%s: the overlay still holds this leg's sentinel — no refusal toast was emitted",
+                    leg);
+    }
+    if (prefix.find("REFUSED") == std::string::npos) {
+        return Fail(baseCode + 3, "%s: the toast's prefix ('%s') does not read as a refusal", leg, prefix.c_str());
+    }
+    if (message.find(term) == std::string::npos) {
+        return Fail(baseCode + 4,
+                    "%s: the refusal does not NAME the diverged rule '%s' (message: '%s'). A refusal that cannot "
+                    "say which rule diverged is the un-repairable case ADR 0009 accepted only for want of an "
+                    "alternative — and it is the whole reason ADR 0011 carves a record instead of a digest",
+                    leg, term, message.c_str());
+    }
+    return 0;
+}
+
+} // namespace
+
+extern "C" int MM_ComboSettingsGate_RunHeadless(void) {
+    printf("[TEST] mm-combo-settings-gate: the arrival refuses a divergent combo record and NAMES the rule; a "
+           "legacy pair freezes the shipped defaults instead (#498, ADR 0011)\n");
+
+    rsbs::SaveManager::Instance().SetSaveDirectory(kScratchSaveDir);
+
+    // ------------------------------------------------------------------------
+    // Leg 1 — `direction` alone diverges: REFUSED, naming the field.
+    // ------------------------------------------------------------------------
+    {
+        ComboContext_Init();
+        ArmPairing();
+        ArmVanillaBootstrapSave();
+        ResetRefusalSurface();
+
+        // Freeze a record that differs from the live resolution in ONE field, so
+        // a refusal that named several fields (or a generic one) is a fail.
+        // Frozen through the real freeze so the fingerprint stays consistent —
+        // otherwise the fingerprint bit would fire too and the leg would pass
+        // for the wrong reason.
+        ComboSettingsRecord divergent;
+        Combo_ResolveComboSettings(&divergent);
+        divergent.direction = (uint8_t)RSBS_COMBO_DIR_FORWARD; // live resolves BOTH
+        Combo_FreezeComboSettings(&divergent);
+
+        const uint32_t bits = Combo_ComboSettingsDivergence();
+        if (bits != RSBS_COMBO_DIVERGE_DIRECTION) {
+            return Fail(1, "leg 1 setup: expected exactly the direction bit, got %04X", (unsigned)bits);
+        }
+
+        MM_Rando_PairOnCrossGameArrival(/*hadFrozenState=*/0);
+
+        const int rc = AssertRefusedNaming(10, "leg 1 (direction diverged)", "direction");
+        if (rc != 0) {
+            return rc;
+        }
+        // NEVER self-healed: overwriting the frozen record with the divergent
+        // resolution would make every divergence disappear the instant it was
+        // detected.
+        if (gComboCtx.comboSettings.direction != (uint8_t)RSBS_COMBO_DIR_FORWARD) {
+            return Fail(15, "leg 1: the refusal SELF-HEALED the frozen record — divergence is corruption to "
+                            "refuse, never a value to overwrite");
+        }
+        // And no world was authored under the divergent rules.
+        if (gSaveContext.save.shipSaveInfo.saveType == SAVETYPE_RANDO) {
+            return Fail(16, "leg 1: a paired MM world was generated under refused rules");
+        }
+    }
+
+    // ------------------------------------------------------------------------
+    // Leg 2 — a LEGACY paired file freezes the shipped defaults at its first
+    // crossing (accepted answer O5), and is NOT refused.
+    // ------------------------------------------------------------------------
+    {
+        ComboContext_Init();
+        ArmPairing();
+        ArmVanillaBootstrapSave();
+        ResetRefusalSurface();
+
+        if (Combo_ComboSettingsFrozen()) {
+            return Fail(20, "leg 2 setup: the record must start ABSENT (a pre-ADR-0011 pair)");
+        }
+
+        // hadFrozenState: a restored MM session. The gate returns before any
+        // generation dispatch, which is exactly the early-return path the
+        // transitional writer has to sit AHEAD of — a legacy pair that always
+        // restores an existing MM save would otherwise stay at formatVersion 0
+        // forever, permanently exempt from comparison.
+        MM_Rando_PairOnCrossGameArrival(/*hadFrozenState=*/1);
+
+        if (!Combo_ComboSettingsFrozen()) {
+            return Fail(21, "leg 2: one crossing did not freeze a legacy pair — 4.4 would describe a behaviour "
+                            "nothing builds, and every pre-carve file would stay exempt from comparison forever");
+        }
+        if (gComboCtx.comboSettings.formatVersion != (uint8_t)RSBS_COMBO_SETTINGS_FORMAT_VERSION) {
+            return Fail(22, "leg 2: the transitional write did not stamp the current format version");
+        }
+        ComboSettingsRecord defaults;
+        Combo_ComboSettingsDefaults(&defaults);
+        if (memcmp(&gComboCtx.comboSettings, &defaults, sizeof(defaults)) != 0) {
+            return Fail(23, "leg 2: the transitional write did not freeze the SHIPPED DEFAULTS");
+        }
+        if (gComboCtx.comboSettingsHash == 0) {
+            return Fail(24, "leg 2: the transitional write left the fingerprint at 0 (= 'not frozen')");
+        }
+        if (Combo_ComboSettingsDivergence() != 0) {
+            return Fail(25, "leg 2: the freshly frozen legacy record reports divergence against its own session");
+        }
+        if (RsbsSave_IsSlotWritable(kSlot) != 1) {
+            return Fail(26, "leg 2: a legacy pair was REFUSED — that orphans every already-written paired "
+                            ".redsave to detect a divergence that cannot have happened");
+        }
+
+        // --------------------------------------------------------------------
+        // Leg 3 — a SECOND crossing COMPARES rather than re-freezing.
+        // --------------------------------------------------------------------
+        const uint32_t frozenHash = gComboCtx.comboSettingsHash;
+        MM_Rando_PairOnCrossGameArrival(/*hadFrozenState=*/1);
+        if (gComboCtx.comboSettingsHash != frozenHash ||
+            memcmp(&gComboCtx.comboSettings, &defaults, sizeof(defaults)) != 0) {
+            return Fail(30, "leg 3: a second crossing rewrote the frozen record — the transitional writer became a "
+                            "self-heal");
+        }
+        if (RsbsSave_IsSlotWritable(kSlot) != 1) {
+            return Fail(31, "leg 3: a second crossing of a healthy pair was refused");
+        }
+    }
+
+    ComboContext_Init();
+    RsbsSave_ResetSlotSessionState();
+    printf("[TEST] PASS: the arrival gate refuses a divergent combo record by name and freezes a legacy pair's "
+           "shipped defaults\n");
+    return 0;
+}
+
+#endif // RSBS_SINGLE_EXECUTABLE

--- a/games/oot/soh/Enhancements/randomizer/3drando/menu.cpp
+++ b/games/oot/soh/Enhancements/randomizer/3drando/menu.cpp
@@ -590,9 +590,23 @@ extern "C" int Rando_HeadlessSeedDeterminismDigest(const char* seedStr, const ch
             "placementHash=%08X\n"
             "placedCount=%zu\n"
             "foreignOoTHash=%08X\n"
-            "foreignOoTCount=%zu\n",
+            "foreignOoTCount=%zu\n"
+            // ADR 0009 decision 1's consequence, finally payable: fold the
+            // combo-level rules into the determinism digest, or "changing a
+            // combo setting changes the derived world" stays unassertable —
+            // which is exactly what #498 says about this digest today. The
+            // creation event stamps it just above the reverse placement pass, so
+            // it is live by the time this runs. The RECORD is emitted beside the
+            // fingerprint deliberately: a digest-only line would tell a diff
+            // that something changed without telling a human what.
+            "comboSettingsHash=%08X\n"
+            "comboSettings=v%u/d%u/p%u,%u/c%04X,%04X/g%u/r%u\n",
             gComboCtx.sharedRandoSeed, gComboCtx.sharedRandoSettingsHash, gComboCtx.sourceIsRando ? 1 : 0,
-            placementHash, placedCount, foreignHash, foreignCount);
+            placementHash, placedCount, foreignHash, foreignCount, gComboCtx.comboSettingsHash,
+            (unsigned)gComboCtx.comboSettings.formatVersion, (unsigned)gComboCtx.comboSettings.direction,
+            (unsigned)gComboCtx.comboSettings.poolSizeOoT, (unsigned)gComboCtx.comboSettings.poolSizeMM,
+            (unsigned)gComboCtx.comboSettings.itemClassOoT, (unsigned)gComboCtx.comboSettings.itemClassMM,
+            (unsigned)gComboCtx.comboSettings.goal, (unsigned)gComboCtx.comboSettings.logicRung);
     if (closeOut) {
         fclose(out);
     }

--- a/games/oot/soh/Enhancements/randomizer/3drando/playthrough.cpp
+++ b/games/oot/soh/Enhancements/randomizer/3drando/playthrough.cpp
@@ -140,6 +140,28 @@ int Playthrough_Init(uint32_t seed, std::set<RandomizerCheck> excludedLocations,
     gComboCtx.mmProfileDigest = MM_Rando_ComputeProfileStamp();
     SPDLOG_INFO("Paired identity: MM profile frozen at creation (digest {:08X})", gComboCtx.mmProfileDigest);
 
+    // ADR 0011 decision 4.1: the creation event also freezes the COMBO-LEVEL
+    // rules — the ones governing the crossing itself, which belong to neither
+    // game's save by construction — and computes the whole-pair fingerprint
+    // over all three terms.
+    //
+    // THE ORDER HERE IS THE ADR'S ORDER AND IT IS LOAD-BEARING: resolve the
+    // combo record -> stamp sharedRandoSettingsHash (above) -> stamp
+    // mmProfileDigest (above) -> compute comboSettingsHash LAST. The fingerprint
+    // folds both half-digests (accepted answer O6, because a digest narrower
+    // than the generator's input set is vacuous), so computing it any earlier
+    // would fold a term that has not been decided yet.
+    //
+    // Frozen BEFORE OoT_PlaceForeignItems below, because that pass reads the
+    // record's pool size — the same reason the identity stamp has to precede it.
+    {
+        ComboSettingsRecord comboSettings;
+        Combo_ResolveComboSettings(&comboSettings);
+        Combo_FreezeComboSettings(&comboSettings);
+        SPDLOG_INFO("Paired identity: combo settings frozen at creation (fingerprint {:08X})",
+                    gComboCtx.comboSettingsHash);
+    }
+
     // #510, the reverse foreign pool: hand a few MM items to OoT checks now that
     // this world's paired identity is stamped just above (the placement stream is
     // derived from it, so the order is load-bearing — not stylistic).

--- a/games/oot/soh/Enhancements/randomizer/ForeignItemsSingleExe.cpp
+++ b/games/oot/soh/Enhancements/randomizer/ForeignItemsSingleExe.cpp
@@ -361,7 +361,22 @@ extern "C" int OoT_PlaceForeignItems(void) {
         poolIndices.push_back(i);
     }
 
-    const int wanted = std::min({ poolCount, (int)RSBS_FOREIGN_PLACEMENT_CAP, (int)candidates.size() });
+    // How many crossings this direction may make comes from the FROZEN COMBO
+    // RECORD (ADR 0011 decision 1, accepted answer O4), not from the cap alone.
+    // Combo_ComboPoolSizeFor already clamps to RSBS_FOREIGN_PLACEMENT_CAP and
+    // falls back to it for an unfrozen record, so the shipped defaults place
+    // exactly what this line placed before the record existed — a count that
+    // could exceed the table's capacity would be a setting that lies, and a
+    // zero-extended legacy record must never resolve to "no crossings".
+    const int poolSize = Combo_ComboPoolSizeFor((uint8_t)GAME_MM);
+    const int wanted = std::min({ poolCount, poolSize, (int)candidates.size() });
+    // The direction itself is READ here and reported; ADR 0011 increment 4 is
+    // where an unarmed direction makes this pass a no-op. It lands last on
+    // purpose: it is the only increment that can change a generated world, and
+    // it should land on top of a frozen, compared, rendered setting rather than
+    // under one.
+    fprintf(stderr, "[OoT] foreign placement: combo rules direction=%u poolSizeMM=%d (frozen=%d)\n",
+            (unsigned)Combo_ComboDirection(), poolSize, Combo_ComboSettingsFrozen() ? 1 : 0);
 
     int placed = 0;
     for (int i = 0; i < wanted; i++) {

--- a/src/common/context.cpp
+++ b/src/common/context.cpp
@@ -361,6 +361,19 @@ void Context_InvalidateSessionState(ComboSeedStampPolicy seedPolicy) {
     // persisted the zeroed table.
     ComboForeignPlacement savedPlacementsOoT[RSBS_FOREIGN_PLACEMENT_CAP];
     memcpy(savedPlacementsOoT, gComboCtx.foreignPlacementsOoT, sizeof(savedPlacementsOoT));
+    // ADR 0011 decision 4.3: the frozen combo record and its whole-pair
+    // fingerprint are authored BY THE CREATION EVENT, at the same moment and by
+    // the same writer as the seed stamp and the MM profile digest above — so the
+    // ComboSeedStampPolicy rule (context.h) puts them in the KEEP set, and the
+    // rule is not optional. A term stamped at or before file-create that KEEP
+    // drops is wiped by the creation itself: the stamping act destroying its own
+    // output, which is a hole under any freeze design.
+    //
+    // Explicitly NOT alongside mmPairedAttempt, which is authored by GENERATION
+    // rather than by creation and is correctly dropped. Getting this backwards
+    // is silent in exactly one direction.
+    const ComboSettingsRecord savedComboSettings = gComboCtx.comboSettings;
+    const uint32_t savedComboSettingsHash = gComboCtx.comboSettingsHash;
 
     // Frozen blobs and shadow copies in one call — they are the same storage
     // (FrozenStateManager::ClearFrozenState memsets the buffer AND clears
@@ -401,6 +414,15 @@ void Context_InvalidateSessionState(ComboSeedStampPolicy seedPolicy) {
         // note above. KEEP-only on purpose: on a DROP path a populated table
         // belongs to a dead session and must go with it.
         memcpy(gComboCtx.foreignPlacementsOoT, savedPlacementsOoT, sizeof(gComboCtx.foreignPlacementsOoT));
+        // The frozen combo rules travel with the stamp (ADR 0011 decision 4.3)
+        // — and, like the stamp, are DROPPED on every other path: a surviving
+        // record with no generation behind it would report a created world's
+        // rules for a pair that no longer exists, and would freeze the combo
+        // pane (Combo_ComboSettingsFrozen) against a world nobody is playing.
+        // The record and its fingerprint move TOGETHER: a reader that found one
+        // without the other could not tell a legacy record from a torn one.
+        gComboCtx.comboSettings = savedComboSettings;
+        gComboCtx.comboSettingsHash = savedComboSettingsHash;
     }
 
     // The unified save's ACTIVE SLOT is session state too, and it lived outside
@@ -420,10 +442,11 @@ void Context_InvalidateSessionState(ComboSeedStampPolicy seedPolicy) {
 
     fprintf(stderr,
             "[Context] Session state invalidated (seed stamp %s: rando=%d seed=%u settings=%08X "
-            "mmProfile=%08X reversePlacements=%d)\n",
+            "mmProfile=%08X reversePlacements=%d comboSettings=v%u/%08X)\n",
             (seedPolicy == RSBS_SEED_STAMP_KEEP) ? "kept" : "dropped", (int)gComboCtx.sourceIsRando,
             (unsigned)gComboCtx.sharedRandoSeed, (unsigned)gComboCtx.sharedRandoSettingsHash,
-            (unsigned)gComboCtx.mmProfileDigest, Combo_CountForeignPlacementsOoT());
+            (unsigned)gComboCtx.mmProfileDigest, Combo_CountForeignPlacementsOoT(),
+            (unsigned)gComboCtx.comboSettings.formatVersion, (unsigned)gComboCtx.comboSettingsHash);
 }
 
 int Context_InvalidateSessionOnReturnToTitle(void) {

--- a/src/common/context.h
+++ b/src/common/context.h
@@ -455,6 +455,75 @@ RSBS_CTX_STATIC_ASSERT(offsetof(ComboSharedResource, kind) == 0 && offsetof(Comb
                            offsetof(ComboSharedResource, value) == 2,
                        "ComboSharedResource member offsets are .redsave format and must not move");
 
+/**
+ * The FROZEN COMBO-LEVEL RULE RECORD (ADR 0011 decision 1, accepted answer O1).
+ *
+ * The rules that govern the CROSSING itself — direction, per-direction pool
+ * size, the item-class bitsets, the combo GOAL and the logic rung. They belong
+ * to neither game's save by construction (that is what "combo-level" means), so
+ * unlike MM's option profile they have no per-half tier to live in: ADR 0009
+ * claim 3 could stay a 4-byte digest only because `RANDO_SAVE_OPTIONS` already
+ * held MM's values one tier down. Nothing holds these.
+ *
+ * A RECORD AND NOT JUST THE DIGEST, for two shipped reasons (decision 1.1):
+ * ADR 0004 §6 state 4 requires a frozen key's value to be shown FROM THE SAVE,
+ * and a hash cannot be shown; and the #533/#568 refusal surface was built to be
+ * loud AND explainable, which requires naming WHICH rule diverged
+ * (Combo_ComboSettingsDivergence, foreign_items.h).
+ *
+ * `formatVersion` IS THE OCCUPANCY TAG, and it is what makes the other eleven
+ * bytes usable. This is the ComboSharedResource device (see above: "0 rupees is
+ * a legal player state") applied to a struct instead of a slot. The growth
+ * contract's "zero means unset" is satisfied AT THE BLOCK, which frees every
+ * field inside a formatted record to use zero legitimately — and it is a
+ * VERSION rather than a bool precisely so `spare0`/`spare1` are safe to spend
+ * later: a field added at version N is authoritative only at
+ * `formatVersion >= N` (ADR 0002 §4's rule for COMBO_CONTEXT_VERSION, scoped to
+ * one block).
+ *
+ * TWO ZERO TRAPS, stated because both are silent (decision 1.3):
+ *   - `direction == 0` must NOT mean "no crossings". A legacy record
+ *     zero-extends to all zeros, so if 0 meant OFF every pre-3.1 paired save
+ *     would silently lose its crossings on the first load by a new build.
+ *     RSBS_COMBO_DIR_OFF is 1u; 0 is reachable only when formatVersion == 0.
+ *   - `goal == 0` inside a FORMATTED record is CORRUPTION, not "unset". ADR
+ *     0010 D1's "stored value 0 means unset" is superseded in mechanism and
+ *     preserved in effect: unset-ness is now a property of formatVersion.
+ *     `logicRung == 0` reads identically.
+ *
+ * Every value space here is PINNED and APPEND-ONLY — see the RSBS_COMBO_DIR_* /
+ * RSBS_COMBO_GOAL_* / RSBS_COMBO_RUNG_* / RSBS_ITEMCLASS_* tables in
+ * foreign_items.h, which carry the retire-never-renumber rule and its
+ * compile-time pinning asserts. The tables live there rather than here because
+ * they are the crossing's SEMANTICS; this struct is its FORMAT.
+ */
+typedef struct {
+    uint8_t formatVersion; // 0 = record ABSENT (legacy / never frozen); nonzero = every field below is authoritative
+    uint8_t direction;     // RSBS_COMBO_DIR_*; OFF is a NONZERO enumerator
+    uint8_t poolSizeOoT;   // max OoT-origin placements into MM checks, 1..RSBS_FOREIGN_PLACEMENT_CAP
+    uint8_t poolSizeMM;    // max MM-origin placements into OoT checks, 1..RSBS_FOREIGN_PLACEMENT_CAP
+    uint16_t itemClassOoT; // RSBS_ITEMCLASS_* bitset over the OoT pool
+    uint16_t itemClassMM;  // RSBS_ITEMCLASS_* bitset over the MM pool
+    uint8_t goal;          // RSBS_COMBO_GOAL_* (ADR 0010 D1); illegal to be 0 inside a formatted record
+    uint8_t logicRung;     // RSBS_COMBO_RUNG_* (ADR 0010 §2.2); likewise
+    uint8_t spare0;        // growth under formatVersion, NOT under zero-means-unset
+    uint8_t spare1;
+} ComboSettingsRecord;
+
+RSBS_CTX_STATIC_ASSERT(sizeof(ComboSettingsRecord) == 12,
+                       "ComboSettingsRecord is serialized raw inside the .redsave Tier-1 record; its layout is "
+                       "format (ADR 0011 decision 1.2)");
+RSBS_CTX_STATIC_ASSERT(offsetof(ComboSettingsRecord, formatVersion) == 0 &&
+                           offsetof(ComboSettingsRecord, direction) == 1 &&
+                           offsetof(ComboSettingsRecord, poolSizeOoT) == 2 &&
+                           offsetof(ComboSettingsRecord, poolSizeMM) == 3 &&
+                           offsetof(ComboSettingsRecord, itemClassOoT) == 4 &&
+                           offsetof(ComboSettingsRecord, itemClassMM) == 6 && offsetof(ComboSettingsRecord, goal) == 8 &&
+                           offsetof(ComboSettingsRecord, logicRung) == 9 &&
+                           offsetof(ComboSettingsRecord, spare0) == 10 && offsetof(ComboSettingsRecord, spare1) == 11,
+                       "ComboSettingsRecord member offsets are .redsave format and must not move; the canonical "
+                       "digest encoder walks them in this declaration order (ADR 0011 decision 1.4)");
+
 typedef struct {
     char magic[8];        // "OoT+MM<3"
     uint32_t version;
@@ -685,6 +754,67 @@ typedef struct {
     // what carries it for a live pair.
     uint32_t mmPairedAttempt;
 
+    // ADR 0009 CLAIM 2, spent exactly as reserved (ADR 0011 decision 1.4,
+    // accepted answer O6): the WHOLE PAIR's fingerprint — not a checksum of the
+    // twelve bytes beside it.
+    //
+    //   comboSettingsHash = Hash( canonical(comboSettings) || ":" ||
+    //                             sharedRandoSettingsHash || ":" || mmProfileDigest )
+    //
+    // Folding both half-digests is what makes the term non-vacuous (ADR 0009
+    // decision 1's amendment: "a digest narrower than the input set is vacuous —
+    // same seed, same digest, different world"). Two peers can already agree on
+    // seed AND settings hash AND MM profile and still be running different
+    // CROSSING rules; this is the term that covers those.
+    //
+    // canonical() is DEFINED, not left to the compiler: field-by-field in
+    // declaration order, each uint16_t little-endian, written a byte at a time —
+    // never a struct memcpy and never a cast of a packed struct (ADR 0007 §2's
+    // codec discipline, adopted here for the same reason). The member-offset
+    // asserts above pin the STORAGE format; the encoder in foreign_items.c pins
+    // the DIGEST INPUT, and a golden-vector test pins the pair of them.
+    //
+    // ORDER IS A CONSTRAINT, NOT A CONVENTION: this is computed LAST, after both
+    // half-digests are stamped and after the record is frozen. Anything else
+    // hashes a term that has not been decided yet.
+    //
+    // Zero DISPLACES (foreign_items.c), exactly as DigestFromIdentity does: a
+    // real identity hashing to 0 would read as "not frozen" and become an
+    // undetectable mismatch. Zero is therefore also the growth contract's
+    // required "unset": a non-rando or zero-extended legacy record reads 0.
+    //
+    // NOT folded into MixPairedFinalSeed(). The digest answers "were these
+    // worlds generated under the same rules"; the seed answers "which world does
+    // this seed derive". Two questions, two computations — folding identity
+    // terms into the SEED derivation would re-derive finalSeed for every
+    // already-generated paired world.
+    //
+    // Carved from the FRONT of the old reserved[124] under the growth contract,
+    // so every field above keeps its shipped offset and the record size is
+    // unchanged.
+    uint32_t comboSettingsHash;
+
+    // ADR 0011 CLAIM 10 (new): the frozen combo-level rule record itself. See
+    // ComboSettingsRecord above for the shape and the two zero traps, and
+    // foreign_items.h for the pinned value tables and the accessors.
+    //
+    // FROZEN AT CREATION, like every other identity term: written once by the
+    // creation event (Playthrough_Init, from the tier-4 authoring surface),
+    // read-only for the life of the file, and NEVER mutated by an arrival or a
+    // load. Under one-game semantics arrival-time divergence is corruption, not
+    // choice — every arrival re-resolves the live rules and REFUSES on a
+    // mismatch through the #533/#568 surface, naming which rule diverged.
+    //
+    // The ONE transitional writer besides creation is the legacy pair (accepted
+    // answer O5): a paired file with formatVersion == 0 predates this carve, was
+    // generated under exactly one set of rules, and freezes the SHIPPED DEFAULTS
+    // at its first crossing — the ResolvePairedProfile precedent, not a refusal.
+    //
+    // Carved from the FRONT of the old reserved[120] under the growth contract:
+    // all-zero = formatVersion 0 = record absent, which is exactly what a
+    // zero-extended pre-ADR-0011 record must read as.
+    ComboSettingsRecord comboSettings;
+
     // Headroom. Carve new fields from the FRONT of this array (as
     // sharedItemsTagged, sharedRandoSettingsHash, foreignPlacements, the
     // grant cursors, and the reverse placement table were) so the struct
@@ -696,17 +826,25 @@ typedef struct {
     // "zero means unset".
     //
     // 264 - 48 (foreignPlacementsOoT) - 4 (mmProfileDigest) - 32 (sharedResources)
-    // - 48 (sharedResourcesExt) - 4 (commitGeneration) - 4 (mmPairedAttempt).
+    // - 48 (sharedResourcesExt) - 4 (commitGeneration) - 4 (mmPairedAttempt)
+    // - 4 (comboSettingsHash) - 12 (comboSettings) = 108.
     // ADR 0009 publishes the remaining
     // allocation across the other claimants and sets a 64-byte floor:
     // Test_SaveComboRecordFixed's scribble loop iterates sizeof(reserved), so
     // at zero it degenerates to zero iterations and passes vacuously, retiring
-    // the only test that proves headroom round-trips at all. NOTE: with the
-    // mmPairedAttempt carve this stands at 124; ADR 0009's outstanding
-    // claims 2 and 4 (4 + 64) would leave 56, UNDER the 64-byte floor, so the
-    // ADR's budget table needs a row before those land (raise the record size
-    // + RSBS_SAVE_VERSION together if the floor would break).
-    uint8_t reserved[124];
+    // the only test that proves headroom round-trips at all.
+    //
+    // THE OUTSTANDING-CLAIM LIST IS NOW EMPTY. An earlier revision of this note
+    // warned that "claims 2 and 4 (4 + 64) would leave 56, UNDER the 64-byte
+    // floor". That arithmetic depended on ADR 0009 claim 4 still being live; the
+    // 2026-08-04 (#584) amendment retired it as ALREADY SPENT by PR #473 (the
+    // grant cursors at 672 and the overflow count at 736 — the 264-byte baseline
+    // was already measured after that carve, so counting it again double-counted
+    // the same 64 bytes). Claim 2 landed here with ADR 0011, together with that
+    // ADR's new claim 10. 108 clears the floor by 44 bytes, and the next carver
+    // starts from 108 with the append-only second-block rule in force — never a
+    // widen in place of anything ahead of it.
+    uint8_t reserved[108];
 } ComboContext;
 
 /**
@@ -852,13 +990,43 @@ RSBS_CTX_STATIC_ASSERT(offsetof(ComboContext, mmPairedAttempt) ==
                            offsetof(ComboContext, commitGeneration) + sizeof(uint32_t),
                        "mmPairedAttempt must be carved from the FRONT of reserved[] (contiguous "
                        "with the commit generation); moving it changes .redsave format");
-RSBS_CTX_STATIC_ASSERT(offsetof(ComboContext, reserved) ==
+// The whole-pair fingerprint is the next carve (ADR 0009 claim 2, spent by ADR
+// 0011, 4 bytes). Pinned to the literal 880 for the same reason 672, 736, 740,
+// 788, 792, 824, 872 and 876 are: anything carved after it inherits its
+// position, so a field growing in place ahead of it must break the build rather
+// than slide it. ADR 0009's budget amendment names 880 explicitly as where
+// reserved[] began before this carve.
+RSBS_CTX_STATIC_ASSERT(offsetof(ComboContext, comboSettingsHash) == 880u,
+                       "comboSettingsHash lives at .redsave byte offset 880; if this fires, a field "
+                       "before it grew in place - carve from reserved[] instead");
+RSBS_CTX_STATIC_ASSERT(offsetof(ComboContext, comboSettingsHash) ==
                            offsetof(ComboContext, mmPairedAttempt) + sizeof(uint32_t),
+                       "comboSettingsHash must be carved from the FRONT of reserved[] (contiguous "
+                       "with the paired-attempt record); moving it changes .redsave format");
+// The frozen combo record is the next carve (ADR 0011 claim 10, 12 bytes),
+// pinned to the literal 884 on the same terms. It is DELIBERATELY contiguous
+// with its own digest: the two are written by one creation event and read by
+// one comparison, and a reader that finds one without the other cannot tell a
+// legacy record from a torn one.
+RSBS_CTX_STATIC_ASSERT(offsetof(ComboContext, comboSettings) == 884u,
+                       "comboSettings lives at .redsave byte offset 884; if this fires, a field "
+                       "before it grew in place - carve from reserved[] instead");
+RSBS_CTX_STATIC_ASSERT(offsetof(ComboContext, comboSettings) ==
+                           offsetof(ComboContext, comboSettingsHash) + sizeof(uint32_t),
+                       "comboSettings must be carved from the FRONT of reserved[] (contiguous with "
+                       "the combo settings digest); moving it changes .redsave format");
+RSBS_CTX_STATIC_ASSERT(offsetof(ComboContext, reserved) ==
+                           offsetof(ComboContext, comboSettings) + sizeof(ComboSettingsRecord),
                        "the tagged-item array, the settings digest, both foreign-placement tables, "
                        "the grant cursors, the overflow count, the MM profile digest, BOTH shared "
-                       "resource blocks, the commit generation, the paired-attempt record, and the "
+                       "resource blocks, the commit generation, the paired-attempt record, the "
+                       "combo settings digest and record, and the "
                        "remaining headroom must stay contiguous (no padding, no fields slipped "
                        "between them)");
+RSBS_CTX_STATIC_ASSERT(offsetof(ComboContext, reserved) == 896u,
+                       "reserved[] begins at .redsave byte offset 896 after the ADR 0011 carve; if "
+                       "this fires, a field ahead of it moved and every shipped save is being "
+                       "reinterpreted - that is a format generation, not an assert edit");
 // ADR 0009's floor. reserved[] is what Test_SaveComboRecordFixed scribbles to
 // prove Tier-1 headroom round-trips; at zero that loop runs zero times and the
 // test passes vacuously, so the carve budget stops here rather than there.
@@ -884,6 +1052,10 @@ static_assert(!std::is_convertible<int, ComboSharedResource>::value &&
                   !std::is_assignable<ComboSharedResource&, int>::value,
               "a raw integer must never become a shared resource — the kind tag is what separates "
               "an unset slot from a legitimate zero");
+static_assert(!std::is_convertible<int, ComboSettingsRecord>::value &&
+                  !std::is_assignable<ComboSettingsRecord&, int>::value,
+              "a raw integer must never become a combo settings record — formatVersion is what "
+              "separates an absent record from a legitimately zero-valued field inside one");
 static_assert(std::is_trivially_copyable<ComboContext>::value,
               "gComboCtx is serialized with memcpy; ComboContext must stay trivially copyable");
 #endif

--- a/src/common/foreign_items.c
+++ b/src/common/foreign_items.c
@@ -20,6 +20,433 @@ bool Combo_ForeignPairingActive(void) {
 }
 
 // ============================================================================
+// Combo-level settings (ADR 0011): defaults, resolution, freeze, digest, diff
+// ============================================================================
+//
+// See foreign_items.h for the model and for why every value space here is
+// pinned and append-only. This TU stays game-header-free, so the whole surface
+// is a function of gComboCtx and of the pinned tables — which is also what lets
+// the golden-vector lock drive the REAL encoder rather than a paraphrase.
+
+void Combo_ComboSettingsDefaults(ComboSettingsRecord* out) {
+    if (out == NULL) {
+        return;
+    }
+    memset(out, 0, sizeof(*out));
+    out->formatVersion = (uint8_t)RSBS_COMBO_SETTINGS_FORMAT_VERSION;
+    // Accepted answer O2: the shipped default is what already ships. A default
+    // that differs from shipped behaviour silently changes every new world at
+    // the moment the setting lands, and the change is invisible in a diff.
+    out->direction = (uint8_t)RSBS_COMBO_DIR_BOTH;
+    // Accepted answer O4: two per-direction counts, each 1..CAP. The cap is the
+    // default because that is precisely what both passes place today —
+    // min(pool, CAP, candidates) — so the record changes no world.
+    out->poolSizeOoT = (uint8_t)RSBS_FOREIGN_PLACEMENT_CAP;
+    out->poolSizeMM = (uint8_t)RSBS_FOREIGN_PLACEMENT_CAP;
+    // Accepted answer O7, and the same "reproduce today" rule: today's pools are
+    // filtered by no class at all, so the default is every ALLOCATED bit.
+    out->itemClassOoT = (uint16_t)RSBS_ITEMCLASS_ALL_V1;
+    out->itemClassMM = (uint16_t)RSBS_ITEMCLASS_ALL_V1;
+    // ADR 0010 D1 / answer O11: GOAL stays beat-both (OoTMM's own goal likewise
+    // defaults to 'both'), and the shipped rung is the strictest Ship of
+    // Harkinian ships — the proved, no-tricks rung, never the base `none`.
+    // Both terms are inert today: their consumers are ADR 0010's increments.
+    // They are frozen anyway, because a term added to the identity later cannot
+    // describe a world that was already created.
+    out->goal = (uint8_t)RSBS_COMBO_GOAL_BEAT_BOTH;
+    out->logicRung = (uint8_t)RSBS_COMBO_RUNG_BEATABLE;
+    // spare0/spare1 stay 0: unallocated at formatVersion 1, and a nonzero spare
+    // in a version-1 record is corruption the divergence diff reports.
+}
+
+void Combo_ResolveComboSettings(ComboSettingsRecord* out) {
+    if (out == NULL) {
+        return;
+    }
+    // INCREMENT 1 RESOLVES TO THE DEFAULTS. The tier-4 authoring keys
+    // (gCombo.Rando.Direction, .PoolSize.OoT/.MM, .ItemClass.OoT/.MM) are
+    // increment 2's work and do not exist in any store yet, so "what the player
+    // chose" and "what ships" are the same record today. When those keys land,
+    // the CVar read goes HERE and every caller follows unchanged — which is the
+    // whole reason this is a named resolver rather than an inlined copy of the
+    // defaults at each site (the same one-resolver discipline
+    // Rando::Foreign::ResolveProfileValues holds for MM's profile).
+    Combo_ComboSettingsDefaults(out);
+}
+
+bool Combo_ForeignPairingRequested(void) {
+    // The FUTURE tense. Derived from the resolved settings and never from
+    // gComboCtx's stamp, so it is answerable before generation by construction
+    // (ADR 0009 decision 2). Do not collapse it into Combo_ForeignPairingActive.
+    ComboSettingsRecord live;
+    Combo_ResolveComboSettings(&live);
+    return live.direction != (uint8_t)RSBS_COMBO_DIR_OFF;
+}
+
+bool Combo_ComboSettingsFrozen(void) {
+    // The PRESENT tense, and the exact twin of Combo_MMProfileFrozen: a
+    // src/common fact, never a gSaveContext read (ADR 0008 rule 5).
+    return gComboCtx.comboSettings.formatVersion != 0;
+}
+
+uint8_t Combo_ComboDirection(void) {
+    if (Combo_ComboSettingsFrozen()) {
+        return gComboCtx.comboSettings.direction;
+    }
+    ComboSettingsRecord live;
+    Combo_ResolveComboSettings(&live);
+    return live.direction;
+}
+
+bool Combo_ComboDirectionArms(uint8_t originGame) {
+    const uint8_t dir = Combo_ComboDirection();
+    if (dir == (uint8_t)RSBS_COMBO_DIR_BOTH) {
+        return true;
+    }
+    if (originGame == (uint8_t)GAME_OOT) {
+        return dir == (uint8_t)RSBS_COMBO_DIR_FORWARD;
+    }
+    if (originGame == (uint8_t)GAME_MM) {
+        return dir == (uint8_t)RSBS_COMBO_DIR_REVERSE;
+    }
+    return false;
+}
+
+int Combo_ComboPoolSizeFor(uint8_t originGame) {
+    if (originGame != (uint8_t)GAME_OOT && originGame != (uint8_t)GAME_MM) {
+        return 0;
+    }
+
+    // The frozen record is the authority for a created world; an UNFROZEN one
+    // falls back to the resolved (shipped) size. That fallback is load-bearing,
+    // not defensive: a zero-extended legacy record reads poolSize 0, and
+    // honouring it would silently generate a paired world with no crossings at
+    // all — the opposite of what a pre-carve world was generated with.
+    ComboSettingsRecord rec;
+    if (Combo_ComboSettingsFrozen()) {
+        rec = gComboCtx.comboSettings;
+    } else {
+        Combo_ResolveComboSettings(&rec);
+    }
+
+    int size = (originGame == (uint8_t)GAME_OOT) ? (int)rec.poolSizeOoT : (int)rec.poolSizeMM;
+    // A count that can exceed a table's capacity is a setting that lies
+    // (accepted answer O4), and neither option may bump the cap in place. So the
+    // clamp lives here, once, rather than at each placement pass.
+    if (size > (int)RSBS_FOREIGN_PLACEMENT_CAP) {
+        size = (int)RSBS_FOREIGN_PLACEMENT_CAP;
+    }
+    if (size < 1) {
+        // Only reachable from a corrupt/absent frozen record, since the
+        // resolver never produces 0. Falling back to the cap keeps a damaged
+        // record from silently deleting the crossings rather than refusing.
+        size = (int)RSBS_FOREIGN_PLACEMENT_CAP;
+    }
+    return size;
+}
+
+// ---- canonical() and the whole-pair fingerprint (decision 1.4) -------------
+
+void Combo_ComboSettingsCanonical(const ComboSettingsRecord* rec, uint8_t* out) {
+    if (out == NULL) {
+        return;
+    }
+    ComboSettingsRecord zero;
+    if (rec == NULL) {
+        memset(&zero, 0, sizeof(zero));
+        rec = &zero;
+    }
+    // FIELD BY FIELD, DECLARATION ORDER, LITTLE-ENDIAN, A BYTE AT A TIME.
+    // Deliberately NOT memcpy(out, rec, sizeof(*rec)): that would make the
+    // world's identity a property of the toolchain's struct layout and of the
+    // host's endianness, in a fingerprint whose other two terms are both
+    // string-encoded specifically to avoid that — and in the exact term #574
+    // wants to exchange between peers. ADR 0007 §2 already paid for this lesson.
+    out[0] = rec->formatVersion;
+    out[1] = rec->direction;
+    out[2] = rec->poolSizeOoT;
+    out[3] = rec->poolSizeMM;
+    out[4] = (uint8_t)(rec->itemClassOoT & 0xFFu);
+    out[5] = (uint8_t)((rec->itemClassOoT >> 8) & 0xFFu);
+    out[6] = (uint8_t)(rec->itemClassMM & 0xFFu);
+    out[7] = (uint8_t)((rec->itemClassMM >> 8) & 0xFFu);
+    out[8] = rec->goal;
+    out[9] = rec->logicRung;
+    out[10] = rec->spare0;
+    out[11] = rec->spare1;
+}
+
+// FNV-1a 32 — the project's hash (SohUtils::Hash / Ship_Hash / the relay's
+// sourceKey all compute exactly this), reimplemented over bytes rather than
+// over a std::string so the fingerprint is computable from this game-header-free
+// C TU. Same offset basis, same prime; a string and its bytes hash identically.
+static uint32_t ComboFnv1a(const uint8_t* bytes, size_t len) {
+    uint32_t h = 0x811C9DC5u;
+    for (size_t i = 0; i < len; i++) {
+        h ^= (uint32_t)bytes[i];
+        h *= 0x01000193u;
+    }
+    return h;
+}
+
+static void ComboAppendLe32(uint8_t* out, uint32_t value) {
+    out[0] = (uint8_t)(value & 0xFFu);
+    out[1] = (uint8_t)((value >> 8) & 0xFFu);
+    out[2] = (uint8_t)((value >> 16) & 0xFFu);
+    out[3] = (uint8_t)((value >> 24) & 0xFFu);
+}
+
+uint32_t Combo_ComputeComboSettingsHash(const ComboSettingsRecord* rec, uint32_t sharedRandoSettingsHash,
+                                        uint32_t mmProfileDigest) {
+    // canonical(12) || ':' || LE32(settingsHash) || ':' || LE32(mmProfileDigest)
+    uint8_t buf[RSBS_COMBO_SETTINGS_CANONICAL_LEN + 1u + 4u + 1u + 4u];
+    Combo_ComboSettingsCanonical(rec, buf);
+    buf[RSBS_COMBO_SETTINGS_CANONICAL_LEN] = (uint8_t)':';
+    ComboAppendLe32(&buf[RSBS_COMBO_SETTINGS_CANONICAL_LEN + 1u], sharedRandoSettingsHash);
+    buf[RSBS_COMBO_SETTINGS_CANONICAL_LEN + 5u] = (uint8_t)':';
+    ComboAppendLe32(&buf[RSBS_COMBO_SETTINGS_CANONICAL_LEN + 6u], mmProfileDigest);
+
+    uint32_t digest = ComboFnv1a(buf, sizeof(buf));
+    if (digest == 0) {
+        // Zero displaces, exactly as DigestFromIdentity does: zero is this
+        // field's growth-contract "unset", so a real identity hashing to 0 would
+        // read as "not frozen" and become an undetectable mismatch. One
+        // collision in 2^32 against a certainty of a false negative.
+        digest = 0x43425348u; // 'CBSH'
+    }
+    return digest;
+}
+
+uint32_t Combo_StampComboSettingsHash(void) {
+    if (!Combo_ComboSettingsFrozen()) {
+        return 0;
+    }
+    gComboCtx.comboSettingsHash = Combo_ComputeComboSettingsHash(
+        &gComboCtx.comboSettings, gComboCtx.sharedRandoSettingsHash, gComboCtx.mmProfileDigest);
+    return gComboCtx.comboSettingsHash;
+}
+
+uint32_t Combo_FreezeComboSettings(const ComboSettingsRecord* rec) {
+    ComboSettingsRecord frozen;
+    if (rec != NULL) {
+        frozen = *rec;
+    } else {
+        Combo_ResolveComboSettings(&frozen);
+    }
+    // A caller must not be able to freeze a record that reads as ABSENT: the
+    // occupancy tag is what makes the other eleven bytes usable at all.
+    frozen.formatVersion = (uint8_t)RSBS_COMBO_SETTINGS_FORMAT_VERSION;
+    gComboCtx.comboSettings = frozen;
+
+    // Computed LAST, over the record and BOTH half-digests. The caller is
+    // responsible for having stamped those first (decision 4.1's order); this
+    // is where that ordering constraint becomes observable, because a hash taken
+    // before mmProfileDigest exists folds a zero that will never be true again.
+    const uint32_t digest = Combo_StampComboSettingsHash();
+    fprintf(stderr,
+            "[Combo] combo settings FROZEN: dir=%u poolOoT=%u poolMM=%u classOoT=%04X classMM=%04X goal=%u rung=%u "
+            "(fingerprint %08X over settingsHash=%08X mmProfile=%08X)\n",
+            (unsigned)frozen.direction, (unsigned)frozen.poolSizeOoT, (unsigned)frozen.poolSizeMM,
+            (unsigned)frozen.itemClassOoT, (unsigned)frozen.itemClassMM, (unsigned)frozen.goal,
+            (unsigned)frozen.logicRung, (unsigned)digest, (unsigned)gComboCtx.sharedRandoSettingsHash,
+            (unsigned)gComboCtx.mmProfileDigest);
+    return digest;
+}
+
+int Combo_FreezeLegacyComboSettings(void) {
+    if (!Combo_ForeignPairingActive()) {
+        // Nothing to freeze rules FOR. An unpaired file must not acquire a combo
+        // identity it has no world to describe.
+        return 0;
+    }
+    if (Combo_ComboSettingsFrozen()) {
+        // A SECOND crossing COMPARES rather than re-freezes. Without this early
+        // return the transitional writer would be a self-healing overwrite —
+        // exactly what ResolvePairedProfile refuses to be, and what would make
+        // every arrival-time divergence silently disappear.
+        return 0;
+    }
+
+    ComboSettingsRecord defaults;
+    Combo_ComboSettingsDefaults(&defaults);
+    fprintf(stderr, "[Combo] combo settings: no creation-time record (pre-ADR-0011 pair); freezing the SHIPPED "
+                    "DEFAULTS at this first crossing — this pair was generated when there was only one rule set\n");
+    Combo_FreezeComboSettings(&defaults);
+    return 1;
+}
+
+// ---- Field-level divergence ------------------------------------------------
+
+uint32_t Combo_ComboSettingsDivergenceBetween(const ComboSettingsRecord* frozen, const ComboSettingsRecord* live) {
+    if (frozen == NULL || live == NULL) {
+        return 0;
+    }
+    if (frozen->formatVersion == 0) {
+        // ABSENT, not divergent. Exempt from comparison until the O5 writer
+        // freezes it (decision 4.2) — this is the one state where "no bits set"
+        // does not mean "the same rules".
+        return 0;
+    }
+    if (frozen->formatVersion > (uint8_t)RSBS_COMBO_SETTINGS_FORMAT_VERSION) {
+        // A record from a NEWER build. Its fields cannot be compared, because
+        // this build does not know which of them are authoritative. Refuse;
+        // never guess.
+        return RSBS_COMBO_DIVERGE_UNREADABLE;
+    }
+
+    // Every field below exists at formatVersion 1, so no per-field version gate
+    // is needed yet. When a field is added at version N, guard it on
+    // `min(frozen->formatVersion, live->formatVersion) >= N` — comparing it
+    // against an older record would refuse a world for carrying rules that did
+    // not exist when it was made.
+    uint32_t bits = 0;
+    if (frozen->direction != live->direction) {
+        bits |= RSBS_COMBO_DIVERGE_DIRECTION;
+    }
+    if (frozen->poolSizeOoT != live->poolSizeOoT) {
+        bits |= RSBS_COMBO_DIVERGE_POOL_SIZE_OOT;
+    }
+    if (frozen->poolSizeMM != live->poolSizeMM) {
+        bits |= RSBS_COMBO_DIVERGE_POOL_SIZE_MM;
+    }
+    if (frozen->itemClassOoT != live->itemClassOoT) {
+        bits |= RSBS_COMBO_DIVERGE_ITEM_CLASS_OOT;
+    }
+    if (frozen->itemClassMM != live->itemClassMM) {
+        bits |= RSBS_COMBO_DIVERGE_ITEM_CLASS_MM;
+    }
+    if (frozen->goal != live->goal) {
+        bits |= RSBS_COMBO_DIVERGE_GOAL;
+    }
+    if (frozen->logicRung != live->logicRung) {
+        bits |= RSBS_COMBO_DIVERGE_LOGIC_RUNG;
+    }
+    if (frozen->spare0 != live->spare0) {
+        bits |= RSBS_COMBO_DIVERGE_SPARE0;
+    }
+    if (frozen->spare1 != live->spare1) {
+        bits |= RSBS_COMBO_DIVERGE_SPARE1;
+    }
+    return bits;
+}
+
+uint32_t Combo_ComboSettingsDivergenceFor(const ComboSettingsRecord* frozen, uint32_t storedHash,
+                                          uint32_t sharedRandoSettingsHash, uint32_t mmProfileDigest) {
+    if (frozen == NULL || frozen->formatVersion == 0) {
+        return 0; // absent, exempt (decision 4.2)
+    }
+    ComboSettingsRecord live;
+    Combo_ResolveComboSettings(&live);
+    uint32_t bits = Combo_ComboSettingsDivergenceBetween(frozen, &live);
+
+    // The fingerprint cross-check. Skipped for an UNREADABLE record, where a
+    // recomputation would be meaningless anyway (this build cannot know which
+    // of that record's fields the newer format made authoritative).
+    if ((bits & RSBS_COMBO_DIVERGE_UNREADABLE) == 0) {
+        const uint32_t expected = Combo_ComputeComboSettingsHash(frozen, sharedRandoSettingsHash, mmProfileDigest);
+        if (storedHash != expected) {
+            bits |= RSBS_COMBO_DIVERGE_FINGERPRINT;
+        }
+    }
+    return bits;
+}
+
+uint32_t Combo_ComboSettingsDivergence(void) {
+    return Combo_ComboSettingsDivergenceFor(&gComboCtx.comboSettings, gComboCtx.comboSettingsHash,
+                                            gComboCtx.sharedRandoSettingsHash, gComboCtx.mmProfileDigest);
+}
+
+const char* Combo_ComboSettingsDivergenceFieldName(uint32_t bit) {
+    switch (bit) {
+        case RSBS_COMBO_DIVERGE_DIRECTION:
+            return "direction";
+        case RSBS_COMBO_DIVERGE_POOL_SIZE_OOT:
+            return "poolSizeOoT";
+        case RSBS_COMBO_DIVERGE_POOL_SIZE_MM:
+            return "poolSizeMM";
+        case RSBS_COMBO_DIVERGE_ITEM_CLASS_OOT:
+            return "itemClassOoT";
+        case RSBS_COMBO_DIVERGE_ITEM_CLASS_MM:
+            return "itemClassMM";
+        case RSBS_COMBO_DIVERGE_GOAL:
+            return "goal";
+        case RSBS_COMBO_DIVERGE_LOGIC_RUNG:
+            return "logicRung";
+        case RSBS_COMBO_DIVERGE_SPARE0:
+            return "spare0";
+        case RSBS_COMBO_DIVERGE_SPARE1:
+            return "spare1";
+        case RSBS_COMBO_DIVERGE_UNREADABLE:
+            return "formatVersion";
+        case RSBS_COMBO_DIVERGE_FINGERPRINT:
+            return "comboSettingsHash";
+        default:
+            return "(unknown)";
+    }
+}
+
+int Combo_ComboSettingsDivergenceDescribe(uint32_t bits, char* out, size_t len) {
+    if (out != NULL && len > 0) {
+        out[0] = '\0';
+    }
+    if (bits == 0) {
+        if (out != NULL && len > 0) {
+            // "(none)" rather than an empty string: a refusal message that
+            // interpolates an empty field list reads as a truncated sentence,
+            // which is how "loud and explainable" degrades back into "loud".
+            const char* none = "(none)";
+            size_t i = 0;
+            while (none[i] != '\0' && i + 1u < len) {
+                out[i] = none[i];
+                i++;
+            }
+            out[i] = '\0';
+        }
+        return 0;
+    }
+
+    int named = 0;
+    size_t used = 0;
+    for (int b = 0; b < 32; b++) {
+        const uint32_t bit = 1u << b;
+        if ((bits & bit) == 0) {
+            continue;
+        }
+        const char* name = Combo_ComboSettingsDivergenceFieldName(bit);
+        if (out != NULL && len > 0) {
+            if (named > 0 && used + 2u < len) {
+                out[used++] = ',';
+                out[used++] = ' ';
+            }
+            size_t i = 0;
+            while (name[i] != '\0' && used + 1u < len) {
+                out[used++] = name[i++];
+            }
+            out[used] = '\0';
+        }
+        named++;
+    }
+    return named;
+}
+
+void Combo_ComboSettingsSummary(ComboSettingsSummary* out) {
+    if (out == NULL) {
+        return;
+    }
+    memset(out, 0, sizeof(*out));
+    // Same predicate the MM profile summary uses: "a paired world exists" is a
+    // post-condition of a successful generation, not an intent. An unpaired
+    // world must not present gComboCtx's zeros as real rules.
+    out->paired = Combo_ForeignPairingActive();
+    if (!out->paired) {
+        return;
+    }
+    out->frozen = Combo_ComboSettingsFrozen();
+    out->record = gComboCtx.comboSettings;
+    out->comboSettingsHash = gComboCtx.comboSettingsHash;
+}
+
+// ============================================================================
 // Pool registry, indexed by origin game (ADR 0009 decision 3)
 // ============================================================================
 //

--- a/src/common/foreign_items.h
+++ b/src/common/foreign_items.h
@@ -204,8 +204,403 @@ bool Combo_GetForeignItemByName(const char* name, SharedItem* outItem);
  * generated in the live path (gComboCtx.sourceIsRando) AND it recorded its
  * settings profile digest (sharedRandoSettingsHash != 0 — Lane B's carrier
  * contract: 0 means "no profile recorded" and the worlds must not pair).
+ *
+ * THE POST-CONDITION, past tense: "a paired world EXISTS". Read at give time.
+ * It has two siblings and reviewers must not collapse the three (ADR 0009
+ * decision 2's amendment — they are three tenses of one noun):
+ *
+ *   Combo_ForeignPairingRequested()  -- future:  a paired world is being ASKED for
+ *   Combo_ComboSettingsFrozen()      -- present: this world's rules are FROZEN
+ *   Combo_ForeignPairingActive()     -- past:    a paired world EXISTS
  */
 bool Combo_ForeignPairingActive(void);
+
+// ============================================================================
+// Combo-level settings: the pinned value spaces (ADR 0011 decision 1.2.1)
+// ============================================================================
+//
+// EVERY ENUMERATOR AND BIT POSITION BELOW IS ASSIGNED AN EXPLICIT NUMERIC
+// LITERAL AND IS APPEND-ONLY. To remove a value, RETIRE IT IN PLACE — keep the
+// literal, mark it dead, never renumber.
+//
+// This is stated as a rule rather than left to the implementer because the
+// default C idiom (a bare sequential `enum`) gets it wrong SILENTLY, and two
+// separate things break when it does:
+//
+//  1. A LOCAL save corruption with no netplay involved. Inserting a value
+//     mid-list reassigns the meaning of direction/goal/logicRung/itemClass* in
+//     every already-written formatVersion >= 1 record, so a newer binary reads
+//     an old world's rules as different rules.
+//  2. comboSettingsHash stops being usable as a cross-peer comparison term the
+//     moment #574's identity handshake exchanges it: two peers on builds either
+//     side of a renumbering compute different hashes for identical settings —
+//     or, if two renumberings cancel, IDENTICAL hashes for DIFFERENT settings,
+//     which is the failure mode a digest exists to prevent.
+//
+// Same discipline as RSBS_SHARED_RES_* (context.h, explicit = 0, = 1, = 2, ...)
+// and as MM's own Options.cpp, which retires a dead option row rather than
+// deleting it because RANDO_SAVE_OPTIONS is indexed by that number in every
+// already-written MM rando save.
+
+/** The ComboSettingsRecord format version this build writes and understands.
+ *  Bump it when old content must be DISTINGUISHED, not merely extended (ADR
+ *  0002 §4's COMBO_CONTEXT_VERSION rule, scoped to one block) — i.e. when
+ *  spare0/spare1 are spent and a reader must tell "field absent" from "field
+ *  zero". */
+#define RSBS_COMBO_SETTINGS_FORMAT_VERSION 1u
+
+// Direction. Pinned, append-only, retire-never-renumber.
+// 0 is unreachable inside a formatted record: a legacy record zero-extends to
+// all zeros, so if 0 meant OFF every pre-3.1 paired save would silently lose
+// its crossings on the first load by a new build (context.h, decision 1.3).
+#define RSBS_COMBO_DIR_OFF 1u     // paired world, zero crossings (a real, chooseable world)
+#define RSBS_COMBO_DIR_FORWARD 2u // OoT-origin items into MM checks only
+#define RSBS_COMBO_DIR_REVERSE 3u // MM-origin items into OoT checks only
+#define RSBS_COMBO_DIR_BOTH 4u    // today's shipped behaviour; the accepted answer O2 default
+
+// GOAL. ADR 0010 D1 owns the value LIST; ADR 0011 owns their ENCODING.
+// Pinned, append-only.
+#define RSBS_COMBO_GOAL_BEAT_BOTH 1u
+#define RSBS_COMBO_GOAL_BEAT_EITHER 2u
+#define RSBS_COMBO_GOAL_TRIFORCE_HUNT 3u
+
+// Logic rung. ADR 0010 §2.2's ladder; same ownership split. The trick set T is
+// a PARAMETER of the rung and is deliberately NOT encoded here — it is each
+// half's own authored settings, reached through the half-digests
+// comboSettingsHash folds.
+#define RSBS_COMBO_RUNG_NONE 1u          // base: no proof; the spoiler carries the burden
+#define RSBS_COMBO_RUNG_BEATABLE 2u      // GOAL provable under the frozen trick set
+#define RSBS_COMBO_RUNG_ALL_REACHABLE 3u // GOAL provable and every location reachable
+
+// Item classes. Pinned BIT POSITIONS, append-only: allocate the next free bit,
+// never re-point an allocated one. Bits 0x0040..0x8000 are UNALLOCATED and must
+// read as 0 in a formatVersion == 1 record, which is what lets a future build
+// tell "class not armed" from "class did not exist yet" by the record's own
+// version.
+//
+// A class bit is only ever a FILTER OVER CANDIDATES THAT ALREADY PASSED the six
+// membership criteria (ADR 0011 decision 3.1). No bit can widen a pool past
+// them — in particular no bit can readmit a #525 shared cross-game resource
+// (wallet / heart / magic / ammo / hookshot), because the criteria run FIRST and
+// the bitset selects among the survivors. Increment 3 may append bits; it may
+// not weaken that ordering.
+#define RSBS_ITEMCLASS_PROGRESSION 0x0001u   // progressive/major items
+#define RSBS_ITEMCLASS_SONGS 0x0002u         //
+#define RSBS_ITEMCLASS_MASKS 0x0004u         //
+#define RSBS_ITEMCLASS_DUNGEON_ITEMS 0x0008u // small/boss keys, maps, compasses
+#define RSBS_ITEMCLASS_DUNGEON_REWARD 0x0010u // medallions, stones, remains
+#define RSBS_ITEMCLASS_SIDEQUEST 0x0020u     // non-progression sidequest rewards
+
+/** Every bit ALLOCATED at formatVersion 1, and the shipped default for both
+ *  directions. It is the union rather than a narrower selection on purpose:
+ *  today's two pools are hand-transcribed and filtered by no class at all, so
+ *  any narrower default would silently narrow them the moment increment 3
+ *  makes the bitset load-bearing. "Reproduce today's world exactly" is the
+ *  binding constraint on every default in this file. */
+#define RSBS_ITEMCLASS_ALL_V1                                                                                   \
+    (RSBS_ITEMCLASS_PROGRESSION | RSBS_ITEMCLASS_SONGS | RSBS_ITEMCLASS_MASKS | RSBS_ITEMCLASS_DUNGEON_ITEMS |   \
+     RSBS_ITEMCLASS_DUNGEON_REWARD | RSBS_ITEMCLASS_SIDEQUEST)
+
+// The pinning lock. A renumbering is a RED BUILD rather than a silently
+// re-read save — the same shape RSBS_SHARED_RES_* carries, and the reason
+// decision 1.2.1 is a BLOCKER finding's disposition rather than a style note.
+RSBS_CTX_STATIC_ASSERT(RSBS_COMBO_DIR_OFF == 1u && RSBS_COMBO_DIR_FORWARD == 2u && RSBS_COMBO_DIR_REVERSE == 3u &&
+                           RSBS_COMBO_DIR_BOTH == 4u,
+                       "RSBS_COMBO_DIR_* values are .redsave format: pinned, append-only, "
+                       "retire-never-renumber (ADR 0011 decision 1.2.1)");
+RSBS_CTX_STATIC_ASSERT(RSBS_COMBO_GOAL_BEAT_BOTH == 1u && RSBS_COMBO_GOAL_BEAT_EITHER == 2u &&
+                           RSBS_COMBO_GOAL_TRIFORCE_HUNT == 3u,
+                       "RSBS_COMBO_GOAL_* values are .redsave format: pinned, append-only, "
+                       "retire-never-renumber (ADR 0011 decision 1.2.1)");
+RSBS_CTX_STATIC_ASSERT(RSBS_COMBO_RUNG_NONE == 1u && RSBS_COMBO_RUNG_BEATABLE == 2u &&
+                           RSBS_COMBO_RUNG_ALL_REACHABLE == 3u,
+                       "RSBS_COMBO_RUNG_* values are .redsave format: pinned, append-only, "
+                       "retire-never-renumber (ADR 0011 decision 1.2.1)");
+RSBS_CTX_STATIC_ASSERT(RSBS_ITEMCLASS_PROGRESSION == 0x0001u && RSBS_ITEMCLASS_SONGS == 0x0002u &&
+                           RSBS_ITEMCLASS_MASKS == 0x0004u && RSBS_ITEMCLASS_DUNGEON_ITEMS == 0x0008u &&
+                           RSBS_ITEMCLASS_DUNGEON_REWARD == 0x0010u && RSBS_ITEMCLASS_SIDEQUEST == 0x0020u &&
+                           RSBS_ITEMCLASS_ALL_V1 == 0x003Fu,
+                       "RSBS_ITEMCLASS_* bit positions are .redsave format: pinned, append-only, "
+                       "allocate the next free bit and never re-point an allocated one (ADR 0011 "
+                       "decision 1.2.1)");
+
+// ============================================================================
+// Combo-level settings: predicates, freeze, digest, divergence (ADR 0011)
+// ============================================================================
+
+/**
+ * Fill @p out with the SHIPPED DEFAULTS — the rules that reproduce today's
+ * world exactly (accepted answers O2, O4, O7 and ADR 0010 answer O11):
+ * direction BOTH, both pool sizes at RSBS_FOREIGN_PLACEMENT_CAP, every
+ * version-1 item class armed, GOAL beat-both, logic rung beatable.
+ *
+ * This is also what the O5 transitional writer freezes into a legacy pair, and
+ * it is deliberately ONE definition rather than a set of scattered fallbacks:
+ * a default that differs from shipped behaviour silently changes every new
+ * world at the moment the setting lands, and the change is invisible in a diff.
+ */
+void Combo_ComboSettingsDefaults(ComboSettingsRecord* out);
+
+/**
+ * The session's RESOLVED combo settings — what a creation event would freeze
+ * right now, and what an arrival compares the frozen record against.
+ *
+ * ONE RESOLVER, TWO CALL SITES, exactly as Rando::Foreign::ResolveProfileValues
+ * is one resolution behind both the creation stamp and the arrival compare:
+ * "what creation froze" and "what arrival checks" cannot drift apart if they
+ * are one computation.
+ *
+ * INCREMENT 1 RESOLVES TO THE SHIPPED DEFAULTS, because the tier-4 authoring
+ * keys (`gCombo.Rando.Direction`, `.PoolSize.*`, `.ItemClass.*`) are increment
+ * 2's work and do not exist yet. When they land, THIS function grows the CVar
+ * read and every call site follows with no change — which is the whole reason
+ * the resolver is a named function rather than an inlined defaults copy.
+ */
+void Combo_ResolveComboSettings(ComboSettingsRecord* out);
+
+/**
+ * The PRE-CONDITION predicate ADR 0009 decision 2 designed and nobody built:
+ * "a paired world is being ASKED for" (future tense), answerable BEFORE
+ * generation by construction.
+ *
+ * Derived from the resolved settings and NEVER from gComboCtx's stamp, so it is
+ * immune to the ordering hazard that made hoisting the stamp above Fill() look
+ * necessary. Do not "simplify" it into Combo_ForeignPairingActive(): that one
+ * is the post-condition and answers a different question in a different tense.
+ */
+bool Combo_ForeignPairingRequested(void);
+
+/**
+ * The PRESENT-tense predicate (ADR 0009 decision 2's amendment; the exact twin
+ * of Combo_MMProfileFrozen): true once a creation event — or the O5
+ * transitional writer — has frozen this world's combo rules. Literally
+ * `gComboCtx.comboSettings.formatVersion != 0`, a src/common fact, never a
+ * gSaveContext read (ADR 0008 rule 5).
+ *
+ * On a LEGACY (pre-carve) file, false means "no combo settings were ever
+ * frozen" — correct, exempt from comparison, repaired at the first crossing.
+ * On a file CREATED since this carve, false means IDENTITY NOT FROZEN, a state
+ * no created combo file may be in; any surface that renders it as a benign
+ * default will report corruption as normal (ADR 0011 decision 4.2).
+ */
+bool Combo_ComboSettingsFrozen(void);
+
+/** The resolved direction: the frozen record's when frozen, else the shipped
+ *  default. Increment 4 is where each placement pass NO-OPS on an unarmed
+ *  direction — increment 1 only reads and reports it, because that increment is
+ *  the only one that can change a generated world and it lands on top of a
+ *  frozen, compared, rendered setting rather than under one. */
+uint8_t Combo_ComboDirection(void);
+
+/** Does the resolved direction arm crossings ORIGINATING in @p originGame?
+ *  (GAME_OOT -> the forward pass, GAME_MM -> the reverse pass.) Increment 4's
+ *  gate; see Combo_ComboDirection. */
+bool Combo_ComboDirectionArms(uint8_t originGame);
+
+/**
+ * How many placements this direction may make: the frozen record's pool size
+ * for @p originGame, CLAMPED to RSBS_FOREIGN_PLACEMENT_CAP.
+ *
+ * An UNFROZEN record yields the shipped default (the cap), so a legacy world,
+ * a pre-freeze world and a world generated before this carve all place exactly
+ * what they place today. That fallback is not defensive tidiness — without it a
+ * zero-extended record would resolve to pool size 0 and silently generate a
+ * paired world with no crossings at all.
+ *
+ * @param originGame GAME_OOT (into MM checks) or GAME_MM (into OoT checks)
+ * @return 1..RSBS_FOREIGN_PLACEMENT_CAP, or 0 for an origin with no pool.
+ */
+int Combo_ComboPoolSizeFor(uint8_t originGame);
+
+/** Number of bytes Combo_ComboSettingsCanonical writes. Equal to
+ *  sizeof(ComboSettingsRecord) on every supported host BY CONSTRUCTION rather
+ *  than by luck — see the encoder. */
+#define RSBS_COMBO_SETTINGS_CANONICAL_LEN 12u
+
+/**
+ * canonical(comboSettings) — the byte-pinned DIGEST INPUT (ADR 0011 decision
+ * 1.4; ADR 0007 §2's codec discipline).
+ *
+ * The twelve bytes of the record encoded FIELD BY FIELD IN DECLARATION ORDER,
+ * each uint16_t little-endian, WRITTEN A BYTE AT A TIME — never a struct memcpy
+ * and never a cast of a packed struct, so a big-endian host emits identical
+ * bytes. The member-offset static_asserts in context.h pin the STORAGE format;
+ * this pins the DIGEST INPUT; on every supported host they are the same twelve
+ * bytes in the same order, and the byte-at-a-time codec makes that true by
+ * construction.
+ *
+ * This also keeps comboSettingsHash in family with the two terms it folds,
+ * which are both encoded-first rather than struct-hashed (OoT's settings hash
+ * runs over a GetOptionText string, MM's profile digest over
+ * ProfileIdentityString). A raw-struct hash beside two string-first digests
+ * would be the one term in the fingerprint whose bytes depend on the toolchain.
+ *
+ * @param rec  NULL is treated as an all-zero record.
+ * @param out  receives exactly RSBS_COMBO_SETTINGS_CANONICAL_LEN bytes.
+ */
+void Combo_ComboSettingsCanonical(const ComboSettingsRecord* rec, uint8_t* out);
+
+/**
+ * The WHOLE PAIR's fingerprint (accepted answer O6):
+ *
+ *   Hash( canonical(rec) || ":" || LE32(sharedRandoSettingsHash) || ":" ||
+ *         LE32(mmProfileDigest) )
+ *
+ * FNV-1a 32 over that byte string — the project's hash, the same one
+ * SohUtils::Hash and Ship_Hash compute — with the two u32 terms encoded
+ * little-endian a byte at a time for decision 1.4's reason.
+ *
+ * ZERO DISPLACES to a fixed nonzero constant, exactly as DigestFromIdentity
+ * does: a real identity hashing to 0 would read as "not frozen" and become an
+ * undetectable mismatch. One collision in 2^32 against a certain false negative.
+ *
+ * Pure — reads nothing, writes nothing. Both the creation stamp and every
+ * arrival cross-check go through it.
+ */
+uint32_t Combo_ComputeComboSettingsHash(const ComboSettingsRecord* rec, uint32_t sharedRandoSettingsHash,
+                                        uint32_t mmProfileDigest);
+
+/**
+ * Freeze @p rec into gComboCtx as this world's combo identity, then compute and
+ * stamp comboSettingsHash over it and BOTH half-digests.
+ *
+ * CALL ORDER IS LOAD-BEARING (ADR 0011 decision 4.1): the creation event must
+ * have stamped sharedRandoSettingsHash and mmProfileDigest FIRST, because the
+ * fingerprint folds them and a hash computed earlier folds a term that has not
+ * been decided yet. The creation event's order is therefore: resolve the combo
+ * record -> stamp sharedRandoSettingsHash -> stamp mmProfileDigest -> call this.
+ *
+ * Forces formatVersion to RSBS_COMBO_SETTINGS_FORMAT_VERSION: a caller must not
+ * be able to freeze a record that reads as absent.
+ *
+ * @return the stamped comboSettingsHash (always nonzero).
+ */
+uint32_t Combo_FreezeComboSettings(const ComboSettingsRecord* rec);
+
+/**
+ * Recompute comboSettingsHash from the RESIDENT record and the two resident
+ * half-digests, and stamp it. Used by Combo_FreezeComboSettings and by the O5
+ * transitional writer; exposed so a caller that re-stamps a half-digest can
+ * restore the fingerprint's ordering invariant without re-freezing the record.
+ * A no-op returning 0 when the record is not frozen.
+ */
+uint32_t Combo_StampComboSettingsHash(void);
+
+/**
+ * THE O5 TRANSITIONAL WRITER (ADR 0011 decision 4.4). A paired file whose
+ * record reads absent (formatVersion == 0) predates this carve; it was
+ * generated when there was only ever ONE rule set, so it freezes the SHIPPED
+ * DEFAULTS at its FIRST CROSSING and compares normally thereafter. This is the
+ * ResolvePairedProfile precedent applied verbatim — the one transitional writer
+ * besides the creation event.
+ *
+ * Refusing legacy pairs instead would orphan every already-written paired
+ * .redsave to detect a divergence that cannot have happened.
+ *
+ * Does nothing (returning 0) when there is no live pairing or the record is
+ * already frozen — so a second crossing COMPARES rather than re-freezes, which
+ * is the property that makes 4.4 a behaviour and not a promise.
+ *
+ * @return 1 if this call froze the defaults, 0 otherwise.
+ */
+int Combo_FreezeLegacyComboSettings(void);
+
+// ---- Field-level divergence (ADR 0011 decision 1.1 justification 2) --------
+//
+// A refusal that can only say "something diverged" is the un-repairable case
+// ADR 0009 accepted for want of an alternative. Twelve stored bytes buy the
+// alternative, and they only buy it if something DIFFS them — so this is a
+// scheduled surface with its own test lock, not an implied benefit of the carve.
+
+#define RSBS_COMBO_DIVERGE_DIRECTION 0x0001u
+#define RSBS_COMBO_DIVERGE_POOL_SIZE_OOT 0x0002u
+#define RSBS_COMBO_DIVERGE_POOL_SIZE_MM 0x0004u
+#define RSBS_COMBO_DIVERGE_ITEM_CLASS_OOT 0x0008u
+#define RSBS_COMBO_DIVERGE_ITEM_CLASS_MM 0x0010u
+#define RSBS_COMBO_DIVERGE_GOAL 0x0020u
+#define RSBS_COMBO_DIVERGE_LOGIC_RUNG 0x0040u
+#define RSBS_COMBO_DIVERGE_SPARE0 0x0080u
+#define RSBS_COMBO_DIVERGE_SPARE1 0x0100u
+/** The frozen record carries a formatVersion this build does not understand, so
+ *  its fields cannot be compared at all. Refuse; never guess. */
+#define RSBS_COMBO_DIVERGE_UNREADABLE 0x0200u
+/** The stored comboSettingsHash is not the fingerprint its own resident record
+ *  and half-digests produce. Set only by the session-level diff, because it is
+ *  a property of gComboCtx rather than of two records. */
+#define RSBS_COMBO_DIVERGE_FINGERPRINT 0x0400u
+
+/**
+ * Which FIELDS differ between a frozen record and a live resolution, as
+ * RSBS_COMBO_DIVERGE_* bits. 0 means "these are the same rules".
+ *
+ * Fields are compared at the LOWER of the two format versions: a field
+ * introduced at version N is authoritative only in a record at version >= N, so
+ * comparing it against an older record would refuse a world for carrying rules
+ * that did not exist when it was made. A frozen record NEWER than this build
+ * yields RSBS_COMBO_DIVERGE_UNREADABLE alone.
+ *
+ * An ABSENT frozen record (formatVersion == 0) yields 0 — it is exempt from
+ * comparison until the O5 writer freezes it, which is decision 4.2's meaning of
+ * zero, not a silent pass.
+ */
+uint32_t Combo_ComboSettingsDivergenceBetween(const ComboSettingsRecord* frozen, const ComboSettingsRecord* live);
+
+/**
+ * The full diff for ONE stored identity: @p frozen against the live resolution,
+ * PLUS the fingerprint cross-check (RSBS_COMBO_DIVERGE_FINGERPRINT) recomputed
+ * from that identity's OWN three terms.
+ *
+ * Takes the terms explicitly rather than reading gComboCtx so the .redsave LOAD
+ * path can run it over the record it just read, BEFORE committing those bytes
+ * over the resident context — a check that had to read the destination would be
+ * checking the wrong world.
+ *
+ * The fingerprint cross-check is not redundant with the field diff: the record,
+ * the two half-digests and the stored hash all ride the SAME Tier-1 write, so a
+ * disagreement between them is not a settings change — it is a record and a hash
+ * that describe different worlds.
+ */
+uint32_t Combo_ComboSettingsDivergenceFor(const ComboSettingsRecord* frozen, uint32_t storedHash,
+                                          uint32_t sharedRandoSettingsHash, uint32_t mmProfileDigest);
+
+/**
+ * The session-level diff the arrival refusal calls: Combo_ComboSettingsDivergenceFor
+ * over the RESIDENT gComboCtx identity. 0 when nothing is frozen (exempt).
+ */
+uint32_t Combo_ComboSettingsDivergence(void);
+
+/** The field name for ONE RSBS_COMBO_DIVERGE_* bit ("direction",
+ *  "poolSizeOoT", ...). Never NULL; an unknown bit reports "(unknown)". */
+const char* Combo_ComboSettingsDivergenceFieldName(uint32_t bit);
+
+/**
+ * Render EVERY set bit of @p bits as a comma-separated field list into @p out —
+ * what the refusal notification and log line say instead of "something
+ * diverged". Always NUL-terminates when len > 0; writes "(none)" for 0.
+ * @return the number of named fields.
+ */
+int Combo_ComboSettingsDivergenceDescribe(uint32_t bits, char* out, size_t len);
+
+/**
+ * The pairing header for the combo pane (ADR 0011 increment 2) and for any
+ * renderer — the twin of Combo_MMProfileSummary, reading gComboCtx and nothing
+ * else (ADR 0008 rule 5).
+ *
+ * `frozen == false` with `paired == true` marks a LEGACY pre-carve pair that has
+ * not crossed yet. ADR 0004 §6 state 4 requires the value shown post-creation to
+ * come FROM THE SAVE rather than from the CVar — after creation the two may
+ * legitimately differ, and the save is the one the world was built from — which
+ * is exactly why the record exists and a digest could not have served.
+ */
+typedef struct {
+    bool paired;
+    bool frozen;
+    ComboSettingsRecord record;
+    uint32_t comboSettingsHash;
+} ComboSettingsSummary;
+
+/** Fill @p out with the combo-settings header. NULL @p out is ignored. */
+void Combo_ComboSettingsSummary(ComboSettingsSummary* out);
 
 /**
  * Record "MM check `mmCheckId` hosts `item`". Rejects (returning -1) an unset

--- a/src/common/save.cpp
+++ b/src/common/save.cpp
@@ -10,6 +10,9 @@
 
 #include "context.h"
 #include "entrance.h" // MM_ENTR_SOUTH_CLOCK_TOWN_0 — the armed blob's return entrance
+// Combo_ComboSettingsDivergenceFor — the combo-level identity check the load
+// runs over the record it just read (ADR 0011 decision 4).
+#include "foreign_items.h"
 #include "game.h"
 #include "shared_resources.h"
 
@@ -694,6 +697,34 @@ RsbsLoadOutcome SaveManager::LoadSlot(int slot, uint32_t ootSavGeneration) {
                      "generation %u — the .redsave's OoT half is the authority for this load (#531/#589).\n",
                      slot, combo.commitGeneration, ootSavGeneration);
         mSlotSkew[slot] = 1;
+    }
+
+    // The COMBO-LEVEL IDENTITY check (ADR 0011 decision 4: "compare at every
+    // arrival and load; refuse on divergence"). Run over the record just READ
+    // and BEFORE the commit below, because a check that read gComboCtx would be
+    // checking the world this load is about to replace.
+    //
+    // A legacy .redsave written before this carve zero-extends to
+    // formatVersion == 0 and is EXEMPT — it is repaired by the O5 transitional
+    // writer at its first crossing, never refused (refusing would orphan every
+    // already-written paired file to detect a divergence that cannot have
+    // happened). So today this can only fire on a record and a fingerprint that
+    // disagree with each other, i.e. genuine damage. It becomes the live guard
+    // the moment increment 2 gives the resolver its tier-4 CVars to read.
+    const uint32_t comboDiverged = Combo_ComboSettingsDivergenceFor(
+        &combo.comboSettings, combo.comboSettingsHash, combo.sharedRandoSettingsHash, combo.mmProfileDigest);
+    if (comboDiverged != 0) {
+        char fields[192];
+        Combo_ComboSettingsDivergenceDescribe(comboDiverged, fields, sizeof(fields));
+        std::fprintf(stderr,
+                     "[RsbsSave] slot %d REFUSED: COMBO SETTINGS IDENTITY — the cross-game rules this file was "
+                     "created under no longer match this session's: %s. Divergence is corruption to refuse, never "
+                     "a choice to honour. Evidence quarantined; erase the slot to release it.\n",
+                     slot, fields);
+        QuarantineSlotFile(slot, RSBS_REFUSE_IDENTITY);
+        mSlotRefused[slot] = RSBS_REFUSE_IDENTITY;
+        mSlotArmed[slot] = false;
+        return RSBS_LOAD_REFUSED;
     }
 
     // All checks passed — commit. gComboCtx and both shadows are updated.

--- a/src/common/test_runner.cpp
+++ b/src/common/test_runner.cpp
@@ -189,6 +189,11 @@ int MM_PairedProfile_RunHeadless(void);
 // Rando::Foreign::RecordForeignPickup. Return 0 on pass.
 int MM_SpoilerIdentity_RunHeadless(void);
 int MM_ForeignPickupGate_RunHeadless(void);
+// games/mm/2s2h/mm_combo_settings_test.cpp (#498, ADR 0011 increment 1): the
+// COMBO-LEVEL arrival identity gate. MM-side because it drives the REAL
+// MM_Rando_PairOnCrossGameArrival, and because reaching its combo leg means
+// first satisfying its MM-profile leg. Returns 0 on pass.
+int MM_ComboSettingsGate_RunHeadless(void);
 // VB-affinity regression: MM's GameInteractor_* calls resolve to OoT's
 // extern "C" wrappers in single-exe builds, and the two games' vanilla-
 // behavior ordinals alias each other. The wrappers gate on the active game;
@@ -259,6 +264,13 @@ extern "C" {
 // the AUTHORITY rather than a warning. FILE SCOPE (compiled as C++), same
 // reason as above.
 #include "tests/test_whole_file_commit.c"
+
+// The frozen COMBO-LEVEL rule record (ADR 0011 increment 1, #498): the 16-byte
+// carve at 880/884 as .redsave format, the byte-pinned canonical() encoder and
+// its golden-vector fingerprint, the field-level divergence diff behind the
+// named refusal, and the O5 transitional writer for legacy pairs. FILE SCOPE
+// (compiled as C++) for rsbs::SaveManager; everything under test is C-linkage.
+#include "tests/test_combo_settings.c"
 
 // Lane C1 foreign-item pipeline locks (#392, ADR 0002): give-path tagging,
 // round-trip survival with a real pool entry, and the foreignPlacements carve
@@ -2070,6 +2082,28 @@ TestResult Test_MMForeignPickupGate(void) {
     return MM_ForeignPickupGate_RunHeadless() == 0 ? TEST_PASS : TEST_FAIL;
 }
 
+// The COMBO-LEVEL arrival identity gate (#498, ADR 0011 increment 1). Drives
+// the REAL MM_Rando_PairOnCrossGameArrival: a divergent frozen record must
+// refuse through the #533/#568 surface AND name the diverged rule (the
+// capability ADR 0011 decision 1.1 justification 2 claims, without which the
+// twelve-byte record buys display alone), while a legacy pair freezes the
+// shipped defaults instead of being orphaned. Needs the shared bring-up: the
+// refusal surfaces through the shared notification overlay, and the MM-profile
+// leg the gate reaches first resolves against MM's option tables.
+TestResult Test_MMComboSettingsGate(void) {
+    auto ctx = CreateHarnessStyleContext();
+    if (!ctx) {
+        printf("[TEST] FAIL: could not create Ship::Context singleton\n");
+        return TEST_FAIL;
+    }
+    if (OoT_InitSharedContextSubsystems() != 0) {
+        printf("[TEST] FAIL: shared bring-up reported failure\n");
+        return TEST_FAIL;
+    }
+
+    return MM_ComboSettingsGate_RunHeadless() == 0 ? TEST_PASS : TEST_FAIL;
+}
+
 TestResult Test_RoundtripIntegrity(void) {
     printf("[TEST] roundtrip-integrity: OoT SaveContext byte-integrity across roundtrip (issue #262)\n");
     int failures = TestRoundtripIntegrity_Run();
@@ -2303,6 +2337,13 @@ const TestDescriptor gTests[] = {
      Test_MMSpoilerIdentity},
     {"mm-foreign-pickup-gate", "An unpaired session authors no durable shared-item record on a foreign pickup (#610)",
      Test_MMForeignPickupGate},
+    // ADR 0011 increment 1 (#498): the arrival gate that CONSUMES the combo
+    // divergence diff. The refusal must NAME the diverged rule, not merely
+    // refuse — that capability is what the twelve-byte record buys over ADR
+    // 0009's reserved four-byte digest.
+    {"mm-combo-settings-gate",
+     "A divergent combo record refuses at arrival BY NAME; a legacy pair freezes the shipped defaults (#498)",
+     Test_MMComboSettingsGate},
     {"combo-mm-options-window",
      "Common-owned MM options pane registers de-collided; inert under every active game (#497)",
      Test_ComboMMOptionsWindow},
@@ -2382,6 +2423,21 @@ const TestDescriptor gTests[] = {
      Test_WholeFileCommit},
     {"whole-file-redeemed-item", "A REDEEMED record and the world it was redeemed into survive together (#531)",
      Test_WholeFileRedeemedItem},
+    // The frozen COMBO-LEVEL rule record (ADR 0011 increment 1, #498). Four
+    // rows split by what each can prove: the carve is format, the digest input
+    // is byte-pinned, the diff names the rule, and a legacy pair freezes rather
+    // than being orphaned. The arrival GATE that consumes the diff is its own
+    // row (mm-combo-settings-gate), MM-side.
+    {"combo-settings-format", "The combo record is .redsave format and its defaults reproduce today's world (#498)",
+     Test_ComboSettingsFormat},
+    {"combo-settings-canonical",
+     "canonical() and the whole-pair fingerprint are pinned byte-for-byte (ADR 0011 decision 1.4)",
+     Test_ComboSettingsCanonical},
+    {"combo-settings-divergence", "The divergence diff names WHICH combo rule diverged (ADR 0011 decision 1.1)",
+     Test_ComboSettingsDivergence},
+    {"combo-settings-legacy-freeze",
+     "A legacy paired file freezes the shipped defaults at its first crossing and compares thereafter (O5)",
+     Test_ComboSettingsLegacyFreeze},
     {"mm-scene-parse", "MM scene commands parse via the S2H factory (#344)", Test_MMSceneParse},
     {"seq-map-bounds", "Sequence-map capacity covers the id range + custom slack (#371, #378)", Test_SeqMapBounds},
     {"cvar-classification", "Cross-game CVar classification matches ADR 0003 + the inventory (#34)",

--- a/src/common/tests/test_combo_settings.c
+++ b/src/common/tests/test_combo_settings.c
@@ -1,0 +1,719 @@
+/**
+ * @file test_combo_settings.c
+ * @brief ROM-free locks for the frozen combo-level rule record (ADR 0011
+ *        increment 1, #498).
+ *
+ * Four rows, split by what each one can prove:
+ *
+ *   combo-settings-format — the carve is FORMAT. sizeof and every member
+ *   offset, the pinned value spaces, the shipped defaults (which must
+ *   reproduce today's world exactly), the freeze/frozen-predicate pair, the
+ *   pool-size resolution with its unfrozen fallback, a byte-exact .redsave
+ *   round trip of both new fields, and the zero-extension of a record written
+ *   before the carve existed.
+ *
+ *   combo-settings-canonical — the GOLDEN VECTOR, modelled on
+ *   test_netplay_relay.c's wire-format vectors. A fixed ComboSettingsRecord
+ *   maps to a fixed byte string and a fixed digest, so a layout change, a
+ *   member reorder, an endianness slip or a "simplify canonical() into a
+ *   memcpy" refactor is a RED TEST rather than a silently different world
+ *   identity. Includes the construction-order leg (the same values assembled
+ *   in a different order digest identically), the whole-pair-fold leg (moving
+ *   either half-digest moves the fingerprint — without it O6 would be
+ *   vacuous), and the zero-displacement leg.
+ *
+ *   combo-settings-divergence — the field-level diff behind the named refusal
+ *   (decision 1.1 justification 2). Each field diverged ALONE names exactly
+ *   itself; the describe form renders the names the refusal message
+ *   interpolates; an unreadable (future-version) record refuses rather than
+ *   guessing; a record and a fingerprint that disagree are caught.
+ *
+ *   NON-VACUITY lives here and is load-bearing for the arrival gate MM-side:
+ *   the gate's condition is literally `Combo_ComboSettingsDivergence() != 0`,
+ *   so proving the diff returns 0 for a healthy pair proves the gate does not
+ *   fire for one. A diff that refused everything would be red here.
+ *
+ *   combo-settings-legacy-freeze — the O5 transitional writer (decision 4.4).
+ *   A paired file whose record reads absent freezes the SHIPPED DEFAULTS at
+ *   its first crossing and COMPARES thereafter; an unpaired session freezes
+ *   nothing. The "compares rather than re-freezes" leg is what stops the
+ *   transitional writer from degenerating into a self-healing overwrite, which
+ *   would make every arrival-time divergence disappear the instant it was
+ *   detected.
+ *
+ * Linkage note: #included into test_runner.cpp at FILE SCOPE (compiled as
+ * C++, like test_save_roundtrip.c) for the rsbs::SaveManager half; every
+ * symbol under test is C-linkage.
+ */
+
+#include "../context.h"
+#include "../foreign_items.h"
+#include "../save.h"
+#include "../test_runner.h"
+
+#include <cstdio>
+#include <cstring>
+#include <string>
+#include <vector>
+
+#define CS_ASSERT(cond, msg)                    \
+    do {                                        \
+        if (!(cond)) {                          \
+            printf("[TEST] FAIL: %s\n", (msg)); \
+            return TEST_FAIL;                   \
+        }                                       \
+    } while (0)
+
+namespace {
+
+const char* const kComboSettingsTestDir = "rsbs_test_combo_settings";
+
+/** Give the commit choke point something to stage. StageCommit refuses when the
+ *  context shadows are absent, and a Tier-1-only test would otherwise never get
+ *  past it — the .redsave is one whole-file commit (ADR 0009 decision 4), not a
+ *  tier the caller can write in isolation. */
+void ComboSettingsSeedShadows(uint8_t fill) {
+    Context_InitFrozenStates();
+    std::vector<uint8_t> oot(OOT_SAVE_CONTEXT_SIZE, fill);
+    std::vector<uint8_t> mm(MM_SAVE_CONTEXT_SIZE, (uint8_t)(fill ^ 0xFFu));
+    Context_UpdateShadowCopy(GAME_OOT, oot.data(), oot.size());
+    Context_UpdateShadowCopy(GAME_MM, mm.data(), mm.size());
+}
+
+/** Publish the live pairing carrier the way Playthrough_Init stamps it. */
+void ComboSettingsArmPairing(uint32_t seed, uint32_t settingsHash, uint32_t profileDigest) {
+    gComboCtx.sourceIsRando = true;
+    gComboCtx.sharedRandoSeed = seed;
+    gComboCtx.sharedRandoSettingsHash = settingsHash;
+    gComboCtx.mmProfileDigest = profileDigest;
+}
+
+/** A record with every field distinct from every other field's value, so a
+ *  member swap in the encoder cannot cancel out. */
+ComboSettingsRecord ComboSettingsGoldenRecord() {
+    ComboSettingsRecord r;
+    memset(&r, 0, sizeof(r));
+    r.formatVersion = 1u;
+    r.direction = (uint8_t)RSBS_COMBO_DIR_FORWARD;         // 2
+    r.poolSizeOoT = 3u;
+    r.poolSizeMM = 5u;
+    r.itemClassOoT = 0x1234u;
+    r.itemClassMM = 0xABCDu;
+    r.goal = (uint8_t)RSBS_COMBO_GOAL_TRIFORCE_HUNT;       // 3
+    r.logicRung = (uint8_t)RSBS_COMBO_RUNG_ALL_REACHABLE;  // 3
+    r.spare0 = 0u;
+    r.spare1 = 0u;
+    return r;
+}
+
+bool ComboSettingsRecordsEqual(const ComboSettingsRecord& a, const ComboSettingsRecord& b) {
+    return a.formatVersion == b.formatVersion && a.direction == b.direction && a.poolSizeOoT == b.poolSizeOoT &&
+           a.poolSizeMM == b.poolSizeMM && a.itemClassOoT == b.itemClassOoT && a.itemClassMM == b.itemClassMM &&
+           a.goal == b.goal && a.logicRung == b.logicRung && a.spare0 == b.spare0 && a.spare1 == b.spare1;
+}
+
+} // namespace
+
+// ============================================================================
+// combo-settings-format
+// ============================================================================
+
+TestResult Test_ComboSettingsFormat(void) {
+    printf("[TEST] combo-settings-format: the ADR 0011 carve is .redsave format and its defaults reproduce "
+           "today's world\n");
+
+    // ---- The struct itself -------------------------------------------------
+    // Companion runtime assertions to context.h's static_asserts. Cheap, and
+    // they put the numbers in the CI log where a reviewer reading a format
+    // change can see them.
+    CS_ASSERT(sizeof(ComboSettingsRecord) == 12, "ComboSettingsRecord is not 12 bytes");
+    CS_ASSERT(offsetof(ComboSettingsRecord, formatVersion) == 0, "formatVersion moved off byte 0");
+    CS_ASSERT(offsetof(ComboSettingsRecord, direction) == 1, "direction moved off byte 1");
+    CS_ASSERT(offsetof(ComboSettingsRecord, poolSizeOoT) == 2, "poolSizeOoT moved off byte 2");
+    CS_ASSERT(offsetof(ComboSettingsRecord, poolSizeMM) == 3, "poolSizeMM moved off byte 3");
+    CS_ASSERT(offsetof(ComboSettingsRecord, itemClassOoT) == 4, "itemClassOoT moved off byte 4");
+    CS_ASSERT(offsetof(ComboSettingsRecord, itemClassMM) == 6, "itemClassMM moved off byte 6");
+    CS_ASSERT(offsetof(ComboSettingsRecord, goal) == 8, "goal moved off byte 8");
+    CS_ASSERT(offsetof(ComboSettingsRecord, logicRung) == 9, "logicRung moved off byte 9");
+    CS_ASSERT(offsetof(ComboSettingsRecord, spare0) == 10, "spare0 moved off byte 10");
+    CS_ASSERT(offsetof(ComboSettingsRecord, spare1) == 11, "spare1 moved off byte 11");
+
+    // ---- The carve's position and the budget it leaves ---------------------
+    CS_ASSERT(offsetof(ComboContext, comboSettingsHash) == 880u, "comboSettingsHash moved off .redsave offset 880");
+    CS_ASSERT(offsetof(ComboContext, comboSettings) == 884u, "comboSettings moved off .redsave offset 884");
+    CS_ASSERT(offsetof(ComboContext, reserved) == 896u, "reserved[] moved off .redsave offset 896");
+    CS_ASSERT(sizeof(((ComboContext*)0)->reserved) == 108u,
+              "reserved[] is not 108 bytes after the ADR 0011 carve — ADR 0009's budget table and context.h "
+              "must reconcile");
+    CS_ASSERT(sizeof(((ComboContext*)0)->reserved) >= 64u, "reserved[] fell below ADR 0009's 64-byte floor");
+    CS_ASSERT(sizeof(ComboContext) <= RSBS_COMBO_CONTEXT_RECORD_SIZE, "ComboContext outgrew its Tier-1 budget");
+
+    // ---- The pinned value spaces (decision 1.2.1) --------------------------
+    // Runtime twins of the compile-time pinning asserts. A renumbering must be
+    // impossible to land quietly, and CI logs are read more often than headers.
+    CS_ASSERT(RSBS_COMBO_DIR_OFF == 1u && RSBS_COMBO_DIR_FORWARD == 2u && RSBS_COMBO_DIR_REVERSE == 3u &&
+                  RSBS_COMBO_DIR_BOTH == 4u,
+              "RSBS_COMBO_DIR_* renumbered — every already-written record now reads different rules");
+    CS_ASSERT(RSBS_COMBO_DIR_OFF != 0u,
+              "RSBS_COMBO_DIR_OFF must not be 0: a legacy record zero-extends, so OFF at zero would silently "
+              "strip the crossings from every pre-carve paired save");
+    CS_ASSERT(RSBS_COMBO_GOAL_BEAT_BOTH == 1u && RSBS_COMBO_GOAL_BEAT_EITHER == 2u &&
+                  RSBS_COMBO_GOAL_TRIFORCE_HUNT == 3u,
+              "RSBS_COMBO_GOAL_* renumbered");
+    CS_ASSERT(RSBS_COMBO_RUNG_NONE == 1u && RSBS_COMBO_RUNG_BEATABLE == 2u && RSBS_COMBO_RUNG_ALL_REACHABLE == 3u,
+              "RSBS_COMBO_RUNG_* renumbered");
+    CS_ASSERT(RSBS_ITEMCLASS_PROGRESSION == 0x0001u && RSBS_ITEMCLASS_SONGS == 0x0002u &&
+                  RSBS_ITEMCLASS_MASKS == 0x0004u && RSBS_ITEMCLASS_DUNGEON_ITEMS == 0x0008u &&
+                  RSBS_ITEMCLASS_DUNGEON_REWARD == 0x0010u && RSBS_ITEMCLASS_SIDEQUEST == 0x0020u,
+              "RSBS_ITEMCLASS_* bit positions moved — a bit may be appended, never re-pointed");
+
+    // ---- The shipped defaults ---------------------------------------------
+    ComboSettingsRecord defaults;
+    Combo_ComboSettingsDefaults(&defaults);
+    CS_ASSERT(defaults.formatVersion == RSBS_COMBO_SETTINGS_FORMAT_VERSION, "defaults must be a FORMATTED record");
+    CS_ASSERT(defaults.direction == RSBS_COMBO_DIR_BOTH,
+              "the shipped default direction must be BOTH (accepted answer O2) — anything else silently changes "
+              "every new world the moment the setting lands");
+    CS_ASSERT(defaults.poolSizeOoT == RSBS_FOREIGN_PLACEMENT_CAP && defaults.poolSizeMM == RSBS_FOREIGN_PLACEMENT_CAP,
+              "the shipped default pool sizes must be the cap — that is exactly what both passes place today");
+    CS_ASSERT(defaults.itemClassOoT == RSBS_ITEMCLASS_ALL_V1 && defaults.itemClassMM == RSBS_ITEMCLASS_ALL_V1,
+              "the shipped default item classes must be every allocated bit — today's pools are filtered by no "
+              "class at all, so a narrower default silently narrows them at increment 3");
+    CS_ASSERT(defaults.goal == RSBS_COMBO_GOAL_BEAT_BOTH, "the default GOAL must stay beat-both (ADR 0010 O11)");
+    CS_ASSERT(defaults.logicRung == RSBS_COMBO_RUNG_BEATABLE,
+              "the default rung must be the proved no-tricks rung, never base `none` (ADR 0010 O11)");
+    CS_ASSERT(defaults.spare0 == 0 && defaults.spare1 == 0,
+              "unallocated spares must read 0 in a formatVersion 1 record");
+
+    // The resolver is what both the creation stamp and the arrival compare go
+    // through; at increment 1 it must BE the defaults, or the two would already
+    // disagree before any CVar exists.
+    ComboSettingsRecord live;
+    Combo_ResolveComboSettings(&live);
+    CS_ASSERT(ComboSettingsRecordsEqual(defaults, live),
+              "the session resolver and the shipped defaults disagree at increment 1 — every freshly created "
+              "world would refuse itself at its first arrival");
+
+    // ---- Predicates and the pool-size fallback -----------------------------
+    ComboContext_Init();
+    CS_ASSERT(!Combo_ComboSettingsFrozen(), "a freshly initialized context must read as NOT frozen");
+    CS_ASSERT(Combo_ForeignPairingRequested(),
+              "the pre-condition predicate must answer YES under the shipped defaults, or nothing generates");
+    // The load-bearing fallback: an unfrozen (zero-extended) record must NOT
+    // resolve to pool size 0, which would silently generate a paired world with
+    // no crossings at all.
+    CS_ASSERT(Combo_ComboPoolSizeFor((uint8_t)GAME_OOT) == (int)RSBS_FOREIGN_PLACEMENT_CAP,
+              "an UNFROZEN record must fall back to the shipped pool size, not to zero");
+    CS_ASSERT(Combo_ComboPoolSizeFor((uint8_t)GAME_MM) == (int)RSBS_FOREIGN_PLACEMENT_CAP,
+              "an UNFROZEN record must fall back to the shipped pool size, not to zero");
+    CS_ASSERT(Combo_ComboPoolSizeFor((uint8_t)GAME_NONE) == 0, "GAME_NONE has no pool");
+    CS_ASSERT(Combo_ComboDirection() == RSBS_COMBO_DIR_BOTH, "an unfrozen direction resolves to the default");
+
+    // A frozen record is the authority, and an over-cap value is CLAMPED rather
+    // than honoured: a count that can exceed the table's capacity is a setting
+    // that lies (accepted answer O4).
+    {
+        ComboSettingsRecord over = defaults;
+        over.poolSizeOoT = 200u;
+        over.poolSizeMM = 2u;
+        Combo_FreezeComboSettings(&over);
+        CS_ASSERT(Combo_ComboSettingsFrozen(), "freezing must set the occupancy tag");
+        CS_ASSERT(Combo_ComboPoolSizeFor((uint8_t)GAME_OOT) == (int)RSBS_FOREIGN_PLACEMENT_CAP,
+                  "an over-cap frozen pool size must clamp to RSBS_FOREIGN_PLACEMENT_CAP");
+        CS_ASSERT(Combo_ComboPoolSizeFor((uint8_t)GAME_MM) == 2, "a frozen in-range pool size must be honoured");
+    }
+
+    // Freezing a record whose tag says ABSENT must still produce a FORMATTED
+    // record — a caller must not be able to freeze something that reads unset.
+    {
+        ComboSettingsRecord untagged = defaults;
+        untagged.formatVersion = 0u;
+        Combo_FreezeComboSettings(&untagged);
+        CS_ASSERT(gComboCtx.comboSettings.formatVersion == RSBS_COMBO_SETTINGS_FORMAT_VERSION,
+                  "freezing must force the occupancy tag; a record that reads absent is not frozen");
+        CS_ASSERT(gComboCtx.comboSettingsHash != 0, "a frozen record must carry a nonzero fingerprint");
+    }
+
+    // ---- Byte-exact .redsave round trip ------------------------------------
+    {
+        rsbs::SaveManager& mgr = rsbs::SaveManager::Instance();
+        mgr.SetSaveDirectory(kComboSettingsTestDir);
+        mgr.DeleteSave(0);
+
+        ComboContext_Init();
+        ComboSettingsSeedShadows(0x3Cu);
+        ComboSettingsArmPairing(0x51EED000u, 0x5E77A11Fu, 0x11FEDCBAu);
+        // The HEALTHY case: a record frozen from the same resolver the load
+        // re-runs. A file this build wrote must be a file this build loads —
+        // the identity check must not refuse its own output.
+        ComboSettingsRecord written;
+        Combo_ResolveComboSettings(&written);
+        const uint32_t writtenHash = Combo_FreezeComboSettings(&written);
+
+        CS_ASSERT(mgr.Save(0), "Save(0) failed");
+
+        // Scribble both fields so a pass cannot come from leftovers.
+        memset(&gComboCtx.comboSettings, 0x5A, sizeof(gComboCtx.comboSettings));
+        gComboCtx.comboSettingsHash = 0x5A5A5A5Au;
+
+        CS_ASSERT(mgr.Load(0),
+                  "Load refused a .redsave carrying a healthy combo record — the ADR 0011 identity check must "
+                  "pass a file it just wrote");
+        CS_ASSERT(ComboSettingsRecordsEqual(gComboCtx.comboSettings, written),
+                  "the frozen combo record did not survive a .redsave round trip byte-exact");
+        CS_ASSERT(gComboCtx.comboSettingsHash == writtenHash,
+                  "comboSettingsHash did not survive a .redsave round trip");
+        mgr.DeleteSave(0);
+    }
+
+    // ---- The LOAD-side refusal (decision 4: "compare at every arrival AND
+    // load"). A slot whose stored rules are not this session's must refuse
+    // through the #533/#568 surface rather than commit its bytes over the
+    // resident context — the check runs on the record just READ, precisely
+    // because a check that read gComboCtx would be checking the world the load
+    // is about to replace.
+    {
+        rsbs::SaveManager& mgr = rsbs::SaveManager::Instance();
+        mgr.SetSaveDirectory(kComboSettingsTestDir);
+        mgr.DeleteSave(0);
+
+        ComboContext_Init();
+        ComboSettingsSeedShadows(0x4Du);
+        ComboSettingsArmPairing(0x51EED001u, 0x5E77A120u, 0x11FEDCBBu);
+        ComboSettingsRecord divergent;
+        Combo_ResolveComboSettings(&divergent);
+        divergent.direction = (uint8_t)RSBS_COMBO_DIR_FORWARD; // this session resolves BOTH
+        Combo_FreezeComboSettings(&divergent);
+        CS_ASSERT(mgr.Save(0), "Save(0) failed for the divergent-record leg");
+
+        // Fresh session state, so the refusal observed is THIS load's.
+        RsbsSave_ResetSlotSessionState();
+        ComboContext_Init();
+        CS_ASSERT(!mgr.Load(0),
+                  "a .redsave whose frozen combo rules diverge from this session was COMMITTED — divergence is "
+                  "corruption to refuse, never a choice to honour");
+        CS_ASSERT(RsbsSave_GetSlotRefuseReason(0) == (int)RSBS_REFUSE_IDENTITY,
+                  "the load-side combo divergence must refuse as RSBS_REFUSE_IDENTITY");
+        CS_ASSERT(RsbsSave_IsSlotWritable(0) == 0, "a refused load must latch the slot against writes (#533)");
+        CS_ASSERT(!Combo_ComboSettingsFrozen(),
+                  "a refused load must not have committed the divergent record over the resident context");
+
+        RsbsSave_ResetSlotSessionState();
+        mgr.DeleteSave(0);
+    }
+
+    // ---- Zero-extension: a pre-carve record reads as ABSENT ----------------
+    // The growth contract made concrete for THIS carve. Simulated the way the
+    // loader produces it — a short Tier-1 leaves the tail zero — by clearing
+    // the two fields and re-reading the predicates.
+    {
+        ComboContext_Init();
+        memset(&gComboCtx.comboSettings, 0, sizeof(gComboCtx.comboSettings));
+        gComboCtx.comboSettingsHash = 0;
+        CS_ASSERT(!Combo_ComboSettingsFrozen(), "an all-zero record must read as ABSENT, never as a formatted one");
+        CS_ASSERT(Combo_ComboSettingsDivergence() == 0,
+                  "an ABSENT record must be EXEMPT from comparison — refusing it would orphan every already-written "
+                  "paired .redsave to detect a divergence that cannot have happened");
+        CS_ASSERT(gComboCtx.comboSettings.direction == 0 && gComboCtx.comboSettings.direction != RSBS_COMBO_DIR_OFF,
+                  "zero must not be a legal direction enumerator");
+    }
+
+    ComboContext_Init();
+    printf("[TEST] PASS: the combo record is format (12 B at 884, digest at 880, reserved[108]) and its defaults "
+           "reproduce today's world\n");
+    return TEST_PASS;
+}
+
+// ============================================================================
+// combo-settings-canonical — the golden vector (decision 1.4)
+// ============================================================================
+
+TestResult Test_ComboSettingsCanonical(void) {
+    printf("[TEST] combo-settings-canonical: canonical() and the whole-pair fingerprint are pinned byte-for-byte "
+           "(ADR 0011 decision 1.4)\n");
+
+    // --- The golden record -> golden bytes ---------------------------------
+    // Every uint16 is byte-swapped-visible (0x1234 -> 34 12), so an
+    // endianness slip or a "just memcpy the struct" refactor cannot pass.
+    const ComboSettingsRecord golden = ComboSettingsGoldenRecord();
+    uint8_t canon[RSBS_COMBO_SETTINGS_CANONICAL_LEN];
+    memset(canon, 0xEE, sizeof(canon));
+    Combo_ComboSettingsCanonical(&golden, canon);
+
+    static const uint8_t kCanonGold[RSBS_COMBO_SETTINGS_CANONICAL_LEN] = {
+        0x01,       // formatVersion
+        0x02,       // direction == RSBS_COMBO_DIR_FORWARD
+        0x03,       // poolSizeOoT
+        0x05,       // poolSizeMM
+        0x34, 0x12, // itemClassOoT LE
+        0xCD, 0xAB, // itemClassMM  LE
+        0x03,       // goal == RSBS_COMBO_GOAL_TRIFORCE_HUNT
+        0x03,       // logicRung == RSBS_COMBO_RUNG_ALL_REACHABLE
+        0x00,       // spare0
+        0x00,       // spare1
+    };
+    CS_ASSERT(memcmp(canon, kCanonGold, sizeof(kCanonGold)) == 0,
+              "canonical() no longer emits the pinned byte string — the digest input is .redsave-adjacent format "
+              "and a layout/endianness change here silently re-identifies every world");
+    CS_ASSERT(RSBS_COMBO_SETTINGS_CANONICAL_LEN == sizeof(ComboSettingsRecord),
+              "the canonical encoding must cover the whole record");
+
+    // --- The golden digest --------------------------------------------------
+    // Hash( canonical || ':' || LE32(settingsHash) || ':' || LE32(mmProfileDigest) )
+    // over FNV-1a 32, computed independently of this build.
+    static const uint32_t kSettingsHash = 0xDEADBEEFu;
+    static const uint32_t kProfileDigest = 0x0BADF00Du;
+    static const uint32_t kGoldenFingerprint = 0xDE17C51Du;
+    const uint32_t fingerprint = Combo_ComputeComboSettingsHash(&golden, kSettingsHash, kProfileDigest);
+    CS_ASSERT(fingerprint == kGoldenFingerprint,
+              "the whole-pair fingerprint moved off its golden vector — this is the lock #574's identity handshake "
+              "inherits, so a drift here is a cross-peer disagreement, not a local detail");
+
+    // The SHIPPED DEFAULTS get their own vector: they are what every legacy
+    // pair and every increment-1 world freezes, so a default change must be a
+    // deliberate red test rather than an invisible identity shift.
+    ComboSettingsRecord defaults;
+    Combo_ComboSettingsDefaults(&defaults);
+    Combo_ComboSettingsCanonical(&defaults, canon);
+    static const uint8_t kDefaultsCanonGold[RSBS_COMBO_SETTINGS_CANONICAL_LEN] = {
+        0x01, 0x04, 0x08, 0x08, 0x3F, 0x00, 0x3F, 0x00, 0x01, 0x02, 0x00, 0x00,
+    };
+    CS_ASSERT(memcmp(canon, kDefaultsCanonGold, sizeof(kDefaultsCanonGold)) == 0,
+              "the shipped defaults' canonical bytes changed — every new world's identity just moved");
+    CS_ASSERT(Combo_ComputeComboSettingsHash(&defaults, kSettingsHash, kProfileDigest) == 0xBA5FC364u,
+              "the shipped defaults' fingerprint changed");
+
+    // --- Construction order is irrelevant; VALUES are the identity ----------
+    // The property the byte-at-a-time encoder exists to guarantee: the digest
+    // is a function of the values, not of how the struct got them.
+    {
+        ComboSettingsRecord other;
+        memset(&other, 0xFF, sizeof(other)); // deliberately dirty before assignment
+        other.spare1 = 0u;
+        other.spare0 = 0u;
+        other.logicRung = (uint8_t)RSBS_COMBO_RUNG_ALL_REACHABLE;
+        other.goal = (uint8_t)RSBS_COMBO_GOAL_TRIFORCE_HUNT;
+        other.itemClassMM = 0xABCDu;
+        other.itemClassOoT = 0x1234u;
+        other.poolSizeMM = 5u;
+        other.poolSizeOoT = 3u;
+        other.direction = (uint8_t)RSBS_COMBO_DIR_FORWARD;
+        other.formatVersion = 1u;
+        CS_ASSERT(Combo_ComputeComboSettingsHash(&other, kSettingsHash, kProfileDigest) == kGoldenFingerprint,
+                  "the same values assembled in a different order produced a different digest");
+    }
+
+    // --- Every field moves the digest ---------------------------------------
+    // Without this a term could be silently dropped from the encoding and the
+    // golden vector alone would not notice (it would just be a different
+    // constant on the day it was written).
+    {
+        const char* names[10] = { "formatVersion", "direction", "poolSizeOoT", "poolSizeMM", "itemClassOoT",
+                                  "itemClassMM",   "goal",      "logicRung",   "spare0",     "spare1" };
+        for (int i = 0; i < 10; i++) {
+            ComboSettingsRecord moved = golden;
+            switch (i) {
+                case 0: moved.formatVersion = 2u; break;
+                case 1: moved.direction = (uint8_t)RSBS_COMBO_DIR_BOTH; break;
+                case 2: moved.poolSizeOoT = 7u; break;
+                case 3: moved.poolSizeMM = 7u; break;
+                case 4: moved.itemClassOoT = 0x4321u; break;
+                case 5: moved.itemClassMM = 0xDCBAu; break;
+                case 6: moved.goal = (uint8_t)RSBS_COMBO_GOAL_BEAT_EITHER; break;
+                case 7: moved.logicRung = (uint8_t)RSBS_COMBO_RUNG_NONE; break;
+                case 8: moved.spare0 = 0x77u; break;
+                default: moved.spare1 = 0x77u; break;
+            }
+            if (Combo_ComputeComboSettingsHash(&moved, kSettingsHash, kProfileDigest) == kGoldenFingerprint) {
+                printf("[TEST] FAIL: changing '%s' did not change the fingerprint — that field is not in the "
+                       "canonical encoding\n",
+                       names[i]);
+                return TEST_FAIL;
+            }
+        }
+    }
+
+    // --- The WHOLE-PAIR fold (accepted answer O6) ---------------------------
+    // A digest narrower than the generator's input set is vacuous: same seed,
+    // same digest, different world. Both half-digests must move it.
+    CS_ASSERT(Combo_ComputeComboSettingsHash(&golden, kSettingsHash + 1u, kProfileDigest) != kGoldenFingerprint,
+              "sharedRandoSettingsHash is not folded into comboSettingsHash — the fingerprint is vacuous");
+    CS_ASSERT(Combo_ComputeComboSettingsHash(&golden, kSettingsHash, kProfileDigest + 1u) != kGoldenFingerprint,
+              "mmProfileDigest is not folded into comboSettingsHash — the fingerprint is vacuous");
+    // And the two terms must not be interchangeable: a fold that concatenated
+    // them without separation would let a swap cancel out.
+    CS_ASSERT(Combo_ComputeComboSettingsHash(&golden, kProfileDigest, kSettingsHash) != kGoldenFingerprint,
+              "swapping the two half-digests produced the same fingerprint — they are not positionally distinct");
+
+    // --- Zero displaces ------------------------------------------------------
+    // Not a search for a preimage (that would be a slow test for no benefit):
+    // assert the invariant the displacement exists to hold — the computation
+    // never returns 0 for anything, including an all-zero record.
+    {
+        ComboSettingsRecord empty;
+        memset(&empty, 0, sizeof(empty));
+        CS_ASSERT(Combo_ComputeComboSettingsHash(&empty, 0, 0) != 0,
+                  "the fingerprint must never be 0: zero is this field's 'not frozen', so a real identity hashing "
+                  "to 0 becomes an undetectable mismatch");
+        CS_ASSERT(Combo_ComputeComboSettingsHash(NULL, 0, 0) ==
+                      Combo_ComputeComboSettingsHash(&empty, 0, 0),
+                  "a NULL record must encode as an all-zero record");
+    }
+
+    printf("[TEST] PASS: canonical() emits its pinned bytes and the fingerprint folds the whole pair\n");
+    return TEST_PASS;
+}
+
+// ============================================================================
+// combo-settings-divergence — the field-level diff behind the named refusal
+// ============================================================================
+
+TestResult Test_ComboSettingsDivergence(void) {
+    printf("[TEST] combo-settings-divergence: the diff names WHICH rule diverged (ADR 0011 decision 1.1 "
+           "justification 2)\n");
+
+    ComboSettingsRecord live;
+    Combo_ResolveComboSettings(&live);
+
+    // ---- NON-VACUITY, first, because everything below depends on it --------
+    // The MM arrival gate's refusal condition is literally
+    // `Combo_ComboSettingsDivergence() != 0`, so this leg is what proves the
+    // gate does NOT fire for a healthy pair. A diff that refused everything
+    // would pass every divergence leg below and prove nothing.
+    {
+        ComboContext_Init();
+        ComboSettingsArmPairing(0xC0FFEE01u, 0x1111AAAAu, 0x2222BBBBu);
+        ComboSettingsRecord healthy;
+        Combo_ResolveComboSettings(&healthy);
+        Combo_FreezeComboSettings(&healthy);
+        CS_ASSERT(Combo_ComboSettingsDivergence() == 0,
+                  "a healthy pair — frozen from the same resolver the arrival re-runs — reported divergence; the "
+                  "arrival gate would refuse every well-formed world");
+    }
+
+    // ---- Each field alone names exactly itself -----------------------------
+    struct Leg {
+        uint32_t bit;
+        const char* name;
+    };
+    static const Leg kLegs[] = {
+        { RSBS_COMBO_DIVERGE_DIRECTION, "direction" },
+        { RSBS_COMBO_DIVERGE_POOL_SIZE_OOT, "poolSizeOoT" },
+        { RSBS_COMBO_DIVERGE_POOL_SIZE_MM, "poolSizeMM" },
+        { RSBS_COMBO_DIVERGE_ITEM_CLASS_OOT, "itemClassOoT" },
+        { RSBS_COMBO_DIVERGE_ITEM_CLASS_MM, "itemClassMM" },
+        { RSBS_COMBO_DIVERGE_GOAL, "goal" },
+        { RSBS_COMBO_DIVERGE_LOGIC_RUNG, "logicRung" },
+        { RSBS_COMBO_DIVERGE_SPARE0, "spare0" },
+        { RSBS_COMBO_DIVERGE_SPARE1, "spare1" },
+    };
+
+    for (size_t i = 0; i < sizeof(kLegs) / sizeof(kLegs[0]); i++) {
+        ComboSettingsRecord frozen = live;
+        switch (kLegs[i].bit) {
+            case RSBS_COMBO_DIVERGE_DIRECTION: frozen.direction = (uint8_t)RSBS_COMBO_DIR_FORWARD; break;
+            case RSBS_COMBO_DIVERGE_POOL_SIZE_OOT: frozen.poolSizeOoT = 1u; break;
+            case RSBS_COMBO_DIVERGE_POOL_SIZE_MM: frozen.poolSizeMM = 1u; break;
+            case RSBS_COMBO_DIVERGE_ITEM_CLASS_OOT: frozen.itemClassOoT = RSBS_ITEMCLASS_SONGS; break;
+            case RSBS_COMBO_DIVERGE_ITEM_CLASS_MM: frozen.itemClassMM = RSBS_ITEMCLASS_MASKS; break;
+            case RSBS_COMBO_DIVERGE_GOAL: frozen.goal = (uint8_t)RSBS_COMBO_GOAL_TRIFORCE_HUNT; break;
+            case RSBS_COMBO_DIVERGE_LOGIC_RUNG: frozen.logicRung = (uint8_t)RSBS_COMBO_RUNG_NONE; break;
+            case RSBS_COMBO_DIVERGE_SPARE0: frozen.spare0 = 1u; break;
+            default: frozen.spare1 = 1u; break;
+        }
+
+        const uint32_t bits = Combo_ComboSettingsDivergenceBetween(&frozen, &live);
+        if (bits != kLegs[i].bit) {
+            printf("[TEST] FAIL: diverging '%s' alone reported bits %04X, expected %04X — a refusal that names the "
+                   "wrong rule is worse than one that names none\n",
+                   kLegs[i].name, (unsigned)bits, (unsigned)kLegs[i].bit);
+            return TEST_FAIL;
+        }
+        if (strcmp(Combo_ComboSettingsDivergenceFieldName(bits), kLegs[i].name) != 0) {
+            printf("[TEST] FAIL: bit %04X names '%s', expected '%s'\n", (unsigned)bits,
+                   Combo_ComboSettingsDivergenceFieldName(bits), kLegs[i].name);
+            return TEST_FAIL;
+        }
+
+        char text[192];
+        const int named = Combo_ComboSettingsDivergenceDescribe(bits, text, sizeof(text));
+        if (named != 1 || strcmp(text, kLegs[i].name) != 0) {
+            printf("[TEST] FAIL: describe(%04X) rendered '%s' (%d fields), expected '%s'\n", (unsigned)bits, text,
+                   named, kLegs[i].name);
+            return TEST_FAIL;
+        }
+    }
+
+    // ---- Several at once render as a list ----------------------------------
+    {
+        ComboSettingsRecord frozen = live;
+        frozen.direction = (uint8_t)RSBS_COMBO_DIR_REVERSE;
+        frozen.goal = (uint8_t)RSBS_COMBO_GOAL_BEAT_EITHER;
+        const uint32_t bits = Combo_ComboSettingsDivergenceBetween(&frozen, &live);
+        CS_ASSERT(bits == (RSBS_COMBO_DIVERGE_DIRECTION | RSBS_COMBO_DIVERGE_GOAL), "two diverged fields, two bits");
+        char text[192];
+        CS_ASSERT(Combo_ComboSettingsDivergenceDescribe(bits, text, sizeof(text)) == 2, "two fields named");
+        CS_ASSERT(strcmp(text, "direction, goal") == 0, "the field list is not rendered as a readable list");
+        // Truncation must not run off the end — the refusal message is built
+        // into a fixed buffer on a boot path.
+        char tiny[6];
+        Combo_ComboSettingsDivergenceDescribe(bits, tiny, sizeof(tiny));
+        CS_ASSERT(tiny[sizeof(tiny) - 1] == '\0', "describe() must always NUL-terminate");
+        CS_ASSERT(Combo_ComboSettingsDivergenceDescribe(0, text, sizeof(text)) == 0 && strcmp(text, "(none)") == 0,
+                  "no divergence must render as '(none)', never as an empty string that truncates the sentence");
+    }
+
+    // ---- An ABSENT record is exempt; a FUTURE record is unreadable ---------
+    {
+        ComboSettingsRecord absent;
+        memset(&absent, 0, sizeof(absent));
+        CS_ASSERT(Combo_ComboSettingsDivergenceBetween(&absent, &live) == 0,
+                  "an absent record must be exempt from comparison (decision 4.2), not divergent");
+
+        ComboSettingsRecord future = live;
+        future.formatVersion = (uint8_t)(RSBS_COMBO_SETTINGS_FORMAT_VERSION + 1u);
+        const uint32_t bits = Combo_ComboSettingsDivergenceBetween(&future, &live);
+        CS_ASSERT(bits == RSBS_COMBO_DIVERGE_UNREADABLE,
+                  "a record from a NEWER build must refuse as UNREADABLE rather than being compared field by "
+                  "field against rules this build cannot know are authoritative");
+        CS_ASSERT(strcmp(Combo_ComboSettingsDivergenceFieldName(bits), "formatVersion") == 0,
+                  "the unreadable refusal must name formatVersion");
+    }
+
+    // ---- A record and a fingerprint that disagree --------------------------
+    // The cross-check that has teeth TODAY, before increment 2 gives the
+    // resolver any CVars to disagree with: the record, both half-digests and
+    // the hash all ride one Tier-1 write, so a mismatch between them is not a
+    // settings change — it is damage.
+    {
+        ComboContext_Init();
+        ComboSettingsArmPairing(0xC0FFEE02u, 0x3333CCCCu, 0x4444DDDDu);
+        ComboSettingsRecord healthy;
+        Combo_ResolveComboSettings(&healthy);
+        Combo_FreezeComboSettings(&healthy);
+        CS_ASSERT(Combo_ComboSettingsDivergence() == 0, "control: a freshly frozen identity is self-consistent");
+
+        gComboCtx.comboSettingsHash ^= 0x00000001u;
+        const uint32_t bits = Combo_ComboSettingsDivergence();
+        CS_ASSERT(bits == RSBS_COMBO_DIVERGE_FINGERPRINT, "a corrupted fingerprint must be reported as such");
+        CS_ASSERT(strcmp(Combo_ComboSettingsDivergenceFieldName(bits), "comboSettingsHash") == 0,
+                  "the fingerprint refusal must name comboSettingsHash");
+
+        // Moving a half-digest under a frozen record moves the fingerprint too:
+        // this is the fold made observable at session level.
+        Combo_FreezeComboSettings(&healthy);
+        CS_ASSERT(Combo_ComboSettingsDivergence() == 0, "re-freezing restores self-consistency");
+        gComboCtx.mmProfileDigest ^= 0x00000001u;
+        CS_ASSERT((Combo_ComboSettingsDivergence() & RSBS_COMBO_DIVERGE_FINGERPRINT) != 0,
+                  "moving mmProfileDigest under a frozen record must break the fingerprint — otherwise the "
+                  "whole-pair fold is not actually being checked");
+    }
+
+    ComboContext_Init();
+    printf("[TEST] PASS: the divergence diff names the rule, exempts an absent record, and refuses an unreadable "
+           "one\n");
+    return TEST_PASS;
+}
+
+// ============================================================================
+// combo-settings-legacy-freeze — the O5 transitional writer (decision 4.4)
+// ============================================================================
+
+TestResult Test_ComboSettingsLegacyFreeze(void) {
+    printf("[TEST] combo-settings-legacy-freeze: a legacy paired file freezes the shipped defaults at its first "
+           "crossing and COMPARES thereafter (accepted answer O5)\n");
+
+    // ---- An UNPAIRED session freezes nothing -------------------------------
+    // An unpaired file must not acquire a combo identity: there is no world for
+    // those rules to describe, and Combo_ComboSettingsFrozen gates the (future)
+    // authoring surface.
+    {
+        ComboContext_Init();
+        CS_ASSERT(Combo_FreezeLegacyComboSettings() == 0, "an unpaired session must not freeze combo rules");
+        CS_ASSERT(!Combo_ComboSettingsFrozen(), "an unpaired session must leave the record absent");
+        CS_ASSERT(gComboCtx.comboSettingsHash == 0, "an unpaired session must leave the fingerprint at 0");
+    }
+
+    // ---- A LEGACY paired file freezes the shipped defaults -----------------
+    {
+        ComboContext_Init();
+        ComboSettingsArmPairing(0x1EAC0000u, 0x7E57A11Fu, 0x9911FFEEu);
+        CS_ASSERT(Combo_ForeignPairingActive(), "the leg needs a live pairing");
+        CS_ASSERT(!Combo_ComboSettingsFrozen(), "the leg starts from a pre-carve record");
+
+        // The pane's read surface (ADR 0004 §6 state 4): before the freeze a
+        // paired world reports NOT frozen, and afterwards the values it shows
+        // come FROM THE SAVE. This is the requirement a digest could never have
+        // satisfied, and the reason twelve bytes were carved.
+        ComboSettingsSummary before;
+        Combo_ComboSettingsSummary(&before);
+        CS_ASSERT(before.paired && !before.frozen, "a legacy pair must present as paired-but-not-frozen");
+
+        CS_ASSERT(Combo_FreezeLegacyComboSettings() == 1, "the first crossing must freeze a legacy pair");
+        CS_ASSERT(Combo_ComboSettingsFrozen(), "the record must read as frozen after the transitional write");
+        CS_ASSERT(gComboCtx.comboSettings.formatVersion == RSBS_COMBO_SETTINGS_FORMAT_VERSION,
+                  "the transitional write must stamp the current format version");
+
+        ComboSettingsRecord defaults;
+        Combo_ComboSettingsDefaults(&defaults);
+        CS_ASSERT(ComboSettingsRecordsEqual(gComboCtx.comboSettings, defaults),
+                  "the transitional write must freeze the SHIPPED DEFAULTS — a legacy pair was generated when "
+                  "there was only ever one rule set, and that set is what the defaults record");
+        CS_ASSERT(gComboCtx.comboSettingsHash ==
+                      Combo_ComputeComboSettingsHash(&defaults, gComboCtx.sharedRandoSettingsHash,
+                                                     gComboCtx.mmProfileDigest),
+                  "the transitional write must recompute the fingerprint over BOTH half-digests (decision 4.1's "
+                  "order), or the next arrival refuses a healthy pair");
+        CS_ASSERT(gComboCtx.comboSettingsHash != 0, "the transitional write must leave a nonzero fingerprint");
+
+        ComboSettingsSummary after;
+        Combo_ComboSettingsSummary(&after);
+        CS_ASSERT(after.paired && after.frozen, "the summary must report the record as frozen after the write");
+        CS_ASSERT(ComboSettingsRecordsEqual(after.record, defaults) &&
+                      after.comboSettingsHash == gComboCtx.comboSettingsHash,
+                  "the summary must serve the values FROM THE SAVE (ADR 0004 §6 state 4)");
+
+        // ---- A SECOND crossing COMPARES rather than re-freezing ------------
+        // The property that makes 4.4 a behaviour and not a promise: a
+        // transitional writer that overwrote on every crossing would be a
+        // self-heal, and every arrival-time divergence would vanish the instant
+        // it was detected.
+        ComboSettingsRecord tampered = defaults;
+        tampered.direction = (uint8_t)RSBS_COMBO_DIR_REVERSE;
+        Combo_FreezeComboSettings(&tampered);
+        const uint32_t tamperedHash = gComboCtx.comboSettingsHash;
+
+        CS_ASSERT(Combo_FreezeLegacyComboSettings() == 0, "a second crossing must not re-freeze");
+        CS_ASSERT(gComboCtx.comboSettings.direction == RSBS_COMBO_DIR_REVERSE,
+                  "a second crossing SELF-HEALED the frozen record — divergence is corruption to refuse, never a "
+                  "value to overwrite");
+        CS_ASSERT(gComboCtx.comboSettingsHash == tamperedHash, "a second crossing must not restamp the fingerprint");
+        CS_ASSERT((Combo_ComboSettingsDivergence() & RSBS_COMBO_DIVERGE_DIRECTION) != 0,
+                  "the divergent record must now be REPORTED as divergent, which is what 'compares normally "
+                  "thereafter' means");
+    }
+
+    // ---- Half-digest re-stamp restores the ordering invariant --------------
+    // A doubly-legacy pair (no combo record AND no MM profile digest) freezes
+    // its combo rules while mmProfileDigest is still 0; ResolvePairedProfile
+    // re-stamps the fingerprint after it freezes the profile. This is the
+    // src/common half of that contract.
+    {
+        ComboContext_Init();
+        ComboSettingsArmPairing(0xD00Du, 0x0BADCAFEu, /*profileDigest=*/0u);
+        CS_ASSERT(Combo_FreezeLegacyComboSettings() == 1, "a doubly-legacy pair still freezes its combo rules");
+        const uint32_t beforeProfile = gComboCtx.comboSettingsHash;
+        CS_ASSERT(Combo_ComboSettingsDivergence() == 0, "self-consistent while the profile digest is still 0");
+
+        gComboCtx.mmProfileDigest = 0xFEEDFACEu; // what ResolvePairedProfile's legacy branch stamps
+        CS_ASSERT((Combo_ComboSettingsDivergence() & RSBS_COMBO_DIVERGE_FINGERPRINT) != 0,
+                  "without a re-stamp the fingerprint must go stale — this is WHY the re-stamp exists");
+        const uint32_t after = Combo_StampComboSettingsHash();
+        CS_ASSERT(after != 0 && after != beforeProfile, "the re-stamp must fold the freshly frozen profile digest");
+        CS_ASSERT(Combo_ComboSettingsDivergence() == 0, "the re-stamp must restore self-consistency");
+    }
+
+    ComboContext_Init();
+    printf("[TEST] PASS: the legacy transitional writer freezes once, compares thereafter, and never self-heals\n");
+    return TEST_PASS;
+}

--- a/src/common/tests/test_save_roundtrip.c
+++ b/src/common/tests/test_save_roundtrip.c
@@ -491,6 +491,15 @@ TestResult Test_SaveComboLegacyRecord(void) {
                         gComboCtx.sharedItemsTagged[i].flags == 0 && gComboCtx.sharedItemsTagged[i].id == 0,
                     "tagged items from a pre-carve record must load as unset slots");
     }
+    // The ADR 0011 carve reads as ABSENT from a pre-carve record, which is the
+    // whole compatibility claim: formatVersion is the occupancy tag, so an
+    // all-zero block is "no combo settings were ever frozen" — exempt from
+    // comparison and repaired at the first crossing (accepted answer O5) —
+    // rather than a formatted record whose direction byte happens to be 0.
+    SAVE_ASSERT(gComboCtx.comboSettings.formatVersion == 0,
+                "the combo settings record from a pre-carve save must read as ABSENT");
+    SAVE_ASSERT(gComboCtx.comboSettingsHash == 0,
+                "the combo settings fingerprint from a pre-carve save must read as unset");
     for (size_t i = 0; i < sizeof(gComboCtx.reserved); i++) {
         SAVE_ASSERT(gComboCtx.reserved[i] == 0, "Tier-1 tail beyond the legacy record not zero-extended");
     }
@@ -535,6 +544,37 @@ TestResult Test_SaveComboLegacyRecord(void) {
     static const uint8_t kCraftedExtKind = RSBS_SHARED_RES_QUIVER_TIER;
     static const uint8_t kCraftedExtFlags = RSBS_SHARED_RES_F_MONOTONIC;
     static const uint16_t kCraftedExtValue = 0x0003u;
+    // The ADR 0011 carve: the whole-pair fingerprint at 880 (ADR 0009 claim 2,
+    // spent exactly as reserved) and the 12-byte frozen rule record at 884 (ADR
+    // 0011 claim 10). Crafted BYTE BY BYTE at the literal offsets, so the record
+    // pins every MEMBER offset too — those same twelve bytes are what the
+    // canonical digest encoder walks in declaration order, so a member reorder
+    // here would silently re-identify every already-created world rather than
+    // merely moving a field.
+    //
+    // formatVersion is crafted as 0 ON PURPOSE, and the other eleven bytes are
+    // distinctive: the tag says ABSENT, so the load's combo identity check
+    // (ADR 0011 decision 4) exempts the record and the file loads — while the
+    // loader still copies all twelve bytes, which is what lets every member be
+    // read back and its offset asserted. A formatted record would be COMPARED,
+    // and an arbitrary crafted one would (correctly) be refused before anything
+    // could be read out of it. The identity refusal has its own lock; this one
+    // is about where the bytes land.
+    static const size_t kComboSettingsHashOffset = 880u;
+    static const size_t kComboSettingsOffset = 884u;
+    static const uint32_t kCraftedComboHash = 0xC0FFEE11u;
+    static const uint8_t kCraftedComboRecord[12] = {
+        0x00,       // formatVersion — ABSENT tag (see above)
+        0x03,       // direction
+        0x06,       // poolSizeOoT
+        0x07,       // poolSizeMM
+        0x21, 0x43, // itemClassOoT LE == 0x4321
+        0x65, 0x87, // itemClassMM  LE == 0x8765
+        0x02,       // goal
+        0x09,       // logicRung
+        0x11,       // spare0
+        0x22,       // spare1
+    };
 
     SaveTestSeed(tag);  // re-inits gComboCtx and restamps the magic/version
     {
@@ -549,6 +589,8 @@ TestResult Test_SaveComboLegacyRecord(void) {
         std::memcpy(image + kSharedResourcesExtOffset + 0, &kCraftedExtKind, sizeof(kCraftedExtKind));
         std::memcpy(image + kSharedResourcesExtOffset + 1, &kCraftedExtFlags, sizeof(kCraftedExtFlags));
         std::memcpy(image + kSharedResourcesExtOffset + 2, &kCraftedExtValue, sizeof(kCraftedExtValue));
+        std::memcpy(image + kComboSettingsHashOffset, &kCraftedComboHash, sizeof(kCraftedComboHash));
+        std::memcpy(image + kComboSettingsOffset, kCraftedComboRecord, sizeof(kCraftedComboRecord));
     }
 
     mgr.DeleteSave(0);
@@ -562,6 +604,8 @@ TestResult Test_SaveComboLegacyRecord(void) {
     std::memset(gComboCtx.foreignPlacements, 0x5A, sizeof(gComboCtx.foreignPlacements));
     std::memset(gComboCtx.sharedResources, 0x5A, sizeof(gComboCtx.sharedResources));
     std::memset(gComboCtx.sharedResourcesExt, 0x5A, sizeof(gComboCtx.sharedResourcesExt));
+    std::memset(&gComboCtx.comboSettings, 0x5A, sizeof(gComboCtx.comboSettings));
+    gComboCtx.comboSettingsHash = 0x5A5A5A5Au;
 
     SAVE_ASSERT(mgr.Load(0), "Load refused a full-length v2 Tier-1 record");
 
@@ -590,9 +634,29 @@ TestResult Test_SaveComboLegacyRecord(void) {
     SAVE_ASSERT(offsetof(ComboContext, sharedResourcesExt) == kSharedResourcesExtOffset,
                 "sharedResourcesExt moved off .redsave byte offset 824");
 
+    SAVE_ASSERT(gComboCtx.comboSettingsHash == kCraftedComboHash,
+                "byte 880 did not land in comboSettingsHash — a field before it grew in place and orphaned every "
+                "shipped save's combo identity (ADR 0009 claim 2)");
+    SAVE_ASSERT(gComboCtx.comboSettings.formatVersion == kCraftedComboRecord[0] &&
+                    gComboCtx.comboSettings.direction == kCraftedComboRecord[1] &&
+                    gComboCtx.comboSettings.poolSizeOoT == kCraftedComboRecord[2] &&
+                    gComboCtx.comboSettings.poolSizeMM == kCraftedComboRecord[3] &&
+                    gComboCtx.comboSettings.itemClassOoT == 0x4321u &&
+                    gComboCtx.comboSettings.itemClassMM == 0x8765u &&
+                    gComboCtx.comboSettings.goal == kCraftedComboRecord[8] &&
+                    gComboCtx.comboSettings.logicRung == kCraftedComboRecord[9] &&
+                    gComboCtx.comboSettings.spare0 == kCraftedComboRecord[10] &&
+                    gComboCtx.comboSettings.spare1 == kCraftedComboRecord[11],
+                "bytes 884..895 did not land member-for-member in comboSettings — the combo rule record's layout "
+                "IS .redsave format, and it is the same byte order the canonical digest encoder walks");
+    SAVE_ASSERT(offsetof(ComboContext, comboSettingsHash) == kComboSettingsHashOffset,
+                "comboSettingsHash moved off .redsave byte offset 880");
+    SAVE_ASSERT(offsetof(ComboContext, comboSettings) == kComboSettingsOffset,
+                "comboSettings moved off .redsave byte offset 884");
+
     mgr.DeleteSave(0);
     printf("[TEST] PASS: pre-headroom Tier-1 loads, added fields read as zero, "
-           "and bytes 672/676/736/824 still land in their carves\n");
+           "and bytes 672/676/736/824/880/884 still land in their carves\n");
     return TEST_PASS;
 }
 


### PR DESCRIPTION
Refs #498; implements **ADR 0011 increment 1** — the carve, the freeze, the gate, the identity fold. No world changes.

## The carve as landed

| Claim | Field | Size | Offset |
|---|---|---|---|
| 2 (ADR 0009) | `comboSettingsHash` | 4 B | **880** — spent exactly as reserved |
| **10 (new, ADR 0011)** | `comboSettings` (`ComboSettingsRecord`) | 12 B | **884** |
| — | `reserved[]` | 108 B | **896** — was `reserved[124]` |

`264 − 48 − 4 − 32 − 48 − 4 − 4 − 4 − 12 = 108`, clear of ADR 0009's 64-byte floor by 44. `sizeof(ComboContext)` stays **1004** against the 1024 budget; `RSBS_SAVE_VERSION`, `RSBS_COMBO_CONTEXT_RECORD_SIZE` and `RSBS_COMBO_CONTEXT_PRECARVE_SIZE` are all unmoved, so this is a pure front-of-`reserved[]` carve under the growth contract — old save / new build zero-extends to `formatVersion == 0`, new save / old build reads the bytes as `reserved[]` and ignores them.

Both offsets are pinned with **literal-integer** `RSBS_CTX_STATIC_ASSERT`s in the style of 672/736/740/788/792/824/872/876, plus `sizeof == 12` and every member offset — an assert phrased in terms of a capacity constant follows a bump instead of catching it, which is the silent break #490 describes. ADR 0009's byte-budget table gains a **dated 2026-08-05 amendment** with claim 10 and re-derives to `reserved[108]` at offset 896, and `context.h`'s stale "claims 2 and 4 (4 + 64) would leave 56, UNDER the 64-byte floor" warning is retired in the same change (ADR 0011 increment 0 — claim 4 was already retired as spent by #584, so that arithmetic was dead and was inviting the next carver to raise the record size to solve a problem that no longer exists).

## Each accepted O-answer, and where it lives

| # | Answer | Where |
|---|---|---|
| **O1** | 4 B `comboSettingsHash` + 12 B `ComboSettingsRecord`, `reserved[108]` | `src/common/context.h` — the struct, the two fields, the literal-offset + member-offset asserts, the C++ raw-assignment probe |
| **O2** | default direction **BOTH** (what already ships) | `Combo_ComboSettingsDefaults`, `src/common/foreign_items.c` |
| **O3** | item class carries **no seed term** | nothing added — the class bitset is a pure `(static table, frozen bits)` function; increment 3 implements it, and no seed enters here |
| **O4** | two per-direction counts, 1..cap 8 | `poolSizeOoT` / `poolSizeMM`, resolved and clamped by `Combo_ComboPoolSizeFor` |
| **O5** | legacy paired saves freeze shipped defaults at first crossing | `Combo_FreezeLegacyComboSettings` + its call site in `MM_Rando_PairOnCrossGameArrival` |
| **O6** | whole-pair fingerprint, byte-pinned encoding | `Combo_ComboSettingsCanonical` + `Combo_ComputeComboSettingsHash` |
| **O7** | append-only `uint16_t` bitset selectors | `RSBS_ITEMCLASS_*` in `foreign_items.h`, with pinning asserts |
| **O8** | criterion-3 narrowing deferred | not touched — belongs to ADR 0010 increment 2 |

## The whole-pair fingerprint (O6, decision 1.4)

```
comboSettingsHash = FNV1a32( canonical(record) ‖ ':' ‖ LE32(sharedRandoSettingsHash) ‖ ':' ‖ LE32(mmProfileDigest) )
```

`canonical()` is **defined, not left to the compiler**: field by field in declaration order, each `uint16_t` little-endian, written a byte at a time — never a struct `memcpy`, never a cast of a packed struct (ADR 0007 §2's codec discipline). The member-offset asserts pin the *storage* format; the encoder pins the *digest input*. Zero displaces to `'CBSH'`, exactly as `DigestFromIdentity` does.

Computed **last**, after both half-digests are stamped. `MixPairedFinalSeed()` is deliberately **not** widened with it — `MMRandoGen` and `MMPairedAttemptDeterminism` did not move, which is the signal decision 1.4 asks for.

## The named refusal — failing-first evidence

`Combo_ComboSettingsDivergence` returns `RSBS_COMBO_DIVERGE_*` bits; `Combo_ComboSettingsDivergenceDescribe` renders them into the refusal text. The MM arrival gate refuses through the shipped #533/#568 surface — slot latched with `RSBS_REFUSE_IDENTITY`, **nothing quarantined** (the file is healthy, the session diverged), a shared-overlay toast that names the rule, and the frozen record **never** self-healed. The same diff also runs on the record a `.redsave` **load** just read, before those bytes are committed over the resident context.

Two counterfactuals, both run and confirmed **red** before restoring:

1. **Refusal removed** (`if (false && comboDiverged != 0)`) → `MMComboSettingsGate` fails: leg 1 falls through into generation and the slot latches `RSBS_REFUSE_GENERATION` (11) instead of `RSBS_REFUSE_IDENTITY`.
2. **Refusal kept, message made generic** → fails on *"the refusal does not NAME the diverged rule 'direction'"*.

Restored → green. This is the capability decision 1.1 justification 2 claims; without the lock the twelve bytes would buy display alone.

## Test rows added

`redship` tier, five new rows:

- `combo-settings-format` — sizeof/member offsets, the pinned value spaces, the shipped defaults (which must reproduce today's world exactly), the freeze/predicate pair, the pool-size fallback, a byte-exact `.redsave` round trip, the **load-side refusal** of a divergent record, and zero-extension of a pre-carve record.
- `combo-settings-canonical` — the **golden vector** (fixed record → fixed 12 bytes → fixed digest), construction-order independence, every field moves the digest, both half-digests move it and are positionally distinct, zero never returned. Modelled on `test_netplay_relay.c`'s wire-format vectors; this is the lock #574's identity handshake will inherit.
- `combo-settings-divergence` — each field diverged alone names exactly itself; the list form; absent = exempt, future-version = `UNREADABLE`; record/fingerprint disagreement. **Non-vacuity leg first**: a healthy pair reports 0 bits, which is decisive because the arrival gate's condition is literally `Combo_ComboSettingsDivergence() != 0`.
- `combo-settings-legacy-freeze` — the O5 writer freezes once, **compares** thereafter (never self-heals), skips an unpaired session, and the half-digest re-stamp restores 4.1's order.
- `mm-combo-settings-gate` (MM-side) — drives the **real** `MM_Rando_PairOnCrossGameArrival`: divergent record → refused by name; legacy pair → frozen defaults, not refused; second crossing → compares.

`Test_SaveComboLegacyRecord` gains crafted bytes at literal offsets **880** and **884**, read back member by member, alongside the existing 672/676/736/824 cases.

## Local verification

| Tier | Result |
|---|---|
| `-L "^redship$"` | **89/89 passed** (84 pre-existing + 5 new) |
| `-L "^rando$"` | **18/18 passed** — incl. `SeedDeterminism` (re-pinned on the digest fold alone), `MMRandoGen` and `MMPairedAttemptDeterminism` unmoved |
| `-L "^integration$"` | **5/6** — only `IntSwitchOoTHmsToMm` timed out, the known-red #544 row. `IntGameplayRoundtrip`, `IntBootOoT`, `IntBootMM`, `IntSwitchMmClockTownSouthToOoT`, `IntArchiveHotswapCycle` all passed |

clang-format clean (`games/mm/2s2h/mm_combo_settings_test.cpp` added to `.github/clang-format-paths.txt`).

## Two judgement calls worth a reviewer's eye

1. **Where the O5 transitional writer sits.** The ADR says "the same arrival gate that already carries `ResolvePairedProfile`'s transitional stamp". It is placed **ahead of every `hadFrozenState` / `alreadyRando` early return**, because those are all still crossings — a legacy pair that always restores an existing MM session would otherwise never freeze, staying permanently exempt from comparison and making 4.4 a behaviour nothing builds. The consequence: on a *doubly*-legacy pair (no combo record **and** no `mmProfileDigest`) the fingerprint is stamped over a zero profile digest, so `ResolvePairedProfile` re-stamps it immediately after freezing the profile — decision 4.1's order, restored where the ADR says ("recomputes `comboSettingsHash` … immediately after").

2. **"Both passes read direction/pool size from the record" vs. increment 4.** Increment 1 lists this; increment 4 says an unarmed direction makes each pass a no-op and is "deliberately last". Resolved as: **pool size is effective now** (through `Combo_ComboPoolSizeFor`, clamped, with a shipped-default fallback for an unfrozen record — load-bearing, since honouring a zero-extended `poolSize == 0` would silently generate a paired world with no crossings), while the **direction is read and reported** but does not yet gate. Increment 4 is a one-line change on top. Under the shipped defaults `wanted` is byte-identical to what both passes computed before, which is why no determinism row moved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!--- section:artifacts:start -->
### Build Artifacts
  - [rsbs-windows.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/8951198211.zip)
  - [rsbs-linux.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/8950940105.zip)
<!--- section:artifacts:end -->