### PR TITLE
Close the reverse direction's give seam and arm the direction byte (#493)

### DIFF
--- a/games/mm/2s2h/Rando/Foreign.cpp
+++ b/games/mm/2s2h/Rando/Foreign.cpp
@@ -515,6 +515,28 @@ int PlaceForeignItems() {
         return 0;
     }
 
+    // THE DIRECTION GATE (ADR 0011 increment 4). Read from the FROZEN record —
+    // never a live CVar — through the same accessor OoT's reverse pass uses for
+    // its own origin. GAME_OOT is this pass's origin: it places OoT-ORIGIN items
+    // into MM checks, so it is armed by RSBS_COMBO_DIR_FORWARD and by
+    // RSBS_COMBO_DIR_BOTH.
+    //
+    // Zero placements, not a failure: RSBS_COMBO_DIR_OFF and
+    // RSBS_COMBO_DIR_REVERSE both describe real, chooseable paired worlds (ADR
+    // 0011 decision 2.3). Returning here also keeps sLastPlacementStats at its
+    // zeroed default, so OnFileCreate's shortfall alarm — which compares
+    // `placed` against `requested` — cannot read "the rules say no crossings" as
+    // "hosts ran short". Under the shipped default (BOTH) the predicate is true
+    // and nothing moves, which is what keeps MMRandoGen's placement digest and
+    // SeedDeterminism's foreign0..3 lines byte-stable.
+    if (!Combo_ComboDirectionArms((uint8_t)GAME_OOT)) {
+        fprintf(stderr,
+                "[MM] foreign placement: direction=%u does not arm OoT-origin crossings — no forward placements "
+                "(frozen=%d)\n",
+                (unsigned)Combo_ComboDirection(), Combo_ComboSettingsFrozen() ? 1 : 0);
+        return 0;
+    }
+
     const ComboForeignItemDef* pool = nullptr;
     const int poolCount = Combo_GetForeignItemPool(&pool);
     if (poolCount <= 0 || pool == nullptr) {
@@ -545,9 +567,9 @@ int PlaceForeignItems() {
     drawable.resize((size_t)(drawableCount > 0 ? drawableCount : 0));
 
     const int wanted = (drawableCount < poolSize) ? drawableCount : poolSize;
-    // Read and reported here; ADR 0011 increment 4 is where an unarmed direction
-    // makes this pass a no-op (deliberately last — it is the only increment that
-    // can change a generated world).
+    // The direction reached here necessarily ARMS this pass — the gate above
+    // returned already if it did not. Still printed: "which rules produced this
+    // world" is the first line a reader of a generation log looks for.
     fprintf(stderr,
             "[MM] foreign placement: combo rules direction=%u poolSizeOoT=%d classOoT=%04X (%d of %d pool entries in "
             "class) (frozen=%d)\n",

--- a/games/mm/2s2h/mm_rando_gen_test.cpp
+++ b/games/mm/2s2h/mm_rando_gen_test.cpp
@@ -1135,6 +1135,77 @@ extern "C" int MM_Rando_HeadlessForeignDigest(const char* outPath) {
     fprintf(stderr, "[MM-FOREIGN-DIGEST] mmFinalSeed=%08X mmPlacementHash=%08X mmReachableHash=%08X foreign=%d\n",
             gSaveContext.save.shipSaveInfo.rando.finalSeed, mmPlacementHash, mmReachableHash,
             Combo_CountForeignPlacements());
+
+    // ------------------------------------------------------------------
+    // THE FORWARD DIRECTION'S GATE (ADR 0011 increment 4, #493).
+    // ------------------------------------------------------------------
+    // The MM twin of the leg Test_ForeignPlacementOoT runs on OoT's reverse
+    // pass, and it lives HERE because this is the only headless bridge that
+    // reaches Rando::Foreign::PlaceForeignItems with a LIVE PAIRING —
+    // MMRandoGen's world is solo, so the same leg there would assert a pass
+    // that returns 0 for the wrong reason (vacuity).
+    //
+    // Deliberately AFTER the digest is written and closed, so it cannot perturb
+    // a single byte of the two-process determinism artifact. The pass is
+    // re-runnable by construction: it re-seeds its selection stream from the
+    // paired identity, so restoring the armed direction rebuilds the identical
+    // table — which is also what this leg asserts, and what makes "the gate is
+    // free at the shipped defaults" a measurement rather than a claim.
+    {
+        ComboForeignPlacement digestTable[RSBS_FOREIGN_PLACEMENT_CAP];
+        memcpy(digestTable, gComboCtx.foreignPlacements, sizeof(digestTable));
+        const int digestPlaced = Combo_CountForeignPlacements();
+        const uint8_t savedDirection = gComboCtx.comboSettings.direction;
+
+        if (!Combo_ComboSettingsFrozen() || savedDirection != RSBS_COMBO_DIR_BOTH) {
+            fprintf(stderr, "[MM-FOREIGN-DIGEST] FAIL(6): the creation event did not freeze direction=BOTH (frozen=%d "
+                            "direction=%u) — the gate has no authority to read\n",
+                    Combo_ComboSettingsFrozen() ? 1 : 0, (unsigned)savedDirection);
+            return 6;
+        }
+
+        // Two unarmed values, because they fail differently in principle:
+        // REVERSE arms the OTHER direction, OFF arms neither. A gate keyed on
+        // "not BOTH" would pass one and fail the other.
+        // PlaceForeignItems signals a STRUCTURAL defect by throwing (the #488
+        // "the table refused an insert" path), which OnFileCreate's attempt
+        // ladder catches in production. Nothing catches it here, so the leg
+        // does — an uncaught throw out of this extern "C" bridge would
+        // std::terminate the determinism row instead of failing it.
+        static const uint8_t kUnarmed[] = { (uint8_t)RSBS_COMBO_DIR_REVERSE, (uint8_t)RSBS_COMBO_DIR_OFF };
+        try {
+            for (uint8_t direction : kUnarmed) {
+                gComboCtx.comboSettings.direction = direction;
+                const int replaced = Rando::Foreign::PlaceForeignItems();
+                if (replaced != 0 || Combo_CountForeignPlacements() != 0) {
+                    fprintf(stderr,
+                            "[MM-FOREIGN-DIGEST] FAIL(7): direction=%u still placed %d OoT items (%d in table) — the "
+                            "forward pass is not gated\n",
+                            (unsigned)direction, replaced, Combo_CountForeignPlacements());
+                    gComboCtx.comboSettings.direction = savedDirection;
+                    return 7;
+                }
+            }
+
+            gComboCtx.comboSettings.direction = savedDirection;
+            const int rearmed = Rando::Foreign::PlaceForeignItems();
+            if (rearmed != digestPlaced || memcmp(digestTable, gComboCtx.foreignPlacements, sizeof(digestTable)) != 0) {
+                fprintf(stderr,
+                        "[MM-FOREIGN-DIGEST] FAIL(8): re-arming direction=BOTH placed %d (expected %d) or produced a "
+                        "different table — the gate is not free at the shipped defaults\n",
+                        rearmed, digestPlaced);
+                return 8;
+            }
+            fprintf(stderr, "[MM-FOREIGN-DIGEST] direction gate: unarmed => 0 placements, re-armed => %d, table "
+                            "byte-identical\n",
+                    rearmed);
+        } catch (const std::exception& e) {
+            gComboCtx.comboSettings.direction = savedDirection;
+            fprintf(stderr, "[MM-FOREIGN-DIGEST] FAIL(9): the direction-gate leg threw: %s\n", e.what());
+            return 9;
+        }
+    }
+
     return 0;
 }
 

--- a/games/oot/soh/Enhancements/randomizer/ForeignItemsSingleExe.cpp
+++ b/games/oot/soh/Enhancements/randomizer/ForeignItemsSingleExe.cpp
@@ -47,6 +47,7 @@
 #include "soh/Enhancements/randomizer/logic.h"
 
 #include "foreign_items.h" // src/common — ComboForeignItemDef, SharedItem
+#include "shared_items.h"  // src/common — Combo_RecordSharedItem (#493)
 
 extern "C" {
 #include <z64.h>
@@ -404,6 +405,27 @@ extern "C" int OoT_PlaceForeignItems(void) {
         return 0; // solo OoT rando: nothing to pair with, and that is normal
     }
 
+    // THE DIRECTION GATE (ADR 0011 increment 4, #493's "the direction byte").
+    // Read from the FROZEN record — never a live CVar — through the same
+    // accessor MM's forward pass uses for its own origin. GAME_MM is this
+    // pass's origin: it places MM-ORIGIN items into OoT checks, so it is armed
+    // by RSBS_COMBO_DIR_REVERSE and by RSBS_COMBO_DIR_BOTH.
+    //
+    // Zero placements is the correct outcome, NOT an error: RSBS_COMBO_DIR_OFF
+    // and RSBS_COMBO_DIR_FORWARD both describe real, chooseable paired worlds
+    // (ADR 0011 decision 2.3), so this returns 0 like the solo case rather than
+    // one of the negative shortfall codes, which mean "a paired world's
+    // cross-game half would be SILENTLY absent". Under the shipped default
+    // (BOTH) this predicate is true and nothing moves — the parity that keeps
+    // SeedDeterminism's foreignOoTHash byte-stable.
+    if (!Combo_ComboDirectionArms((uint8_t)GAME_MM)) {
+        fprintf(stderr,
+                "[OoT] foreign placement: direction=%u does not arm MM-origin crossings — no reverse placements "
+                "(frozen=%d)\n",
+                (unsigned)Combo_ComboDirection(), Combo_ComboSettingsFrozen() ? 1 : 0);
+        return 0;
+    }
+
     const ComboForeignItemDef* pool = nullptr;
     const int poolCount = Combo_GetForeignItemPoolFor((uint8_t)GAME_MM, &pool);
     if (poolCount <= 0 || pool == nullptr) {
@@ -488,11 +510,10 @@ extern "C" int OoT_PlaceForeignItems(void) {
     // poolIndices.size() rather than poolCount is what makes the two compose —
     // bounding on the raw pool would let the draw index past the filtered list.
     const int wanted = std::min({ (int)poolIndices.size(), poolSize, (int)candidates.size() });
-    // The direction itself is READ here and reported; ADR 0011 increment 4 is
-    // where an unarmed direction makes this pass a no-op. It lands last on
-    // purpose: it is the only increment that can change a generated world, and
-    // it should land on top of a frozen, compared, rendered setting rather than
-    // under one.
+    // The direction reached here is necessarily one that ARMS this pass — the
+    // gate above returned already if it did not (ADR 0011 increment 4). It is
+    // still printed, because "which rules produced this world" is the line a
+    // reader of a generation log looks for first.
     fprintf(stderr,
             "[OoT] foreign placement: combo rules direction=%u poolSizeMM=%d classMM=%04X (%zu of %d pool entries in "
             "class) (frozen=%d)\n",
@@ -525,6 +546,78 @@ extern "C" int OoT_PlaceForeignItems(void) {
 // lock that restates the rule stops testing it the moment the rule moves.
 extern "C" int OoT_Foreign_IsEligibleHost(uint16_t rc) {
     return OoT_Foreign_IsEligibleHostImpl((RandomizerCheck)rc) ? 1 : 0;
+}
+
+// ============================================================================
+// REVERSE DIRECTION (#493): the PICKUP CORE — the OoT twin of
+// Rando::Foreign::RecordForeignPickup
+// ============================================================================
+//
+// WHY THIS IS A NAMED FUNCTION AND NOT THE FOUR LINES IT REPLACES. Until now
+// the reverse leg's producer lived entirely inside the RC-queue drain lambda in
+// hook_handlers.cpp, which needs a live PlayState, a Player and the CheckTracker
+// — so nothing ROM-free could enter it, and #493's own Lock section says in as
+// many words that a row which pokes the placement table instead "would be
+// vacuous". The forward direction has had the extraction since Lane C1
+// (Rando::Foreign::RecordForeignPickup + the MM_Rando_Foreign_RecordPickup
+// bridge); this is the missing twin, and the ForeignItemGiveReverse row now
+// drives it.
+//
+// The split is deliberately the SAME one MM makes: this function owns the
+// DECISION and the durable RECORD, and owns nothing about presentation. The
+// toast, the tracker write and the queue pop stay at the hook, because they are
+// display/gameplay concerns that a display-free tier cannot honestly assert.
+//
+// THE PAIRING REFUSAL IS THE #610 RULE, APPLIED TO THE DIRECTION THAT DID NOT
+// HAVE IT. Combo_RecordSharedItem takes no identity argument and performs no
+// identity check (src/common/shared_items.c): whatever it records is redeemed by
+// whichever paired MM world arrives next, blind to which world authored it. MM's
+// forward-side core has refused to author such a record since #610; the reverse
+// side did not, so an OoT session whose foreignPlacementsOoT survived into an
+// unpaired state (a .redsave loaded into a solo session, a future spoiler-drop
+// route, a session invalidation that KEEPs the table) could mint a crossing with
+// no paired world to receive it. The check DEGRADES to the junk-class OoT item
+// the host physically holds — the documented absent-placement behaviour
+// (foreign_items.h) — rather than to a crossing nobody can receive.
+//
+// @return true only when a durable shared-item record was authored. The caller
+//         presents the foreign pickup if and only if that happened.
+static bool OoT_Foreign_RecordPickupImpl(uint16_t rc) {
+    const SharedItem* item = Combo_GetForeignPlacementForOoTCheck(rc);
+    if (item == nullptr) {
+        return false;
+    }
+
+    if (!Combo_ForeignPairingActive()) {
+        fprintf(stderr,
+                "[OoT] foreign pickup REFUSED: OoT check %u holds a foreign placement, but this session has no live "
+                "cross-game pairing (sourceIsRando=%d settingsHash=%08X). No durable shared-item record is authored — "
+                "there is no paired world it could belong to (#610/#493)\n",
+                (unsigned)rc, gComboCtx.sourceIsRando ? 1 : 0, gComboCtx.sharedRandoSettingsHash);
+        fflush(stderr);
+        return false;
+    }
+
+    // Durable immediately (Combo_RecordSharedItem writes the serialized array,
+    // so an OoT save+quit before the next switch cannot lose the pickup — the
+    // stage/commit outbox is RAM-only, see shared_items.h). The producer de-dups
+    // an identical un-redeemed entry, so a re-fired queue cannot double-record.
+    return Combo_RecordSharedItem((GameId)item->originGame, item->id) >= 0;
+}
+
+/**
+ * The reverse direction's give-path entry point, called by the RC-queue drain
+ * (hook_handlers.cpp) and driven directly by the ForeignItemGiveReverse lock.
+ *
+ * The exact twin of MM_Rando_Foreign_RecordPickup, and named to match: one
+ * production function, two callers, so the lock covers the real recording path
+ * rather than a copy of it.
+ *
+ * @return 1 if a durable crossing was authored for this OoT check, 0 otherwise
+ *         (no foreign placement here, or no live pairing to author it for).
+ */
+extern "C" int OoT_Rando_Foreign_RecordPickup(uint16_t rc) {
+    return OoT_Foreign_RecordPickupImpl(rc) ? 1 : 0;
 }
 
 /**

--- a/games/oot/soh/Enhancements/randomizer/hook_handlers.cpp
+++ b/games/oot/soh/Enhancements/randomizer/hook_handlers.cpp
@@ -20,8 +20,7 @@
 // src/common. OUTSIDE the extern "C" block below: these headers manage their own
 // linkage and pull in context.h, whose <type_traits> include must not be wrapped
 // in C linkage (see context.h's header comment).
-#include "foreign_items.h" // Combo_GetForeignPlacementForOoTCheck, Combo_GetForeignItemName (#510)
-#include "shared_items.h"  // Combo_RecordSharedItem (#510)
+#include "foreign_items.h" // Combo_GetForeignPlacementForOoTCheck, OoT_Rando_Foreign_RecordPickup (#510/#493)
 #endif
 
 extern "C" {
@@ -380,13 +379,20 @@ void RandomizerOnPlayerUpdateForRCQueueHandler() {
     //
     // Deliberately BEFORE the local getItemEntry resolution and the collectible
     // drop: a foreign host must not also give its local item.
+    //
+    // THE DECISION AND THE RECORD ARE NOT HERE (#493). Both live in
+    // OoT_Rando_Foreign_RecordPickup (ForeignItemsSingleExe.cpp), the twin of
+    // MM's Rando::Foreign::RecordForeignPickup, so the ROM-free
+    // ForeignItemGiveReverse row can drive the REAL producer instead of poking
+    // the placement table. This block keeps only what a display-free tier cannot
+    // honestly assert: the toast, the tracker write and the queue pop.
+    //
+    // It also inherits that function's #610 pairing refusal. A refusal falls
+    // THROUGH to the ordinary give below, which is the documented degrade: the
+    // host still physically holds its own junk item, so the player gets that
+    // rather than a crossing no paired world could receive.
     const SharedItem* foreignItem = Combo_GetForeignPlacementForOoTCheck((uint16_t)rc);
-    if (foreignItem != nullptr && !loc->HasObtained()) {
-        // Durable immediately (Combo_RecordSharedItem writes the serialized
-        // array, so an OoT save+quit before the next switch cannot lose the
-        // pickup), and de-duped by content so a re-fired queue cannot double it.
-        Combo_RecordSharedItem(GAME_MM, foreignItem->id);
-
+    if (foreignItem != nullptr && !loc->HasObtained() && OoT_Rando_Foreign_RecordPickup((uint16_t)rc) != 0) {
         // Presented as an ORDINARY OoT pickup (#510): "You found the Bunny
         // Hood" — no mention of Termina, no "will be awarded there", no
         // stand-in model. The item is not given locally (it belongs to MM's

--- a/src/common/foreign_items.c
+++ b/src/common/foreign_items.c
@@ -99,6 +99,18 @@ uint8_t Combo_ComboDirection(void) {
 }
 
 bool Combo_ComboDirectionArms(uint8_t originGame) {
+    // THE ORIGIN TEST RUNS FIRST, and that ordering is the bug fix rather than
+    // a style choice (#493). With BOTH short-circuiting ahead of it, every
+    // origin — including GAME_NONE, which is what a zero-initialised or
+    // mis-typed argument reads as — answered "armed" under the shipped default.
+    // That is the shape of trap ADR 0002 exists to remove: the wrong call is
+    // indistinguishable from the right one at exactly the setting nobody
+    // changes. Combo_ComboPoolSizeFor already refuses a non-origin the same
+    // way, so this also makes the two accessors agree about what an origin is.
+    if (originGame != (uint8_t)GAME_OOT && originGame != (uint8_t)GAME_MM) {
+        return false;
+    }
+
     const uint8_t dir = Combo_ComboDirection();
     if (dir == (uint8_t)RSBS_COMBO_DIR_BOTH) {
         return true;
@@ -106,10 +118,7 @@ bool Combo_ComboDirectionArms(uint8_t originGame) {
     if (originGame == (uint8_t)GAME_OOT) {
         return dir == (uint8_t)RSBS_COMBO_DIR_FORWARD;
     }
-    if (originGame == (uint8_t)GAME_MM) {
-        return dir == (uint8_t)RSBS_COMBO_DIR_REVERSE;
-    }
-    return false;
+    return dir == (uint8_t)RSBS_COMBO_DIR_REVERSE;
 }
 
 int Combo_ComboPoolSizeFor(uint8_t originGame) {

--- a/src/common/foreign_items.h
+++ b/src/common/foreign_items.h
@@ -859,6 +859,36 @@ int OoT_PlaceForeignItems(void);
  */
 int OoT_Foreign_IsEligibleHost(uint16_t rc);
 
+/**
+ * THE REVERSE DIRECTION'S GIVE-PATH CORE (#493) — the exact twin of
+ * MM_Rando_Foreign_RecordPickup, and the OoT counterpart of
+ * Rando::Foreign::RecordForeignPickup.
+ *
+ * "OoT check @p rc was just collected; if it hosts an MM-origin foreign item,
+ * author the durable crossing." Called by the RC-queue drain
+ * (soh/Enhancements/randomizer/hook_handlers.cpp) — which is where OoT's rando
+ * delivers CHEST checks, the only host class OoT_Foreign_IsEligibleHost accepts,
+ * because the vanilla chest give is suppressed for a shuffled location
+ * (VB_GIVE_ITEM_FROM_CHEST) and the item is granted from the queue instead.
+ *
+ * ONE PRODUCTION FUNCTION, TWO CALLERS: the hook and the ForeignItemGiveReverse
+ * lock. That is the whole reason it is extracted — a lock that reached the
+ * placement table directly would assert the accessors and never the give.
+ *
+ * Records nothing when the check hosts no foreign item, and REFUSES to record
+ * when there is no live cross-game pairing (the #610 rule, which the forward
+ * direction has carried since that fix and this one did not): a record authored
+ * with no paired world is redeemed by whichever world arrives next. The check
+ * then degrades to the junk-class OoT item it physically holds.
+ *
+ * Presentation is deliberately NOT here — the caller emits the pickup toast and
+ * marks the tracker, so a display-free tier can drive the record without
+ * pretending to assert pixels.
+ *
+ * @return 1 if a durable crossing was authored, 0 otherwise.
+ */
+int OoT_Rando_Foreign_RecordPickup(uint16_t rc);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/common/test_runner.cpp
+++ b/src/common/test_runner.cpp
@@ -1026,8 +1026,64 @@ TestResult Test_ForeignPlacementOoT(void) {
         return TEST_FAIL;
     }
 
+    // ------------------------------------------------------------------
+    // THE DIRECTION GATE, on the REAL pass (ADR 0011 increment 4, #493).
+    // ------------------------------------------------------------------
+    // Driven by re-running OoT_PlaceForeignItems over the LIVE fill this test
+    // already has, with the frozen record's direction byte moved — which is the
+    // only way to assert the gate without a second generation, and which drives
+    // the production function rather than the predicate it calls.
+    //
+    // The frozen record is the authority: generation froze it (Playthrough_Init,
+    // ADR 0011 decision 4.1), and no CVar may reach a placement pass. Two
+    // unarmed values, because they fail differently in principle —
+    // RSBS_COMBO_DIR_FORWARD arms the OTHER direction, RSBS_COMBO_DIR_OFF arms
+    // neither — and a gate that keyed on "not BOTH" rather than on this pass's
+    // own origin would pass one and fail the other.
+    //
+    // Restoring BOTH must reproduce the SAME table byte for byte. That is the
+    // acceptance bar the whole increment is bounded by: under the shipped
+    // default nothing moves, which is why SeedDeterminism's foreignOoTHash and
+    // foreignOoTCount are unchanged by this change.
+    {
+        const uint8_t savedDirection = gComboCtx.comboSettings.direction;
+        if (!Combo_ComboSettingsFrozen()) {
+            printf("[TEST] FAIL: generation did not freeze the combo record — the gate has no authority to read\n");
+            return TEST_FAIL;
+        }
+        if (savedDirection != RSBS_COMBO_DIR_BOTH) {
+            printf("[TEST] FAIL: the shipped default direction is not BOTH (got %u) — every world just changed\n",
+                   (unsigned)savedDirection);
+            return TEST_FAIL;
+        }
+
+        static const uint8_t kUnarmed[] = { (uint8_t)RSBS_COMBO_DIR_FORWARD, (uint8_t)RSBS_COMBO_DIR_OFF };
+        for (size_t i = 0; i < sizeof(kUnarmed) / sizeof(kUnarmed[0]); i++) {
+            gComboCtx.comboSettings.direction = kUnarmed[i];
+            const int replaced = OoT_PlaceForeignItems();
+            if (replaced != 0 || Combo_CountForeignPlacementsOoT() != 0) {
+                printf("[TEST] FAIL: direction=%u still placed %d MM items (%d in table) — the reverse pass is not "
+                       "gated\n",
+                       (unsigned)kUnarmed[i], replaced, Combo_CountForeignPlacementsOoT());
+                return TEST_FAIL;
+            }
+        }
+
+        gComboCtx.comboSettings.direction = savedDirection;
+        const int rearmed = OoT_PlaceForeignItems();
+        if (rearmed != placedCount) {
+            printf("[TEST] FAIL: re-arming direction=BOTH placed %d, expected %d\n", rearmed, placedCount);
+            return TEST_FAIL;
+        }
+        if (memcmp(firstRun, gComboCtx.foreignPlacementsOoT, sizeof(firstRun)) != 0) {
+            printf("[TEST] FAIL: the re-armed pass produced a DIFFERENT table — the gate is not free\n");
+            return TEST_FAIL;
+        }
+    }
+
     Combo_ClearSharedItemOutbox();
-    printf("[TEST] PASS: %d MM items hosted over %d eligible OoT checks, deterministic, MM awards each once\n",
+    printf("[TEST] PASS: %d MM items hosted over %d eligible OoT checks, deterministic, gated on the frozen "
+           "direction, MM awards each once\n",
            placedCount, eligibleHosts);
     return TEST_PASS;
 }

--- a/src/common/tests/test_combo_settings.c
+++ b/src/common/tests/test_combo_settings.c
@@ -209,6 +209,46 @@ TestResult Test_ComboSettingsFormat(void) {
     CS_ASSERT(Combo_ComboPoolSizeFor((uint8_t)GAME_NONE) == 0, "GAME_NONE has no pool");
     CS_ASSERT(Combo_ComboDirection() == RSBS_COMBO_DIR_BOTH, "an unfrozen direction resolves to the default");
 
+    // ---- The direction GATE (ADR 0011 increment 4, #493) -------------------
+    //
+    // Combo_ComboDirectionArms is what each placement pass reads to decide
+    // whether to run at all, and the ORIGIN argument is the pass's own origin,
+    // not the host's: GAME_OOT is the FORWARD pass (OoT items into MM checks),
+    // GAME_MM is the REVERSE pass (MM items into OoT checks). Getting that
+    // backwards compiles, generates, and produces a world with exactly the
+    // crossings the player did not ask for — so the mapping is pinned here,
+    // value by value, rather than left to the two call sites to agree on.
+    //
+    // The unfrozen row first, because it is the one that must never narrow: a
+    // legacy or pre-freeze world places what it places today.
+    CS_ASSERT(Combo_ComboDirectionArms((uint8_t)GAME_OOT) && Combo_ComboDirectionArms((uint8_t)GAME_MM),
+              "an UNFROZEN record must arm BOTH directions — the shipped default is what already ships (O2)");
+    CS_ASSERT(!Combo_ComboDirectionArms((uint8_t)GAME_NONE), "GAME_NONE is not a crossing origin");
+    {
+        static const struct {
+            uint8_t direction;
+            bool armsForward;
+            bool armsReverse;
+        } kDirectionTruth[] = {
+            { (uint8_t)RSBS_COMBO_DIR_OFF, false, false },    // a real, chooseable world: paired, zero crossings
+            { (uint8_t)RSBS_COMBO_DIR_FORWARD, true, false }, // OoT-origin items into MM checks only
+            { (uint8_t)RSBS_COMBO_DIR_REVERSE, false, true }, // MM-origin items into OoT checks only
+            { (uint8_t)RSBS_COMBO_DIR_BOTH, true, true },     // today's shipped behaviour
+        };
+        for (int i = 0; i < (int)(sizeof(kDirectionTruth) / sizeof(kDirectionTruth[0])); i++) {
+            ComboSettingsRecord dirRec = defaults;
+            dirRec.direction = kDirectionTruth[i].direction;
+            Combo_FreezeComboSettings(&dirRec);
+            CS_ASSERT(Combo_ComboDirection() == kDirectionTruth[i].direction,
+                      "the frozen record is the authority for a created world's direction");
+            CS_ASSERT(Combo_ComboDirectionArms((uint8_t)GAME_OOT) == kDirectionTruth[i].armsForward,
+                      "the FORWARD pass (GAME_OOT origin) is armed by the wrong direction values");
+            CS_ASSERT(Combo_ComboDirectionArms((uint8_t)GAME_MM) == kDirectionTruth[i].armsReverse,
+                      "the REVERSE pass (GAME_MM origin) is armed by the wrong direction values");
+        }
+        ComboContext_Init();
+    }
+
     // A frozen record is the authority, and an over-cap value is CLAMPED rather
     // than honoured: a count that can exceed the table's capacity is a setting
     // that lies (accepted answer O4).

--- a/src/common/tests/test_foreign_items.c
+++ b/src/common/tests/test_foreign_items.c
@@ -83,6 +83,24 @@ int OoT_ForeignItem_TestExclusionAt(int index, uint16_t* outId, uint8_t* outCrit
 // nothing until a real generation has run: see Test_ForeignPlacementOoT, which
 // lives in the display-requiring `rando` tier for exactly that reason.
 int OoT_Foreign_IsEligibleHost(uint16_t rc);
+
+// #493 REVERSE-DIRECTION PRODUCTION CHAIN. Every symbol below is the real
+// shipping one; there is no stand-in anywhere in this list, which is the whole
+// point of the row that drives them:
+//   OoT_Rando_Foreign_RecordPickup  the give-path core the RC-queue drain calls
+//                                   (soh/.../ForeignItemsSingleExe.cpp)
+//   MM_ConsumeSharedItems           MM's real consumer hook (the exact function
+//                                   z_play.c's startup-entrance consumption calls)
+//   MM_ForeignItem_TestPending*     the observable for "MM's real award reached
+//                                   the real give" — with no PlayState the give
+//                                   DEFERS into this queue (#502) rather than
+//                                   dereferencing, which is exactly the state
+//                                   MM's arrival point is in.
+int OoT_Rando_Foreign_RecordPickup(uint16_t rc);
+void MM_ConsumeSharedItems(void);
+int MM_ForeignItem_TestPendingCount(void);
+uint16_t MM_ForeignItem_TestPendingAt(int index);
+void MM_ForeignItem_TestResetPending(void);
 }
 
 #define FI_ASSERT(cond)                                                                                                \
@@ -455,14 +473,23 @@ TestResult Test_ForeignItemGiveReverse(void) {
     // RandomizerCheck, sharing a struct whose member is named mmCheckId and
     // sharing a .redsave record with the forward table.
     //
-    // Scope note, stated because a reader will look for it: the production
-    // give-path bridge (OoT_Rando_Foreign_RecordPickup -> the same core
-    // Randomizer_Item_Give's foreign branch calls) and MM's real award are
-    // #493 steps 5-8 and Lane 6's MM_AwardSharedItem, neither of which exists
-    // yet. This row therefore drives the real ACCESSORS, the real
-    // SaveManager::Load, and the real Combo_RedeemSharedItemsForGame walk; it
-    // does not yet enter the OoT give path. It must gain that leg when the
-    // interception lands, or it locks the carve without locking the give.
+    // SCOPE, RESTATED (#493). This row used to carry a note saying it "does not
+    // yet enter the OoT give path" and that MM's real award did not exist. Both
+    // halves of that note are now discharged and the row drives the WHOLE
+    // reverse chain with no stand-in at any step:
+    //
+    //   Combo_SetForeignPlacementOoT       the real generation-side accessor
+    //     -> OoT_Rando_Foreign_RecordPickup  the real give-path core the
+    //                                        RC-queue drain calls
+    //       -> Combo_RecordSharedItem        the real durable producer
+    //         -> MM_ConsumeSharedItems       MM's real arrival hook
+    //           -> MM_AwardSharedItem        MM's real award callback (#507)
+    //             -> MM_ForeignItem_Give     the real give entry point
+    //
+    // plus the REDEEMED latch, and a whole-file commit + reload over the top.
+    // The one thing it still does NOT assert is presentation: the pickup toast
+    // and the tracker write stay at the hook, in the gameplay tier, because a
+    // display-free process cannot honestly claim anything about pixels.
 
     ComboContext_Init();
     Context_InitFrozenStates();
@@ -606,11 +633,12 @@ TestResult Test_ForeignItemGiveReverse(void) {
     // ------------------------------------------------------------------
     // The redeem walk: an MM-origin crossing awards exactly once, to MM.
     // ------------------------------------------------------------------
-    // The real Combo_RedeemSharedItemsForGame, with a test award callback
-    // standing in for MM_AwardSharedItem (which is still a Lane-C placeholder
-    // fprintf, so asserting through it would assert nothing). What this locks
-    // is that an MM-tagged crossing is delivered to MM and not to OoT, and
-    // that redemption is single-use.
+    // The real Combo_RedeemSharedItemsForGame with an INSTRUMENTED award
+    // callback. It is kept alongside the real-award chain below rather than
+    // replaced by it, because it observes something the pending queue cannot:
+    // WHICH game an entry was offered to. The real MM award simply ignores an
+    // OoT-origin entry, so "not awarded to OoT" and "MM declined it" are
+    // indistinguishable downstream; here they are not.
     ComboContext_Init();
     Combo_ClearSharedItemOutbox();
     FI_ASSERT(Combo_RecordSharedItem(GAME_MM, mmItem.id) >= 0);
@@ -632,12 +660,141 @@ TestResult Test_ForeignItemGiveReverse(void) {
     FI_ASSERT(Combo_RedeemSharedItemsForGame(GAME_MM, ForeignTestAward, &award) == 0);
     FI_ASSERT(award.awardCount == 0);
 
+    // ==================================================================
+    // THE PRODUCTION CHAIN (#493). No stand-in at any step.
+    // ==================================================================
+    // Everything above drives ACCESSORS. This drives the give: the same
+    // function the RC-queue drain calls, into the same durable producer, into
+    // MM's real arrival hook, into MM's real award, into MM's real give. A row
+    // that reached Combo_RecordSharedItem directly would assert that the
+    // shared-item machinery works — which SharedItemRoundtrip already asserts —
+    // and would say nothing at all about the reverse direction.
+    ComboContext_Init();
+    Context_ClearAllFrozenStates();
+    Combo_ClearSharedItemOutbox();
+    MM_ForeignItem_TestResetPending();
+    FI_ASSERT(MM_ForeignItem_TestPendingCount() == 0);
+
+    // A REAL MM pool entry: the reverse pass can only ever place one of these,
+    // and MM's give only accepts ids its own table knows. An arbitrary u16
+    // would be refused downstream and the chain would look broken for the wrong
+    // reason.
+    const ComboForeignItemDef* mmPool = NULL;
+    const int mmPoolCount = Combo_GetForeignItemPoolFor((uint8_t)GAME_MM, &mmPool);
+    FI_ASSERT(mmPoolCount > 0 && mmPool != NULL);
+    const SharedItem placedItem = mmPool[0].item;
+    FI_ASSERT(placedItem.originGame == (uint8_t)GAME_MM);
+
+    FI_ASSERT(Combo_SetForeignPlacementOoT(kForeignTestCheckA, placedItem) >= 0);
+
+    // ---- (1) THE #610 REFUSAL, FIRST -----------------------------------
+    // Non-vacuity leg, and the bug this lane found: the forward direction has
+    // refused to author a crossing for a world that does not exist since #610
+    // (Rando::Foreign::RecordForeignPickup), and the reverse direction did not.
+    // Combo_RecordSharedItem performs no identity check of its own, so whatever
+    // reaches it is redeemed by whichever paired MM world arrives next — blind
+    // to which world authored it. RED before the gate landed: the pickup
+    // recorded, and an unpaired OoT session minted a crossing.
+    FI_ASSERT(!Combo_ForeignPairingActive());
+    FI_ASSERT(OoT_Rando_Foreign_RecordPickup(kForeignTestCheckA) == 0);
+    FI_ASSERT(Combo_CountSharedItems(GAME_MM, /*includeRedeemed=*/true) == 0);
+
+    // ---- (2) Paired: the real core records the crossing, MM-tagged -----
+    gComboCtx.sourceIsRando = true;
+    gComboCtx.sharedRandoSeed = 0xC0FFEE03u;
+    gComboCtx.sharedRandoSettingsHash = 0x5EED5A5Cu;
+    FI_ASSERT(Combo_ForeignPairingActive());
+
+    // A check that hosts nothing records nothing — the ordinary case for every
+    // OoT check in the world, and the reason the hook falls through to the
+    // local give.
+    FI_ASSERT(OoT_Rando_Foreign_RecordPickup(kForeignTestCheckB) == 0);
+    FI_ASSERT(Combo_CountSharedItems(GAME_MM, /*includeRedeemed=*/true) == 0);
+
+    FI_ASSERT(OoT_Rando_Foreign_RecordPickup(kForeignTestCheckA) == 1);
+    FI_ASSERT(Combo_CountSharedItems(GAME_MM, /*includeRedeemed=*/false) == 1);
+    FI_ASSERT(gComboCtx.sharedItemsTagged[0].originGame == (uint8_t)GAME_MM);
+    FI_ASSERT(gComboCtx.sharedItemsTagged[0].id == placedItem.id);
+    FI_ASSERT(gComboCtx.sharedItemsTagged[0].flags == 0);
+
+    // ---- (3) A re-fired queue de-dups rather than doubling -------------
+    FI_ASSERT(OoT_Rando_Foreign_RecordPickup(kForeignTestCheckA) == 1);
+    FI_ASSERT(Combo_CountSharedItems(GAME_MM, /*includeRedeemed=*/true) == 1);
+
+    // ---- (4) The crossing: OoT suspends, MM arrives, MM awards ---------
+    // The real switch seam, then MM's real consumer. With no PlayState the give
+    // DEFERS into MM's pending queue (#502) — the state MM's arrival point is
+    // genuinely in — so the queue is the faithful observable that the id
+    // survived the whole path in MM's own id-space.
+    {
+        static uint8_t ootSave[256];
+        static uint8_t mmScratch[256];
+        memset(ootSave, 0xA7, sizeof(ootSave));
+        FI_ASSERT(Switch_PrepareHotSwap(GAME_OOT, ootSave, sizeof(ootSave)) == 1);
+        FI_ASSERT(Combo_CommitStagedSharedItems() == 0); // recorded directly; the outbox stays empty
+        memset(mmScratch, 0x00, sizeof(mmScratch));
+        Combo_ConsumeFrozenState("mm", mmScratch, sizeof(mmScratch)); // first MM arrival: nothing frozen
+    }
+
+    MM_ConsumeSharedItems();
+    FI_ASSERT(MM_ForeignItem_TestPendingCount() == 1);
+    FI_ASSERT(MM_ForeignItem_TestPendingAt(0) == placedItem.id);
+    // The REDEEMED latch: retired, still present (the durable record of the
+    // crossing, which is what keeps the spoiler truthful).
+    FI_ASSERT((gComboCtx.sharedItemsTagged[0].flags & RSBS_SHARED_ITEM_REDEEMED) != 0);
+    FI_ASSERT(Combo_CountSharedItems(GAME_MM, /*includeRedeemed=*/false) == 0);
+    FI_ASSERT(Combo_CountSharedItems(GAME_MM, /*includeRedeemed=*/true) == 1);
+    // And the placement survived redemption: the world still hosts the item.
+    FI_ASSERT(Combo_GetForeignPlacementForOoTCheck(kForeignTestCheckA) != NULL);
+
+    // ---- (5) Single-use: a second arrival awards nothing ---------------
+    MM_ForeignItem_TestResetPending();
+    MM_ConsumeSharedItems();
+    FI_ASSERT(MM_ForeignItem_TestPendingCount() == 0);
+
+    // ---- (6) A WHOLE-FILE COMMIT + RELOAD carries all three ------------
+    // Tier-1 is written as one unit (ADR 0009 decision 4 / #612), so the
+    // placement, the REDEEMED crossing and the pairing identity ride the same
+    // write. What must NOT happen is the REDEEMED bit going durable while the
+    // placement does not (the crossing would re-fire into a world that already
+    // has it) or the reverse (a redeemed crossing re-awarded on the next
+    // arrival). Scribbled before the load so a pass cannot come from residue.
+    {
+        rsbs::SaveManager& commitMgr = rsbs::SaveManager::Instance();
+        commitMgr.SetSaveDirectory(kForeignSaveDir);
+        commitMgr.DeleteSave(0);
+        FI_ASSERT(commitMgr.Save(0));
+
+        ComboContext_Init();
+        memset(gComboCtx.foreignPlacementsOoT, 0x5A, sizeof(gComboCtx.foreignPlacementsOoT));
+        memset(gComboCtx.sharedItemsTagged, 0x5A, sizeof(gComboCtx.sharedItemsTagged));
+        FI_ASSERT(commitMgr.Load(0));
+
+        const SharedItem* reloaded = Combo_GetForeignPlacementForOoTCheck(kForeignTestCheckA);
+        FI_ASSERT(reloaded != NULL);
+        FI_ASSERT(reloaded->originGame == (uint8_t)GAME_MM && reloaded->id == placedItem.id);
+        FI_ASSERT(Combo_CountSharedItems(GAME_MM, /*includeRedeemed=*/true) == 1);
+        FI_ASSERT(Combo_CountSharedItems(GAME_MM, /*includeRedeemed=*/false) == 0);
+        FI_ASSERT((gComboCtx.sharedItemsTagged[0].flags & RSBS_SHARED_ITEM_REDEEMED) != 0);
+        FI_ASSERT(Combo_ForeignPairingActive()); // the identity rode the same record
+
+        // The load-side arrival awards nothing: the latch is what makes the
+        // crossing single-use ACROSS a process, not merely within one.
+        MM_ForeignItem_TestResetPending();
+        MM_ConsumeSharedItems();
+        FI_ASSERT(MM_ForeignItem_TestPendingCount() == 0);
+        commitMgr.DeleteSave(0);
+    }
+
     // Leave global state clean for any subsequent test.
+    MM_ForeignItem_TestResetPending();
     Context_ClearAllFrozenStates();
     Combo_ClearSharedItemOutbox();
     ComboContext_Init();
 
-    printf("[TEST] PASS: reverse carve is a separate key space, serializes byte-exact, zero-extends, redeems once\n");
+    printf("[TEST] PASS: reverse carve is a separate key space, serializes byte-exact, zero-extends; the real "
+           "pickup core refuses an unpaired session, records once, and MM's real award redeems it once across a "
+           "whole-file commit\n");
     return TEST_PASS;
 }
 


### PR DESCRIPTION
Fixes #493.

#493 has the highest stale-premise risk of the week, so every one of its three named gaps was re-derived at `origin/main` = `e8b49fba` before a line was written. **Two were already discharged and one is superseded** — none of them is re-landed here. What this branch implements is the residue the 2026-08-02 staleness re-check named, plus a one-sided bug found on the way, plus ADR 0011 increment 4.

## Gap-by-gap verdict

| #493's named gap | Verdict | Evidence at `e8b49fba` |
|---|---|---|
| **Second placement carve** | **ALREADY COVERED — verify, not re-land.** | `ComboForeignPlacement foreignPlacementsOoT[8]` at `.redsave` offset 740 (`src/common/context.h`), four mirror accessors sharing one body (`src/common/foreign_items.c`), in `Context_InvalidateSessionState`'s KEEP set since #545, folded into `Rando_HeadlessSeedDeterminismDigest`, and locked by `ForeignItemGiveReverse`'s byte-exact round trip + zero-extension legs. Landed #505. |
| **OoT sentinel item id** (`RG_RSBS_FOREIGN_SLOT_*`) | **SUPERSEDED — and the supersession is now verified at source, which it was not before.** | ADR 0011 decision 2.4 says "do not resurrect it… do not append enumerators to `RandomizerGet` for this", on the ground that the RC-queue path knows the check id at give time. #493's own audit called that unproven: the only host class is `ACTOR_EN_BOX`, i.e. exactly the actor path step 8 said "drops the check id". **Traced and answered:** in rando a shuffled chest does *not* give its own item. `VB_GIVE_ITEM_FROM_CHEST` is raised from `z_player.c:7409` and the rando handler sets `*should = false` for any shuffled location (`hook_handlers.cpp:959-975`); the chest's `Flags_SetTreasure` (`z_en_box.c:443`) then queues the RC through `RandomizerOnSceneFlagSetHandler` → `GetRandomizerCheckFromSceneFlag`'s `FLAG_SCENE_TREASURE`/`SPOILER_CHK_CHEST` arm, and the item is delivered from `randomizerQueuedChecks`. The reverse intercept sits at the head of that drain, ahead of the local resolution. **No sentinel is owed, and the residue "sentinel *or* a chest-path test" is answered by the trace rather than by adding an enumerator.** |
| **Pre-Fill pairing gate** | **ALREADY COVERED, twice.** | `OoT_PlaceForeignItems` runs after the identity stamp and reads the post-condition `Combo_ForeignPairingActive()` (verified again by #627); the pre-condition predicate ADR 0009 D2 designed, `Combo_ForeignPairingRequested()`, landed with #628 (`foreign_items.c:77`). Nothing added. |

## What was genuinely still missing, and is implemented here

### 1. The give-path core had no name — `OoT_Rando_Foreign_RecordPickup`

The reverse leg's producer lived entirely inside the RC-queue drain lambda, which needs a live `PlayState`, a `Player` and the `CheckTracker`. Nothing ROM-free could enter it, and the `ForeignItemGiveReverse` row said so in its own scope note ("does not yet enter the OoT give path… It must gain that leg when the interception lands, or it locks the carve without locking the give").

Extracted into `ForeignItemsSingleExe.cpp` as the exact twin of MM's `Rando::Foreign::RecordForeignPickup` / `MM_Rando_Foreign_RecordPickup`, with the **same split MM makes**: the core owns the decision and the durable record; the hook keeps the toast, the tracker write and the queue pop, because those are display/gameplay concerns a display-free tier cannot honestly assert. One production function, two callers.

### 2. The #610 pairing refusal was one-sided — a real bug

`Combo_RecordSharedItem` takes no identity argument and performs no identity check: whatever reaches it is redeemed by whichever paired world arrives next, blind to which world authored it. MM's forward core has refused to author such a record since **#610**; **the reverse core did not**. An OoT session whose `foreignPlacementsOoT` survived into an unpaired state could mint a crossing with no paired world to receive it. It now refuses, with the same message shape and the same consequence: the check degrades to the junk-class OoT item it physically holds, which is the documented absent-placement behaviour.

### 3. ADR 0011 increment 4 — the direction byte becomes a gate

`Combo_ComboDirectionArms` had **zero consumers** in the tree. Both passes now no-op when their own origin's direction is unarmed, read from the **frozen record** and never from a CVar:

- `OoT_PlaceForeignItems` gates on `Combo_ComboDirectionArms(GAME_MM)` — the reverse pass's origin.
- `Rando::Foreign::PlaceForeignItems` gates on `Combo_ComboDirectionArms(GAME_OOT)` — the forward pass's.

**Landed for both directions together on purpose.** Gating only the reverse half would leave a `RSBS_COMBO_DIR_REVERSE` world still generating forward crossings, which is worse than not landing the gate at all.

Both return `0` rather than a negative shortfall code: `DIR_OFF` and the one-way values describe real, chooseable paired worlds (decision 2.3), not "a paired world's cross-game half is silently absent". On MM's side the early return also leaves `sLastPlacementStats` zeroed, so `OnFileCreate`'s shortfall alarm cannot read "the rules say no crossings" as "hosts ran short".

**One accessor fix fell out of writing the truth table:** `Combo_ComboDirectionArms` short-circuited on `RSBS_COMBO_DIR_BOTH` *before* testing the origin, so it answered "armed" for `GAME_NONE` — a zero-initialised or mis-typed argument — at exactly the setting nobody changes. The origin test now runs first, matching what `Combo_ComboPoolSizeFor` already does.

## Determinism: byte-identical at the shipped defaults

Baseline captured from a build of `origin/main` (`e8b49fba`) on this machine with the same staged ROMs, then re-captured from this branch. `Compare-Object` over both digest files (`run1` and `run2`): **no differences**.

```
seed=4FF39390            settingsHash=16E0CEF5      sourceIsRando=1
placementHash=5E0B1FA7   placedCount=490
foreignOoTHash=8FBA56D2  foreignOoTCount=8
comboSettingsHash=4215BD80
comboSettings=v1/d4/p8,8/c003F,003F/g1/r2
mmFinalSeed=74C32F12     mmPlacementHash=C73D3F4E
mmReachableCount=2256    mmReachableHash=DED50CE6
foreignCount=4           mmPairedAttempt=1
foreign0=198:1:40  foreign1=232:1:13  foreign2=291:1:12  foreign3=222:1:14
```

`foreignOoTHash` is the reverse pass running **through the new gate** and `foreign0..3` are the forward pass running through its twin, so this is the gate being *free* at `direction=BOTH`, not the gate being bypassed. Same acceptance bar #631 set.

## Failing-first, each counterfactual run and restored

| Counterfactual | Row | Red at |
|---|---|---|
| `if (false && !Combo_ForeignPairingActive())` in the pickup core | `ForeignItemGiveReverse` | `test_foreign_items.c:699: OoT_Rando_Foreign_RecordPickup(kForeignTestCheckA) == 0` |
| `return true;` ahead of `Combo_RecordSharedItem` (report success, author nothing) | `ForeignItemGiveReverse` | `test_foreign_items.c:715: Combo_CountSharedItems(GAME_MM, false) == 1` |
| reverse direction gate short-circuited | `ForeignPlacementOoT` | `direction=2 still placed 8 MM items (8 in table) — the reverse pass is not gated` |
| forward direction gate short-circuited | `RandoDeterminism` + `SeedDeterminism` | `[MM-FOREIGN-DIGEST] FAIL(7): direction=3 still placed 4 OoT items (4 in table) — the forward pass is not gated` |

And the fifth, which is a compile failure rather than an assertion: `OoT_Rando_Foreign_RecordPickup` had **no definition anywhere in the tree** at `e8b49fba` (its sole hit was the comment in the row's own scope note), so the new leg could not have been written against `main` at all.

The `GAME_NONE` accessor fix is also failing-first in the ordinary way: `ComboSettingsFormat` went red on `"GAME_NONE is not a crossing origin"` against the pre-fix accessor, which is how the bug was found.

## Locks

- **`ForeignItemGiveReverse`** now drives the whole reverse chain with **no stand-in at any step** — `Combo_SetForeignPlacementOoT` → `OoT_Rando_Foreign_RecordPickup` → `Combo_RecordSharedItem` → `MM_ConsumeSharedItems` → `MM_AwardSharedItem` (#507) → `MM_ForeignItem_Give` — plus the unpaired refusal, the de-dup, the `RSBS_SHARED_ITEM_REDEEMED` latch, single-use across a second arrival, and a **whole-file commit + reload** (ADR 0009 D4 / #612) after which the placement, the redeemed crossing and the pairing identity all come back together and a post-reload arrival awards nothing. The instrumented-callback leg is *kept alongside* the real chain rather than replaced by it, because it observes something the pending queue cannot: which game an entry was offered to.
- **`ForeignPlacementOoT`** re-runs the real reverse pass over its live fill with the frozen direction moved. Two unarmed values, because they fail differently in principle — `FORWARD` arms the *other* direction, `OFF` arms neither, and a gate keyed on "not BOTH" would pass one and fail the other. Re-arming must reproduce the table byte for byte.
- **`MM_Rando_HeadlessForeignDigest`** gains the forward twin of that leg. It lives there because it is the **only** headless bridge that reaches MM's pass with a *live pairing* — `MMRandoGen`'s world is solo, so the same leg there would assert a pass returning 0 for the wrong reason. Placed **after** the digest is written and closed, so it cannot perturb a byte of the two-process artifact, and wrapped in a `try`/`catch` because `PlaceForeignItems` signals a structural defect by throwing and an uncaught throw out of that `extern "C"` bridge would `std::terminate` the row instead of failing it.
- **`ComboSettingsFormat`** pins the direction→origin truth table value by value (all four directions × both origins, plus the unfrozen fallback and `GAME_NONE`).

## Local verification

Full ROM-staged build on Windows, `cmake --build --parallel 5`, exit 0.

| tier | result |
|---|---|
| `redship` | **91/91 passed** |
| `rando` | **18/18 passed** |
| `integration` | **5/6** — only `IntSwitchOoTHmsToMm` (known-red timeout, #544) |

clang-format clean: every one of the 73 paths in `.github/clang-format-paths.txt` verified conformant with clang-format 14.0.6 (`--dry-run -Werror`), including the two this change touches.

## For a reviewer's eye

1. **The presentation half of the reverse pickup is unchanged and remains untested by CI**, by design: the pickup toast reuses `Notification::Emit` with the pool's name + article (the #494/#510 arrangement), and an MM-origin item resolves **no icon** in OoT because `kForeignPoolMMV1`'s rows carry no `iconName` — reaching the other game's texture needs a cross-archive accessor `src/common` does not have. That is the documented text-only degradation, not a regression this branch introduces.
2. **Increment 4 lands here ahead of increment 2, and that is a deviation worth naming rather than burying.** ADR 0011 orders increment 4 last because "it should land on top of a frozen, compared, **rendered** setting rather than under one". Frozen ✔ and compared ✔ both landed with #628; **rendered has not** — the tier-4 `gCombo.Rando.*` keys and the pane are increment 2 and do not exist. The deviation is inert in practice: `Combo_ResolveComboSettings` still resolves to the shipped defaults with no CVar read, so nothing can author an unarmed direction and the gate can only ever be armed today — which is exactly what the byte-identical digest shows. It is landed here because #493's title names the direction byte as the reverse leg's arming and the gate is genuinely the ADR's one-liner. **If the operator would rather hold increment 4 until the pane exists, dropping the two gate hunks (`ForeignItemsSingleExe.cpp` and `Foreign.cpp`) plus their three test legs leaves items 1 and 2 — the actual #493 residue — intact and independently mergeable.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!--- section:artifacts:start -->
### Build Artifacts
  - [rsbs-windows.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/8953554392.zip)
  - [rsbs-linux.zip](https://nightly.link/spencerduncan/redshipblueship/actions/artifacts/8953359592.zip)
<!--- section:artifacts:end -->