### PR TITLE
Replace the hand-pinned foreign pool with a rule-defined item class (#495)

### DIFF
--- a/CMake/SingleExecutable.cmake
+++ b/CMake/SingleExecutable.cmake
@@ -425,6 +425,19 @@ if(BUILD_TESTING)
     # silent at compile and link time and would leave OoT unable to place
     # anything (#516's dead-registrar class).
     redship_add_test(NAME ForeignPoolMM COMMAND redship --test foreign-pool-mm)
+    # #495 / ADR 0011 decision 3: the cross-game item class is a RULE over both
+    # pools and the RSBS_ITEMCLASS_* bitset in the frozen combo record is the
+    # setting that selects it. Three claims, in the order they can fail: the
+    # DEFAULT bitset draws the pinned tables byte-identically (the parity pin —
+    # SeedDeterminism's foreignOoTHash and MMRandoGen's placement digest both
+    # fold the drawn entries, so this row failing is those rows moving); a
+    # NARROWED bitset draws only members of the armed classes (red before the
+    # rule engine, when the bitset was stored and compared but consumed by
+    # nothing); and the name inverse stays TOTAL over every item any class can
+    # name even with ZERO classes armed, which is why the class carries no seed
+    # term (accepted answer O3) and why the spoiler-LOAD path can run in a
+    # process that never generated. Display-free and ROM-free like its siblings.
+    redship_add_test(NAME ForeignItemClass COMMAND redship --test foreign-item-class)
     # Shared cross-game resources (#525): rupees and hearts are ONE quantity
     # spanning both games. Locks the delta-harvest watermark that survives MM's
     # 500-rupee tier-3 wallet against OoT's 999 (a naive copy costs the player

--- a/games/mm/2s2h/Rando/Foreign.cpp
+++ b/games/mm/2s2h/Rando/Foreign.cpp
@@ -528,12 +528,38 @@ int PlaceForeignItems() {
     // than `poolCount` so the shortfall alarm below stays honest: placing fewer
     // than the pool BECAUSE THE RULES SAY SO is not a host-supply shortfall.
     const int poolSize = Combo_ComboPoolSizeFor((uint8_t)GAME_OOT);
-    const int wanted = (poolCount < poolSize) ? poolCount : poolSize;
+
+    // WHICH pool entries are drawable is the RULE (#495, ADR 0011 decision 3):
+    // Combo_ForeignPoolDrawFor filters OoT's pool by the FROZEN itemClassOoT
+    // bitset, in pool order, with NO seed term (accepted answer O3). With the
+    // shipped defaults (every allocated bit) `drawable` is the identity
+    // permutation 0..poolCount-1, so pool[drawable[i]] IS pool[i] and no
+    // generated world moves — the parity this increment is bounded by.
+    //
+    // FILTER FIRST, THEN DRAW TO COUNT: the class decides WHICH entries may
+    // cross, the pool size decides HOW MANY do. `wanted` therefore bounds on the
+    // filtered count, never on the raw pool, or the loop would index past the
+    // filtered list the first time a class is unarmed.
+    std::vector<int> drawable((size_t)poolCount, 0);
+    const int drawableCount = Combo_ForeignPoolDrawFor((uint8_t)GAME_OOT, drawable.data(), poolCount);
+    drawable.resize((size_t)(drawableCount > 0 ? drawableCount : 0));
+
+    const int wanted = (drawableCount < poolSize) ? drawableCount : poolSize;
     // Read and reported here; ADR 0011 increment 4 is where an unarmed direction
     // makes this pass a no-op (deliberately last — it is the only increment that
     // can change a generated world).
-    fprintf(stderr, "[MM] foreign placement: combo rules direction=%u poolSizeOoT=%d (frozen=%d)\n",
-            (unsigned)Combo_ComboDirection(), poolSize, Combo_ComboSettingsFrozen() ? 1 : 0);
+    fprintf(stderr,
+            "[MM] foreign placement: combo rules direction=%u poolSizeOoT=%d classOoT=%04X (%d of %d pool entries in "
+            "class) (frozen=%d)\n",
+            (unsigned)Combo_ComboDirection(), poolSize, (unsigned)Combo_ComboItemClassFor((uint8_t)GAME_OOT),
+            drawableCount, poolCount, Combo_ComboSettingsFrozen() ? 1 : 0);
+    if (drawableCount <= 0) {
+        // Every class unarmed for this direction: a real, chooseable world under
+        // ADR 0011 decision 3.3 (the direction byte, not this, is what says
+        // "off"). Zero placements and a loud log, never a generation failure.
+        fprintf(stderr, "[MM] foreign placement: OoT item classes select no pool entry — no crossings\n");
+        return 0;
+    }
     sLastPlacementStats.requested = wanted;
 
     // The reachability gate (ADR 0010 increment 1.3, #500 work item 2): the
@@ -591,13 +617,18 @@ int PlaceForeignItems() {
 
     int placed = 0;
     for (int i = 0; i < wanted && !candidates.empty(); i++) {
+        // The i-th DRAWABLE entry, not the i-th pool row. Under the shipped
+        // defaults these are the same index, which is the parity pin; under a
+        // narrowed bitset this is what keeps the pass inside the armed classes.
+        const ComboForeignItemDef& entry = pool[drawable[(size_t)i]];
+
         const size_t pick = (size_t)(SelectNext() % (uint32_t)candidates.size());
         const RandoCheckId hostCheck = candidates[pick];
         candidates.erase(candidates.begin() + (std::ptrdiff_t)pick);
 
-        if (Combo_SetForeignPlacement((uint16_t)hostCheck, pool[i].item) >= 0) {
+        if (Combo_SetForeignPlacement((uint16_t)hostCheck, entry.item) >= 0) {
             placed++;
-            fprintf(stderr, "[MM] foreign placement: '%s' hosted at MM check %s\n", pool[i].name,
+            fprintf(stderr, "[MM] foreign placement: '%s' hosted at MM check %s\n", entry.name,
                     Rando::StaticData::Checks[hostCheck].name);
         } else {
             // A refused insert while candidates remained is a STRUCTURAL
@@ -605,7 +636,7 @@ int PlaceForeignItems() {
             // supply — the under-supply rule below must not absorb it.
             // Throwing lands in OnFileCreate's catch exactly as the old
             // placed<poolCount check did for this case.
-            throw std::runtime_error("foreign placement table refused an insert for '" + std::string(pool[i].name) +
+            throw std::runtime_error("foreign placement table refused an insert for '" + std::string(entry.name) +
                                      "' with candidates remaining — placement-table defect, not host supply");
         }
     }

--- a/games/mm/2s2h/Rando/ForeignItemsSingleExe.cpp
+++ b/games/mm/2s2h/Rando/ForeignItemsSingleExe.cpp
@@ -222,6 +222,39 @@ extern "C" {
 // moment somebody added a row. This pool is that row, 116 times over, and it
 // relies on the deferral instead of re-auditing it.
 //
+// ---------------------------------------------------------------------------
+// THE CLASS COLUMN (#495, ADR 0011 decision 3)
+// ---------------------------------------------------------------------------
+// Every row names the ONE RSBS_ITEMCLASS_* bit it belongs to, and the pool draw
+// is a RULE EVALUATION over those bits rather than "the whole array, in order":
+// OoT's placement pass calls Combo_ForeignPoolDrawFor, which filters this table
+// by the FROZEN itemClassMM bitset and preserves pool order.
+//
+// THE CRITERIA RUN FIRST, THE BITSET SELECTS AMONG SURVIVORS. Every row below
+// already passed the six criteria above; a class bit can only ever narrow that
+// set, never widen it, so no bit can readmit a #525 shared cross-game resource.
+// That ordering is the invariant, not a convention (see foreign_items.h).
+//
+// NO SEED TERM (accepted answer O3). The class is a pure function of (this
+// table, the frozen bitset). Seed-to-seed variety already comes from the
+// placement draw, which picks pool entry AND host without replacement from an
+// identity-seeded stream; a second randomisation of the same axis would buy
+// nothing and would make Combo_GetForeignItemByNameFor PARTIAL on the
+// spoiler-LOAD path, which runs in processes that never generated.
+//
+// WHERE THE BLOCK HEADINGS AND THE CLASSES DISAGREE, THE CLASS WINS -- the
+// headings below are presentational groupings that predate the rule:
+//   - "Progressive Goron Lullaby" sits under progressives but is a SONG.
+//   - "Bomber's Notebook" sits under core equipment but is the sidequest
+//     tracker, so it is SIDEQUEST.
+//   - "Ocarina of Time" sits under quest items but is PROGRESSION: every song
+//     in the game is unusable without it.
+//   - The boss REMAINS are DUNGEON_REWARD (MM's medallion analogue), while the
+//     keys/maps/compasses are DUNGEON_ITEMS -- the bit table's own split.
+//   - Stray fairies are SIDEQUEST, not DUNGEON_ITEMS: the bit's published
+//     meaning is "small/boss keys, maps, compasses", and the fairy chain is a
+//     Great Fairy reward sidequest that happens to be dungeon-scoped.
+//
 // Display names are MM's own (Rando::StaticData::Items) verbatim. They are a
 // PERSISTENCE KEY, not decoration: Combo_GetForeignItemByNameFor is the
 // spoiler-LOAD inverse, so renaming an entry breaks spoiler round-trips for
@@ -234,150 +267,348 @@ extern "C" {
 // the collision test goes red the instant one side exists without the other.
 static const ComboForeignItemDef kForeignPoolMMV1[] = {
     // --- Progressive upgrades: resolve against the live MM save at give time.
-    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_PROGRESSIVE_SWORD }, "Progressive Sword", "a " },
-    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_PROGRESSIVE_LULLABY }, "Progressive Goron Lullaby", "" },
+    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_PROGRESSIVE_SWORD }, "Progressive Sword", "a ", RSBS_ITEMCLASS_PROGRESSION },
+    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_PROGRESSIVE_LULLABY },
+      "Progressive Goron Lullaby",
+      "",
+      RSBS_ITEMCLASS_SONGS },
 
     // --- Core equipment, abilities and capacity upgrades.
-    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_LENS }, "Lens of Truth", "the " },
-    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_ARROW_FIRE }, "Fire Arrows", "" },
-    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_ARROW_ICE }, "Ice Arrows", "" },
-    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_ARROW_LIGHT }, "Light Arrows", "" },
-    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_POWDER_KEG }, "Powder Keg", "a " },
-    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_PICTOGRAPH_BOX }, "Pictograph Box", "a " },
-    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_MAGIC_BEAN }, "Magic Bean", "a " },
-    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_BOMBERS_NOTEBOOK }, "Bomber's Notebook", "the " },
-    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_SHIELD_HERO }, "Hero's Shield", "the " },
-    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_SHIELD_MIRROR }, "Mirror Shield", "the " },
-    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_SWORD_KOKIRI }, "Kokiri Sword", "the " },
-    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_SWORD_RAZOR }, "Razor Sword", "the " },
-    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_SWORD_GILDED }, "Gilded Sword", "the " },
-    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_GREAT_FAIRY_SWORD }, "Great Fairy's Sword", "the " },
-    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_GREAT_SPIN_ATTACK }, "Great Spin Attack", "the " },
+    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_LENS }, "Lens of Truth", "the ", RSBS_ITEMCLASS_PROGRESSION },
+    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_ARROW_FIRE }, "Fire Arrows", "", RSBS_ITEMCLASS_PROGRESSION },
+    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_ARROW_ICE }, "Ice Arrows", "", RSBS_ITEMCLASS_PROGRESSION },
+    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_ARROW_LIGHT }, "Light Arrows", "", RSBS_ITEMCLASS_PROGRESSION },
+    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_POWDER_KEG }, "Powder Keg", "a ", RSBS_ITEMCLASS_PROGRESSION },
+    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_PICTOGRAPH_BOX }, "Pictograph Box", "a ", RSBS_ITEMCLASS_PROGRESSION },
+    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_MAGIC_BEAN }, "Magic Bean", "a ", RSBS_ITEMCLASS_PROGRESSION },
+    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_BOMBERS_NOTEBOOK }, "Bomber's Notebook", "the ", RSBS_ITEMCLASS_SIDEQUEST },
+    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_SHIELD_HERO }, "Hero's Shield", "the ", RSBS_ITEMCLASS_PROGRESSION },
+    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_SHIELD_MIRROR }, "Mirror Shield", "the ", RSBS_ITEMCLASS_PROGRESSION },
+    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_SWORD_KOKIRI }, "Kokiri Sword", "the ", RSBS_ITEMCLASS_PROGRESSION },
+    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_SWORD_RAZOR }, "Razor Sword", "the ", RSBS_ITEMCLASS_PROGRESSION },
+    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_SWORD_GILDED }, "Gilded Sword", "the ", RSBS_ITEMCLASS_PROGRESSION },
+    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_GREAT_FAIRY_SWORD },
+      "Great Fairy's Sword",
+      "the ",
+      RSBS_ITEMCLASS_PROGRESSION },
+    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_GREAT_SPIN_ATTACK },
+      "Great Spin Attack",
+      "the ",
+      RSBS_ITEMCLASS_PROGRESSION },
 
     // --- Bottles (the bottle itself, not its refills).
-    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_BOTTLE_EMPTY }, "Empty Bottle", "an " },
-    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_BOTTLE_MILK }, "Bottle of Milk", "a " },
-    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_BOTTLE_RED_POTION }, "Bottle with Red Potion", "a " },
-    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_BOTTLE_GOLD_DUST }, "Bottle With Gold Dust", "a " },
-    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_BOTTLE_CHATEAU_ROMANI }, "Bottle of Chateau Romani", "a " },
+    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_BOTTLE_EMPTY }, "Empty Bottle", "an ", RSBS_ITEMCLASS_PROGRESSION },
+    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_BOTTLE_MILK }, "Bottle of Milk", "a ", RSBS_ITEMCLASS_PROGRESSION },
+    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_BOTTLE_RED_POTION },
+      "Bottle with Red Potion",
+      "a ",
+      RSBS_ITEMCLASS_PROGRESSION },
+    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_BOTTLE_GOLD_DUST },
+      "Bottle With Gold Dust",
+      "a ",
+      RSBS_ITEMCLASS_PROGRESSION },
+    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_BOTTLE_CHATEAU_ROMANI },
+      "Bottle of Chateau Romani",
+      "a ",
+      RSBS_ITEMCLASS_PROGRESSION },
 
     // --- Masks. All 24, transformation masks included.
-    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_MASK_DEKU }, "Deku Mask", "the " },
-    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_MASK_GORON }, "Goron Mask", "the " },
-    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_MASK_ZORA }, "Zora Mask", "the " },
-    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_MASK_FIERCE_DEITY }, "Fierce Deity Mask", "the " },
-    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_MASK_ALL_NIGHT }, "All-Night Mask", "the " },
-    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_MASK_BLAST }, "Blast Mask", "the " },
-    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_MASK_BREMEN }, "Bremen Mask", "the " },
-    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_MASK_BUNNY }, "Bunny Hood", "the " },
-    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_MASK_CAPTAIN }, "Captain's Hat", "the " },
-    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_MASK_CIRCUS_LEADER }, "Circus Leader's Mask", "the " },
-    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_MASK_COUPLE }, "Couples Mask", "the " },
-    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_MASK_DON_GERO }, "Don Gero Mask", "the " },
-    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_MASK_GARO }, "Garo's Mask", "" },
-    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_MASK_GIANT }, "Giant's Mask", "the " },
-    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_MASK_GIBDO }, "Gibdo Mask", "the " },
-    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_MASK_GREAT_FAIRY }, "Great Fairy Mask", "the " },
-    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_MASK_KAFEIS_MASK }, "Kafei's Mask", "" },
-    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_MASK_KAMARO }, "Kamaro's Mask", "" },
-    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_MASK_KEATON }, "Keaton Mask", "the " },
-    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_MASK_POSTMAN }, "Postman's Hat", "the " },
-    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_MASK_ROMANI }, "Romani's Mask", "" },
-    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_MASK_SCENTS }, "Mask of Scents", "the " },
-    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_MASK_STONE }, "Stone Mask", "the " },
-    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_MASK_TRUTH }, "Mask of Truth", "the " },
+    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_MASK_DEKU }, "Deku Mask", "the ", RSBS_ITEMCLASS_MASKS },
+    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_MASK_GORON }, "Goron Mask", "the ", RSBS_ITEMCLASS_MASKS },
+    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_MASK_ZORA }, "Zora Mask", "the ", RSBS_ITEMCLASS_MASKS },
+    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_MASK_FIERCE_DEITY }, "Fierce Deity Mask", "the ", RSBS_ITEMCLASS_MASKS },
+    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_MASK_ALL_NIGHT }, "All-Night Mask", "the ", RSBS_ITEMCLASS_MASKS },
+    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_MASK_BLAST }, "Blast Mask", "the ", RSBS_ITEMCLASS_MASKS },
+    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_MASK_BREMEN }, "Bremen Mask", "the ", RSBS_ITEMCLASS_MASKS },
+    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_MASK_BUNNY }, "Bunny Hood", "the ", RSBS_ITEMCLASS_MASKS },
+    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_MASK_CAPTAIN }, "Captain's Hat", "the ", RSBS_ITEMCLASS_MASKS },
+    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_MASK_CIRCUS_LEADER }, "Circus Leader's Mask", "the ", RSBS_ITEMCLASS_MASKS },
+    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_MASK_COUPLE }, "Couples Mask", "the ", RSBS_ITEMCLASS_MASKS },
+    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_MASK_DON_GERO }, "Don Gero Mask", "the ", RSBS_ITEMCLASS_MASKS },
+    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_MASK_GARO }, "Garo's Mask", "", RSBS_ITEMCLASS_MASKS },
+    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_MASK_GIANT }, "Giant's Mask", "the ", RSBS_ITEMCLASS_MASKS },
+    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_MASK_GIBDO }, "Gibdo Mask", "the ", RSBS_ITEMCLASS_MASKS },
+    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_MASK_GREAT_FAIRY }, "Great Fairy Mask", "the ", RSBS_ITEMCLASS_MASKS },
+    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_MASK_KAFEIS_MASK }, "Kafei's Mask", "", RSBS_ITEMCLASS_MASKS },
+    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_MASK_KAMARO }, "Kamaro's Mask", "", RSBS_ITEMCLASS_MASKS },
+    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_MASK_KEATON }, "Keaton Mask", "the ", RSBS_ITEMCLASS_MASKS },
+    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_MASK_POSTMAN }, "Postman's Hat", "the ", RSBS_ITEMCLASS_MASKS },
+    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_MASK_ROMANI }, "Romani's Mask", "", RSBS_ITEMCLASS_MASKS },
+    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_MASK_SCENTS }, "Mask of Scents", "the ", RSBS_ITEMCLASS_MASKS },
+    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_MASK_STONE }, "Stone Mask", "the ", RSBS_ITEMCLASS_MASKS },
+    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_MASK_TRUTH }, "Mask of Truth", "the ", RSBS_ITEMCLASS_MASKS },
 
     // --- Songs.
-    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_SONG_SONATA }, "Sonata of Awakening", "the " },
-    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_SONG_LULLABY }, "Goron Lullaby", "the " },
-    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_SONG_LULLABY_INTRO }, "Goron Lullaby Intro", "the " },
-    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_SONG_NOVA }, "New Wave Bossa Nova", "the " },
-    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_SONG_ELEGY }, "Elegy of Emptiness", "the " },
-    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_SONG_OATH }, "Oath to Order", "the " },
-    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_SONG_SOARING }, "Song of Soaring", "the " },
-    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_SONG_HEALING }, "Song of Healing", "the " },
-    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_SONG_EPONA }, "Epona's Song", "" },
-    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_SONG_SUN }, "Sun's Song", "the " },
-    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_SONG_TIME }, "Song of Time", "the " },
-    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_SONG_STORMS }, "Song of Storms", "the " },
+    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_SONG_SONATA }, "Sonata of Awakening", "the ", RSBS_ITEMCLASS_SONGS },
+    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_SONG_LULLABY }, "Goron Lullaby", "the ", RSBS_ITEMCLASS_SONGS },
+    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_SONG_LULLABY_INTRO }, "Goron Lullaby Intro", "the ", RSBS_ITEMCLASS_SONGS },
+    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_SONG_NOVA }, "New Wave Bossa Nova", "the ", RSBS_ITEMCLASS_SONGS },
+    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_SONG_ELEGY }, "Elegy of Emptiness", "the ", RSBS_ITEMCLASS_SONGS },
+    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_SONG_OATH }, "Oath to Order", "the ", RSBS_ITEMCLASS_SONGS },
+    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_SONG_SOARING }, "Song of Soaring", "the ", RSBS_ITEMCLASS_SONGS },
+    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_SONG_HEALING }, "Song of Healing", "the ", RSBS_ITEMCLASS_SONGS },
+    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_SONG_EPONA }, "Epona's Song", "", RSBS_ITEMCLASS_SONGS },
+    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_SONG_SUN }, "Sun's Song", "the ", RSBS_ITEMCLASS_SONGS },
+    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_SONG_TIME }, "Song of Time", "the ", RSBS_ITEMCLASS_SONGS },
+    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_SONG_STORMS }, "Song of Storms", "the ", RSBS_ITEMCLASS_SONGS },
 
     // --- Quest and sidequest items.
-    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_OCARINA }, "Ocarina of Time", "the " },
-    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_MOONS_TEAR }, "Moon's Tear", "the " },
-    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_DEED_LAND }, "Land Title Deed", "the " },
-    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_DEED_SWAMP }, "Swamp Title Deed", "the " },
-    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_DEED_MOUNTAIN }, "Mountain Title Deed", "the " },
-    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_DEED_OCEAN }, "Ocean Title Deed", "the " },
-    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_ROOM_KEY }, "Room Key", "the " },
-    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_LETTER_TO_KAFEI }, "Letter to Kafei", "the " },
-    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_LETTER_TO_MAMA }, "Letter to Mama", "the " },
-    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_PENDANT_OF_MEMORIES }, "Pendant of Memories", "the " },
-    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_MUSHROOM }, "Magic Mushroom", "a " },
-    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_FROG_BLUE }, "Blue Frog", "a " },
-    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_FROG_CYAN }, "Cyan Frog", "a " },
-    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_FROG_PINK }, "Pink Frog", "a " },
-    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_FROG_WHITE }, "White Frog", "a " },
+    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_OCARINA }, "Ocarina of Time", "the ", RSBS_ITEMCLASS_PROGRESSION },
+    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_MOONS_TEAR }, "Moon's Tear", "the ", RSBS_ITEMCLASS_SIDEQUEST },
+    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_DEED_LAND }, "Land Title Deed", "the ", RSBS_ITEMCLASS_SIDEQUEST },
+    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_DEED_SWAMP }, "Swamp Title Deed", "the ", RSBS_ITEMCLASS_SIDEQUEST },
+    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_DEED_MOUNTAIN }, "Mountain Title Deed", "the ", RSBS_ITEMCLASS_SIDEQUEST },
+    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_DEED_OCEAN }, "Ocean Title Deed", "the ", RSBS_ITEMCLASS_SIDEQUEST },
+    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_ROOM_KEY }, "Room Key", "the ", RSBS_ITEMCLASS_SIDEQUEST },
+    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_LETTER_TO_KAFEI }, "Letter to Kafei", "the ", RSBS_ITEMCLASS_SIDEQUEST },
+    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_LETTER_TO_MAMA }, "Letter to Mama", "the ", RSBS_ITEMCLASS_SIDEQUEST },
+    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_PENDANT_OF_MEMORIES },
+      "Pendant of Memories",
+      "the ",
+      RSBS_ITEMCLASS_SIDEQUEST },
+    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_MUSHROOM }, "Magic Mushroom", "a ", RSBS_ITEMCLASS_SIDEQUEST },
+    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_FROG_BLUE }, "Blue Frog", "a ", RSBS_ITEMCLASS_SIDEQUEST },
+    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_FROG_CYAN }, "Cyan Frog", "a ", RSBS_ITEMCLASS_SIDEQUEST },
+    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_FROG_PINK }, "Pink Frog", "a ", RSBS_ITEMCLASS_SIDEQUEST },
+    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_FROG_WHITE }, "White Frog", "a ", RSBS_ITEMCLASS_SIDEQUEST },
 
     // --- Boss remains.
-    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_REMAINS_ODOLWA }, "Odolwa's Remains", "" },
-    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_REMAINS_GOHT }, "Goht's Remains", "" },
-    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_REMAINS_GYORG }, "Gyorg's Remains", "" },
-    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_REMAINS_TWINMOLD }, "Twinmold's Remains", "" },
+    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_REMAINS_ODOLWA }, "Odolwa's Remains", "", RSBS_ITEMCLASS_DUNGEON_REWARD },
+    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_REMAINS_GOHT }, "Goht's Remains", "", RSBS_ITEMCLASS_DUNGEON_REWARD },
+    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_REMAINS_GYORG }, "Gyorg's Remains", "", RSBS_ITEMCLASS_DUNGEON_REWARD },
+    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_REMAINS_TWINMOLD }, "Twinmold's Remains", "", RSBS_ITEMCLASS_DUNGEON_REWARD },
 
     // --- Health: EMPTY since #525. Heart containers, heart pieces and double
     // defense are a SHARED RESOURCE now (criterion 6 below), not a crossing.
 
     // --- Skulltula tokens.
-    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_GS_TOKEN_SWAMP }, "Swamp Gold Skulltula Token", "a " },
-    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_GS_TOKEN_OCEAN }, "Ocean Gold Skulltula Token", "an " },
+    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_GS_TOKEN_SWAMP },
+      "Swamp Gold Skulltula Token",
+      "a ",
+      RSBS_ITEMCLASS_SIDEQUEST },
+    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_GS_TOKEN_OCEAN },
+      "Ocean Gold Skulltula Token",
+      "an ",
+      RSBS_ITEMCLASS_SIDEQUEST },
 
     // --- Owl statues (Sram_ActivateOwl: always a real warp unlock).
-    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_OWL_CLOCK_TOWN_SOUTH }, "Clock Town Owl Statue", "the " },
-    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_OWL_MILK_ROAD }, "Milk Road Owl Statue", "the " },
-    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_OWL_SOUTHERN_SWAMP }, "Southern Swamp Owl Statue", "the " },
-    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_OWL_WOODFALL }, "Woodfall Owl Statue", "the " },
-    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_OWL_MOUNTAIN_VILLAGE }, "Mountain Village Owl Statue", "the " },
-    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_OWL_SNOWHEAD }, "Snowhead Owl Statue", "the " },
-    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_OWL_GREAT_BAY_COAST }, "Great Bay Coast Owl Statue", "the " },
-    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_OWL_ZORA_CAPE }, "Zora Cape Owl Statue", "the " },
-    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_OWL_IKANA_CANYON }, "Ikana Canyon Owl Statue", "the " },
-    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_OWL_STONE_TOWER }, "Stone Tower Owl Statue", "the " },
+    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_OWL_CLOCK_TOWN_SOUTH },
+      "Clock Town Owl Statue",
+      "the ",
+      RSBS_ITEMCLASS_SIDEQUEST },
+    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_OWL_MILK_ROAD }, "Milk Road Owl Statue", "the ", RSBS_ITEMCLASS_SIDEQUEST },
+    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_OWL_SOUTHERN_SWAMP },
+      "Southern Swamp Owl Statue",
+      "the ",
+      RSBS_ITEMCLASS_SIDEQUEST },
+    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_OWL_WOODFALL }, "Woodfall Owl Statue", "the ", RSBS_ITEMCLASS_SIDEQUEST },
+    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_OWL_MOUNTAIN_VILLAGE },
+      "Mountain Village Owl Statue",
+      "the ",
+      RSBS_ITEMCLASS_SIDEQUEST },
+    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_OWL_SNOWHEAD }, "Snowhead Owl Statue", "the ", RSBS_ITEMCLASS_SIDEQUEST },
+    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_OWL_GREAT_BAY_COAST },
+      "Great Bay Coast Owl Statue",
+      "the ",
+      RSBS_ITEMCLASS_SIDEQUEST },
+    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_OWL_ZORA_CAPE }, "Zora Cape Owl Statue", "the ", RSBS_ITEMCLASS_SIDEQUEST },
+    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_OWL_IKANA_CANYON },
+      "Ikana Canyon Owl Statue",
+      "the ",
+      RSBS_ITEMCLASS_SIDEQUEST },
+    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_OWL_STONE_TOWER },
+      "Stone Tower Owl Statue",
+      "the ",
+      RSBS_ITEMCLASS_SIDEQUEST },
 
     // --- Tingle maps.
-    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_TINGLE_MAP_CLOCK_TOWN }, "Tingle's Clock Town Map", "" },
-    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_TINGLE_MAP_WOODFALL }, "Tingle's Woodfall Map", "" },
-    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_TINGLE_MAP_SNOWHEAD }, "Tingle's Snowhead Map", "" },
-    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_TINGLE_MAP_ROMANI_RANCH }, "Tingle's Romani Ranch Map", "" },
-    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_TINGLE_MAP_GREAT_BAY }, "Tingle's Great Bay Map", "" },
-    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_TINGLE_MAP_STONE_TOWER }, "Tingle's Stone Tower Map", "" },
+    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_TINGLE_MAP_CLOCK_TOWN },
+      "Tingle's Clock Town Map",
+      "",
+      RSBS_ITEMCLASS_SIDEQUEST },
+    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_TINGLE_MAP_WOODFALL },
+      "Tingle's Woodfall Map",
+      "",
+      RSBS_ITEMCLASS_SIDEQUEST },
+    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_TINGLE_MAP_SNOWHEAD },
+      "Tingle's Snowhead Map",
+      "",
+      RSBS_ITEMCLASS_SIDEQUEST },
+    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_TINGLE_MAP_ROMANI_RANCH },
+      "Tingle's Romani Ranch Map",
+      "",
+      RSBS_ITEMCLASS_SIDEQUEST },
+    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_TINGLE_MAP_GREAT_BAY },
+      "Tingle's Great Bay Map",
+      "",
+      RSBS_ITEMCLASS_SIDEQUEST },
+    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_TINGLE_MAP_STONE_TOWER },
+      "Tingle's Stone Tower Map",
+      "",
+      RSBS_ITEMCLASS_SIDEQUEST },
 
     // --- Dungeon items. Additive, so an extra key can only ever trivialize.
-    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_WOODFALL_BOSS_KEY }, "Woodfall Boss Key", "the " },
-    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_WOODFALL_SMALL_KEY }, "Woodfall Small Key", "a " },
-    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_WOODFALL_MAP }, "Woodfall Map", "the " },
-    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_WOODFALL_COMPASS }, "Woodfall Compass", "the " },
-    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_SNOWHEAD_BOSS_KEY }, "Snowhead Boss Key", "the " },
-    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_SNOWHEAD_SMALL_KEY }, "Snowhead Small Key", "a " },
-    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_SNOWHEAD_MAP }, "Snowhead Map", "the " },
-    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_SNOWHEAD_COMPASS }, "Snowhead Compass", "the " },
-    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_GREAT_BAY_BOSS_KEY }, "Great Bay Boss Key", "the " },
-    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_GREAT_BAY_SMALL_KEY }, "Great Bay Small Key", "a " },
-    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_GREAT_BAY_MAP }, "Great Bay Map", "the " },
-    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_GREAT_BAY_COMPASS }, "Great Bay Compass", "the " },
-    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_STONE_TOWER_BOSS_KEY }, "Stone Tower Boss Key", "the " },
-    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_STONE_TOWER_SMALL_KEY }, "Stone Tower Small Key", "a " },
-    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_STONE_TOWER_MAP }, "Stone Tower Map", "the " },
-    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_STONE_TOWER_COMPASS }, "Stone Tower Compass", "the " },
+    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_WOODFALL_BOSS_KEY },
+      "Woodfall Boss Key",
+      "the ",
+      RSBS_ITEMCLASS_DUNGEON_ITEMS },
+    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_WOODFALL_SMALL_KEY },
+      "Woodfall Small Key",
+      "a ",
+      RSBS_ITEMCLASS_DUNGEON_ITEMS },
+    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_WOODFALL_MAP }, "Woodfall Map", "the ", RSBS_ITEMCLASS_DUNGEON_ITEMS },
+    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_WOODFALL_COMPASS },
+      "Woodfall Compass",
+      "the ",
+      RSBS_ITEMCLASS_DUNGEON_ITEMS },
+    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_SNOWHEAD_BOSS_KEY },
+      "Snowhead Boss Key",
+      "the ",
+      RSBS_ITEMCLASS_DUNGEON_ITEMS },
+    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_SNOWHEAD_SMALL_KEY },
+      "Snowhead Small Key",
+      "a ",
+      RSBS_ITEMCLASS_DUNGEON_ITEMS },
+    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_SNOWHEAD_MAP }, "Snowhead Map", "the ", RSBS_ITEMCLASS_DUNGEON_ITEMS },
+    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_SNOWHEAD_COMPASS },
+      "Snowhead Compass",
+      "the ",
+      RSBS_ITEMCLASS_DUNGEON_ITEMS },
+    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_GREAT_BAY_BOSS_KEY },
+      "Great Bay Boss Key",
+      "the ",
+      RSBS_ITEMCLASS_DUNGEON_ITEMS },
+    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_GREAT_BAY_SMALL_KEY },
+      "Great Bay Small Key",
+      "a ",
+      RSBS_ITEMCLASS_DUNGEON_ITEMS },
+    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_GREAT_BAY_MAP }, "Great Bay Map", "the ", RSBS_ITEMCLASS_DUNGEON_ITEMS },
+    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_GREAT_BAY_COMPASS },
+      "Great Bay Compass",
+      "the ",
+      RSBS_ITEMCLASS_DUNGEON_ITEMS },
+    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_STONE_TOWER_BOSS_KEY },
+      "Stone Tower Boss Key",
+      "the ",
+      RSBS_ITEMCLASS_DUNGEON_ITEMS },
+    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_STONE_TOWER_SMALL_KEY },
+      "Stone Tower Small Key",
+      "a ",
+      RSBS_ITEMCLASS_DUNGEON_ITEMS },
+    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_STONE_TOWER_MAP }, "Stone Tower Map", "the ", RSBS_ITEMCLASS_DUNGEON_ITEMS },
+    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_STONE_TOWER_COMPASS },
+      "Stone Tower Compass",
+      "the ",
+      RSBS_ITEMCLASS_DUNGEON_ITEMS },
 
     // --- Stray fairies.
-    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_CLOCK_TOWN_STRAY_FAIRY }, "Clock Town Stray Fairy", "a " },
-    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_WOODFALL_STRAY_FAIRY }, "Woodfall Stray Fairy", "a " },
-    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_SNOWHEAD_STRAY_FAIRY }, "Snowhead Stray Fairy", "a " },
-    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_GREAT_BAY_STRAY_FAIRY }, "Great Bay Stray Fairy", "a " },
-    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_STONE_TOWER_STRAY_FAIRY }, "Stone Tower Stray Fairy", "a " },
+    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_CLOCK_TOWN_STRAY_FAIRY },
+      "Clock Town Stray Fairy",
+      "a ",
+      RSBS_ITEMCLASS_SIDEQUEST },
+    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_WOODFALL_STRAY_FAIRY },
+      "Woodfall Stray Fairy",
+      "a ",
+      RSBS_ITEMCLASS_SIDEQUEST },
+    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_SNOWHEAD_STRAY_FAIRY },
+      "Snowhead Stray Fairy",
+      "a ",
+      RSBS_ITEMCLASS_SIDEQUEST },
+    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_GREAT_BAY_STRAY_FAIRY },
+      "Great Bay Stray Fairy",
+      "a ",
+      RSBS_ITEMCLASS_SIDEQUEST },
+    { { (uint8_t)GAME_MM, 0, (uint16_t)RI_STONE_TOWER_STRAY_FAIRY },
+      "Stone Tower Stray Fairy",
+      "a ",
+      RSBS_ITEMCLASS_SIDEQUEST },
 };
 
 static constexpr int kForeignPoolMMCount = sizeof(kForeignPoolMMV1) / sizeof(kForeignPoolMMV1[0]);
+
+// ----------------------------------------------------------------------------
+// THE EXCLUSIONS, WITH ATTRIBUTION (#495, ADR 0011 decision 3.4)
+// ----------------------------------------------------------------------------
+//
+// The six criteria are numbered in src/common/foreign_items.h. Every id below
+// was considered for this pool and REJECTED, and each names the criterion that
+// rejected it. This is the prose above promoted to code, and it is what makes
+// the class lock a test of the RULE rather than of a table that happens to look
+// right: without an attributed exclusion set, a row that quietly drifted back
+// into the pool would be invisible to CI.
+//
+// It is the ADJUDICATED set, not a machine sweep of RI_UNKNOWN..RI_MAX. Two
+// criteria are not decidable from any table this build can read: criterion 3 is
+// a property of the PAIRED world's option profile, which OoT's placement pass
+// cannot see (ADR 0011 decision 3.5 / answer O8 keep it blanket until the MM
+// freeze moves ahead of Fill() AND a values-publishing src/common surface
+// exists), and criterion 4 is a property of a give's control flow. Guessing
+// either is exactly the promise -- "it will be awarded there!" -- that criteria
+// 3 and 4 exist to protect.
+//
+// The soul rows are REPRESENTED rather than enumerated: there are ~55 of them,
+// all excluded by criterion 3 for one reason (a bare rando-inf flag whose
+// meaning comes from an MM shuffle setting), and listing every one would make
+// this table a second copy of the enum instead of a record of decisions.
+namespace {
+struct ForeignExclusionMM {
+    uint16_t id;
+    uint8_t criterion;
+};
+
+const ForeignExclusionMM kForeignExclusionsMM[] = {
+    // (1) Sentinels -- the #488 trap. RI_UNKNOWN is enumerator 0, i.e. a
+    //     zero-initialised slot; RI_NONE is "literally nothing".
+    { (uint16_t)RI_UNKNOWN, (uint8_t)RSBS_FOREIGN_CRIT_REAL_ITEM },
+    { (uint16_t)RI_NONE, (uint8_t)RSBS_FOREIGN_CRIT_REAL_ITEM },
+    // (2) Junk-class, plus the row that is typed RITYPE_LESSER but is
+    //     semantically a bottle refill.
+    { (uint16_t)RI_JUNK, (uint8_t)RSBS_FOREIGN_CRIT_NOT_JUNK },
+    { (uint16_t)RI_GOLD_DUST_REFILL, (uint8_t)RSBS_FOREIGN_CRIT_NOT_JUNK },
+    // (3) Settings-armed gives. Each is a bare rando-inf / week-event flag whose
+    //     only meaning comes from a specific MM shuffle setting.
+    { (uint16_t)RI_SOUL_ENEMY_DINOLFOS, (uint8_t)RSBS_FOREIGN_CRIT_UNCONDITIONAL_GIVE }, // representative soul row
+    { (uint16_t)RI_OCARINA_BUTTON_A, (uint8_t)RSBS_FOREIGN_CRIT_UNCONDITIONAL_GIVE },
+    { (uint16_t)RI_OCARINA_BUTTON_C_DOWN, (uint8_t)RSBS_FOREIGN_CRIT_UNCONDITIONAL_GIVE },
+    { (uint16_t)RI_OCARINA_BUTTON_C_RIGHT, (uint8_t)RSBS_FOREIGN_CRIT_UNCONDITIONAL_GIVE },
+    { (uint16_t)RI_OCARINA_BUTTON_C_LEFT, (uint8_t)RSBS_FOREIGN_CRIT_UNCONDITIONAL_GIVE },
+    { (uint16_t)RI_OCARINA_BUTTON_C_UP, (uint8_t)RSBS_FOREIGN_CRIT_UNCONDITIONAL_GIVE },
+    { (uint16_t)RI_ABILITY_SWIM, (uint8_t)RSBS_FOREIGN_CRIT_UNCONDITIONAL_GIVE },
+    { (uint16_t)RI_TIME_PROGRESSIVE, (uint8_t)RSBS_FOREIGN_CRIT_UNCONDITIONAL_GIVE },
+    // (4) Global world event: Rando::GiveItem's Triforce branch fires
+    //     GameInteractor_ExecuteOnGameCompletion() and queues a forced scene
+    //     transition once the required count is reached.
+    { (uint16_t)RI_TRIFORCE_PIECE, (uint8_t)RSBS_FOREIGN_CRIT_NO_WORLD_EVENT },
+    { (uint16_t)RI_TRIFORCE_PIECE_PREVIOUS, (uint8_t)RSBS_FOREIGN_CRIT_NO_WORLD_EVENT },
+    // (5) Reward, not punishment.
+    { (uint16_t)RI_TRAP, (uint8_t)RSBS_FOREIGN_CRIT_REWARD },
+    // (6) #525 shared cross-game resources -- the eighteen rows that LEFT this
+    //     table across the three sharing tiers. Listed here rather than merely
+    //     deleted, so the reason survives the deletion.
+    { (uint16_t)RI_PROGRESSIVE_WALLET, (uint8_t)RSBS_FOREIGN_CRIT_NOT_SHARED_RESOURCE },
+    { (uint16_t)RI_WALLET_ADULT, (uint8_t)RSBS_FOREIGN_CRIT_NOT_SHARED_RESOURCE },
+    { (uint16_t)RI_WALLET_GIANT, (uint8_t)RSBS_FOREIGN_CRIT_NOT_SHARED_RESOURCE },
+    { (uint16_t)RI_DOUBLE_DEFENSE, (uint8_t)RSBS_FOREIGN_CRIT_NOT_SHARED_RESOURCE },
+    { (uint16_t)RI_HEART_CONTAINER, (uint8_t)RSBS_FOREIGN_CRIT_NOT_SHARED_RESOURCE },
+    { (uint16_t)RI_HEART_PIECE, (uint8_t)RSBS_FOREIGN_CRIT_NOT_SHARED_RESOURCE },
+    { (uint16_t)RI_PROGRESSIVE_MAGIC, (uint8_t)RSBS_FOREIGN_CRIT_NOT_SHARED_RESOURCE },
+    { (uint16_t)RI_SINGLE_MAGIC, (uint8_t)RSBS_FOREIGN_CRIT_NOT_SHARED_RESOURCE },
+    { (uint16_t)RI_DOUBLE_MAGIC, (uint8_t)RSBS_FOREIGN_CRIT_NOT_SHARED_RESOURCE },
+    { (uint16_t)RI_BOMB_BAG_20, (uint8_t)RSBS_FOREIGN_CRIT_NOT_SHARED_RESOURCE },
+    { (uint16_t)RI_BOMB_BAG_30, (uint8_t)RSBS_FOREIGN_CRIT_NOT_SHARED_RESOURCE },
+    { (uint16_t)RI_BOMB_BAG_40, (uint8_t)RSBS_FOREIGN_CRIT_NOT_SHARED_RESOURCE },
+    { (uint16_t)RI_PROGRESSIVE_BOMB_BAG, (uint8_t)RSBS_FOREIGN_CRIT_NOT_SHARED_RESOURCE },
+    { (uint16_t)RI_QUIVER_40, (uint8_t)RSBS_FOREIGN_CRIT_NOT_SHARED_RESOURCE },
+    { (uint16_t)RI_QUIVER_50, (uint8_t)RSBS_FOREIGN_CRIT_NOT_SHARED_RESOURCE },
+    // MM's own bow give sets UPG_QUIVER to 1, so in MM owning the bow IS quiver
+    // tier 1 -- a bow crossing would mutate the shared quantity itself.
+    { (uint16_t)RI_BOW, (uint8_t)RSBS_FOREIGN_CRIT_NOT_SHARED_RESOURCE },
+    { (uint16_t)RI_PROGRESSIVE_BOW, (uint8_t)RSBS_FOREIGN_CRIT_NOT_SHARED_RESOURCE },
+    { (uint16_t)RI_HOOKSHOT, (uint8_t)RSBS_FOREIGN_CRIT_NOT_SHARED_RESOURCE },
+};
+
+constexpr int kForeignExclusionsMMCount = sizeof(kForeignExclusionsMM) / sizeof(kForeignExclusionsMM[0]);
+} // namespace
 
 // Publish into src/common's origin-indexed registry (ADR 0009 decision 3), the
 // same way the OoT pool does. File-scope initializer, so it runs before main()
@@ -610,6 +841,31 @@ extern "C" int MM_ForeignItem_TestItemIdMax(void) {
  *  moves. */
 extern "C" int MM_ForeignItem_TestIsGiveableId(uint16_t riId) {
     return IsGiveableItemId(riId) ? 1 : 0;
+}
+
+/**
+ * Walk the CRITERION-ATTRIBUTED EXCLUSION table (#495, ADR 0011 decision 3.4):
+ * entry `index`'s rejected RI_* id and the criterion number that rejected it.
+ *
+ * The observable that makes the class rule testable. src/common has no MM enum
+ * in scope by design, so the lock cannot name RI_TRAP itself; it walks this
+ * bridge instead and asserts each excluded id is absent from the pool and from
+ * the name inverse. Exposed rather than re-listed in the test for the standing
+ * reason a lock never keeps its own copy of the rule.
+ *
+ * @return 1 while `index` names an entry, 0 once it is past the end.
+ */
+extern "C" int MM_ForeignItem_TestExclusionAt(int index, uint16_t* outId, uint8_t* outCriterion) {
+    if (index < 0 || index >= kForeignExclusionsMMCount) {
+        return 0;
+    }
+    if (outId != nullptr) {
+        *outId = kForeignExclusionsMM[index].id;
+    }
+    if (outCriterion != nullptr) {
+        *outCriterion = kForeignExclusionsMM[index].criterion;
+    }
+    return 1;
 }
 
 /** Is `riId` declared RITYPE_JUNK in MM's item table? (#510)

--- a/games/mm/2s2h/Rando/MiscBehavior/OnFileCreate.cpp
+++ b/games/mm/2s2h/Rando/MiscBehavior/OnFileCreate.cpp
@@ -276,15 +276,21 @@ void Rando::MiscBehavior::OnFileCreate(s16 fileNum) {
                         // shortfall is the spoiler's foreignShortfall section
                         // (Spoiler/Generate.cpp); the stderr line here is the
                         // greppable alarm on the generation log.
-                        const ComboForeignItemDef* pool = nullptr;
-                        const int poolCount = Combo_GetForeignItemPool(&pool);
+                        // Compared against the DRAWABLE count, not the raw pool
+                        // (#495): once the frozen itemClassOoT bitset narrows the
+                        // class, placing fewer than the whole pool is the rules
+                        // working rather than hosts running short, and an alarm
+                        // that cannot tell those apart is an alarm nobody reads.
+                        // With the shipped defaults the two counts are equal, so
+                        // this line says exactly what it said before.
+                        const int drawable = Combo_ForeignPoolDrawFor((uint8_t)GAME_OOT, nullptr, 0);
                         const int placed = Rando::Foreign::PlaceForeignItems();
-                        if (placed < poolCount) {
+                        if (placed < drawable) {
                             fprintf(stderr,
                                     "[MM] OnFileCreate: paired world hosts %d of %d foreign items (reachable eligible "
                                     "hosts ran short — see the [MM] foreign placement SHORTFALL line above; the "
                                     "spoiler records it)\n",
-                                    placed, poolCount);
+                                    placed, drawable);
                         }
                     }
 #endif

--- a/games/oot/soh/Enhancements/randomizer/ForeignItemsSingleExe.cpp
+++ b/games/oot/soh/Enhancements/randomizer/ForeignItemsSingleExe.cpp
@@ -104,19 +104,118 @@ void GiveLinkRupees(int numOfRupees);
 // stable representative rather than a per-tier lookup on the NULL-play redemption
 // path — a decoration, not the give. src/common serves these back verbatim via
 // Combo_GetForeignItemIconName; it never has to translate an RG_* itself.
+//
+// THE CLASS COLUMN (#495, ADR 0011 decision 3). Every row now names the ONE
+// RSBS_ITEMCLASS_* bit it belongs to, and the pool draw is a rule evaluation
+// over those bits rather than "the whole array, in order". Both placement
+// passes call Combo_ForeignPoolDrawFor, which filters this table by the frozen
+// itemClass* bitset and preserves pool order.
+//
+// ALL FOUR ROWS ARE `PROGRESSION`, and that is the point rather than an
+// accident: this table WAS the entire cross-game item class, and it becomes ONE
+// CLASS'S MEMBERSHIP. Every row is a major/progressive OoT item whose give is
+// unconditionally effectful and NULL-play safe — which is exactly what
+// RSBS_ITEMCLASS_PROGRESSION names. The other five classes are unpopulated on
+// this side today: OoT's songs, masks (it has none), dungeon items and dungeon
+// rewards have not been adjudicated against the six criteria, and an unaudited
+// row admitted by a class bit would be a crossing the redemption path cannot
+// safely give. Appending members later is a table edit here, not a format
+// change anywhere — which is the whole reason the class is a rule.
 static const ComboForeignItemDef kForeignPoolV1[] = {
     { { (uint8_t)GAME_OOT, 0, (uint16_t)RG_PROGRESSIVE_STRENGTH },
       "Progressive Strength Upgrade",
       "a ",
+      RSBS_ITEMCLASS_PROGRESSION,
       "ITEM_BRACELET" },
-    { { (uint8_t)GAME_OOT, 0, (uint16_t)RG_LENS_OF_TRUTH }, "Lens of Truth", "the ", "ITEM_LENS" },
-    { { (uint8_t)GAME_OOT, 0, (uint16_t)RG_BOOMERANG }, "Boomerang", "the ", "ITEM_BOOMERANG" },
-    { { (uint8_t)GAME_OOT, 0, (uint16_t)RG_MEGATON_HAMMER }, "Megaton Hammer", "the ", "ITEM_HAMMER" },
+    { { (uint8_t)GAME_OOT, 0, (uint16_t)RG_LENS_OF_TRUTH },
+      "Lens of Truth",
+      "the ",
+      RSBS_ITEMCLASS_PROGRESSION,
+      "ITEM_LENS" },
+    { { (uint8_t)GAME_OOT, 0, (uint16_t)RG_BOOMERANG },
+      "Boomerang",
+      "the ",
+      RSBS_ITEMCLASS_PROGRESSION,
+      "ITEM_BOOMERANG" },
+    { { (uint8_t)GAME_OOT, 0, (uint16_t)RG_MEGATON_HAMMER },
+      "Megaton Hammer",
+      "the ",
+      RSBS_ITEMCLASS_PROGRESSION,
+      "ITEM_HAMMER" },
 };
 
 static constexpr int kForeignPoolCount = sizeof(kForeignPoolV1) / sizeof(kForeignPoolV1[0]);
+// A COMPILE-TIME BOUND ON THE MAXIMUM, not the runtime limit. How many of these
+// rows a given world may actually place is the frozen record's poolSizeOoT,
+// clamped by Combo_ComboPoolSizeFor and applied at the placement pass (ADR 0011
+// increment 3). This assert survives because the OoT table happens to be
+// smaller than the carve; the MM table deliberately carries no such assert, for
+// the reason its own header states.
 static_assert(kForeignPoolCount <= (int)RSBS_FOREIGN_PLACEMENT_CAP,
               "the pinned foreign pool must fit the gComboCtx placement carve");
+
+// ----------------------------------------------------------------------------
+// THE EXCLUSIONS, WITH ATTRIBUTION (ADR 0011 decision 3.4)
+// ----------------------------------------------------------------------------
+//
+// The six criteria are numbered in src/common/foreign_items.h. Every id below
+// was considered for this pool and REJECTED, and each names the criterion that
+// rejected it. Promoting these from prose to a table is what gives the class
+// rule an observable: without it, the only evidence "the rule ran" is a table
+// that happens to look right, and a row that quietly drifted back in would be
+// invisible to CI. The ForeignItemClass lock walks this table and asserts every
+// entry is absent from the pool AND absent from the name inverse.
+//
+// This is deliberately the ADJUDICATED set, not a machine sweep of RG_NONE..
+// RG_MAX. Criterion 3 ("the give is unconditionally effectful") is a property of
+// the PAIRED world's option profile, which OoT's generation pass cannot read —
+// ADR 0011 decision 3.5 / answer O8 keep that criterion blanket until ADR 0010
+// increment 2 moves the MM freeze ahead of Fill() and publishes option VALUES
+// rather than a digest. A sweep would therefore have to guess criterion 3, and
+// guessing it is precisely the promise ("it will be awarded there!") that
+// criterion 3 exists to protect.
+namespace {
+struct ForeignExclusionOoT {
+    uint16_t id;
+    uint8_t criterion;
+};
+
+const ForeignExclusionOoT kForeignExclusionsOoT[] = {
+    // (1) Sentinels. RG_NONE is "the fill placed nothing here"; it is not an item.
+    { (uint16_t)RG_NONE, (uint8_t)RSBS_FOREIGN_CRIT_REAL_ITEM },
+    // (2) Junk-class. A foreign HOST already physically holds an OoT junk item —
+    //     that is the degrade invariant — so crossing junk spends one of at most
+    //     RSBS_FOREIGN_PLACEMENT_CAP slots on a worse duplicate of what is there.
+    { (uint16_t)RG_GREEN_RUPEE, (uint8_t)RSBS_FOREIGN_CRIT_NOT_JUNK },
+    // (4) Global world event: the Triforce completion cascade is a per-world goal
+    //     quantity, and detonating it from a redemption flush is exactly what a
+    //     cross-game seam must not do.
+    { (uint16_t)RG_TRIFORCE, (uint8_t)RSBS_FOREIGN_CRIT_NO_WORLD_EVENT },
+    { (uint16_t)RG_TRIFORCE_PIECE, (uint8_t)RSBS_FOREIGN_CRIT_NO_WORLD_EVENT },
+    // (5) Reward, not punishment. The MM-side pickup text promises an award in
+    //     Hyrule; delivering a trap instead would make that text a lie. (The give
+    //     still HANDLES RG_ICE_TRAP — it arrives through other paths — but the
+    //     cross-game class does not source it.)
+    { (uint16_t)RG_ICE_TRAP, (uint8_t)RSBS_FOREIGN_CRIT_REWARD },
+    // (6) #525 shared cross-game resources. These are one quantity spanning both
+    //     games now, so there is nothing left for them to CROSS. The first three
+    //     were REALLY IN THIS TABLE and left with the sharing that replaced them —
+    //     "Fairy Bow" and "Bomb Bag" with shared ammo, "Progressive Hookshot" with
+    //     RSBS_SHARED_RES_HOOKSHOT_TIER — which is what makes this block a record
+    //     of decisions rather than a hypothetical.
+    { (uint16_t)RG_FAIRY_BOW, (uint8_t)RSBS_FOREIGN_CRIT_NOT_SHARED_RESOURCE },
+    { (uint16_t)RG_BOMB_BAG, (uint8_t)RSBS_FOREIGN_CRIT_NOT_SHARED_RESOURCE },
+    { (uint16_t)RG_PROGRESSIVE_HOOKSHOT, (uint8_t)RSBS_FOREIGN_CRIT_NOT_SHARED_RESOURCE },
+    { (uint16_t)RG_PROGRESSIVE_BOW, (uint8_t)RSBS_FOREIGN_CRIT_NOT_SHARED_RESOURCE },
+    { (uint16_t)RG_PROGRESSIVE_BOMB_BAG, (uint8_t)RSBS_FOREIGN_CRIT_NOT_SHARED_RESOURCE },
+    { (uint16_t)RG_PROGRESSIVE_WALLET, (uint8_t)RSBS_FOREIGN_CRIT_NOT_SHARED_RESOURCE },
+    { (uint16_t)RG_PROGRESSIVE_MAGIC_METER, (uint8_t)RSBS_FOREIGN_CRIT_NOT_SHARED_RESOURCE },
+    { (uint16_t)RG_HEART_CONTAINER, (uint8_t)RSBS_FOREIGN_CRIT_NOT_SHARED_RESOURCE },
+    { (uint16_t)RG_PIECE_OF_HEART, (uint8_t)RSBS_FOREIGN_CRIT_NOT_SHARED_RESOURCE },
+};
+
+constexpr int kForeignExclusionsOoTCount = sizeof(kForeignExclusionsOoT) / sizeof(kForeignExclusionsOoT[0]);
+} // namespace
 
 // Publish the table into src/common's origin-indexed registry (ADR 0009
 // decision 3) rather than defining the lookups here. The pool DEFINITION still
@@ -355,10 +454,25 @@ extern "C" int OoT_PlaceForeignItems(void) {
     // order (as the forward pass does, where pool <= cap made that equivalent)
     // would place the same first 8 entries in every seed and make the other ~126
     // dead weight.
-    std::vector<int> poolIndices;
-    poolIndices.reserve((size_t)poolCount);
-    for (int i = 0; i < poolCount; i++) {
-        poolIndices.push_back(i);
+    //
+    // WHICH pool entries are drawable is now the RULE (#495, ADR 0011 decision
+    // 3): Combo_ForeignPoolDrawFor filters MM's pool by the FROZEN itemClassMM
+    // bitset, in pool order. With the shipped defaults (every allocated bit) this
+    // is the identity permutation 0..poolCount-1 — byte-identical to the list
+    // this loop used to build by hand — which is what keeps SeedDeterminism's
+    // foreignOoTHash from moving. There is NO seed term in the class (accepted
+    // answer O3): variety comes from the draw below, and a seed-varying class
+    // would make the spoiler-load name inverse partial.
+    std::vector<int> poolIndices((size_t)poolCount, 0);
+    const int drawable = Combo_ForeignPoolDrawFor((uint8_t)GAME_MM, poolIndices.data(), poolCount);
+    poolIndices.resize((size_t)(drawable > 0 ? drawable : 0));
+    if (poolIndices.empty()) {
+        // Every class unarmed for this direction. A real, chooseable world under
+        // ADR 0011 decision 3.3 (the direction byte, not this, is what says
+        // "off"), so it is a loud log and zero placements rather than a failure.
+        fprintf(stderr, "[OoT] foreign placement: MM item classes %04X select no pool entry — no crossings\n",
+                (unsigned)Combo_ComboItemClassFor((uint8_t)GAME_MM));
+        return 0;
     }
 
     // How many crossings this direction may make comes from the FROZEN COMBO
@@ -369,14 +483,21 @@ extern "C" int OoT_PlaceForeignItems(void) {
     // could exceed the table's capacity would be a setting that lies, and a
     // zero-extended legacy record must never resolve to "no crossings".
     const int poolSize = Combo_ComboPoolSizeFor((uint8_t)GAME_MM);
-    const int wanted = std::min({ poolCount, poolSize, (int)candidates.size() });
+    // FILTER FIRST, THEN DRAW TO COUNT. The class rule decides WHICH entries are
+    // drawable; the pool size decides HOW MANY of them get placed. Bounding on
+    // poolIndices.size() rather than poolCount is what makes the two compose —
+    // bounding on the raw pool would let the draw index past the filtered list.
+    const int wanted = std::min({ (int)poolIndices.size(), poolSize, (int)candidates.size() });
     // The direction itself is READ here and reported; ADR 0011 increment 4 is
     // where an unarmed direction makes this pass a no-op. It lands last on
     // purpose: it is the only increment that can change a generated world, and
     // it should land on top of a frozen, compared, rendered setting rather than
     // under one.
-    fprintf(stderr, "[OoT] foreign placement: combo rules direction=%u poolSizeMM=%d (frozen=%d)\n",
-            (unsigned)Combo_ComboDirection(), poolSize, Combo_ComboSettingsFrozen() ? 1 : 0);
+    fprintf(stderr,
+            "[OoT] foreign placement: combo rules direction=%u poolSizeMM=%d classMM=%04X (%zu of %d pool entries in "
+            "class) (frozen=%d)\n",
+            (unsigned)Combo_ComboDirection(), poolSize, (unsigned)Combo_ComboItemClassFor((uint8_t)GAME_MM),
+            poolIndices.size(), poolCount, Combo_ComboSettingsFrozen() ? 1 : 0);
 
     int placed = 0;
     for (int i = 0; i < wanted; i++) {
@@ -404,6 +525,31 @@ extern "C" int OoT_PlaceForeignItems(void) {
 // lock that restates the rule stops testing it the moment the rule moves.
 extern "C" int OoT_Foreign_IsEligibleHost(uint16_t rc) {
     return OoT_Foreign_IsEligibleHostImpl((RandomizerCheck)rc) ? 1 : 0;
+}
+
+/**
+ * Walk the CRITERION-ATTRIBUTED EXCLUSION table (#495, ADR 0011 decision 3.4):
+ * entry `index`'s rejected RG_* id and the criterion number that rejected it.
+ *
+ * The observable that makes the class rule testable. src/common has no OoT enum
+ * in scope by design, so the lock cannot name RG_FAIRY_BOW itself; it walks this
+ * bridge instead and asserts each excluded id is absent from the pool and from
+ * the name inverse. Exposed rather than re-listed in the test for the standing
+ * reason: a lock that keeps its own copy of the rule stops testing the rule.
+ *
+ * @return 1 while `index` names an entry, 0 once it is past the end.
+ */
+extern "C" int OoT_ForeignItem_TestExclusionAt(int index, uint16_t* outId, uint8_t* outCriterion) {
+    if (index < 0 || index >= kForeignExclusionsOoTCount) {
+        return 0;
+    }
+    if (outId != nullptr) {
+        *outId = kForeignExclusionsOoT[index].id;
+    }
+    if (outCriterion != nullptr) {
+        *outCriterion = kForeignExclusionsOoT[index].criterion;
+    }
+    return 1;
 }
 
 #endif // RSBS_SINGLE_EXECUTABLE

--- a/src/common/foreign_items.c
+++ b/src/common/foreign_items.c
@@ -145,6 +145,106 @@ int Combo_ComboPoolSizeFor(uint8_t originGame) {
     return size;
 }
 
+uint16_t Combo_ComboItemClassFor(uint8_t originGame) {
+    if (originGame != (uint8_t)GAME_OOT && originGame != (uint8_t)GAME_MM) {
+        return 0;
+    }
+
+    // The frozen record is the authority for a created world. Unlike the pool
+    // SIZE, a frozen ZERO is honoured verbatim: inside a formatted record
+    // "itemClass == 0" is a legitimate "no classes armed for this direction"
+    // (ADR 0011 decision 3.3), and clamping it up to the defaults would silently
+    // re-arm a direction the player turned off. The size clamp is different only
+    // because 0 is not a value poolSize can legitimately carry.
+    if (Combo_ComboSettingsFrozen()) {
+        return (originGame == (uint8_t)GAME_OOT) ? gComboCtx.comboSettings.itemClassOoT
+                                                 : gComboCtx.comboSettings.itemClassMM;
+    }
+
+    // UNFROZEN: the shipped default (every allocated bit). Load-bearing for the
+    // same reason the pool-size fallback is — a zero-extended legacy record must
+    // not resolve to "no eligible source items at all".
+    ComboSettingsRecord live;
+    Combo_ResolveComboSettings(&live);
+    return (originGame == (uint8_t)GAME_OOT) ? live.itemClassOoT : live.itemClassMM;
+}
+
+int Combo_ForeignPoolClassMembersFor(uint8_t originGame, uint16_t classMask, int* outIndices, int maxIndices) {
+    const ComboForeignItemDef* pool = NULL;
+    const int poolCount = Combo_GetForeignItemPoolFor(originGame, &pool);
+    if (poolCount <= 0 || pool == NULL) {
+        return 0;
+    }
+
+    // IN POOL ORDER, because pool order is world-visible: the forward pass
+    // assigns pool[members[i]] to the i-th drawn host, so regrouping by class
+    // here would re-order every already-generated world's crossings.
+    //
+    // An UNCLASSIFIED row (itemClass == 0) matches no mask and is therefore
+    // never drawn. That is deliberate rather than defensive — a row nobody
+    // classified is a row nobody adjudicated the criteria for — and the
+    // ForeignItemClass lock refuses one at CI rather than at an operator's
+    // generation.
+    int selected = 0;
+    for (int i = 0; i < poolCount; i++) {
+        if ((pool[i].itemClass & classMask) == 0) {
+            continue;
+        }
+        if (outIndices != NULL) {
+            if (selected >= maxIndices) {
+                break;
+            }
+            outIndices[selected] = i;
+        }
+        selected++;
+    }
+    return selected;
+}
+
+int Combo_ForeignPoolDrawFor(uint8_t originGame, int* outIndices, int maxIndices) {
+    return Combo_ForeignPoolClassMembersFor(originGame, Combo_ComboItemClassFor(originGame), outIndices, maxIndices);
+}
+
+const char* Combo_ForeignCriterionName(uint8_t criterion) {
+    switch (criterion) {
+        case RSBS_FOREIGN_CRIT_NONE:
+            return "(none)";
+        case RSBS_FOREIGN_CRIT_REAL_ITEM:
+            return "real-item";
+        case RSBS_FOREIGN_CRIT_NOT_JUNK:
+            return "not-junk";
+        case RSBS_FOREIGN_CRIT_UNCONDITIONAL_GIVE:
+            return "unconditional-give";
+        case RSBS_FOREIGN_CRIT_NO_WORLD_EVENT:
+            return "no-world-event";
+        case RSBS_FOREIGN_CRIT_REWARD:
+            return "reward-not-punishment";
+        case RSBS_FOREIGN_CRIT_NOT_SHARED_RESOURCE:
+            return "not-shared-resource";
+        default:
+            return "(unknown)";
+    }
+}
+
+const char* Combo_ForeignItemClassName(uint16_t classBit) {
+    switch (classBit) {
+        case RSBS_ITEMCLASS_PROGRESSION:
+            return "progression";
+        case RSBS_ITEMCLASS_SONGS:
+            return "songs";
+        case RSBS_ITEMCLASS_MASKS:
+            return "masks";
+        case RSBS_ITEMCLASS_DUNGEON_ITEMS:
+            return "dungeon-items";
+        case RSBS_ITEMCLASS_DUNGEON_REWARD:
+            return "dungeon-reward";
+        case RSBS_ITEMCLASS_SIDEQUEST:
+            return "sidequest";
+        default:
+            return "(unknown)";
+    }
+}
+
 // ---- canonical() and the whole-pair fingerprint (decision 1.4) -------------
 
 void Combo_ComboSettingsCanonical(const ComboSettingsRecord* rec, uint8_t* out) {

--- a/src/common/foreign_items.h
+++ b/src/common/foreign_items.h
@@ -48,6 +48,25 @@ typedef struct {
     SharedItem item;     // originGame == GAME_OOT, flags == 0, id == the RG_* value
     const char* name;    // e.g. "Megaton Hammer"
     const char* article; // "the ", "a ", "an " or "" — see below
+    // WHICH ITEM CLASS THIS MEMBER BELONGS TO (#495, ADR 0011 decision 3):
+    // EXACTLY ONE allocated RSBS_ITEMCLASS_* bit, decided in the pool's own TU
+    // where the item's enum is in scope, and served back through this header so
+    // src/common can evaluate the class rule without ever translating an RG_* /
+    // RI_* itself — the same division of labour `name`, `article` and `iconName`
+    // already use.
+    //
+    // A row's class is authored, not derived at runtime, because the six
+    // membership criteria (RSBS_FOREIGN_CRIT_*) that admitted it are themselves
+    // hand-adjudicated: criterion 3 in particular ("the give is unconditionally
+    // effectful") is a property of another game's option profile, not of any
+    // table this build can read (ADR 0011 decision 3.5 / answer O8). What the
+    // rule engine below evaluates is the SELECTION — which classes are armed —
+    // over rows that have already passed the criteria.
+    //
+    // Zero means UNCLASSIFIED, which no shipping row may be: an unclassified row
+    // is selected by no mask at all and would silently leave the pool. The
+    // ForeignItemClass lock asserts exactly-one-bit over both real tables.
+    uint16_t itemClass;
     // The host game's texture-map key for this item's arrival-toast icon, or
     // NULL for a text-only toast. Like `name`, it is filled in by the pool's
     // defining TU (where the item's icon is known) and served back through this
@@ -323,6 +342,125 @@ RSBS_CTX_STATIC_ASSERT(RSBS_ITEMCLASS_PROGRESSION == 0x0001u && RSBS_ITEMCLASS_S
                        "RSBS_ITEMCLASS_* bit positions are .redsave format: pinned, append-only, "
                        "allocate the next free bit and never re-point an allocated one (ADR 0011 "
                        "decision 1.2.1)");
+
+// ============================================================================
+// The six MEMBERSHIP CRITERIA, and the class rule (#495; ADR 0011 decision 3)
+// ============================================================================
+//
+// WHERE THE CRITERIA LIVE. The predicates must name RG_* / RI_*, so they cannot
+// leave their pool TUs. The CRITERIA can and must (ADR 0011 decision 3.4): they
+// are numbered HERE, game-header-free, exactly as ADR 0010 answer O8 places the
+// shared-item classification table in the sanctioned shared_items pair rather
+// than in a per-game duplicate that can disagree with itself. Each pool TU
+// evaluates them against its own enum and reports, per REJECTED candidate,
+// which criterion rejected it — that attribution is what makes the lock a test
+// of the rule rather than of a table that happens to look right.
+//
+// ORDER IS THE RULE, not presentation. The criteria run FIRST and the
+// RSBS_ITEMCLASS_* bitset selects among the survivors, so no class bit can
+// widen a pool past them — in particular no bit can readmit a #525 shared
+// cross-game resource. A future increment may append classes; it may not
+// weaken that ordering.
+
+#define RSBS_FOREIGN_CRIT_NONE 0u /* not rejected — this id is a class member */
+/** A real item, not a sentinel (each game's "unknown" / "nothing" enumerators). */
+#define RSBS_FOREIGN_CRIT_REAL_ITEM 1u
+/** Not junk-class: junk is what a foreign HOST degrades to when the placement
+ *  table is absent, so crossing it spends a slot on a strictly worse duplicate
+ *  of what the host already physically holds. */
+#define RSBS_FOREIGN_CRIT_NOT_JUNK 2u
+/** The give is UNCONDITIONALLY effectful — it changes save state whatever
+ *  options the paired world was generated under. A settings-gated entry is a
+ *  crossing promised in one game and silently never delivered in the other. */
+#define RSBS_FOREIGN_CRIT_UNCONDITIONAL_GIVE 3u
+/** The give fires no GLOBAL WORLD EVENT (a completion cascade, a forced scene
+ *  transition, a per-world goal quantity). */
+#define RSBS_FOREIGN_CRIT_NO_WORLD_EVENT 4u
+/** A reward, not a punishment: the far side's pickup text promises an award. */
+#define RSBS_FOREIGN_CRIT_REWARD 5u
+/** Not a #525 SHARED CROSS-GAME RESOURCE (wallet / heart / magic / ammo /
+ *  hookshot). One quantity spanning both games has nothing left to cross. */
+#define RSBS_FOREIGN_CRIT_NOT_SHARED_RESOURCE 6u
+/** One past the highest criterion. */
+#define RSBS_FOREIGN_CRIT_COUNT 7u
+
+// The criteria are a published, numbered list for the same reason the value
+// spaces above are: an exclusion recorded as "criterion 4" in one TU and read
+// as "criterion 5" in a lock is worse than no attribution at all.
+RSBS_CTX_STATIC_ASSERT(RSBS_FOREIGN_CRIT_REAL_ITEM == 1u && RSBS_FOREIGN_CRIT_NOT_JUNK == 2u &&
+                           RSBS_FOREIGN_CRIT_UNCONDITIONAL_GIVE == 3u && RSBS_FOREIGN_CRIT_NO_WORLD_EVENT == 4u &&
+                           RSBS_FOREIGN_CRIT_REWARD == 5u && RSBS_FOREIGN_CRIT_NOT_SHARED_RESOURCE == 6u,
+                       "the six membership criteria are numbered in ADR 0011 decision 3.1 and both pool TUs "
+                       "report exclusions by that number");
+
+/** The criterion's name ("real-item", "not-junk", ...); "(none)" for
+ *  RSBS_FOREIGN_CRIT_NONE and "(unknown)" past the table. Never NULL. */
+const char* Combo_ForeignCriterionName(uint8_t criterion);
+
+/** One class bit's name ("progression", "songs", ...), or "(unknown)" for an
+ *  unallocated bit or a mask with more than one bit set. Never NULL. */
+const char* Combo_ForeignItemClassName(uint16_t classBit);
+
+/**
+ * The RESOLVED item-class bitset for crossings ORIGINATING in @p originGame:
+ * the frozen record's when frozen, else the shipped default (every allocated
+ * bit). The exact twin of Combo_ComboPoolSizeFor, read for the same reason —
+ * the world's rules are FROZEN AT CREATION, so no live CVar may reach a
+ * placement pass mid-session.
+ *
+ * A FROZEN zero is honoured verbatim: inside a formatted record `itemClass == 0`
+ * is a legitimate "no classes armed for this direction", and it is not a hidden
+ * second OFF because the direction byte says so first (ADR 0011 decision 3.3).
+ * An UNFROZEN record falls back to the default instead — a zero-extended legacy
+ * record would otherwise resolve to "no eligible source items at all", which is
+ * the opposite of the world it was generated with.
+ *
+ * @return an RSBS_ITEMCLASS_* mask, or 0 for an origin with no pool.
+ */
+uint16_t Combo_ComboItemClassFor(uint8_t originGame);
+
+/**
+ * THE RULE EVALUATION (#495). Filter @p originGame's registered pool down to
+ * the members of @p classMask, writing their INDICES into @p outIndices in POOL
+ * ORDER.
+ *
+ * INDICES, NOT A FILTERED COPY, for two reasons that are both load-bearing.
+ * Pool ORDER is world-visible — the forward pass walks the result positionally
+ * and both passes draw from it — so the filter must preserve it rather than
+ * regroup by class. And the `name` pointers must stay the pool's OWN storage:
+ * test_foreign_items.c asserts pointer identity against Combo_GetForeignItemName,
+ * so a copy would need an arena and would break that identity for no gain.
+ *
+ * THE REGISTRY STILL SERVES THE WHOLE POOL, and that is the whole of accepted
+ * answer O3: Combo_GetForeignItemPoolFor and Combo_GetForeignItemByNameFor keep
+ * spanning every item ANY class can name, independent of the frozen selection,
+ * so the spoiler-LOAD inverse stays TOTAL in a process that never generated.
+ * Only the DRAW narrows. A selection-scoped inverse would make a spoiler that
+ * was valid at generation unreadable at load, which is the failure ADR 0011
+ * decision 3.2 rejects a seed term to avoid.
+ *
+ * @param classMask   an RSBS_ITEMCLASS_* mask; 0 selects nothing
+ * @param outIndices  receives the selected pool indices; NULL COUNTS ONLY (and
+ *                    then @p maxIndices is ignored)
+ * @param maxIndices  capacity of outIndices; selection stops there
+ * @return the number of members selected (>= 0).
+ */
+int Combo_ForeignPoolClassMembersFor(uint8_t originGame, uint16_t classMask, int* outIndices, int maxIndices);
+
+/**
+ * THE PRODUCTION DRAW: Combo_ForeignPoolClassMembersFor under the RESOLVED
+ * class bitset for @p originGame. Both placement passes call this, so "which
+ * classes are armed" is read from the frozen record in exactly one place.
+ *
+ * With the shipped defaults (every allocated bit) the result is the identity
+ * permutation 0..poolCount-1 — byte-identical to the table both passes walked
+ * before the rule existed. That parity is a test lock (ForeignItemClass), not
+ * a hope: it is what keeps SeedDeterminism's foreignOoTHash and MMRandoGen's
+ * placement digest from moving when the rule lands.
+ *
+ * @param outIndices NULL counts only, as above.
+ */
+int Combo_ForeignPoolDrawFor(uint8_t originGame, int* outIndices, int maxIndices);
 
 // ============================================================================
 // Combo-level settings: predicates, freeze, digest, divergence (ADR 0011)

--- a/src/common/test_runner.cpp
+++ b/src/common/test_runner.cpp
@@ -2379,6 +2379,14 @@ const TestDescriptor gTests[] = {
     // main() — so this also proves that registrar survived the link.
     {"foreign-pool-mm", "MM's cross-game source pool: registered, well-formed, giveable, non-junk (#510)",
      Test_ForeignPoolMM},
+    // #495: the cross-game item class is a RULE over the pool and the class
+    // BITSET is the setting. The parity half is the acceptance bar — under the
+    // shipped defaults the draw is the identity permutation, so no generated
+    // world moves — and the totality half is why the class carries no seed term.
+    {"foreign-item-class",
+     "Item class is a rule: default bitset draws the pinned pool byte-identically, a narrowed one draws only its "
+     "classes, the name inverse stays total (#495)",
+     Test_ForeignItemClass},
     // #525: shared cross-game resources. Display-free, ROM-free and save-free —
     // everything under test is gComboCtx plus a RAM watermark table.
     {"shared-resources", "One quantity across both games: watermark, disciplines, seed, heart clamp (#525)",

--- a/src/common/tests/test_foreign_items.c
+++ b/src/common/tests/test_foreign_items.c
@@ -69,6 +69,14 @@ void MM_Rando_Foreign_TestItemSentinels(uint16_t* outJunk, uint16_t* outNone, ui
 int MM_ForeignItem_TestIsGiveableId(uint16_t riId);
 int MM_ForeignItem_TestIsJunkClassId(uint16_t riId);
 
+// #495 criterion-attribution bridges: each pool TU's table of ids that were
+// CONSIDERED and rejected, with the criterion number that rejected them. This
+// TU has neither game's enum in scope by design, so it cannot name RI_TRAP or
+// RG_FAIRY_BOW itself — it walks these instead, which is also what keeps the
+// lock testing the real tables rather than a second copy of them.
+int MM_ForeignItem_TestExclusionAt(int index, uint16_t* outId, uint8_t* outCriterion);
+int OoT_ForeignItem_TestExclusionAt(int index, uint16_t* outId, uint8_t* outCriterion);
+
 // #510 OoT-side host predicate (games/oot/soh/Enhancements/randomizer/
 // ForeignItemsSingleExe.cpp) — the SAME function OoT_PlaceForeignItems' candidate
 // loop calls. Its fill-side half reads GetPlacedRandomizerGet(), so it accepts
@@ -149,10 +157,35 @@ TestResult Test_ForeignItemGive(void) {
     // ------------------------------------------------------------------
     // Pool sanity: pinned, OoT-tagged, named, lookup round-trips.
     // ------------------------------------------------------------------
+    //
+    // #495'S PRIMARY LOCK LIVES HERE, AND IT IS RE-AIMED (ADR 0011 decision
+    // 3.2). The issue asked for "a different sharedRandoSeed must produce a
+    // different pool — otherwise the 'rule' is a constant wearing a rule's
+    // clothes". That assertion MUST NOT BE WRITTEN: it is satisfiable only by a
+    // seed-varying class, which makes Combo_GetForeignItemByNameFor PARTIAL on
+    // the spoiler-LOAD path (a name that was in the pool at generation is absent
+    // at load, in a process that never generated). A lock that cannot pass gets
+    // "fixed" by weakening it, which is why the correction is recorded in an ADR
+    // rather than in a review comment.
+    //
+    // Re-aimed at the two observables that DO matter, and both are asserted —
+    // "a different seed must produce different PLACEMENTS" by SeedDeterminism's
+    // foreignOoTHash fold and MMRandoGen's digest, and "a different itemClass*
+    // bitset must produce a different derived pool" by the ForeignItemClass row
+    // below, which also carries the parity pin this one leaves implicit.
     const ComboForeignItemDef* pool = NULL;
     const int poolCount = Combo_GetForeignItemPool(&pool);
     FI_ASSERT(pool != NULL);
     FI_ASSERT(poolCount >= 1 && poolCount <= (int)RSBS_FOREIGN_PLACEMENT_CAP);
+    // The pool this row goes on to drive is the DRAWN pool under the shipped
+    // rules: with every class armed the draw is the whole table, so everything
+    // below is testing what a created world actually places. Written against
+    // the explicit v1 union rather than the resolved mask because this block
+    // runs BEFORE the clean-slate ComboContext_Init below, and `--test all`
+    // shares one process — the claim is about the TABLE, not about whatever the
+    // previous row left frozen.
+    FI_ASSERT(Combo_ForeignPoolClassMembersFor((uint8_t)GAME_OOT, (uint16_t)RSBS_ITEMCLASS_ALL_V1, NULL, 0) ==
+              poolCount);
     for (int i = 0; i < poolCount; i++) {
         FI_ASSERT(pool[i].item.originGame == (uint8_t)GAME_OOT);
         FI_ASSERT(pool[i].item.id != 0);
@@ -950,5 +983,320 @@ TestResult Test_ForeignPoolMM(void) {
 
     printf("[TEST] PASS: MM source pool registered, well-formed, giveable, non-junk, name-invertible, "
            "no shared resources\n");
+    return TEST_PASS;
+}
+
+// ============================================================================
+// #495: the cross-game item class is a RULE, and the class BITSET is the
+// setting (ADR 0011 decision 3; accepted answers O3 and O7).
+//
+// What replaced what: the pool draw used to be "the literal table, in order",
+// so the four pinned OoT rows WERE the whole universe and the bitset carved by
+// increment 1 was read but unconsumed. Now every row names one
+// RSBS_ITEMCLASS_* bit, the draw is Combo_ForeignPoolDrawFor over the FROZEN
+// bitset, and the pinned table is one class's membership.
+//
+// THE THREE CLAIMS THIS ROW EXISTS FOR, in the order they can fail:
+//
+//  (P) PARITY. Under the shipped defaults the draw is the identity permutation,
+//      so every already-generated world is byte-identical. This is the pin the
+//      whole increment is bounded by — SeedDeterminism's foreignOoTHash and
+//      MMRandoGen's placement digest both fold the drawn entries, so if this
+//      assertion is wrong those rows move.
+//
+//  (N) NARROWING. A narrowed bitset draws ONLY members of the armed classes.
+//      RED before the rule engine: the bitset was stored and compared but no
+//      code consumed it, so every mask produced the same full pool.
+//
+//  (T) TOTALITY. Combo_GetForeignItemByNameFor stays TOTAL over every item ANY
+//      class can name, whatever is frozen. This is why the class carries no
+//      seed term (O3) and why the FILTER returns indices while the REGISTRY
+//      keeps serving the whole pool: the spoiler-LOAD path runs in processes
+//      that never generated, and a selection-scoped inverse would make a
+//      spoiler that was valid at generation unreadable at load.
+//
+// Display-free, ROM-free, save-free: both tables are statics in WHOLE_ARCHIVE'd
+// libraries whose registrars run before main().
+// ============================================================================
+
+namespace {
+// Every allocated bit, spelled out rather than reusing RSBS_ITEMCLASS_ALL_V1,
+// so a bit ADDED to the union without a matching lock update is a red row here
+// instead of a silently widened default.
+const uint16_t kAllocatedClassBits[] = {
+    (uint16_t)RSBS_ITEMCLASS_PROGRESSION,   (uint16_t)RSBS_ITEMCLASS_SONGS,
+    (uint16_t)RSBS_ITEMCLASS_MASKS,         (uint16_t)RSBS_ITEMCLASS_DUNGEON_ITEMS,
+    (uint16_t)RSBS_ITEMCLASS_DUNGEON_REWARD, (uint16_t)RSBS_ITEMCLASS_SIDEQUEST,
+};
+const int kAllocatedClassBitCount = (int)(sizeof(kAllocatedClassBits) / sizeof(kAllocatedClassBits[0]));
+
+int PopCount16(uint16_t v) {
+    int n = 0;
+    while (v != 0) {
+        n += (v & 1u);
+        v = (uint16_t)(v >> 1);
+    }
+    return n;
+}
+} // namespace
+
+TestResult Test_ForeignItemClass(void) {
+    printf("[TEST] foreign-item-class: the frozen class bitset selects the DRAW; the pool and the name inverse stay "
+           "whole (#495)\n");
+
+    ComboContext_Init();
+
+    const uint8_t kOrigins[] = { (uint8_t)GAME_OOT, (uint8_t)GAME_MM };
+
+    // ------------------------------------------------------------------
+    // (0) The bit table is pinned, and every bit has a name.
+    // ------------------------------------------------------------------
+    // A renumbering is already a red BUILD (foreign_items.h's static_assert);
+    // this is the runtime half — an allocated bit with no name would render as
+    // "(unknown)" in every log line and refusal message the rule produces.
+    FI_ASSERT((uint16_t)RSBS_ITEMCLASS_ALL_V1 == 0x003Fu);
+    uint16_t unionOfBits = 0;
+    for (int b = 0; b < kAllocatedClassBitCount; b++) {
+        FI_ASSERT(PopCount16(kAllocatedClassBits[b]) == 1);
+        FI_ASSERT(strcmp(Combo_ForeignItemClassName(kAllocatedClassBits[b]), "(unknown)") != 0);
+        unionOfBits = (uint16_t)(unionOfBits | kAllocatedClassBits[b]);
+    }
+    FI_ASSERT(unionOfBits == (uint16_t)RSBS_ITEMCLASS_ALL_V1);
+    // An UNALLOCATED bit has no name and, below, no members.
+    FI_ASSERT(strcmp(Combo_ForeignItemClassName(0x0040u), "(unknown)") == 0);
+    // The criteria are named too — an exclusion attributed to a criterion the
+    // name table does not know is an exclusion nobody can read.
+    for (uint8_t c = (uint8_t)RSBS_FOREIGN_CRIT_REAL_ITEM; c < (uint8_t)RSBS_FOREIGN_CRIT_COUNT; c++) {
+        FI_ASSERT(strcmp(Combo_ForeignCriterionName(c), "(unknown)") != 0);
+    }
+    FI_ASSERT(strcmp(Combo_ForeignCriterionName((uint8_t)RSBS_FOREIGN_CRIT_COUNT), "(unknown)") == 0);
+
+    // ------------------------------------------------------------------
+    // (1) EVERY ROW OF BOTH POOLS IS CLASSIFIED, with EXACTLY ONE bit.
+    // ------------------------------------------------------------------
+    // Zero bits: the row is selected by no mask and would silently leave the
+    // pool the moment the rule went live. Two bits: the row is drawn by either
+    // class, which makes claim (N) untestable. C cannot express "exactly one
+    // allocated bit" in an initializer, so it is asserted here.
+    for (int o = 0; o < 2; o++) {
+        const ComboForeignItemDef* pool = NULL;
+        const int poolCount = Combo_GetForeignItemPoolFor(kOrigins[o], &pool);
+        FI_ASSERT(poolCount >= 1 && pool != NULL);
+        for (int i = 0; i < poolCount; i++) {
+            FI_ASSERT(PopCount16(pool[i].itemClass) == 1);
+            FI_ASSERT((pool[i].itemClass & (uint16_t)RSBS_ITEMCLASS_ALL_V1) == pool[i].itemClass);
+        }
+    }
+
+    // ------------------------------------------------------------------
+    // (P) THE PARITY PIN. Default bitset => the identity permutation.
+    // ------------------------------------------------------------------
+    // Asserted as index-for-index equality with 0..poolCount-1, not merely as
+    // an equal COUNT: the forward pass assigns pool[draw[i]] to the i-th drawn
+    // host, so a permutation with the right size and the wrong order would
+    // re-order every already-generated world's crossings while passing a
+    // count check.
+    FI_ASSERT(!Combo_ComboSettingsFrozen()); // fresh gComboCtx: the unfrozen fallback path
+    for (int o = 0; o < 2; o++) {
+        const uint8_t origin = kOrigins[o];
+        const ComboForeignItemDef* pool = NULL;
+        const int poolCount = Combo_GetForeignItemPoolFor(origin, &pool);
+
+        // The unfrozen fallback is the shipped default, NOT zero. A
+        // zero-extended legacy record resolving to "no classes" would silently
+        // generate a paired world with no crossings at all.
+        FI_ASSERT(Combo_ComboItemClassFor(origin) == (uint16_t)RSBS_ITEMCLASS_ALL_V1);
+
+        std::vector<int> draw((size_t)poolCount, -1);
+        const int drawCount = Combo_ForeignPoolDrawFor(origin, draw.data(), poolCount);
+        FI_ASSERT(drawCount == poolCount);
+        for (int i = 0; i < poolCount; i++) {
+            FI_ASSERT(draw[(size_t)i] == i);
+        }
+        printf("[TEST] foreign-item-class: origin %u parity — draw is the identity permutation over %d rows\n",
+               (unsigned)origin, poolCount);
+    }
+
+    // The same parity under an explicitly FROZEN default record, because that
+    // is the path a created world actually takes (the fallback above is only
+    // for legacy/pre-freeze files).
+    {
+        ComboSettingsRecord defaults;
+        Combo_ComboSettingsDefaults(&defaults);
+        gComboCtx.comboSettings = defaults;
+        FI_ASSERT(Combo_ComboSettingsFrozen());
+        for (int o = 0; o < 2; o++) {
+            const ComboForeignItemDef* pool = NULL;
+            const int poolCount = Combo_GetForeignItemPoolFor(kOrigins[o], &pool);
+            FI_ASSERT(Combo_ComboItemClassFor(kOrigins[o]) == (uint16_t)RSBS_ITEMCLASS_ALL_V1);
+            std::vector<int> draw((size_t)poolCount, -1);
+            FI_ASSERT(Combo_ForeignPoolDrawFor(kOrigins[o], draw.data(), poolCount) == poolCount);
+            for (int i = 0; i < poolCount; i++) {
+                FI_ASSERT(draw[(size_t)i] == i);
+            }
+        }
+    }
+
+    // ------------------------------------------------------------------
+    // (N) NARROWING. Each armed bit yields ONLY members of that class, the
+    //     classes PARTITION the pool, and the frozen record is what selects.
+    // ------------------------------------------------------------------
+    for (int o = 0; o < 2; o++) {
+        const uint8_t origin = kOrigins[o];
+        const ComboForeignItemDef* pool = NULL;
+        const int poolCount = Combo_GetForeignItemPoolFor(origin, &pool);
+
+        int summed = 0;
+        for (int b = 0; b < kAllocatedClassBitCount; b++) {
+            const uint16_t bit = kAllocatedClassBits[b];
+
+            // Freeze a record that arms exactly this one class for this origin.
+            // Written through the RECORD, not through a parameter, because the
+            // claim under test is "the FROZEN setting selects" — a filter
+            // driven only by an explicit mask argument would pass even if no
+            // production path ever read gComboCtx.
+            ComboSettingsRecord rec;
+            Combo_ComboSettingsDefaults(&rec);
+            if (origin == (uint8_t)GAME_OOT) {
+                rec.itemClassOoT = bit;
+            } else {
+                rec.itemClassMM = bit;
+            }
+            gComboCtx.comboSettings = rec;
+            FI_ASSERT(Combo_ComboItemClassFor(origin) == bit);
+
+            std::vector<int> draw((size_t)poolCount, -1);
+            const int n = Combo_ForeignPoolDrawFor(origin, draw.data(), poolCount);
+            FI_ASSERT(n >= 0 && n <= poolCount);
+            summed += n;
+
+            int prev = -1;
+            for (int i = 0; i < n; i++) {
+                const int idx = draw[(size_t)i];
+                FI_ASSERT(idx >= 0 && idx < poolCount);
+                // ONLY members of the armed class...
+                FI_ASSERT(pool[idx].itemClass == bit);
+                // ...and still in POOL ORDER, which is world-visible.
+                FI_ASSERT(idx > prev);
+                prev = idx;
+            }
+            // The count-only form must agree with the filled form, or the
+            // shortfall alarm that uses it reports a different number from the
+            // pass it is describing.
+            FI_ASSERT(Combo_ForeignPoolDrawFor(origin, NULL, 0) == n);
+
+            printf("[TEST] foreign-item-class: origin %u class %-14s -> %d of %d rows\n", (unsigned)origin,
+                   Combo_ForeignItemClassName(bit), n, poolCount);
+        }
+        // The classes PARTITION the pool: exactly-one-bit per row (asserted
+        // above) plus per-class counts summing to the whole means no row is
+        // double-counted and none is stranded.
+        FI_ASSERT(summed == poolCount);
+    }
+
+    // The empty and unallocated masks select nothing — "no classes armed" is a
+    // legitimate state (the direction byte is what says OFF), and an
+    // unallocated bit must not resolve to members it cannot have.
+    for (int o = 0; o < 2; o++) {
+        FI_ASSERT(Combo_ForeignPoolClassMembersFor(kOrigins[o], 0u, NULL, 0) == 0);
+        FI_ASSERT(Combo_ForeignPoolClassMembersFor(kOrigins[o], 0x0040u, NULL, 0) == 0);
+    }
+    // An origin with no pool has no members and no class, whatever is frozen.
+    FI_ASSERT(Combo_ForeignPoolDrawFor((uint8_t)GAME_NONE, NULL, 0) == 0);
+    FI_ASSERT(Combo_ComboItemClassFor((uint8_t)GAME_NONE) == 0);
+
+    // A FROZEN zero is honoured verbatim rather than clamped up to the
+    // defaults (ADR 0011 decision 3.3). This is the one place the class differs
+    // from the pool SIZE, whose zero IS clamped, and getting it backwards would
+    // silently re-arm a direction the player turned off.
+    {
+        ComboSettingsRecord rec;
+        Combo_ComboSettingsDefaults(&rec);
+        rec.itemClassOoT = 0;
+        rec.itemClassMM = 0;
+        gComboCtx.comboSettings = rec;
+        FI_ASSERT(Combo_ComboItemClassFor((uint8_t)GAME_OOT) == 0);
+        FI_ASSERT(Combo_ComboItemClassFor((uint8_t)GAME_MM) == 0);
+        FI_ASSERT(Combo_ForeignPoolDrawFor((uint8_t)GAME_OOT, NULL, 0) == 0);
+        FI_ASSERT(Combo_ForeignPoolDrawFor((uint8_t)GAME_MM, NULL, 0) == 0);
+    }
+
+    // ------------------------------------------------------------------
+    // (T) TOTALITY of the name inverse, UNDER THE NARROWEST SELECTION.
+    // ------------------------------------------------------------------
+    // Left frozen at itemClass == 0 from the block above — the state in which a
+    // selection-scoped inverse would resolve NOTHING. Every name any class can
+    // produce must still round-trip, because this is the spoiler-LOAD path and
+    // it runs in processes that never generated (accepted answer O3).
+    FI_ASSERT(Combo_ComboItemClassFor((uint8_t)GAME_OOT) == 0);
+    for (int o = 0; o < 2; o++) {
+        const uint8_t origin = kOrigins[o];
+        const ComboForeignItemDef* pool = NULL;
+        const int poolCount = Combo_GetForeignItemPoolFor(origin, &pool);
+        // The REGISTRY still serves the whole pool: only the DRAW narrows.
+        FI_ASSERT(poolCount >= 1 && pool != NULL);
+        for (int i = 0; i < poolCount; i++) {
+            SharedItem back;
+            FI_ASSERT(Combo_GetForeignItemByNameFor(origin, pool[i].name, &back));
+            FI_ASSERT(back.originGame == origin && back.id == pool[i].item.id);
+            // And the forward direction with it — a spoiler writes the name the
+            // pool gave it, so both halves must span the same set.
+            FI_ASSERT(Combo_GetForeignItemName(pool[i].item) == pool[i].name);
+        }
+        printf("[TEST] foreign-item-class: origin %u name inverse total over %d rows with ZERO classes armed\n",
+               (unsigned)origin, poolCount);
+    }
+
+    // ------------------------------------------------------------------
+    // (C) CRITERION ATTRIBUTION: every excluded candidate names the criterion
+    //     that excluded it, and is absent from the pool AND the inverse.
+    // ------------------------------------------------------------------
+    // Without this the class rule has no observable and the lock degenerates
+    // into "the table looks right" (ADR 0011's increment-3 test-locks row). It
+    // is driven through each pool TU's own table rather than a list kept here,
+    // so a row that drifts back into a pool goes red at the exclusion it
+    // contradicts rather than passing quietly.
+    for (int o = 0; o < 2; o++) {
+        const uint8_t origin = kOrigins[o];
+        const ComboForeignItemDef* pool = NULL;
+        const int poolCount = Combo_GetForeignItemPoolFor(origin, &pool);
+
+        int exclusions = 0;
+        uint16_t excludedId = 0;
+        uint8_t criterion = 0;
+        int seenCriteria = 0;
+        for (int index = 0;; index++) {
+            const int ok = (origin == (uint8_t)GAME_OOT)
+                               ? OoT_ForeignItem_TestExclusionAt(index, &excludedId, &criterion)
+                               : MM_ForeignItem_TestExclusionAt(index, &excludedId, &criterion);
+            if (!ok) {
+                break;
+            }
+            exclusions++;
+            // A real criterion, in the published range, with a real name.
+            FI_ASSERT(criterion >= (uint8_t)RSBS_FOREIGN_CRIT_REAL_ITEM &&
+                      criterion < (uint8_t)RSBS_FOREIGN_CRIT_COUNT);
+            FI_ASSERT(strcmp(Combo_ForeignCriterionName(criterion), "(unknown)") != 0);
+            seenCriteria |= (1 << criterion);
+            // ...and the id it names really is out of the pool. This is the
+            // assertion that catches a shared resource drifting back in.
+            for (int i = 0; i < poolCount; i++) {
+                FI_ASSERT(pool[i].item.id != excludedId);
+            }
+        }
+        // Non-vacuous: an empty table would make every assertion above a no-op.
+        FI_ASSERT(exclusions >= 5);
+        // And the exclusions are not all one criterion — a table that only ever
+        // said "criterion 6" would not be evidence that six criteria exist.
+        FI_ASSERT(PopCount16((uint16_t)(seenCriteria & 0xFFFF)) >= 4);
+        printf("[TEST] foreign-item-class: origin %u — %d attributed exclusions across %d criteria\n",
+               (unsigned)origin, exclusions, PopCount16((uint16_t)(seenCriteria & 0xFFFF)));
+    }
+
+    // Leave global state clean for any subsequent row in `--test all`.
+    ComboContext_Init();
+
+    printf("[TEST] PASS: default bitset draws the pinned pool byte-identically; a narrowed bitset draws only its "
+           "classes; the name inverse stays total\n");
     return TEST_PASS;
 }


### PR DESCRIPTION
ADR 0011 increment 3. Increment 1 (#628) carved `itemClassOoT`/`itemClassMM` into the frozen `ComboSettingsRecord`, defaulted both to every allocated bit (`0x003F`), and then read them nowhere. This is the consumer: the pool draw stops being *"the literal table, in order"* and becomes a rule evaluation over item classes, with the pinned four-entry OoT array becoming **one class's membership** rather than the whole universe.

## The parity pin, first, because it is the acceptance bar

The `SeedDeterminism` digest is **byte-identical before and after**, every field. Captured from a baseline build of `origin/main` (`c414a6d1`) and again from this branch, same machine, same staged ROMs:

```
seed=4FF39390            settingsHash=16E0CEF5      sourceIsRando=1
placementHash=5E0B1FA7   placedCount=490
foreignOoTHash=8FBA56D2  foreignOoTCount=8
comboSettingsHash=4215BD80
comboSettings=v1/d4/p8,8/c003F,003F/g1/r2
mmFinalSeed=74C32F12     mmPlacementHash=C73D3F4E
mmReachableCount=2256    mmReachableHash=DED50CE6
foreignCount=4           mmPairedAttempt=1
foreign0=198:1:40  foreign1=232:1:13  foreign2=291:1:12  foreign3=222:1:14
```

`Compare-Object` over the two digest files: **no differences**.

`foreignOoTHash` is the reverse pass running **through the new rule**, and `foreign0..3` are the forward pass's four crossings — so this is the rule *reproducing* the hand-pinned draw, not the rule being bypassed. Under the default bitset the draw is the identity permutation `0..poolCount-1`, so `pool[draw[i]] == pool[i]` and no generated world moves.

## Failing-first, measured

With the rule engine's mask test short-circuited to the pre-change behaviour (the bitset read but unconsumed) and everything else identical:

```
1/1 Test #20: ForeignItemClass .................***Failed    2.66 sec
[TEST] foreign-item-class: origin 1 parity — draw is the identity permutation over 4 rows
[TEST] foreign-item-class: origin 2 parity — draw is the identity permutation over 116 rows
[TEST] foreign-item-class: origin 1 class progression    -> 4 of 4 rows
[TEST] FAIL: test_foreign_items.c:1178: pool[idx].itemClass == bit
```

The right shape: the **narrowing** claim goes red and the **parity** claim still passes. Parity is what the change must not break; narrowing is what it buys.

## The class table as landed

`ComboForeignItemDef` gains a `uint16_t itemClass` column carrying exactly one `RSBS_ITEMCLASS_*` bit, decided in the pool's own TU where the enum is in scope and served back through the header — the same division of labour `name`, `article` and `iconName` already use, so `src/common` never translates an `RG_*`/`RI_*` and ADR 0002's one-TU rule is untouched.

| origin | progression | songs | masks | dungeon-items | dungeon-reward | sidequest | total |
|---|---|---|---|---|---|---|---|
| OoT | 4 | 0 | 0 | 0 | 0 | 0 | 4 |
| MM | 21 | 13 | 24 | 16 | 4 | 38 | 116 |

OoT's four rows are all `PROGRESSION`, which is the point rather than an accident: that table *was* the entire cross-game item class and is now one class's membership.

Where the presentational block headings and the classes disagree, the class wins, and each disagreement is written down at the table: *Progressive Goron Lullaby* is a SONG, *Bomber's Notebook* is SIDEQUEST, *Ocarina of Time* is PROGRESSION, boss remains are DUNGEON_REWARD against the keys/maps/compasses' DUNGEON_ITEMS, and stray fairies are SIDEQUEST because the bit's published meaning is *"small/boss keys, maps, compasses"*.

## The rule

- `Combo_ForeignPoolClassMembersFor(origin, mask, …)` — filter by an explicit mask.
- `Combo_ForeignPoolDrawFor(origin, …)` — filter by the **resolved** mask; this is what both placement passes call.
- `Combo_ComboItemClassFor(origin)` — the twin of `Combo_ComboPoolSizeFor`, reading the **frozen** record, never a live CVar.

Both filters return **indices in pool order**, not a filtered copy: pool order is world-visible (the forward pass assigns `pool[draw[i]]` to the i-th drawn host) and the `name` pointers must stay the pool's own storage, which `test_foreign_items.c` asserts pointer identity against.

`Combo_ComboItemClassFor` differs from the pool-size accessor in exactly one way, deliberately: **a frozen zero is honoured verbatim**, because inside a formatted record `itemClass == 0` is a legitimate "no classes armed" and the direction byte is what says OFF (decision 3.3). Only an *unfrozen* record falls back to the default, so a zero-extended legacy record cannot resolve to "no eligible source items at all".

**Filter first, then draw to count**: both passes now bound `wanted` on the filtered count rather than the raw pool, so the class and the pool size compose instead of the draw indexing past the filtered list.

## No seed term (answer O3) — #495 step 2 is corrected, not implemented

The class is a pure function of *(that game's table, the frozen bitset)*. Variety already exists at placement time — both passes draw entry and host without replacement from an identity-seeded stream — and a seed term would make `Combo_GetForeignItemByNameFor` **partial** on the spoiler-LOAD path, which runs in processes that never generated.

So the registry keeps serving the **whole** pool and only the **draw** narrows. The lock asserts totality under the narrowest possible selection: with **zero** classes armed, every name either pool can produce still round-trips through `Combo_GetForeignItemByNameFor` and `Combo_GetForeignItemName`.

## #495's primary lock is re-aimed, not extended (decision 3.2)

Its *"a different `sharedRandoSeed` must produce a different pool"* assertion is recorded in `ForeignItemGive` as one that **must not be written** — it is satisfiable only by the design that makes the load inverse partial, and a lock that cannot pass gets "fixed" by weakening it. The two observables that do matter are asserted instead: different seed ⇒ different **placements** (`SeedDeterminism`'s `foreignOoTHash` fold and `MMRandoGen`'s digest, both already in place), and different `itemClass*` ⇒ different **derived pool** (the new row).

## The six criteria are promoted from prose to code

Numbered in `src/common/foreign_items.h` — game-header-free, per decision 3.4 — and each pool TU carries an **attributed exclusion table** naming, per rejected id, the criterion that rejected it: OoT 14 exclusions across 5 criteria, MM 33 across 6. That is what makes the lock a test of the *rule* rather than of a table that happens to look right — a shared resource drifting back in goes red at the exclusion it contradicts.

It is deliberately the **adjudicated** set and not a machine sweep of the enum range: criterion 3 is a property of the paired world's option profile that this build cannot read (decision 3.5 / answer O8 keep it blanket), and criterion 4 is a property of a give's control flow. A sweep would have to guess exactly the promise those criteria protect.

## New lock: `ForeignItemClass`

`redship` tier, ROM-free and display-free. Three claims, in the order they can fail:

- **Parity** — default bitset ⇒ identity permutation over both pools, asserted **index-for-index** rather than by count (a permutation of the right size and the wrong order would re-order every already-generated world's crossings while passing a count check). Asserted through the unfrozen fallback *and* through an explicitly frozen default record, since a created world takes the second path.
- **Narrowing** — each armed bit yields only members of that class, still in pool order, driven by **writing the record** rather than passing a mask, so the claim under test is "the frozen setting selects" and not "the function filters". Per-class counts sum to the pool, which with exactly-one-bit-per-row makes the classes a partition.
- **Totality** — as above, under zero armed classes.

Plus: every row carries exactly one *allocated* bit; empty and unallocated masks select nothing; a frozen zero is honoured; an origin with no pool has no members.

## Also

MM's `OnFileCreate` shortfall alarm now compares against the **drawable** count rather than the raw pool. Once a bitset narrows the class, placing fewer than the whole pool is the rules working rather than hosts running short, and an alarm that cannot tell those apart is an alarm nobody reads. Identical under the shipped defaults.

## Stale premise checked

#495 work item 6 (the stale `RSBS_FOREIGN_PLACEMENT_CAP` growth comment) is **already fixed at HEAD** — `context.h:202-215` now carries the second-block prescription and the literal-offset rationale — so nothing was changed there.

## Not in scope, named so it is not absorbed

Criterion 3's narrowing to profile-conditional (answer O8, owned by ADR 0010 increment 2), the `RSBS_FOREIGN_PLACEMENT_CAP` raise, and increment 4's direction gate.

## Local verification

Full ROM-staged build on Windows (`cmake --build --parallel 5`, exit 0), all three tiers:

| tier | result |
|---|---|
| `redship` | **91/91 passed** |
| `rando` | **18/18 passed** |
| `integration` | 5/6 — only `IntSwitchOoTHmsToMm` (known-red, #544) |

Determinism pins unmoved: `SeedDeterminism`, `RandoDeterminism`, `MMRandoGen`, `MMPairedAttemptGen`, `MMPairedAttemptDeterminism` all green, and the digest diff above shows they did not merely pass — they produced the same bytes.

Fixes #495

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!--- section:artifacts:start -->
### Build Artifacts
  - [rsbs-windows.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/8952453838.zip)
  - [rsbs-linux.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/8952255624.zip)
<!--- section:artifacts:end -->